### PR TITLE
Group the Missions board by the mission a session is attached to

### DIFF
--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -1,6 +1,7 @@
-import { createContext, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { type SessionDto } from "@devthrottle/client-core/api/client";
+import { listMissions, type MissionDto } from "@devthrottle/client-core/missions/missions";
 import { dotColor, dotHex, effectiveColor, stateLabel } from "@devthrottle/client-core/sessions/ordering";
 import {
   reachabilityFor,
@@ -217,11 +218,42 @@ export function FleetMapView() {
   }, [list]);
   const redCount = list.filter((s) => effectiveColor(s) === "red").length;
   const workingCount = list.filter((s) => effectiveColor(s) === "blue").length;
+  // The Gateway's mission RECORDS, loaded when the Missions pivot is opened. They are what make a mission
+  // with nobody on it yet appear at all - the roster alone can only reveal missions that already have a
+  // session attached. Missions change rarely, so this is a one-shot read per pivot entry rather than a
+  // poll; a mission attached while the page is open still renders, because the grouping falls back to the
+  // name cached on the session for a mission id it has no record for.
+  const [missions, setMissions] = useState<MissionDto[]>([]);
+  const [missionsError, setMissionsError] = useState<string | null>(null);
+  useEffect(() => {
+    if (pivot !== "mission") return;
+    let cancelled = false;
+    // Drop any previous failure before re-reading, so a banner from an earlier visit cannot survive next to
+    // a list that has since loaded cleanly.
+    setMissionsError(null);
+    listMissions()
+      .then((m) => {
+        if (cancelled) return;
+        setMissions(m);
+        setMissionsError(null);
+      })
+      .catch((e: unknown) => {
+        // Loudly, not silently: without the records this board can still show every mission that has a
+        // session on it, but it CANNOT show the empty ones - and a short list that looks complete is
+        // exactly the kind of quiet wrong answer this screen was rebuilt to stop telling.
+        if (cancelled) return;
+        setMissionsError(e instanceof Error ? e.message : "The mission list could not be loaded.");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pivot]);
+
   // Mission / standalone tally, shown in the header only while the Missions pivot is active so it
   // carries the count the standalone Missions page used to show. Grouped only when needed.
   const missionStats = useMemo(
-    () => (pivot === "mission" ? missionCounts(list) : null),
-    [pivot, list],
+    () => (pivot === "mission" ? missionCounts(list, missions) : null),
+    [pivot, list, missions],
   );
 
   return (
@@ -333,7 +365,12 @@ export function FleetMapView() {
         )}
 
       {pivot === "mission"
-        ? list.length > 0 && <MissionsBoard sessions={list} />
+        ? // The board also mounts on a mission-load FAILURE with nothing else to show: otherwise the one
+          // case where we know least - no sessions and no mission list - is the case that renders the most
+          // confident answer, a silent "no missions at all".
+          (list.length > 0 || missions.length > 0 || missionsError !== null) && (
+            <MissionsBoard sessions={list} missions={missions} error={missionsError} />
+          )
         : pivot === "list"
         ? flatSessions.length > 0 && (
             <FleetList

--- a/apps/cockpit/src/missions/MissionsBoard.test.tsx
+++ b/apps/cockpit/src/missions/MissionsBoard.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { SessionDto } from "@devthrottle/client-core/api/client";
+import type { MissionDto } from "@devthrottle/client-core/missions/missions";
+
+// The WHY store is keyed by the mission's lower-cased NAME; the board now groups by mission ID. Those two
+// keys are not the same string, and the gap between them is invisible to the pure grouping tests - the
+// board renders, the cards are right, and the WHY text is just silently gone.
+//
+// That is exactly what happened when the grouping moved to ids: the card looked its WHY up by the group's
+// key, which had become an id, and every WHY the owner had written disappeared without any error. These
+// tests render the real board so a repeat cannot pass.
+vi.mock("@devthrottle/client-core/missions/missionNotes", () => ({
+  getMissionNotes: vi.fn(),
+  setMissionNote: vi.fn(),
+}));
+
+import { getMissionNotes } from "@devthrottle/client-core/missions/missionNotes";
+import { MissionsBoard } from "./MissionsBoard";
+
+const M_RELEASE: MissionDto = { missionId: "45e28f0c", missionName: "Release 2.0.1" };
+
+// The Gateway stamps the color and the label; the shared ordering module THROWS rather than re-deriving
+// them (the client-is-dumb rule), so a fixture has to carry them exactly as the roster would.
+function session(fields: Record<string, unknown>): SessionDto {
+  return {
+    effectiveColor: "blue",
+    stateLabel: "Working",
+    dotHex: "#4a9eff",
+    ...fields,
+  } as unknown as SessionDto;
+}
+
+const ARCHITECT = session({
+  name: "Release 2.0.1 - Architect",
+  number: 124,
+  sessionId: "s-124",
+  missionId: "45e28f0c",
+  sessionRole: "Architect",
+});
+
+const WORKER = session({
+  name: "fix: 2481 delete bias path",
+  number: 113,
+  sessionId: "s-113",
+  missionId: "45e28f0c",
+  sessionRole: "Worker",
+});
+
+function renderBoard(props: Parameters<typeof MissionsBoard>[0]) {
+  return render(
+    <MemoryRouter>
+      <MissionsBoard {...props} />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(getMissionNotes).mockResolvedValue([]);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MissionsBoard", () => {
+  it("shows the mission's WHY - the store is keyed by NAME, the grouping by ID", async () => {
+    vi.mocked(getMissionNotes).mockResolvedValue([
+      {
+        key: "release 2.0.1",
+        mission: "Release 2.0.1",
+        why: "So we can get the Video Competition started",
+        updatedAt: "2026-08-07T00:00:00Z",
+      },
+    ]);
+
+    renderBoard({ sessions: [ARCHITECT], missions: [M_RELEASE] });
+
+    await waitFor(() =>
+      expect(screen.getByText("So we can get the Video Competition started")).toBeTruthy(),
+    );
+    // ...and therefore NOT the "no why set" flag.
+    expect(screen.queryByText(/No why set/i)).toBeNull();
+  });
+
+  it("shows the loud flag when a mission genuinely has no WHY", async () => {
+    renderBoard({ sessions: [ARCHITECT], missions: [M_RELEASE] });
+    await waitFor(() => expect(screen.getByText(/No why set/i)).toBeTruthy());
+  });
+
+  it("lists every attached session by NAME, with its role as a badge", async () => {
+    renderBoard({ sessions: [ARCHITECT, WORKER], missions: [M_RELEASE] });
+
+    // The name is what tells one worker from another - the role alone would repeat down the card.
+    expect(screen.getByText("fix: 2481 delete bias path")).toBeTruthy();
+    expect(screen.getByText("Release 2.0.1 - Architect")).toBeTruthy();
+    expect(screen.getByText("Architect")).toBeTruthy();
+    expect(screen.getByText("Worker")).toBeTruthy();
+    expect(screen.getByText("2 sessions")).toBeTruthy();
+  });
+
+  it("renders a mission nobody is on yet", async () => {
+    renderBoard({ sessions: [], missions: [M_RELEASE] });
+
+    expect(screen.getByText("Release 2.0.1")).toBeTruthy();
+    expect(screen.getByText("0 sessions")).toBeTruthy();
+    expect(screen.getByText("no sessions yet")).toBeTruthy();
+  });
+
+  it("marks a mission the Gateway's mission list does not contain", async () => {
+    renderBoard({
+      sessions: [
+        session({
+          name: "worker one",
+          number: 140,
+          sessionId: "s-140",
+          missionId: "ghost",
+          missionName: "BPM Studio QA cleanup",
+          sessionRole: "Worker",
+        }),
+      ],
+      missions: [M_RELEASE],
+    });
+
+    expect(screen.getByText("BPM Studio QA cleanup")).toBeTruthy();
+    expect(screen.getByText(/not in the mission list/i)).toBeTruthy();
+  });
+
+  it("says so loudly when the mission list could not be loaded", async () => {
+    renderBoard({ sessions: [], missions: [], error: "Gateway said 503." });
+
+    expect(screen.getByText(/could not be loaded/i)).toBeTruthy();
+    expect(screen.getByText(/Gateway said 503\./)).toBeTruthy();
+  });
+});

--- a/apps/cockpit/src/missions/MissionsBoard.tsx
+++ b/apps/cockpit/src/missions/MissionsBoard.tsx
@@ -3,14 +3,15 @@ import { useNavigate } from "react-router-dom";
 import { type SessionDto } from "@devthrottle/client-core/api/client";
 import { dotColor, dotHex, effectiveColor, stateLabel } from "@devthrottle/client-core/sessions/ordering";
 import { getMissionNotes, setMissionNote } from "@devthrottle/client-core/missions/missionNotes";
+import type { MissionDto } from "@devthrottle/client-core/missions/missions";
 import { repoBasename, relativeTime } from "../fleet/format";
 import { groupByMission, type MissionGroup } from "./missionGrouping";
 
 // The Missions board (issue #1405): the same live fleet the Fleet Map draws, seen the way the owner
-// actually thinks about the work - grouped into MISSIONS rather than machines or repos. A mission is
-// derived purely from the session name ("<Mission> - <Role>") by the pure module missionGrouping.ts;
-// this board only lays the result out. Sessions that are not a mission member fall into a Standalone
-// group shown last.
+// actually thinks about the work - grouped into MISSIONS rather than machines or repos. A mission is the
+// one a session is ATTACHED to (SessionDto.missionId), joined against the Gateway's mission records so a
+// mission nobody is on yet still appears; the pure module missionGrouping.ts does that join and this board
+// only lays the result out. Sessions attached to no mission fall into a Standalone group shown last.
 //
 // This is the "Missions" pivot of the Fleet Map (the page that owns the roster, the header, and the
 // error/empty handling): the board is handed the already-loaded fleet roster as a prop rather than
@@ -19,18 +20,45 @@ import { groupByMission, type MissionGroup } from "./missionGrouping";
 // Cockpit surface. Clicking a session row opens that session (/session/:id) - the "linking".
 //
 // The WHY (Phase 1b): every card carries its mission's WHY, front and center, from the durable + shared
-// Gateway mission-notes store (getMissionNotes / setMissionNote in client-core) - keyed by the SAME
-// normalized mission key groupByMission produces, so every client and the future chat/API read the same
-// WHY. A mission with no WHY shows a loud flag (the mission's founding rule), never a silent blank; the
-// flag is the button that adds one, and the WHY is editable inline. Roster parsing stays in
-// missionGrouping.ts; the only writes here go through the WHY store.
+// Gateway mission-notes store (getMissionNotes / setMissionNote in client-core). A mission with no WHY
+// shows a loud flag (the mission's founding rule), never a silent blank; the flag is the button that adds
+// one, and the WHY is editable inline. The only writes here go through the WHY store.
+//
+// KNOWN, and deliberately not fixed in this change: the WHY store is keyed by the mission's lower-cased
+// NAME, not its id, so it is attached to a string rather than to the mission. Two missions sharing a name
+// share one WHY, and renaming a mission would orphan it. Folding the WHY onto the Mission record is the
+// next piece of work; it needs a Gateway migration, and it is not a reason to hold back the grouping fix.
 
 // The loud flag shown when a mission has no WHY set - a mission with no stated WHY is a red flag the
 // screen makes obvious (the mission's founding rule), never a silent blank. It is also the button that
 // opens the inline editor to add one.
 const NO_WHY_TEXT = "No why set - add one";
 
-export function MissionsBoard({ sessions }: { sessions: SessionDto[] }) {
+// The key the WHY store uses: the mission's TRIMMED, LOWER-CASED NAME. It is deliberately not the mission
+// id, because the store predates the grouping being keyed by id and has not been migrated yet.
+//
+// This function exists so the mismatch is stated once, in the open. When the grouping moved from name to
+// id, the card briefly looked the WHY up by the group's key - which was now an id - and every existing WHY
+// silently vanished from the board. Nothing failed; the text was simply gone. Keep every WHY lookup going
+// through here, and delete it in the same change that moves the WHY onto the Mission record.
+function whyKeyFor(missionName: string): string {
+  return missionName.trim().toLowerCase();
+}
+
+export function MissionsBoard({
+  sessions,
+  missions = [],
+  error = null,
+}: {
+  sessions: SessionDto[];
+  /** The Gateway's mission records, so a mission with nobody on it still gets a card. Defaults to none,
+   *  which renders only the missions at least one session is attached to. */
+  missions?: MissionDto[];
+  /** Set when the mission records could not be loaded. Shown as a banner: the board can still draw every
+   *  mission that has a session on it, but not the empty ones, and it must say so rather than present a
+   *  short list as the whole truth. */
+  error?: string | null;
+}) {
   const navigate = useNavigate();
 
   // The mission WHYs, keyed by the normalized mission key (the same key groupByMission produces). Read
@@ -56,21 +84,26 @@ export function MissionsBoard({ sessions }: { sessions: SessionDto[] }) {
     const note = await setMissionNote(missionName, why);
     setWhyByKey((prev) => {
       const next = new Map(prev);
-      const key = missionName.trim().toLowerCase();
+      const key = whyKeyFor(missionName);
       if (note === null) next.delete(key);
       else next.set(note.key, note.why);
       return next;
     });
   }, []);
 
-  const grouped = useMemo(() => groupByMission(sessions), [sessions]);
+  const grouped = useMemo(() => groupByMission(sessions, missions), [sessions, missions]);
 
   const openSession = (sid: string | null | undefined) => {
     const id = (sid ?? "").trim();
     if (id.length > 0) navigate(`/session/${encodeURIComponent(id)}`);
   };
 
-  if (grouped.missions.length === 0 && grouped.standalone.length === 0) {
+  // "There is nothing to show" is only true if we actually managed to READ what there is. When the mission
+  // list failed to load, this same screen would otherwise state, calmly and with no error anywhere on it,
+  // that the fleet is running no missions at all - the most confident possible answer produced from the
+  // least information. So the failure banner wins over the empty state, and the empty state speaks only
+  // when the read succeeded.
+  if (error === null && grouped.missions.length === 0 && grouped.standalone.length === 0) {
     return (
       <div className="msn-empty">
         <p>No missions are running anywhere on the fleet.</p>
@@ -81,11 +114,18 @@ export function MissionsBoard({ sessions }: { sessions: SessionDto[] }) {
 
   return (
     <div className="msn-list">
+      {error !== null && (
+        <div className="msn-loaderr" role="status">
+          The mission list could not be loaded, so any mission with no sessions on it is missing from this
+          board. {error}
+        </div>
+      )}
+
       {grouped.missions.map((m) => (
         <MissionCard
           key={m.key}
           mission={m}
-          why={whyByKey.get(m.key) ?? ""}
+          why={whyByKey.get(whyKeyFor(m.name)) ?? ""}
           onSaveWhy={saveWhy}
           onOpen={openSession}
         />
@@ -115,8 +155,11 @@ export function MissionsBoard({ sessions }: { sessions: SessionDto[] }) {
 // Fleet-wide mission counts, derived from the same grouping the board renders. The Fleet Map header
 // shows these when the Missions pivot is active so the owner sees the mission / standalone tally the
 // standalone Missions page used to carry.
-export function missionCounts(sessions: SessionDto[]): { missions: number; standalone: number } {
-  const grouped = groupByMission(sessions);
+export function missionCounts(
+  sessions: SessionDto[],
+  missions: MissionDto[] = [],
+): { missions: number; standalone: number } {
+  const grouped = groupByMission(sessions, missions);
   return { missions: grouped.missions.length, standalone: grouped.standalone.length };
 }
 
@@ -136,13 +179,15 @@ function MissionCard({ mission, why, onSaveWhy, onOpen }: MissionCardProps) {
   const working = sessions.filter((s) => effectiveColor(s) === "blue").length;
   const accent = needs > 0 ? "red" : working > 0 ? "blue" : "grey";
 
-  // The repositories this mission spans - one label when they agree, a count when they do not.
+  // The repositories this mission spans - one label when they agree, a count when they do not. A mission
+  // nobody is on yet spans none, and says so rather than rendering an empty chip.
   const repos = useMemo(() => {
     const set = new Set<string>();
     for (const s of sessions) set.add(repoBasename(s.repoPath));
     return [...set];
   }, [sessions]);
-  const repoLabel = repos.length === 1 ? repos[0] : `${repos.length} repos`;
+  const repoLabel =
+    repos.length === 0 ? "no sessions yet" : repos.length === 1 ? repos[0] : `${repos.length} repos`;
 
   const count = mission.members.length;
 
@@ -156,6 +201,15 @@ function MissionCard({ mission, why, onSaveWhy, onOpen }: MissionCardProps) {
             <span>
               {count} session{count === 1 ? "" : "s"}
             </span>
+            {/* Sessions say they are on this mission, but the Gateway's mission list does not contain it -
+                so this card's name is the copy cached on a session, not the record. Say so rather than
+                presenting it as though the two agreed: the mission records and the workflow runs are
+                separate stores and are already known to disagree in exactly this direction. */}
+            {mission.fromSessionOnly && (
+              <span className="msn-unlisted" title="Sessions are attached to this mission, but it is not in the Gateway's mission list. The name shown is the one cached on those sessions.">
+                not in the mission list
+              </span>
+            )}
           </div>
         </div>
         <MissionPill needs={needs} working={working} />
@@ -166,11 +220,20 @@ function MissionCard({ mission, why, onSaveWhy, onOpen }: MissionCardProps) {
       <WhySlot missionName={mission.name} why={why} onSave={onSaveWhy} />
 
       <div className="msn-sessions">
+        {/* The row's primary label is the session's NAME, with its role as a badge beside it. The role
+            alone is not an address: a mission with five workers on it would read "Worker" five times and
+            tell the owner nothing about which is which. This is the same reason the mission model says a
+            Worker is addressed by its TASK rather than by its role. */}
         {mission.members.map((m) => (
           <SessionRow
             key={m.session.sessionId ?? m.session.number}
             session={m.session}
-            label={m.role}
+            label={
+              (m.session.name ?? "").trim().length === 0
+                ? "(unnamed)"
+                : (m.session.name as string)
+            }
+            role={m.role}
             onOpenSession={onOpen}
           />
         ))}
@@ -294,15 +357,18 @@ function MissionPill({ needs, working }: { needs: number; working: number }) {
 
 interface SessionRowProps {
   session: SessionDto;
-  // The primary label for the row: the parsed role inside a mission, or the session name in Standalone.
+  // The primary label for the row: the session's name, on both a mission card and in Standalone.
   label: string;
+  // The Gateway-resolved role, shown as a badge beside the name. Null on a Standalone row and on any
+  // session the Gateway gave no role - never inferred here.
+  role?: string | null;
   onOpenSession: (sessionId: string | null | undefined) => void;
 }
 
 // One clickable session row: number badge, primary label, a short context line, machine chip, and the
 // live state label - all colored by the ONE shared effective-color rule so the row agrees with the rail
 // and the Fleet Map. Clicking (or Enter/Space) opens the session.
-function SessionRow({ session: s, label, onOpenSession }: SessionRowProps) {
+function SessionRow({ session: s, label, role = null, onOpenSession }: SessionRowProps) {
   // A real session row paints the Gateway-stamped dot hex, not the local COLORS table (which is only for
   // the mission-card accent and the priority-legend swatches below, none of which have a session).
   const hex = dotHex(s);
@@ -329,7 +395,10 @@ function SessionRow({ session: s, label, onOpenSession }: SessionRowProps) {
       <span className="msn-lbar" style={{ backgroundColor: hex }} />
       {hasNum && <span className="num-badge">{num}</span>}
       <div className="msn-srow-grow">
-        <div className="msn-role">{label}</div>
+        <div className="msn-role">
+          <span className="msn-sname">{label}</span>
+          {role !== null && <span className={`msn-rolebadge ${role.toLowerCase()}`}>{role}</span>}
+        </div>
         {context.length > 0 && <div className="msn-rmeta">{context}</div>}
       </div>
       {machine.length > 0 && <span className="msn-machine">{machine}</span>}

--- a/apps/cockpit/src/missions/missionGrouping.test.ts
+++ b/apps/cockpit/src/missions/missionGrouping.test.ts
@@ -1,141 +1,204 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
-import { groupByMission, parseMissionName, stripBracketTag } from "./missionGrouping";
+import type { MissionDto } from "@devthrottle/client-core/missions/missions";
+import { displayRole, groupByMission } from "./missionGrouping";
 
-// Phase 1a of the Mission Screen (issue #1405) derives missions purely from the session name. These
-// lock the two rules the Architect pinned before it was built: strip a leading bracket tag, and match
-// on the LAST " - Role" - plus the non-role dash (#108 "mindzieWeb - remove Ask Mindzie") staying
-// Standalone rather than becoming a bogus "mindzieWeb" mission.
+// The Missions board groups by the mission a session is ATTACHED to (SessionDto.missionId), with the role
+// the Gateway resolved (SessionDto.sessionRole). These tests lock that, and in particular they lock the
+// regression that made the rewrite necessary: this module used to derive missions by pattern-matching the
+// session NAME for "<Mission> - <Role>", so an attached session whose name did not fit the convention fell
+// to Standalone and no amount of attaching could move it. See the first test in `groupByMission`.
 
-describe("stripBracketTag", () => {
-  it("removes one leading bracket tag and its trailing space", () => {
-    expect(stripBracketTag("[Moving Started] Gateway Cleanup - Manager")).toBe(
-      "Gateway Cleanup - Manager",
-    );
-    expect(stripBracketTag("[moving] Gateway Connection - Architect")).toBe(
-      "Gateway Connection - Architect",
-    );
-  });
+const M_RELEASE: MissionDto = { missionId: "m-release", missionName: "Release 2.0.1" };
+const M_EMPTY: MissionDto = { missionId: "m-empty", missionName: "Website truth report" };
 
-  it("leaves a name without a leading tag untouched", () => {
-    expect(stripBracketTag("Car Mode - Architect")).toBe("Car Mode - Architect");
-  });
-
-  it("only strips a LEADING bracket - brackets elsewhere are kept", () => {
-    expect(stripBracketTag("Car Mode [beta] - Manager")).toBe("Car Mode [beta] - Manager");
-  });
-});
-
-describe("parseMissionName", () => {
-  it("parses <Mission> - <Role> for each known role, case-insensitively", () => {
-    expect(parseMissionName("Gateway Cleanup - Manager")).toEqual({
-      mission: "Gateway Cleanup",
-      role: "Manager",
-    });
-    expect(parseMissionName("Car Mode - architect")).toEqual({
-      mission: "Car Mode",
-      role: "Architect",
-    });
-    expect(parseMissionName("Docs - WORKER")).toEqual({ mission: "Docs", role: "Worker" });
-  });
-
-  it("strips a leading bracket tag before parsing (the move markers)", () => {
-    expect(parseMissionName("[Moving Started] Gateway Cleanup - Manager")).toEqual({
-      mission: "Gateway Cleanup",
-      role: "Manager",
-    });
-    expect(parseMissionName("[moving] Gateway Connection - Architect")).toEqual({
-      mission: "Gateway Connection",
-      role: "Architect",
-    });
-  });
-
-  it("matches the LAST ' - Role', so the mission keeps its own inner dash", () => {
-    expect(parseMissionName("Foo - Bar - Manager")).toEqual({
-      mission: "Foo - Bar",
-      role: "Manager",
-    });
-  });
-
-  it("returns null for a trailing token that is not a known role (stays Standalone)", () => {
-    // The live #108 case: a dash, but the trailing text is not a role.
-    expect(parseMissionName("mindzieWeb - remove Ask Mindzie")).toBeNull();
-  });
-
-  it("returns null when there is no ' - ' separator at all", () => {
-    expect(parseMissionName("Mac Cleanup")).toBeNull();
-    expect(parseMissionName("Working Mac")).toBeNull();
-  });
-
-  it("returns null for empty, whitespace, or missing names", () => {
-    expect(parseMissionName("")).toBeNull();
-    expect(parseMissionName("   ")).toBeNull();
-    expect(parseMissionName(null)).toBeNull();
-    expect(parseMissionName(undefined)).toBeNull();
-  });
-
-  it("returns null when the mission part is empty (only a role after the dash)", () => {
-    expect(parseMissionName(" - Manager")).toBeNull();
-  });
-});
-
-// A minimal SessionDto factory for the grouping tests - only the fields the parser and sort read.
-function session(name: string, number: number, sessionId: string): SessionDto {
-  return { name, number, sessionId } as unknown as SessionDto;
+// A minimal SessionDto factory - only the fields the grouping and the sort read.
+function session(
+  fields: {
+    name: string;
+    number: number;
+    sessionId: string;
+    missionId?: string | null;
+    missionName?: string | null;
+    sessionRole?: string | null;
+  },
+): SessionDto {
+  return fields as unknown as SessionDto;
 }
 
+describe("displayRole", () => {
+  it("returns the Gateway's role in canonical casing", () => {
+    expect(displayRole(session({ name: "a", number: 1, sessionId: "a", sessionRole: "architect" })))
+      .toBe("Architect");
+    expect(displayRole(session({ name: "a", number: 1, sessionId: "a", sessionRole: "MANAGER" })))
+      .toBe("Manager");
+    expect(displayRole(session({ name: "a", number: 1, sessionId: "a", sessionRole: "Worker" })))
+      .toBe("Worker");
+  });
+
+  it("treats 'Standalone' as no role, not as a role", () => {
+    expect(displayRole(session({ name: "a", number: 1, sessionId: "a", sessionRole: "Standalone" })))
+      .toBeNull();
+  });
+
+  it("returns null when the Gateway sent no role", () => {
+    expect(displayRole(session({ name: "a", number: 1, sessionId: "a" }))).toBeNull();
+    expect(displayRole(session({ name: "a", number: 1, sessionId: "a", sessionRole: "  " }))).toBeNull();
+  });
+
+  it("passes an unknown role through rather than overruling the Gateway", () => {
+    expect(displayRole(session({ name: "a", number: 1, sessionId: "a", sessionRole: "Inspector" })))
+      .toBe("Inspector");
+  });
+});
+
 describe("groupByMission", () => {
-  it("groups members under their mission and puts non-members in Standalone", () => {
-    const { missions, standalone } = groupByMission([
-      session("Gateway Cleanup - Manager", 102, "a"),
-      session("Gateway Cleanup - Architect", 107, "b"),
-      session("mindzieWeb - remove Ask Mindzie", 108, "c"),
-      session("Working Mac", 101, "d"),
-    ]);
+  // THE REGRESSION. Every one of these sessions is attached to the same mission; only one is NAMED in the
+  // old "<Mission> - <Role>" convention. Under the name parser the other four fell to Standalone, which is
+  // exactly what the owner saw: a mission reading "1 session" with its other members listed below it as
+  // unrelated work.
+  it("groups every attached session, whatever it is called", () => {
+    const { missions, standalone } = groupByMission(
+      [
+        session({ name: "Release 2.0.1 - Architect", number: 124, sessionId: "a",
+          missionId: "m-release", sessionRole: "Architect" }),
+        session({ name: "fix: 2481 delete bias path", number: 113, sessionId: "b",
+          missionId: "m-release", sessionRole: "Worker" }),
+        session({ name: "fix: 2487 wingman card", number: 114, sessionId: "c",
+          missionId: "m-release", sessionRole: "Worker" }),
+        session({ name: "fix: 2483 dictionary fail-open", number: 117, sessionId: "d",
+          missionId: "m-release", sessionRole: "Worker" }),
+        session({ name: "fix: 2482 tenant glossary", number: 122, sessionId: "e",
+          missionId: "m-release", sessionRole: "Worker" }),
+      ],
+      [M_RELEASE],
+    );
 
     expect(missions).toHaveLength(1);
-    expect(missions[0].name).toBe("Gateway Cleanup");
-    expect(missions[0].members.map((m) => m.role)).toEqual(["Architect", "Manager"]);
-    expect(standalone.map((s) => s.number)).toEqual([101, 108]);
+    expect(missions[0].name).toBe("Release 2.0.1");
+    expect(missions[0].members).toHaveLength(5);
+    expect(standalone).toHaveLength(0);
   });
 
-  it("sorts missions alphabetically (case-insensitive) and groups case-insensitively", () => {
-    const { missions } = groupByMission([
-      session("Zebra - Manager", 3, "a"),
-      session("apple - Manager", 1, "b"),
-      session("APPLE - Architect", 2, "c"),
-    ]);
+  it("puts a session attached to no mission in Standalone", () => {
+    const { missions, standalone } = groupByMission(
+      [
+        session({ name: "Release 2.0.1 - Architect", number: 124, sessionId: "a",
+          missionId: "m-release", sessionRole: "Architect" }),
+        session({ name: "Working Mac", number: 101, sessionId: "b" }),
+        session({ name: "Tidy branches", number: 102, sessionId: "c", missionId: "   " }),
+      ],
+      [M_RELEASE],
+    );
 
-    expect(missions.map((m) => m.name)).toEqual(["apple", "Zebra"]);
-    // "apple" and "APPLE" collapse into one mission (display = first seen).
-    expect(missions[0].members).toHaveLength(2);
+    expect(missions).toHaveLength(1);
+    expect(missions[0].members).toHaveLength(1);
+    expect(standalone.map((s) => s.number)).toEqual([101, 102]);
   });
 
-  it("orders members Architect, Manager, Worker then by number", () => {
-    const { missions } = groupByMission([
-      session("Big - Worker", 50, "a"),
-      session("Big - Manager", 20, "b"),
-      session("Big - Architect", 30, "c"),
-      session("Big - Worker", 10, "d"),
-    ]);
+  // A name that LOOKS like the old convention must not create a mission - the attachment is the only thing
+  // that decides. This is the guard against the parser creeping back in.
+  it("never invents a mission from a session's name", () => {
+    const { missions, standalone } = groupByMission(
+      [session({ name: "Gateway Cleanup - Manager", number: 130, sessionId: "a" })],
+      [],
+    );
 
-    expect(missions[0].members.map((m) => `${m.role}:${m.session.number}`)).toEqual([
+    expect(missions).toHaveLength(0);
+    expect(standalone.map((s) => s.number)).toEqual([130]);
+  });
+
+  it("shows a mission with no sessions attached to it yet", () => {
+    const { missions } = groupByMission([], [M_RELEASE, M_EMPTY]);
+
+    expect(missions.map((m) => m.name)).toEqual(["Release 2.0.1", "Website truth report"]);
+    expect(missions[0].members).toHaveLength(0);
+  });
+
+  // The mission records and the session roster are two different reads, and the mission stores are already
+  // observed to disagree. An attachment we cannot resolve to a record is still an attachment.
+  it("keeps a session whose mission is not in the record list, using the cached name", () => {
+    const { missions, standalone } = groupByMission(
+      [
+        session({ name: "worker one", number: 140, sessionId: "a",
+          missionId: "m-ghost", missionName: "BPM Studio QA cleanup", sessionRole: "Worker" }),
+      ],
+      [M_RELEASE],
+    );
+
+    expect(standalone).toHaveLength(0);
+    const ghost = missions.find((m) => m.key === "m-ghost");
+    expect(ghost?.name).toBe("BPM Studio QA cleanup");
+    expect(ghost?.fromSessionOnly).toBe(true);
+    expect(missions.find((m) => m.key === "m-release")?.fromSessionOnly).toBe(false);
+  });
+
+  it("prefers the record's name over the copy cached on the session (which a rename would stale)", () => {
+    const { missions } = groupByMission(
+      [
+        session({ name: "w", number: 1, sessionId: "a",
+          missionId: "m-release", missionName: "Release 2.0.0 (old name)" }),
+      ],
+      [M_RELEASE],
+    );
+
+    expect(missions[0].name).toBe("Release 2.0.1");
+  });
+
+  it("joins the roster to the records regardless of id casing", () => {
+    const { missions } = groupByMission(
+      [session({ name: "w", number: 1, sessionId: "a", missionId: "M-RELEASE" })],
+      [M_RELEASE],
+    );
+
+    expect(missions).toHaveLength(1);
+    expect(missions[0].members).toHaveLength(1);
+  });
+
+  it("orders members Architect, Manager, Worker, then no-role, then by number", () => {
+    const { missions } = groupByMission(
+      [
+        session({ name: "d", number: 50, sessionId: "a", missionId: "m-release", sessionRole: "Worker" }),
+        session({ name: "b", number: 20, sessionId: "b", missionId: "m-release", sessionRole: "Manager" }),
+        session({ name: "c", number: 30, sessionId: "c", missionId: "m-release", sessionRole: "Architect" }),
+        session({ name: "a", number: 10, sessionId: "d", missionId: "m-release", sessionRole: "Worker" }),
+        session({ name: "e", number: 5, sessionId: "e", missionId: "m-release" }),
+      ],
+      [M_RELEASE],
+    );
+
+    expect(missions[0].members.map((m) => `${m.role ?? "-"}:${m.session.number}`)).toEqual([
       "Architect:30",
       "Manager:20",
       "Worker:10",
       "Worker:50",
+      "-:5",
     ]);
   });
 
-  it("groups mid-move sessions with their mission (bracket tag stripped)", () => {
-    const { missions, standalone } = groupByMission([
-      session("[Moving Started] Gateway Cleanup - Manager", 115, "a"),
-      session("Gateway Cleanup - Architect", 107, "b"),
-    ]);
+  it("sorts missions alphabetically by display name, case-insensitively", () => {
+    const { missions } = groupByMission(
+      [],
+      [
+        { missionId: "m3", missionName: "Zebra" },
+        { missionId: "m1", missionName: "apple" },
+        { missionId: "m2", missionName: "Banya" },
+      ],
+    );
 
-    expect(standalone).toHaveLength(0);
-    expect(missions).toHaveLength(1);
-    expect(missions[0].name).toBe("Gateway Cleanup");
-    expect(missions[0].members).toHaveLength(2);
+    expect(missions.map((m) => m.name)).toEqual(["apple", "Banya", "Zebra"]);
+  });
+
+  it("labels a mission whose name is unknown rather than rendering a blank card", () => {
+    const { missions } = groupByMission(
+      [session({ name: "w", number: 1, sessionId: "a", missionId: "m-x" })],
+      [],
+    );
+
+    expect(missions[0].name).toBe("(unnamed mission)");
+  });
+
+  it("returns an empty fleet unchanged", () => {
+    expect(groupByMission([], [])).toEqual({ missions: [], standalone: [] });
   });
 });

--- a/apps/cockpit/src/missions/missionGrouping.ts
+++ b/apps/cockpit/src/missions/missionGrouping.ts
@@ -1,100 +1,86 @@
-// Phase 1a of the Mission Screen (issue #1405): derive "missions" from the live fleet purely from the
-// session NAME, with no backend change. The Cockpit's SessionDto (from the Gateway roster) does not
-// carry a mission or role field, so for now a mission is read from the naming convention
-// "<Mission> - <Role>" (dash, role second). Everything here is a pure function so the parser and the
-// grouping are unit-tested on their own (see missionGrouping.test.ts); the view does no parsing.
+// Group the live fleet into MISSIONS, using the mission a session is actually ATTACHED to.
 //
-// Two rules the Architect pinned before this was built (session 3457ddcf):
-//   1. Strip ONE leading bracket tag first. Live names carry a move marker, e.g.
-//      "[Moving Started] Gateway Cleanup - Manager" - without stripping the "[...]" the name would fall
-//      to Standalone and we would lose the very mission we want grouped.
-//   2. Match on the LAST " - <Role>". The mission is the text BEFORE that final " - <Role>", so a name
-//      that itself contains " - " (e.g. "Foo - Bar - Manager") groups under "Foo - Bar".
-// A trailing token that is NOT one of the known roles keeps the session Standalone (a bogus mission is
-// worse than Standalone) - e.g. "mindzieWeb - remove Ask Mindzie" is Standalone, not a "mindzieWeb"
-// mission.
+// A session's mission is `SessionDto.missionId` - the attachment link the Gateway stamps (at spawn, or
+// later through `POST /sessions/{sid}/mission`, which is what `cc-devthrottle mission attach` drives). Its
+// role is `SessionDto.sessionRole`, which the Gateway resolves and pushes. Both arrive on every session in
+// the roster. Nothing here parses, infers, or re-derives either one.
+//
+// WHAT THIS REPLACED, so it is not reintroduced. Until now this module derived "missions" by pattern-
+// matching the session NAME for "<Mission> - <Role>". That was Phase 1a of issue #1405, written when the
+// roster genuinely carried no mission field, and explicitly temporary. The field arrived; the stand-in did
+// not get removed. The result was a screen wired to the weakest of five different notions of "mission":
+// eleven live missions rendered as two, and seven sessions attached to one mission showed up as one,
+// because the other six were not NAMED the right way. Attaching a session could not move it, and renaming a
+// session could.
+//
+// So: the name is DISPLAY ONLY. "<Mission> - <Role>" remains a good human naming habit - it reads well and
+// sorts well - but it is never again load-bearing. If a session's mission is wrong on screen, the fix is the
+// attachment, not the name.
+//
+// There is deliberately NO fallback to name parsing when a session has no `missionId`. A session with no
+// mission is Standalone, which is a true and ordinary state. Guessing a mission from its name would be the
+// same defect in a quieter form: the screen would show a mission that the fleet does not agree exists, and
+// nothing the owner did to the attachment would change it.
 import type { SessionDto } from "@devthrottle/client-core/api/client";
+import type { MissionDto } from "@devthrottle/client-core/missions/missions";
 
-// The known roles a mission is staffed with. Only a session whose name ends in one of these (after the
-// final " - ") is treated as part of a mission; anything else is Standalone. Case-insensitive match,
-// canonical display casing.
+// Canonical display casing for the roles the Gateway resolves. A role outside this set is still SHOWN (it
+// is the Gateway's answer and the client does not overrule it), it just sorts last.
 const ROLE_DISPLAY: Record<string, string> = {
   architect: "Architect",
   manager: "Manager",
   worker: "Worker",
 };
 
-// The " - " that separates a mission name from its role in the naming convention.
-const ROLE_SEPARATOR = " - ";
+// "Standalone" is the Gateway's way of saying "no role", not a role. It must not render as a badge - see
+// FleetMapView, which suppresses it the same way on the other pivots.
+const NOT_A_ROLE = "standalone";
 
-export interface ParsedMissionName {
-  // The mission name exactly as written (bracket tag stripped, the text before the final " - Role").
-  mission: string;
-  // The role in canonical casing ("Architect" | "Manager" | "Worker").
-  role: string;
+// The role to display for a session, or null when it has none. Read from the Gateway's `sessionRole`,
+// never computed.
+export function displayRole(session: SessionDto): string | null {
+  const raw = (session.sessionRole ?? "").trim();
+  if (raw.length === 0 || raw.toLowerCase() === NOT_A_ROLE) return null;
+  return ROLE_DISPLAY[raw.toLowerCase()] ?? raw;
 }
 
-// Strip one leading bracket tag from a session name: "[Moving Started] Gateway Cleanup - Manager" ->
-// "Gateway Cleanup - Manager". Only a single leading "[...]" group (and the whitespace after it) is
-// removed; brackets elsewhere in the name are left alone.
-export function stripBracketTag(name: string): string {
-  return name.replace(/^\s*\[[^\]]*\]\s*/, "").trim();
-}
-
-// Parse a raw session name into its mission + role, or null when the name is not a mission member. The
-// name is first trimmed of a leading bracket tag, then split on its LAST " - "; the trailing token must
-// be a known role for it to count as a mission.
-export function parseMissionName(rawName: string | null | undefined): ParsedMissionName | null {
-  const stripped = stripBracketTag((rawName ?? "").trim());
-  if (stripped.length === 0) return null;
-
-  const lastSep = stripped.lastIndexOf(ROLE_SEPARATOR);
-  if (lastSep < 0) return null;
-
-  const rolePart = stripped.slice(lastSep + ROLE_SEPARATOR.length).trim();
-  const roleDisplay = ROLE_DISPLAY[rolePart.toLowerCase()];
-  if (roleDisplay === undefined) return null;
-
-  const mission = stripped.slice(0, lastSep).trim();
-  if (mission.length === 0) return null;
-
-  return { mission, role: roleDisplay };
-}
-
-// One session inside a mission card, carrying the role parsed from its name.
+// One session inside a mission card, with the role the Gateway gave it (null when it has none).
 export interface MissionMember {
   session: SessionDto;
-  role: string;
+  role: string | null;
 }
 
-// One mission: a display name (as first seen) and its member sessions, ordered role-first.
+// One mission: its identity, its display name, and the sessions attached to it. A mission with no attached
+// session is still a mission and still appears - `members` is simply empty.
 export interface MissionGroup {
-  // Lowercased mission name - the grouping identity, case-insensitive.
+  /** The mission id - the grouping identity, and the value a future drag-and-drop would attach by. */
   key: string;
-  // The mission name as first seen in the fleet (display casing).
+  /** The mission's display name. */
   name: string;
   members: MissionMember[];
+  /** True when this mission came only from an attached session, not from the mission list (see below). */
+  fromSessionOnly: boolean;
 }
 
-// The whole fleet split into missions (alphabetical) plus the Standalone sessions (rendered last as
-// their own group).
+// The whole fleet split into missions plus the Standalone sessions (rendered last as their own group).
 export interface GroupedFleet {
   missions: MissionGroup[];
   standalone: SessionDto[];
 }
 
-// Order roles Architect -> Manager -> Worker within a mission card, so the lead reads first; an
-// unknown role (should not happen past the parser) sorts last.
+// Order roles Architect -> Manager -> Worker within a mission card, so the lead reads first. A role the
+// Gateway sent that is not one of the three, and a session with no role at all, sort last.
 const ROLE_RANK: Record<string, number> = { Architect: 0, Manager: 1, Worker: 2 };
 
-function roleRank(role: string): number {
+function roleRank(role: string | null): number {
+  if (role === null) return 98;
   const r = ROLE_RANK[role];
   return r === undefined ? 99 : r;
 }
 
-// Stable order by session number ascending (the identity the owner reads), numbers before the
-// unnumbered, then session id - so a row never jumps when its color changes. Mirrors the Fleet Map's
-// flat sort so the two surfaces agree.
+// Stable order by session number ascending (the identity the owner reads), numbers before the unnumbered,
+// then session id - so a row never jumps when its color changes. Mirrors the Fleet Map's flat sort so the
+// two surfaces agree.
 function byNumber(a: SessionDto, b: SessionDto): number {
   const na = Number(a.number);
   const nb = Number(b.number);
@@ -105,35 +91,83 @@ function byNumber(a: SessionDto, b: SessionDto): number {
   return String(a.sessionId ?? "").localeCompare(String(b.sessionId ?? ""));
 }
 
-// Group the live fleet by mission. Missions come out alphabetical (case-insensitive) by display name;
-// each mission's members are ordered role-first then by session number; Standalone sessions (no
-// parseable mission role) come out in session-number order for the caller to render last.
-export function groupByMission(sessions: SessionDto[]): GroupedFleet {
+// A mission id in whatever casing it arrived in, folded so the roster and the mission list join reliably.
+// Both sides are Gateway-minted GUIDs, so this only guards the casing, not a format difference.
+function missionKey(id: string): string {
+  return id.trim().toLowerCase();
+}
+
+/**
+ * Group the live fleet by the mission each session is ATTACHED to.
+ *
+ * `missions` is the Gateway's mission list. Pass it so missions with no attached session still appear;
+ * omit it (or pass an empty list) and the result contains only missions that at least one session is on -
+ * which is what the caller should render if the mission list could not be loaded, because showing a
+ * shorter list of real missions is honest, while showing none of them is not.
+ *
+ * A session attached to a mission the list does not contain still gets a card, built from the name cached
+ * on the session and flagged `fromSessionOnly`. That case is real: the mission records and the workflow
+ * runs are two different stores, and they are already observed to disagree. Dropping such a session to
+ * Standalone would hide a genuine attachment - exactly the failure this module was rewritten to end.
+ *
+ * Missions come out alphabetical by display name (case-insensitive); each mission's members are ordered
+ * role-first then by session number; Standalone comes out in session-number order for the caller to render
+ * last.
+ */
+export function groupByMission(
+  sessions: SessionDto[],
+  missions: MissionDto[] = [],
+): GroupedFleet {
   const byKey = new Map<string, MissionGroup>();
+
+  // Seed from the mission RECORDS first, so an unstaffed mission is present and so the record's name wins
+  // over the copy cached on a session (which is stamped at attach time and would be stale after a rename).
+  for (const m of missions) {
+    const id = (m.missionId ?? "").trim();
+    if (id.length === 0) continue;
+    byKey.set(missionKey(id), {
+      key: id,
+      name: (m.missionName ?? "").trim(),
+      members: [],
+      fromSessionOnly: false,
+    });
+  }
+
   const standalone: SessionDto[] = [];
 
   for (const s of sessions) {
-    const parsed = parseMissionName(s.name);
-    if (parsed === null) {
+    const id = (s.missionId ?? "").trim();
+    if (id.length === 0) {
       standalone.push(s);
       continue;
     }
-    const key = parsed.mission.toLowerCase();
+    const key = missionKey(id);
     let group = byKey.get(key);
     if (group === undefined) {
-      group = { key, name: parsed.mission, members: [] };
+      group = {
+        key: id,
+        name: (s.missionName ?? "").trim(),
+        members: [],
+        fromSessionOnly: true,
+      };
       byKey.set(key, group);
     }
-    group.members.push({ session: s, role: parsed.role });
+    group.members.push({ session: s, role: displayRole(s) });
   }
 
-  const missions = [...byKey.values()].sort((a, b) =>
+  // A mission whose name we know from neither the record nor the session still has to render as SOMETHING
+  // the owner can click - never a blank card that looks like a rendering fault.
+  for (const g of byKey.values()) {
+    if (g.name.length === 0) g.name = "(unnamed mission)";
+  }
+
+  const missionGroups = [...byKey.values()].sort((a, b) =>
     a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
   );
-  for (const m of missions) {
+  for (const m of missionGroups) {
     m.members.sort((a, b) => roleRank(a.role) - roleRank(b.role) || byNumber(a.session, b.session));
   }
   standalone.sort(byNumber);
 
-  return { missions, standalone };
+  return { missions: missionGroups, standalone };
 }

--- a/apps/cockpit/src/missions/missions.css
+++ b/apps/cockpit/src/missions/missions.css
@@ -81,6 +81,33 @@
   color: var(--text-dim);
 }
 
+/* A mission the roster knows about but the Gateway's mission list does not contain. Amber, not red: the
+   sessions and their grouping are real and correct - it is the agreement between the two stores that is
+   not, and that is worth showing without shouting. */
+.msn-unlisted {
+  padding: 1px 7px;
+  border-radius: 9px;
+  border: 1px solid rgba(251, 191, 36, 0.45);
+  color: #fbbf24;
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+/* The mission records failed to load. The board still draws every mission that has a session attached,
+   so this says exactly what is MISSING rather than replacing the whole board with an error. */
+.msn-loaderr {
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  background: rgba(248, 113, 113, 0.08);
+  color: #fca5a5;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
 /* ---- list ---- */
 .msn-list {
   padding-bottom: 28px;
@@ -370,10 +397,53 @@
   min-width: 0;
 }
 
+/* The row's primary line: the session NAME, with its role as a badge beside it. The name is what tells
+   one worker from another - the role alone repeats itself down a mission with several workers on it. */
 .msn-role {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
   font-size: 12.5px;
   font-weight: 500;
   color: var(--text);
+}
+
+.msn-sname {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* Same shape and the same three role colors as the Fleet Map's .fmap-role, so a role reads identically
+   on both surfaces. */
+.msn-rolebadge {
+  flex: 0 0 auto;
+  font-size: 9.5px;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-dim);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.msn-rolebadge.architect {
+  border-color: rgba(168, 85, 247, 0.5);
+  color: #c084fc;
+}
+
+.msn-rolebadge.manager {
+  border-color: rgba(59, 130, 246, 0.5);
+  color: #60a5fa;
+}
+
+.msn-rolebadge.worker {
+  border-color: rgba(148, 163, 184, 0.4);
+  color: #94a3b8;
 }
 
 .msn-rmeta {

--- a/packages/client-core/src/missions/missions.test.ts
+++ b/packages/client-core/src/missions/missions.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listMissions } from "./missions";
+
+// GET /missions is the read that makes a mission with no sessions on it visible at all. What matters here
+// is that a BROKEN answer never reaches the screen looking like an EMPTY one: "the Gateway is answering
+// wrongly" and "you have no missions" are different facts, and the second is the one that renders as a
+// calm, complete-looking page.
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function stubFetch(res: Response) {
+  const fetchMock = vi.fn().mockResolvedValue(res);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("listMissions", () => {
+  it("returns the missions the Gateway sent", async () => {
+    stubFetch(
+      jsonResponse([
+        { missionId: "m1", missionName: "Release 2.0.1" },
+        { missionId: "m2", missionName: "Banya", parentMissionId: null },
+      ]),
+    );
+
+    const missions = await listMissions();
+
+    expect(missions.map((m) => m.missionName)).toEqual(["Release 2.0.1", "Banya"]);
+  });
+
+  it("returns an empty list when the account genuinely has no missions", async () => {
+    stubFetch(jsonResponse([]));
+    await expect(listMissions()).resolves.toEqual([]);
+  });
+
+  it("THROWS on a 200 whose body is not an array, rather than reporting no missions", async () => {
+    stubFetch(jsonResponse({ missions: [{ missionId: "m1", missionName: "Release 2.0.1" }] }));
+    await expect(listMissions()).rejects.toThrow(/shape this app cannot read/i);
+  });
+
+  it("THROWS on a null body rather than reporting no missions", async () => {
+    stubFetch(jsonResponse(null));
+    await expect(listMissions()).rejects.toThrow(/shape this app cannot read/i);
+  });
+
+  it("THROWS when a mission has no id - it could never be joined or attached to", async () => {
+    stubFetch(jsonResponse([{ missionId: "", missionName: "Nameless" }]));
+    await expect(listMissions()).rejects.toThrow(/no id/i);
+
+    stubFetch(jsonResponse([{ missionName: "Nameless" }]));
+    await expect(listMissions()).rejects.toThrow(/no id/i);
+  });
+
+  it("throws on a non-2xx", async () => {
+    stubFetch(jsonResponse({ error: "nope" }, 403));
+    await expect(listMissions()).rejects.toBeInstanceOf(Error);
+  });
+});

--- a/packages/client-core/src/missions/missions.ts
+++ b/packages/client-core/src/missions/missions.ts
@@ -1,0 +1,59 @@
+// The Mission RECORDS on the Gateway - the first-class objects sessions attach to (see
+// docs/new_architecture/mission-as-first-class-unit-of-work.md). This is what makes a mission exist on a
+// screen INDEPENDENTLY of whether any session happens to be attached to it right now: a mission the owner
+// created and has not staffed yet is still a mission, and it has to be visible or there is nowhere to drop
+// a session onto.
+//
+// Before this client existed the Cockpit never read these records at all - it inferred "missions" by
+// pattern-matching session NAMES, so a real mission with no name-matching session simply did not appear,
+// and eleven live missions rendered as two. The records are the truth; the roster says who is on them.
+import { authHeaders, gatewayFetch, GatewayError } from "../api/client";
+
+/**
+ * One Mission as the Gateway serves it (GET /missions). Hand-written rather than taken from `schema.ts`
+ * for the same reason as `ModelDisplay` in the api client: the committed generated schema declares the
+ * /missions responses as `never`, so there is no generated type to import. Delete this in favor of the
+ * generated one when the schema is next regenerated properly - the two agree.
+ */
+export interface MissionDto {
+  /** Stable identity of the Mission. This is the value sessions attach by, and the grouping identity. */
+  missionId: string;
+  /** Human-friendly name of the Mission. */
+  missionName: string;
+  /** The parent Mission this one nests under, or null for a root Mission. */
+  parentMissionId?: string | null;
+}
+
+/**
+ * Every Mission this account owns, newest ordering left to the Gateway. Tenant-scoped server-side from the
+ * authenticated device key - the client neither sends nor can influence which account's missions it gets.
+ *
+ * Throws GatewayError on a non-2xx so the caller decides what to show. There is deliberately NO fallback to
+ * an empty list here: a failed read means "we do not know what missions exist", which is a different thing
+ * from "there are none", and a caller that cannot tell them apart will render the second while the first is
+ * true.
+ */
+export async function listMissions(signal?: AbortSignal): Promise<MissionDto[]> {
+  const res = await gatewayFetch("/missions", {
+    method: "GET",
+    headers: { Accept: "application/json" as const, ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw await GatewayError.from(res, "load the mission list");
+
+  // A 200 carrying something that is not an array of missions is a BROKEN response, not an empty fleet of
+  // missions, and the two must not arrive at the same screen looking alike. Coercing the malformed case to
+  // `[]` would render "no missions" over a Gateway that is answering wrongly - the caller would show a
+  // confident, complete-looking, false answer. Throw instead and let the board say it does not know.
+  const body: unknown = await res.json();
+  if (!Array.isArray(body)) {
+    throw new GatewayError(res.status, "The mission list came back in a shape this app cannot read.");
+  }
+  for (const m of body) {
+    const id = (m as MissionDto | null)?.missionId;
+    if (typeof id !== "string" || id.trim().length === 0) {
+      throw new GatewayError(res.status, "The mission list contains a mission with no id.");
+    }
+  }
+  return body as MissionDto[];
+}


### PR DESCRIPTION
## The problem

The Cockpit's Missions screen built its idea of a mission by pattern-matching each session's **name** for `"<Mission> - <Role>"`. That was Phase 1a of issue #1405 - an explicitly temporary stand-in, written when the session roster carried no mission field at all.

The field arrived. The stand-in was never removed.

So the screen was wired to the weakest of five different notions of "mission" in this codebase:

| | |
|---|---|
| Mission records on the Gateway | 11 |
| Missions the Cockpit could display | **2** |
| Sessions attached to "Release 2.0.1" | 7 |
| Of those, shown under it | **1** |

Attaching a session could not move it on screen. Renaming a session could. The only working way to put a session under a mission was to rename it to end in ` - Worker`.

## The change

Group by `SessionDto.missionId` - the attachment the Gateway stamps, and that `cc-devthrottle mission attach` has been writing correctly all along. Take the role from `SessionDto.sessionRole`, which the Gateway already resolves and already sends (the Fleet Map reads it three files away). Join against `GET /missions` so a mission with nobody on it yet still appears - which a drag-and-drop target will need later.

The name parser is **deleted**, not kept as a fallback. A fallback here would quietly re-create the same defect: the screen would show a mission the fleet does not agree exists, and nothing done to the attachment would change it.

Also in this change, because the screen is only honest if these are true:

- A mission row shows the session's **name** with its role as a badge, not the role alone. A mission with five workers read "Worker" five times and told you nothing about which was which. The mission model already says a Worker is addressed by its task.
- A mission that sessions claim but the mission list does not contain is **marked**, not passed off as a normal card. The mission records and the workflow runs are separate stores and already disagree in exactly this direction (two live runs name a mission absent from the list).
- A failed mission-list read **says so**. Previously the least-informed case - no sessions and no list - produced the most confident output on the page: a calm "no missions are running anywhere on the fleet".
- `listMissions` throws on a malformed 200 rather than coercing it to an empty list.

## Known, and deliberately left

The WHY store is still keyed by the mission's lower-cased **name** rather than its id, so two missions sharing a name share a WHY, and a rename would orphan one. Folding the WHY onto the Mission record needs a Gateway migration and is the next piece of work. `whyKeyFor()` states the mismatch in one place - moving the grouping to ids silently blanked every WHY on the board until review caught it, so the lookup no longer shares a key with the grouping by accident.

Rename, mission numbers, and a way for a mission to end do not exist at all yet and are Gateway work.

## Testing

- `missionGrouping.test.ts` - 15 tests, rewritten. Locks the regression directly: five sessions attached to one mission, only one named in the old convention, all five grouped. Plus a guard that a mission-shaped **name** never invents a mission.
- `MissionsBoard.test.tsx` - new, 6 tests. Renders the real board, so the WHY-key gap that unit-level grouping tests cannot see is covered.
- `missions.test.ts` - new, 6 tests on the malformed-response paths.
- Full suites green: cockpit 274, client-core 905, mobile 3. Root typecheck clean. Production build clean.
- Reviewed by Codex (different agent family). Six findings, all fixed - including a real regression where every existing WHY silently vanished from the board, and a product bug where the empty state pre-empted the error banner.

Lint reports 3 pre-existing errors in files this branch does not touch (`sw.test.ts`, `Recorder.tsx`, `VoiceMode.tsx` - missing eslint rule definitions). None in changed files.