### PR TITLE
An agent can add a word to the dictation dictionary, add only

### DIFF
--- a/.claude/skills/dev-throttle/SKILL.md
+++ b/.claude/skills/dev-throttle/SKILL.md
@@ -136,6 +136,38 @@ An unregistered name fails loudly, and a name matching two Directors fails listi
 falls back to another Director - if you get one of those errors, run `director list` and pick, rather
 than dropping the flag and spawning wherever.
 
+## Teaching dictation a word: `cc-devthrottle dictionary add`
+
+DevThrottle cleans up what it hears against a per-account glossary of words the person cares about -
+product names, surnames, repositories, tools. When the person says a word the transcriber keeps
+getting wrong, or when you notice one, add it:
+
+```
+cc-devthrottle dictionary add "Kubernetes"
+cc-devthrottle dictionary add "mindzie" "DevThrottle" "Frederiksen"
+```
+
+There is no confirmation step and you do not need to ask. The owner ruled on 2026-08-07 that being
+asked to confirm every addition is worse than the occasional stray entry, so just add the word.
+
+**SPELL IT THE WAY IT IS WRITTEN DOWN.** This is the one thing that can go wrong here, and it is
+yours to get right. The spelling you add becomes the CANONICAL one - it is what dictation will
+correct other spellings *to*. A word that reached you THROUGH dictation may already be mangled, and
+adding that mangled spelling as canonical teaches the transcriber the error instead of the fix. So
+take the spelling from something you can SEE: the repository in front of you, the code, the file
+name, the product's own page. Never add a spelling you only heard. If you are not sure how a word is
+written, look it up before adding it, or do not add it.
+
+**ADD ONLY - and that is deliberate, not a gap.** You can add a term. You CANNOT remove one, rename
+one, overwrite one, or touch the wrong-spellings list attached to an existing term. The Gateway
+refuses every one of those to a session key, so the worst you can do here is leave a stray extra
+word, and a correction the person relies on can never be lost. The person prunes the list in the
+Cockpit dictionary editor, where anything you added looks exactly like a word they typed themselves.
+
+**Which session added which word is recorded.** Because nothing confirms an addition at the time,
+the Gateway notes the adding session beside that account's glossary, so a bad entry can be traced
+back and swept later. Add carefully - the note says who did it.
+
 ## Closing a session - yours and the ones you started
 
 A session can close itself. When an agent has finished its work and nothing is waiting on the
@@ -201,8 +233,14 @@ use the identity the preamble gave you. If no user is named (nobody signed in), 
 - It does not replace the **fleet-comms** skill, which is the full reference for `cc-devthrottle`.
 
 
-**Skill Version:** 6.0 (no Director listener)
-**Last Updated:** 2026-08-03
+**Skill Version:** 6.1 (an agent can teach dictation a word)
+**Last Updated:** 2026-08-07
+**Changes in 6.1:** Added "Teaching dictation a word" - `cc-devthrottle dictionary add`, the owner's
+ruling of 2026-08-07 (issue #2484). An agent may add words to the dictation dictionary with no
+confirmation step; the grant is ADD ONLY (no delete, rename, overwrite, or wrong-spellings edit) and
+the adding session is recorded. The spelling instruction lives here rather than in a runtime prompt,
+because a rule an agent reads before it acts is the only kind that can stop a mangled word being
+added as canonical.
 **Changes in 6.0:** The remove-the-network-port mission deleted the Director's listener entirely.
 There is no loopback floor, no `/healthz`, no `/fleet/*` relay, no `/reconnect`, no local settings
 routes, and no `CC_DIRECTOR_API` or `CC_DIRECTOR_TOKEN` in any session's environment. Agents reach

--- a/.claude/skills/dev-throttle/SKILL.md
+++ b/.claude/skills/dev-throttle/SKILL.md
@@ -164,9 +164,19 @@ refuses every one of those to a session key, so the worst you can do here is lea
 word, and a correction the person relies on can never be lost. The person prunes the list in the
 Cockpit dictionary editor, where anything you added looks exactly like a word they typed themselves.
 
-**Which session added which word is recorded.** Because nothing confirms an addition at the time,
-the Gateway notes the adding session beside that account's glossary, so a bad entry can be traced
-back and swept later. Add carefully - the note says who did it.
+**Which session added which word is recorded, and you can read it back.** Because nothing confirms
+an addition at the time, the Gateway notes the adding session beside that account's glossary:
+
+```
+cc-devthrottle dictionary additions
+cc-devthrottle dictionary additions --session 9b2f     # one session's batch
+```
+
+That is how a bad entry gets traced and swept - find the session that added it, see the rest of what
+that session added, and hand the batch to the person to prune. Add carefully: the note says who did
+it. The trail shows only what AGENTS added; the person's own terms and every wrong-spellings list
+are not in it, which is why you can read this while the dictionary itself stays closed to you. You
+can find a bad batch; you cannot remove one.
 
 ## Closing a session - yours and the ones you started
 
@@ -235,12 +245,14 @@ use the identity the preamble gave you. If no user is named (nobody signed in), 
 
 **Skill Version:** 6.1 (an agent can teach dictation a word)
 **Last Updated:** 2026-08-07
-**Changes in 6.1:** Added "Teaching dictation a word" - `cc-devthrottle dictionary add`, the owner's
-ruling of 2026-08-07 (issue #2484). An agent may add words to the dictation dictionary with no
-confirmation step; the grant is ADD ONLY (no delete, rename, overwrite, or wrong-spellings edit) and
-the adding session is recorded. The spelling instruction lives here rather than in a runtime prompt,
-because a rule an agent reads before it acts is the only kind that can stop a mangled word being
-added as canonical.
+**Changes in 6.1:** Added "Teaching dictation a word" - `cc-devthrottle dictionary add` and
+`dictionary additions`, the owner's ruling of 2026-08-07 (issue #2484). An agent may add words to the
+dictation dictionary with no confirmation step; the grant is ADD ONLY (no delete, rename, overwrite,
+or wrong-spellings edit), the adding session is recorded, and that trail is readable so a bad entry
+can be traced and its batch swept - the ruling asks for both verbs, and writing a record nothing can
+read would satisfy only the first. The spelling instruction lives here rather than in a runtime
+prompt, because a rule an agent reads before it acts is the only kind that can stop a mangled word
+being added as canonical.
 **Changes in 6.0:** The remove-the-network-port mission deleted the Director's listener entirely.
 There is no loopback floor, no `/healthz`, no `/fleet/*` relay, no `/reconnect`, no local settings
 routes, and no `CC_DIRECTOR_API` or `CC_DIRECTOR_TOKEN` in any session's environment. Agents reach

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -916,6 +916,34 @@ COMMANDS:
   doctor [--json]
 ```
 
+### Dictionary
+
+Add words to the account's dictation dictionary, so dictation stops getting them wrong.
+
+```
+USAGE: cc-devthrottle dictionary add TERM [TERM ...]
+
+ARGUMENTS:
+  TERM  A word or phrase to add. One word or phrase per argument. [required]
+```
+
+```
+cc-devthrottle dictionary add "Kubernetes"
+cc-devthrottle dictionary add "mindzie" "DevThrottle" "Frederiksen"
+```
+
+**ADD is the only verb, deliberately.** A session key may add a term and nothing else - it can never
+delete, rename or overwrite an existing term, and it can never touch the wrong-spellings list
+attached to one (the owner's ruling of 2026-08-07, issue #2484). So the worst an agent can do is
+leave a stray extra word; the person prunes the list in the Cockpit dictionary editor. There is no
+confirmation step: being asked every time is worse than the occasional stray entry.
+
+**Spell it the way it is written down.** The spelling you add becomes the canonical one that
+dictation corrects other spellings to, and a word that reached you through dictation may already be
+mangled. Take the spelling from the repository, the code, or the product name in front of you -
+never from something you only heard. Which session added which word is recorded beside that
+account's glossary, so a bad entry can be traced back and swept.
+
 ---
 
 ## cc-reddit

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -925,18 +925,32 @@ USAGE: cc-devthrottle dictionary add TERM [TERM ...]
 
 ARGUMENTS:
   TERM  A word or phrase to add. One word or phrase per argument. [required]
+
+USAGE: cc-devthrottle dictionary additions [OPTIONS]
+
+OPTIONS:
+  --session   Only terms added by this session (full id or an id prefix)
+  --json  -j  Output as JSON
 ```
 
 ```
 cc-devthrottle dictionary add "Kubernetes"
 cc-devthrottle dictionary add "mindzie" "DevThrottle" "Frederiksen"
+cc-devthrottle dictionary additions --session 9b2f
 ```
 
-**ADD is the only verb, deliberately.** A session key may add a term and nothing else - it can never
-delete, rename or overwrite an existing term, and it can never touch the wrong-spellings list
-attached to one (the owner's ruling of 2026-08-07, issue #2484). So the worst an agent can do is
-leave a stray extra word; the person prunes the list in the Cockpit dictionary editor. There is no
-confirmation step: being asked every time is worse than the occasional stray entry.
+**ADD is the only WRITE verb, deliberately.** A session key may add a term and read back what agents
+added, and nothing else - it can never delete, rename or overwrite an existing term, and it can never
+touch the wrong-spellings list attached to one (the owner's ruling of 2026-08-07, issue #2484). So
+the worst an agent can do is leave a stray extra word; the person prunes the list in the Cockpit
+dictionary editor. There is no confirmation step: being asked every time is worse than the occasional
+stray entry.
+
+**`additions` is the sweep.** It lists every word an agent added, when, and which session added it,
+so a bad entry can be traced and the rest of that session's batch found. It shows only what agents
+added - a person's own edit leaves no entry, so the owner's terms and every wrong-spellings list stay
+out of reach of a session key, which is why this one read is open while `GET /ingest/dictionary` is
+not. Finding is not removing: the person prunes.
 
 **Spell it the way it is written down.** The spelling you add becomes the canonical one that
 dictation corrects other spellings to, and a word that reached you through dictation may already be

--- a/src/CcDirector.Gateway.Tests/AgentDictionaryAddTests.cs
+++ b/src/CcDirector.Gateway.Tests/AgentDictionaryAddTests.cs
@@ -339,4 +339,103 @@ public sealed class AgentDictionaryAddTests : IAsyncLifetime
         Assert.Contains("Kubernetes", await Vocabulary(_personA));
         Assert.Empty(GlossaryAdditionLog.Read(_tenantA));
     }
+
+    // ---------- THE TRAIL CAN BE READ, WHICH IS WHAT MAKES IT A SWEEP ----------
+
+    /// <summary>The ruling asks that a bad entry can be traced AND SWEPT. Writing the trail satisfies only
+    /// the first verb; until it can be read it is a file somebody has to find on disk. This is the read.</summary>
+    [Fact]
+    public async Task An_agent_can_read_back_what_agents_added()
+    {
+        (await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\",\"Helm\"]}")))
+            .EnsureSuccessStatusCode();
+
+        var resp = await _agentA.GetAsync("ingest/dictionary/additions");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+
+        Assert.Equal(2, doc.RootElement.GetProperty("count").GetInt32());
+        var entries = doc.RootElement.GetProperty("additions").EnumerateArray().ToArray();
+        // Newest first, so the batch somebody just noticed is at the top.
+        Assert.Equal("Helm", entries[0].GetProperty("term").GetString());
+        Assert.Equal("Kubernetes", entries[1].GetProperty("term").GetString());
+        Assert.All(entries, e => Assert.Equal(_sessionA.ToString(), e.GetProperty("sessionId").GetString()));
+        Assert.All(entries, e => Assert.Equal("director-a", e.GetProperty("directorId").GetString()));
+    }
+
+    /// <summary>The sweep it has to support: two sessions added words, and the trail says which was which,
+    /// so ONE session's bad batch can be picked out rather than the person having to distrust the lot.</summary>
+    [Fact]
+    public async Task The_trail_separates_one_sessions_batch_from_anothers()
+    {
+        var (sessionTwo, agentTwo) = LiveSessionIn(_tenantA, "director-b");
+        using var second = agentTwo;
+
+        (await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\"]}"))).EnsureSuccessStatusCode();
+        (await second.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetees\",\"Kuberentes\"]}"))).EnsureSuccessStatusCode();
+
+        var resp = await _agentA.GetAsync("ingest/dictionary/additions");
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var entries = doc.RootElement.GetProperty("additions").EnumerateArray().ToArray();
+
+        var badBatch = entries
+            .Where(e => e.GetProperty("sessionId").GetString() == sessionTwo.ToString())
+            .Select(e => e.GetProperty("term").GetString())
+            .OrderBy(t => t)
+            .ToArray();
+
+        Assert.Equal(new[] { "Kuberentes", "Kubernetees" }, badBatch);
+        Assert.Single(entries, e => e.GetProperty("sessionId").GetString() == _sessionA.ToString());
+    }
+
+    /// <summary>The trail is partitioned like the glossary it describes: one account's agents never see
+    /// another account's additions.</summary>
+    [Fact]
+    public async Task One_tenants_trail_is_invisible_to_another()
+    {
+        (await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"alphaonlyagentterm\"]}")))
+            .EnsureSuccessStatusCode();
+
+        var (_, agentB) = LiveSessionIn(_tenantB, "director-b");
+        using var otherAccount = agentB;
+
+        var resp = await otherAccount.GetAsync("ingest/dictionary/additions");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.DoesNotContain("alphaonlyagentterm", await resp.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>Reading the trail is not reading the dictionary. The trail holds only what AGENTS wrote, so
+    /// the owner's own curation stays out of reach of a session key - which is the whole reason this one
+    /// read could be opened while GET /ingest/dictionary stays refused.</summary>
+    [Fact]
+    public async Task The_trail_does_not_expose_the_persons_own_terms()
+    {
+        (await _personA.PostAsync("ingest/dictionary/terms",
+            Body("{\"terms\":[\"PersonsPrivateTerm\"],\"mistranscriptions\":{\"PersonsPrivateTerm\":[\"Mangled\"]}}")))
+            .EnsureSuccessStatusCode();
+        (await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\"]}"))).EnsureSuccessStatusCode();
+
+        var body = await (await _agentA.GetAsync("ingest/dictionary/additions")).Content.ReadAsStringAsync();
+
+        Assert.Contains("Kubernetes", body);
+        Assert.DoesNotContain("PersonsPrivateTerm", body);
+        Assert.DoesNotContain("Mangled", body);
+    }
+
+    /// <summary>Finding is not acting. The trail read offers no way to act on what it finds - removal stays
+    /// the person's, in the Cockpit editor.</summary>
+    [Theory]
+    [InlineData("POST", "ingest/dictionary/additions")]
+    [InlineData("PUT", "ingest/dictionary/additions")]
+    [InlineData("DELETE", "ingest/dictionary/additions")]
+    public async Task The_trail_cannot_be_written_or_swept_by_an_agent(string method, string path)
+    {
+        var request = new HttpRequestMessage(new HttpMethod(method), path);
+        if (method is "PUT" or "POST") request.Content = Body("{}");
+
+        var resp = await _agentA.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.Contains("session_key_out_of_scope", await resp.Content.ReadAsStringAsync());
+    }
 }

--- a/src/CcDirector.Gateway.Tests/AgentDictionaryAddTests.cs
+++ b/src/CcDirector.Gateway.Tests/AgentDictionaryAddTests.cs
@@ -422,6 +422,56 @@ public sealed class AgentDictionaryAddTests : IAsyncLifetime
         Assert.DoesNotContain("Mangled", body);
     }
 
+    // ---------- A CONCURRENT HUMAN EDIT SURVIVES AN AGENT ADD, THROUGH THE REAL ENDPOINTS ----------
+
+    /// <summary>
+    /// The invariant the whole grant rests on, raced over HTTP rather than at the writer.
+    /// <see cref="TenantGlossaryWriterRaceTests"/> proves the lock itself and runs in the fast suite; this
+    /// proves the two ENDPOINTS actually go through it, which is the part a later edit could quietly undo
+    /// by writing the file directly in a handler again.
+    ///
+    /// Asserts a serial ordering, not a fixed winner: the person's save may legitimately overwrite the
+    /// agent's word and vice versa, but the agent's word must never survive while the person's
+    /// wrong-spellings list is dropped - that is half of each write and no ordering at all.
+    /// </summary>
+    [Fact]
+    public async Task A_persons_save_racing_an_agent_add_over_http_never_loses_the_persons_corrections()
+    {
+        const string curated =
+            "{\"vocabulary\":[\"Frederiksen\"]," +
+            "\"commonMistranscriptions\":{\"Frederiksen\":[\"Fredrickson\",\"Fredriksson\"]}," +
+            "\"profiles\":{}}";
+
+        for (var round = 0; round < 12; round++)
+        {
+            // A fresh account per round, so one round's file cannot carry another's state and turn a lost
+            // update into a pass.
+            var (tenant, person) = Enrolled($"dev-race-{round}", $"sub-race-{round}", $"race{round}@example.com");
+            using var personClient = person;
+            var (_, agent) = LiveSessionIn(tenant, "director-race");
+            using var agentClient = agent;
+
+            var saveTask = personClient.PutAsync("ingest/dictionary", Body(curated));
+            var addTask = agentClient.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\"]}"));
+            var save = await saveTask;
+            var add = await addTask;
+
+            Assert.Equal(HttpStatusCode.OK, save.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, add.StatusCode);
+
+            var vocabulary = await Vocabulary(personClient);
+            var wrongSpellings = await WrongSpellingsFor(personClient, "Frederiksen");
+
+            Assert.Contains("Frederiksen", vocabulary);
+            Assert.Equal(new[] { "Fredrickson", "Fredriksson" }, wrongSpellings);
+
+            var agentWordSurvived = vocabulary.Contains("Kubernetes");
+            Assert.True(
+                agentWordSurvived ? vocabulary.Length == 2 : vocabulary.Length == 1,
+                $"round {round}: no serial ordering produces [{string.Join(", ", vocabulary)}]");
+        }
+    }
+
     /// <summary>Finding is not acting. The trail read offers no way to act on what it finds - removal stays
     /// the person's, in the Cockpit editor.</summary>
     [Theory]

--- a/src/CcDirector.Gateway.Tests/AgentDictionaryAddTests.cs
+++ b/src/CcDirector.Gateway.Tests/AgentDictionaryAddTests.cs
@@ -1,0 +1,342 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CcDirector.Core.Security;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// AN AGENT ADDS A WORD TO THE DICTATION DICTIONARY - issue #2484, the owner's ruling of 2026-08-07.
+///
+/// THE RULING, in the words it was given in: "yes - allow agents to add words to the dictation dictionary,
+/// and do NOT put a confirmation step in the way... ADD ONLY. A session key may add a term. It may not
+/// delete, rename or overwrite an existing term, and it may not touch the wrong-spellings list attached to
+/// an existing term. Worst case is therefore a stray extra word, never the loss of a correction the owner
+/// relies on... record which session added a term so a bad entry can be traced and swept."
+///
+/// WHAT WAS BROKEN. <c>SessionKeyGuard</c> allowed nothing under <c>/ingest</c>, so a session key got 403 on
+/// the dictionary term endpoint and the documented "add Kubernetes to my dictionary" instruction could not
+/// be carried out by any connected agent.
+///
+/// WHY THE PROOF IS HTTP AND HOSTED, NOT A CALL TO THE GUARD. The grant has two halves that live in two
+/// files - the route is opened in <c>SessionKeyGuard</c>, and the narrowing a path cannot express (terms
+/// yes, wrong spellings no) is enforced in <c>RecordingEndpoints</c>. A test against either half alone would
+/// pass while the other half was wrong. And the tenancy claim - the word lands in the REQUESTING tenant's
+/// glossary and nowhere else - is only true if the whole stack agrees, so it is proven on a real hosted
+/// Gateway with two fully enrolled accounts, exactly as <see cref="HostedRecordingServeTests"/> proves the
+/// device-key half of the same surface.
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class AgentDictionaryAddTests : IAsyncLifetime
+{
+    private const string Token = "test-token-agent-dictionary";
+
+    private readonly string _root;
+    private readonly string? _priorRoot;
+    private readonly string? _priorHosted;
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-agent-dict-" + Guid.NewGuid().ToString("N"));
+    private readonly string _vaultPath =
+        Path.Combine(Path.GetTempPath(), "cc-agent-dict-" + Guid.NewGuid().ToString("N") + ".json");
+
+    private GatewayHost _gateway = null!;
+
+    // Tenant A: the account whose agent does the adding. Two clients onto it - the SESSION key an agent
+    // holds, and the DEVICE key the person's Cockpit reads with (a session key cannot read the glossary,
+    // which is itself part of the grant being narrow).
+    private TenantId _tenantA;
+    private Guid _sessionA;
+    private HttpClient _agentA = null!;
+    private HttpClient _personA = null!;
+
+    // Tenant B: a second, entirely separate account. Nothing tenant A's agent does may reach it.
+    private TenantId _tenantB;
+    private HttpClient _personB = null!;
+
+    public AgentDictionaryAddTests()
+    {
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-agent-dict-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+        Assert.True(GatewayHostedMode.IsHosted);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            keyVaultPath: _vaultPath,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        (_tenantA, _personA) = Enrolled("dev-a", "sub-alice", "alice@example.com");
+        (_tenantB, _personB) = Enrolled("dev-b", "sub-bob", "bob@example.com");
+
+        (_sessionA, _agentA) = LiveSessionIn(_tenantA, "director-a");
+    }
+
+    /// <summary>An enrolled account, and the device-key client its person browses with.</summary>
+    private (TenantId Tenant, HttpClient Http) Enrolled(string deviceId, string subject, string email)
+    {
+        var key = _gateway.Devices.Register(deviceId, "MA").DeviceKey;
+        var tenant = _gateway.TenantRegistry.MintOrLookupBySubject(subject, email);
+        _gateway.Devices.SetAccountBinding(deviceId, subject, tenant.Value);
+        return (tenant, Client(key));
+    }
+
+    /// <summary>A live session inside an account, and the client an agent in it would use - the SAME shape
+    /// the Director mints at launch and stamps into the session's environment as CC_GATEWAY_SESSION_KEY.</summary>
+    private (Guid Session, HttpClient Http) LiveSessionIn(TenantId tenant, string directorId)
+    {
+        var session = Guid.NewGuid();
+        var key = GatewaySessionKey.Mint();
+        Assert.True(_gateway.SessionKeys.Register(
+            tenant, directorId, session.ToString(), GatewaySessionKey.Hash(key), DateTime.UtcNow.AddHours(12)));
+        return (session, Client(key));
+    }
+
+    private HttpClient Client(string bearer)
+    {
+        var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        return http;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _agentA.Dispose();
+        _personA.Dispose();
+        _personB.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (File.Exists(_vaultPath)) File.Delete(_vaultPath); } catch { /* best effort */ }
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    private static StringContent Body(string json) => new(json, Encoding.UTF8, "application/json");
+
+    private static async Task<string[]> Vocabulary(HttpClient http)
+    {
+        var resp = await http.GetAsync("ingest/dictionary");
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        return doc.RootElement.TryGetProperty("vocabulary", out var vocab) && vocab.ValueKind == JsonValueKind.Array
+            ? vocab.EnumerateArray().Select(e => e.GetString() ?? "").ToArray()
+            : Array.Empty<string>();
+    }
+
+    private static async Task<string[]> WrongSpellingsFor(HttpClient http, string term)
+    {
+        var resp = await http.GetAsync("ingest/dictionary");
+        resp.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        if (!doc.RootElement.TryGetProperty("commonMistranscriptions", out var map)
+            || map.ValueKind != JsonValueKind.Object
+            || !map.TryGetProperty(term, out var list)
+            || list.ValueKind != JsonValueKind.Array)
+            return Array.Empty<string>();
+        return list.EnumerateArray().Select(e => e.GetString() ?? "").ToArray();
+    }
+
+    // ---------- ADD SUCCEEDS ----------
+
+    /// <summary>The whole point of the issue: an agent's session key adds a word, with nothing in the way.
+    /// This is the exact call that returned 403 before.</summary>
+    [Fact]
+    public async Task A_session_key_adds_a_term()
+    {
+        var resp = await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\"]}"));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Contains("Kubernetes", await Vocabulary(_personA));
+    }
+
+    /// <summary>Adding is idempotent, so an agent that adds a word twice leaves ONE entry - and the entry
+    /// that was already there is the one that survives. That is what "may not overwrite" means for the add
+    /// verb itself: the second call changes nothing at all.</summary>
+    [Fact]
+    public async Task Adding_a_term_that_is_already_there_changes_nothing()
+    {
+        (await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"mindzie\"]}"))).EnsureSuccessStatusCode();
+        (await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"MINDZIE\"]}"))).EnsureSuccessStatusCode();
+
+        var vocabulary = await Vocabulary(_personA);
+        Assert.Equal(new[] { "mindzie" }, vocabulary.Where(v => v.Equals("mindzie", StringComparison.OrdinalIgnoreCase)).ToArray());
+    }
+
+    // ---------- DELETE AND OVERWRITE ARE STILL REFUSED ----------
+
+    /// <summary>The destructive half of the ruling. Every one of these is a way to LOSE a correction the
+    /// person relies on, and every one is refused with the credential intact - 403, not 401, because the key
+    /// is genuine and only the route is out of scope.</summary>
+    [Theory]
+    // Replacing the whole glossary - the Cockpit editor's save. It can drop a term, rename one, or empty a
+    // wrong-spellings list in a single call.
+    [InlineData("PUT", "ingest/dictionary")]
+    // Reading it back is not part of the grant either: adding is idempotent and needs no read.
+    [InlineData("GET", "ingest/dictionary")]
+    // Deleting, by any spelling somebody might reach for.
+    [InlineData("DELETE", "ingest/dictionary")]
+    [InlineData("DELETE", "ingest/dictionary/terms")]
+    [InlineData("DELETE", "ingest/dictionary/terms/mindzie")]
+    // The suggestion surface: apply writes a term AND its wrong spellings; dismiss and restore change what
+    // the person is shown.
+    [InlineData("POST", "ingest/dictionary/suggestions/apply")]
+    [InlineData("POST", "ingest/dictionary/suggestions/dismiss")]
+    [InlineData("POST", "ingest/dictionary/dismissed/restore")]
+    public async Task The_destructive_verbs_are_refused_for_a_session_key(string method, string path)
+    {
+        var request = new HttpRequestMessage(new HttpMethod(method), path);
+        if (method is "PUT" or "POST")
+            request.Content = Body("{\"vocabulary\":[],\"commonMistranscriptions\":{},\"profiles\":{}}");
+
+        var resp = await _agentA.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.Contains("session_key_out_of_scope", await resp.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>A refusal must leave the glossary exactly as it was. Asserting the status code alone would
+    /// pass even if the handler had already written before the refusal was returned.</summary>
+    [Fact]
+    public async Task A_refused_replacement_leaves_the_glossary_untouched()
+    {
+        (await _personA.PostAsync("ingest/dictionary/terms",
+            Body("{\"terms\":[\"Frederiksen\"],\"mistranscriptions\":{\"Frederiksen\":[\"Fredrickson\"]}}")))
+            .EnsureSuccessStatusCode();
+
+        var replace = await _agentA.PutAsync("ingest/dictionary",
+            Body("{\"vocabulary\":[],\"commonMistranscriptions\":{},\"profiles\":{}}"));
+
+        Assert.Equal(HttpStatusCode.Forbidden, replace.StatusCode);
+        Assert.Contains("Frederiksen", await Vocabulary(_personA));
+        Assert.Equal(new[] { "Fredrickson" }, await WrongSpellingsFor(_personA, "Frederiksen"));
+    }
+
+    /// <summary>The narrowing a path cannot express, and the reason it exists: a wrong-spellings entry
+    /// rewrites what the transcriber HEARS, so a careless one corrupts dictation everywhere instead of
+    /// leaving a stray word. The route is open to a session key; this FIELD on it is not.</summary>
+    [Fact]
+    public async Task A_session_key_may_not_touch_the_wrong_spellings_list()
+    {
+        (await _personA.PostAsync("ingest/dictionary/terms",
+            Body("{\"terms\":[\"mindzie\"],\"mistranscriptions\":{\"mindzie\":[\"Mindsee\"]}}")))
+            .EnsureSuccessStatusCode();
+
+        var resp = await _agentA.PostAsync("ingest/dictionary/terms",
+            Body("{\"terms\":[\"mindzie\"],\"mistranscriptions\":{\"mindzie\":[\"the\"]}}"));
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        Assert.Contains("session_key_add_only", await resp.Content.ReadAsStringAsync());
+        Assert.Equal(new[] { "Mindsee" }, await WrongSpellingsFor(_personA, "mindzie"));
+    }
+
+    /// <summary>The person keeps the pruning shears. A term an agent added is removable through the ordinary
+    /// editor save exactly like a hand-added one - the grant narrows the AGENT, never the owner.</summary>
+    [Fact]
+    public async Task The_person_can_still_remove_a_term_an_agent_added()
+    {
+        (await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\"]}"))).EnsureSuccessStatusCode();
+        Assert.Contains("Kubernetes", await Vocabulary(_personA));
+
+        (await _personA.PutAsync("ingest/dictionary",
+            Body("{\"vocabulary\":[],\"commonMistranscriptions\":{},\"profiles\":{}}"))).EnsureSuccessStatusCode();
+
+        Assert.DoesNotContain("Kubernetes", await Vocabulary(_personA));
+    }
+
+    // ---------- THE TERM LANDS IN THE REQUESTING TENANT'S GLOSSARY AND NOWHERE ELSE ----------
+
+    /// <summary>Tenancy. The word goes into the glossary of the account whose session key made the call, and
+    /// a second account on the same Gateway never sees it - not in its glossary, and not on disk.</summary>
+    [Fact]
+    public async Task A_term_added_by_one_tenants_agent_reaches_no_other_tenant()
+    {
+        const string term = "alphaonlyagentterm";
+
+        (await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"" + term + "\"]}")))
+            .EnsureSuccessStatusCode();
+
+        Assert.Contains(term, await Vocabulary(_personA));
+        Assert.DoesNotContain(term, await Vocabulary(_personB));
+
+        // And on disk: the two accounts are physically different files, and only one of them was written.
+        var pathA = TenantGlossary.PathFor(_tenantA);
+        var pathB = TenantGlossary.PathFor(_tenantB);
+        Assert.NotEqual(pathA, pathB);
+        Assert.Contains(term, File.ReadAllText(pathA));
+        Assert.False(File.Exists(pathB) && File.ReadAllText(pathB).Contains(term));
+    }
+
+    // ---------- THE ADDING SESSION IS RECORDED ----------
+
+    /// <summary>There is no confirmation step by the owner's ruling, so the trail is the only thing that
+    /// lets a bad entry be traced back and swept. It names the session, the Director it belonged to, and the
+    /// word - in the tenant's own partition, never anywhere shared.</summary>
+    [Fact]
+    public async Task The_session_that_added_a_term_is_recorded()
+    {
+        (await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\",\"Helm\"]}")))
+            .EnsureSuccessStatusCode();
+
+        var trail = GlossaryAdditionLog.Read(_tenantA);
+
+        Assert.Equal(2, trail.Count);
+        Assert.All(trail, entry =>
+        {
+            Assert.Equal(_sessionA.ToString(), entry.SessionId);
+            Assert.Equal("director-a", entry.DirectorId);
+            Assert.NotEqual(default, entry.AddedAtUtc);
+        });
+        Assert.Equal(new[] { "Kubernetes", "Helm" }, trail.Select(e => e.Term).ToArray());
+
+        // The trail is partitioned like the glossary it sits beside.
+        Assert.Empty(GlossaryAdditionLog.Read(_tenantB));
+    }
+
+    /// <summary>A second session adding the SAME word records nothing, because it added nothing - a trail
+    /// that named a session which changed no state would send whoever reads it after the wrong agent.</summary>
+    [Fact]
+    public async Task A_term_that_was_already_there_records_no_second_adder()
+    {
+        var (_, agentTwo) = LiveSessionIn(_tenantA, "director-a");
+        using var second = agentTwo;
+
+        (await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\"]}"))).EnsureSuccessStatusCode();
+        (await second.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\"]}"))).EnsureSuccessStatusCode();
+
+        var trail = GlossaryAdditionLog.Read(_tenantA);
+
+        Assert.Single(trail);
+        Assert.Equal(_sessionA.ToString(), trail[0].SessionId);
+    }
+
+    /// <summary>A person adding through the Cockpit is not a session and leaves no session in the trail -
+    /// the record exists to say WHICH AGENT, and stamping the owner's own edit with an empty one would be a
+    /// false trail rather than an absent one.</summary>
+    [Fact]
+    public async Task A_person_adding_a_term_writes_no_session_trail()
+    {
+        (await _personA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\"]}")))
+            .EnsureSuccessStatusCode();
+
+        Assert.Contains("Kubernetes", await Vocabulary(_personA));
+        Assert.Empty(GlossaryAdditionLog.Read(_tenantA));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/AgentDictionaryAddTests.cs
+++ b/src/CcDirector.Gateway.Tests/AgentDictionaryAddTests.cs
@@ -472,6 +472,49 @@ public sealed class AgentDictionaryAddTests : IAsyncLifetime
         }
     }
 
+    /// <summary>
+    /// An add whose provenance cannot be recorded FAILS, over HTTP, and adds nothing. The endpoint used to
+    /// swallow a trail-write failure and return 200, which is a silent loss of the traceability the owner
+    /// traded the confirmation step for. Forced by putting a directory where the trail file belongs.
+    /// </summary>
+    [Fact]
+    public async Task An_add_whose_provenance_cannot_be_written_fails_over_http()
+    {
+        Directory.CreateDirectory(GlossaryAdditionLog.PathFor(_tenantA));
+
+        var resp = await _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\"]}"));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, resp.StatusCode);
+        Assert.Contains("glossary_write_failed", await resp.Content.ReadAsStringAsync());
+
+        // And it really added nothing - failing loudly after doing the damage would not satisfy the ruling.
+        Assert.DoesNotContain("Kubernetes", await Vocabulary(_personA));
+    }
+
+    /// <summary>Every term a racing pair of sessions lands is attributable afterwards - the pair of writes
+    /// is atomic through the real endpoints, not only at the writer.</summary>
+    [Fact]
+    public async Task Racing_sessions_over_http_keep_every_terms_provenance()
+    {
+        var (sessionTwo, agentTwo) = LiveSessionIn(_tenantA, "director-b");
+        using var second = agentTwo;
+
+        var one = _agentA.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Kubernetes\"]}"));
+        var two = second.PostAsync("ingest/dictionary/terms", Body("{\"terms\":[\"Helm\"]}"));
+        Assert.Equal(HttpStatusCode.OK, (await one).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await two).StatusCode);
+
+        var vocabulary = await Vocabulary(_personA);
+        var trail = GlossaryAdditionLog.Read(_tenantA);
+
+        Assert.Contains("Kubernetes", vocabulary);
+        Assert.Contains("Helm", vocabulary);
+        foreach (var term in vocabulary)
+            Assert.True(trail.Any(e => e.Term == term), $"'{term}' has no trail entry - it cannot be swept");
+        Assert.Equal("Kubernetes", trail.Single(e => e.SessionId == _sessionA.ToString()).Term);
+        Assert.Equal("Helm", trail.Single(e => e.SessionId == sessionTwo.ToString()).Term);
+    }
+
     /// <summary>Finding is not acting. The trail read offers no way to act on what it finds - removal stays
     /// the person's, in the Cockpit editor.</summary>
     [Theory]

--- a/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTestSuiteLock.cs
@@ -58,6 +58,20 @@ namespace CcDirector.Gateway.Tests;
 /// They exist so a blocked run can name its blocker - a blocked run that cannot say who is blocking it is
 /// indistinguishable from a hang, and somebody will kill the wrong thing. They never decide ownership.
 ///
+/// IF YOU ARE ABOUT TO KILL A GATEWAY TEST RUN THAT LOOKS HUNG, READ THIS FIRST.
+///
+/// FROM OUTSIDE THE PROCESS, WAITING ON THIS LOCK AND BEING WEDGED LOOK IDENTICAL: long wall-clock time,
+/// almost no processor time. Measured on 2026-08-07 - a run showing 1.9 seconds of processor time after
+/// more than an hour of wall clock was not stuck at all. It was queued behind another suite, and its tests
+/// took 57 seconds once it got in. Low processor time is what CORRECT waiting looks like, so it is evidence
+/// of nothing on its own, and it is the exact reading that makes somebody reach for the kill.
+///
+/// Do not judge it from Task Manager or <c>Get-Process</c>. Read the run's own output, or the log beside
+/// the lock file (<see cref="LogFilePath"/>): a waiting run prints WAITING with its holder named, and
+/// reprints the wait every 30 seconds. A WAITING line means it is behaving correctly, and the thing to look
+/// at is the HOLDER, not the waiter. Killing the waiter accomplishes nothing either way, because the waiter
+/// is not what is slow.
+///
 /// THE GUARANTEE IS PER-USER-PER-MACHINE. Not machine-wide - say it precisely, because someone will
 /// eventually rely on the words. Two runs by the SAME operating-system user on the SAME machine cannot
 /// overlap. Two runs by DIFFERENT users on one machine are NOT serialized by this, and on Windows they

--- a/src/CcDirector.Gateway.UnitTests/CrossProcessGlossaryLockTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/CrossProcessGlossaryLockTests.cs
@@ -93,9 +93,15 @@ public sealed class CrossProcessGlossaryLockTests : IDisposable
 
         // The child must actually have written, or this proves nothing at all - a silently-failed child
         // would leave the parent racing itself and passing.
+        var diagnosticsPath = Path.Combine(_root, "child-diagnostics.txt");
+        var childDiagnostics = File.Exists(diagnosticsPath)
+            ? File.ReadAllText(diagnosticsPath)
+            : "(the child wrote no diagnostics at all)";
         Assert.True(
             trail.Any(e => e.SessionId == "child"),
-            $"the second process wrote nothing, so no cross-process race happened. Child output:\n{ReadOutput(child)}");
+            $"the second process wrote nothing, so no cross-process race happened.\n" +
+            $"Parent glossary path: {TenantGlossary.PathFor(new TenantId(tenant))}\n" +
+            $"Child said:\n{childDiagnostics}\nChild output:\n{ReadOutput(child)}");
         Assert.True(trail.Any(e => e.SessionId == "parent"), "the parent wrote nothing");
 
         // THE ASSERTION. Every word that survives is attributable. Unlocked, two processes tear the shared
@@ -200,6 +206,27 @@ public sealed class CrossProcessGlossaryWriterHelper
         if (string.IsNullOrEmpty(tenant) || string.IsNullOrEmpty(readyPath) || string.IsNullOrEmpty(goPath))
             return;
 
+        // A diagnostic the PARENT can read, so a child that silently does the wrong thing is debuggable.
+        // A child process that fails invisibly is worse than no child: the parent races itself and passes.
+        var diagnostics = Path.Combine(Path.GetDirectoryName(readyPath)!, "child-diagnostics.txt");
+        void Note(string line) { try { File.AppendAllText(diagnostics, line + "\n"); } catch { } }
+
+        // POINT THE CHILD AT THE PARENT'S ROOT, and note why this line is not redundant. Something in this
+        // assembly's start-up redirects CC_DIRECTOR_ROOT to a per-run isolated directory, so the value the
+        // parent passed in the environment is overwritten before any test runs. The first version of this
+        // test looked like a child that "wrote nothing" - it had in fact written all forty terms, into its
+        // own private root, where the parent could never see them. That is precisely the shape of a
+        // cross-process test that passes while proving nothing, so the root is re-asserted here, from the
+        // separate variable the redirect does not touch, and CcStorage reads it live.
+        var parentRoot = Environment.GetEnvironmentVariable(CrossProcessGlossaryLockTests.ChildRootVar);
+        if (!string.IsNullOrEmpty(parentRoot))
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", parentRoot);
+
+        Note($"root={Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT")}");
+        Note($"tenant={tenant}");
+        Note($"glossaryPath={TenantGlossary.PathFor(new TenantId(tenant))}");
+        Note($"trailPath={GlossaryAdditionLog.PathFor(new TenantId(tenant))}");
+
         File.WriteAllText(readyPath, "ready");
 
         var deadline = DateTime.UtcNow.AddMinutes(3);
@@ -207,7 +234,16 @@ public sealed class CrossProcessGlossaryWriterHelper
             Thread.Sleep(10);
         Assert.True(File.Exists(goPath), "the parent never released the race");
 
-        CrossProcessGlossaryLockTests.WriteMany(
-            new TenantId(tenant), "child", CrossProcessGlossaryLockTests.WritesPerSide);
+        try
+        {
+            CrossProcessGlossaryLockTests.WriteMany(
+                new TenantId(tenant), "child", CrossProcessGlossaryLockTests.WritesPerSide);
+            Note("wrote " + CrossProcessGlossaryLockTests.WritesPerSide + " terms");
+        }
+        catch (Exception ex)
+        {
+            Note("WRITE FAILED: " + ex);
+            throw;
+        }
     }
 }

--- a/src/CcDirector.Gateway.UnitTests/CrossProcessGlossaryLockTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/CrossProcessGlossaryLockTests.cs
@@ -43,6 +43,7 @@ namespace CcDirector.Gateway.Tests;
 /// variable the redirect does not touch, it writes a diagnostics file, and the parent asserts BOTH sides
 /// wrote before judging anything.
 /// </summary>
+[Collection("DirectorRoot")]
 public sealed class CrossProcessGlossaryLockTests : IDisposable
 {
     /// <summary>Set for the child process only. Its presence is what wakes the helper up.</summary>

--- a/src/CcDirector.Gateway.UnitTests/CrossProcessGlossaryLockTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/CrossProcessGlossaryLockTests.cs
@@ -1,0 +1,213 @@
+using System.Diagnostics;
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// THE CROSS-PROCESS FILE LOCK, PROVEN ACROSS TWO REAL PROCESSES.
+///
+/// WHY THIS FILE EXISTS. <see cref="TenantGlossaryWriterRaceTests"/> proves the writer is atomic, but every
+/// one of its races runs inside ONE process, where the static per-tenant monitor already serialises
+/// everything. So those tests are BLIND to the file lock: with <c>AcquireFileLock</c> deleted outright, all
+/// eight of them still pass - measured, not assumed. A guard whose removal changes no test is a guard
+/// nothing is holding, and the claim that this Gateway is safe against two containers on one shared file
+/// share rested entirely on reading the code.
+///
+/// The file lock exists for OVERLAPPING GATEWAY PROCESSES on one file share - a state a hosted deploy has
+/// really been in - so it is proven where it operates: this test starts a SECOND operating-system process
+/// that writes the same tenant's glossary at the same time, and asserts that every term that survives has
+/// its provenance entry. The two processes share nothing but the directory, so the in-process monitor
+/// cannot be what makes it pass.
+///
+/// HOW THE SECOND PROCESS IS RUN. It is this same test assembly, re-entered by <c>dotnet test</c> with a
+/// filter selecting <see cref="CrossProcessGlossaryWriterHelper"/> - the repository has no spare console
+/// project to borrow, and adding one to carry a test would be a heavier change than the test. The helper is
+/// inert unless its environment variable is present, so a normal suite run never executes the writing path.
+///
+/// WHAT THIS STILL DOES NOT PROVE, stated plainly rather than left implied: it proves the lock serialises
+/// two processes on THIS machine's local file system. It does NOT prove that the operating system's file
+/// locking is honoured by the hosted deployment's network file share, which no test in this repository can
+/// reach. If that guarantee matters it needs a check against the real share, not a unit test.
+/// </summary>
+public sealed class CrossProcessGlossaryLockTests : IDisposable
+{
+    /// <summary>Set for the child process only. Its presence is what wakes the helper up.</summary>
+    internal const string ChildRootVar = "CC_TEST_GLOSSARY_CHILD_ROOT";
+    internal const string ChildTenantVar = "CC_TEST_GLOSSARY_CHILD_TENANT";
+    internal const string ChildReadyVar = "CC_TEST_GLOSSARY_CHILD_READY";
+    internal const string ChildGoVar = "CC_TEST_GLOSSARY_CHILD_GO";
+
+    /// <summary>Writes per side. Enough overlap that the unlocked version cannot get through by luck.</summary>
+    internal const int WritesPerSide = 40;
+
+    private readonly string _root;
+    private readonly string? _priorRoot;
+
+    public CrossProcessGlossaryLockTests()
+    {
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "cc-glossary-xproc-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    [Trait("Category", "CrossProcess")]
+    public void Two_processes_writing_one_tenants_glossary_lose_no_provenance()
+    {
+        var tenant = $"xproc-{Guid.NewGuid():N}";
+        var readyPath = Path.Combine(_root, "child-ready");
+        var goPath = Path.Combine(_root, "go");
+
+        using var child = StartChild(tenant, readyPath, goPath);
+        Assert.True(child is not null, "could not start the second process");
+
+        // Wait for the child's test host to boot and reach the helper. This is the slow part - a test host
+        // start, not the race - so it gets a generous window.
+        var bootDeadline = DateTime.UtcNow.AddMinutes(3);
+        while (!File.Exists(readyPath) && DateTime.UtcNow < bootDeadline)
+        {
+            if (child!.HasExited)
+                Assert.Fail($"the second process exited before signalling ready (exit {child.ExitCode}):\n{ReadOutput(child)}");
+            Thread.Sleep(100);
+        }
+        Assert.True(File.Exists(readyPath), "the second process never signalled ready; cannot race what did not start");
+
+        // Release both sides together.
+        File.WriteAllText(goPath, "go");
+        WriteMany(new TenantId(tenant), "parent", WritesPerSide);
+
+        Assert.True(child!.WaitForExit(120_000), "the second process did not finish in time");
+
+        var glossary = TenantGlossary.Load(new TenantId(tenant));
+        var trail = GlossaryAdditionLog.Read(new TenantId(tenant));
+
+        // The child must actually have written, or this proves nothing at all - a silently-failed child
+        // would leave the parent racing itself and passing.
+        Assert.True(
+            trail.Any(e => e.SessionId == "child"),
+            $"the second process wrote nothing, so no cross-process race happened. Child output:\n{ReadOutput(child)}");
+        Assert.True(trail.Any(e => e.SessionId == "parent"), "the parent wrote nothing");
+
+        // THE ASSERTION. Every word that survives is attributable. Unlocked, two processes tear the shared
+        // staging file and lose trail lines, so terms arrive with no entry naming who added them.
+        foreach (var term in glossary.Vocabulary)
+            Assert.True(trail.Any(e => e.Term == term),
+                $"'{term}' is in the glossary with NO trail entry after a two-process race - it cannot be " +
+                $"traced or swept. Glossary has {glossary.Vocabulary.Count} terms, trail has {trail.Count} entries.");
+
+        // And nothing was lost outright: both sides' full batches are present.
+        Assert.Equal(WritesPerSide * 2, glossary.Vocabulary.Count);
+    }
+
+    /// <summary>Write <paramref name="count"/> terms as one session, the way the endpoint composes an add.</summary>
+    internal static void WriteMany(TenantId tenant, string session, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var term = $"{session}-term-{i}";
+            TenantGlossaryWriter.MutateAndRecord(
+                tenant,
+                current =>
+                {
+                    var vocab = current.Vocabulary.ToList();
+                    var added = new List<string>();
+                    if (!vocab.Contains(term))
+                    {
+                        vocab.Add(term);
+                        added.Add(term);
+                    }
+                    return (new DictationDictionary(vocab, current.CommonMistranscriptions, current.Profiles),
+                            (IReadOnlyList<string>)added);
+                },
+                session,
+                "director-xproc",
+                new DateTime(2026, 8, 7, 12, 0, 0, DateTimeKind.Utc));
+        }
+    }
+
+    private Process? StartChild(string tenant, string readyPath, string goPath)
+    {
+        var assembly = typeof(CrossProcessGlossaryLockTests).Assembly.Location;
+        var info = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assembly)!,
+        };
+        info.ArgumentList.Add("test");
+        info.ArgumentList.Add(assembly);
+        info.ArgumentList.Add("--no-build");
+        info.ArgumentList.Add("--nologo");
+        info.ArgumentList.Add("--filter");
+        info.ArgumentList.Add("FullyQualifiedName~CrossProcessGlossaryWriterHelper");
+
+        // The child needs the same data root, and the coordination paths. CC_DIRECTOR_ROOT is what makes it
+        // resolve the SAME tenant directory this process is using.
+        info.Environment["CC_DIRECTOR_ROOT"] = _root;
+        info.Environment[ChildRootVar] = _root;
+        info.Environment[ChildTenantVar] = tenant;
+        info.Environment[ChildReadyVar] = readyPath;
+        info.Environment[ChildGoVar] = goPath;
+
+        var process = Process.Start(info);
+        if (process is null) return null;
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.OutputDataReceived += (_, e) => { if (e.Data is not null) lock (_output) _output.Add(e.Data); };
+        process.ErrorDataReceived += (_, e) => { if (e.Data is not null) lock (_output) _output.Add(e.Data); };
+        return process;
+    }
+
+    private readonly List<string> _output = new();
+
+    private string ReadOutput(Process? process)
+    {
+        lock (_output)
+            return _output.Count == 0 ? "(no output captured)" : string.Join("\n", _output.TakeLast(40));
+    }
+}
+
+/// <summary>
+/// The writing half of <see cref="CrossProcessGlossaryLockTests"/>, run in a SECOND process.
+///
+/// It is a test only because re-entering this assembly with <c>dotnet test</c> is the cheapest way to get a
+/// second process that already has the Gateway loaded. It does NOTHING unless the coordinating environment
+/// variables are set, so an ordinary suite run executes the first line and returns - it never writes, never
+/// touches a glossary, and cannot interfere with anything.
+/// </summary>
+public sealed class CrossProcessGlossaryWriterHelper
+{
+    [Fact]
+    [Trait("Category", "CrossProcess")]
+    public void WriteAsTheSecondProcess()
+    {
+        var tenant = Environment.GetEnvironmentVariable(CrossProcessGlossaryLockTests.ChildTenantVar);
+        var readyPath = Environment.GetEnvironmentVariable(CrossProcessGlossaryLockTests.ChildReadyVar);
+        var goPath = Environment.GetEnvironmentVariable(CrossProcessGlossaryLockTests.ChildGoVar);
+
+        // Not the child. This is the ordinary suite running, and there is nothing to do.
+        if (string.IsNullOrEmpty(tenant) || string.IsNullOrEmpty(readyPath) || string.IsNullOrEmpty(goPath))
+            return;
+
+        File.WriteAllText(readyPath, "ready");
+
+        var deadline = DateTime.UtcNow.AddMinutes(3);
+        while (!File.Exists(goPath) && DateTime.UtcNow < deadline)
+            Thread.Sleep(10);
+        Assert.True(File.Exists(goPath), "the parent never released the race");
+
+        CrossProcessGlossaryLockTests.WriteMany(
+            new TenantId(tenant), "child", CrossProcessGlossaryLockTests.WritesPerSide);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/CrossProcessGlossaryLockTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/CrossProcessGlossaryLockTests.cs
@@ -16,11 +16,11 @@ namespace CcDirector.Gateway.Tests;
 /// nothing is holding, and the claim that this Gateway is safe against two containers on one shared file
 /// share rested entirely on reading the code.
 ///
-/// The file lock exists for OVERLAPPING GATEWAY PROCESSES on one file share - a state a hosted deploy has
-/// really been in - so it is proven where it operates: this test starts a SECOND operating-system process
-/// that writes the same tenant's glossary at the same time, and asserts that every term that survives has
-/// its provenance entry. The two processes share nothing but the directory, so the in-process monitor
-/// cannot be what makes it pass.
+/// The file lock exists for OVERLAPPING GATEWAY PROCESSES writing one glossary directory, so it is proven
+/// where it operates: this test starts a SECOND operating-system process that writes the same tenant's
+/// glossary at the same time, and asserts that every term that survives has its provenance entry. The two
+/// processes share nothing but the directory, so the in-process monitor cannot be what makes it pass.
+/// Measured both ways - with the lock, 80 terms and no flake over three runs; without it, 40.
 ///
 /// HOW THE SECOND PROCESS IS RUN. It is this same test assembly, re-entered by <c>dotnet test</c> with a
 /// filter selecting <see cref="CrossProcessGlossaryWriterHelper"/> - the repository has no spare console
@@ -28,9 +28,20 @@ namespace CcDirector.Gateway.Tests;
 /// inert unless its environment variable is present, so a normal suite run never executes the writing path.
 ///
 /// WHAT THIS STILL DOES NOT PROVE, stated plainly rather than left implied: it proves the lock serialises
-/// two processes on THIS machine's local file system. It does NOT prove that the operating system's file
-/// locking is honoured by the hosted deployment's network file share, which no test in this repository can
-/// reach. If that guarantee matters it needs a check against the real share, not a unit test.
+/// two processes on a LOCAL file system. It does NOT prove that the operating system's file locking is
+/// honoured by the hosted deployment's NETWORK FILE SHARE, which no test in this repository can reach. A
+/// hosted Gateway running two containers against one share therefore rests on an assumption, not on this
+/// evidence; the gap is tracked as its own issue. If that guarantee matters it needs a check against the
+/// real share, not a unit test.
+///
+/// AND THE TRAP THAT ALMOST MADE THIS TEST WORTHLESS, kept here because it will catch the next person too:
+/// A CROSS-PROCESS TEST THAT RACES NOTHING STILL PASSES. The first version reported a child that "wrote
+/// nothing" - it had written all forty terms, into its OWN redirected root, because this assembly's
+/// start-up points CC_DIRECTOR_ROOT at a per-run isolated directory and overwrote the value the parent
+/// passed. Had the parent not checked that both sides actually wrote, it would have raced only itself,
+/// passed, and certified a lock it never exercised. Hence: the child re-asserts the parent's root from a
+/// variable the redirect does not touch, it writes a diagnostics file, and the parent asserts BOTH sides
+/// wrote before judging anything.
 /// </summary>
 public sealed class CrossProcessGlossaryLockTests : IDisposable
 {

--- a/src/CcDirector.Gateway.UnitTests/SessionKeyGuardTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionKeyGuardTests.cs
@@ -219,8 +219,31 @@ public sealed class SessionKeyGuardTests
     public void A_session_may_add_a_dictionary_term()
     {
         // The owner's ruling of 2026-08-07: an agent may add words to the dictation dictionary, with no
-        // confirmation step in the way. This is the ONE route that grant opens.
+        // confirmation step in the way. This is the ONE write route that grant opens.
         Assert.True(SessionKeyGuard.Check("POST", "/ingest/dictionary/terms").Allowed);
+    }
+
+    [Fact]
+    public void A_session_may_read_back_what_agents_added_but_not_the_glossary()
+    {
+        // The pair that carries the whole shape of the grant, and the one a later edit is most likely to
+        // collapse into "the dictionary is readable". It is not. The ADDITION TRAIL is open because it holds
+        // only what agents wrote - a person's own edit leaves no entry - so an agent reads back agents'
+        // writes and reaches none of the owner's curation. The GLOSSARY holds the owner's hand-added terms
+        // and every wrong-spellings list, and stays refused.
+        Assert.True(SessionKeyGuard.Check("GET", "/ingest/dictionary/additions").Allowed);
+        Assert.False(SessionKeyGuard.Check("GET", "/ingest/dictionary").Allowed);
+    }
+
+    [Fact]
+    public void The_addition_trail_is_readable_and_nothing_more()
+    {
+        // Finding is not acting. There is deliberately no verb to remove what the trail finds - pruning is
+        // the person's, in the Cockpit editor - so every write shape on this path is refused.
+        Assert.False(SessionKeyGuard.Check("POST", "/ingest/dictionary/additions").Allowed);
+        Assert.False(SessionKeyGuard.Check("PUT", "/ingest/dictionary/additions").Allowed);
+        Assert.False(SessionKeyGuard.Check("DELETE", "/ingest/dictionary/additions").Allowed);
+        Assert.False(SessionKeyGuard.Check("GET", "/ingest/dictionary/additions/sweep").Allowed);
     }
 
     [Theory]

--- a/src/CcDirector.Gateway.UnitTests/SessionKeyGuardTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionKeyGuardTests.cs
@@ -213,6 +213,49 @@ public sealed class SessionKeyGuardTests
         Assert.False(SessionKeyGuard.Check("GET", "/sessions/11111111-1111-1111-1111-111111111111/transcript").Allowed);
     }
 
+    // ---------- Adding a word to the dictation dictionary (issue #2484) ----------
+
+    [Fact]
+    public void A_session_may_add_a_dictionary_term()
+    {
+        // The owner's ruling of 2026-08-07: an agent may add words to the dictation dictionary, with no
+        // confirmation step in the way. This is the ONE route that grant opens.
+        Assert.True(SessionKeyGuard.Check("POST", "/ingest/dictionary/terms").Allowed);
+    }
+
+    [Theory]
+    // Replacing the whole glossary. This is the verb the Cockpit editor uses to save a hand-edited
+    // document, and it is exactly the loss the ruling forbids: it can drop a term, rename one, or empty a
+    // wrong-spellings list the owner relies on. A person does this; a session key does not.
+    [InlineData("PUT", "/ingest/dictionary")]
+    // Reading the glossary back. Not needed to add - adding is idempotent, a term already there is skipped -
+    // and the grant is deliberately no wider than the ruling's words.
+    [InlineData("GET", "/ingest/dictionary")]
+    // The suggestion surface: applying a suggestion writes a term AND its wrong spellings, dismissing and
+    // restoring change what the owner is shown, and scanning reads his transcripts.
+    [InlineData("GET", "/ingest/dictionary/suggestions")]
+    [InlineData("POST", "/ingest/dictionary/suggestions/scan")]
+    [InlineData("POST", "/ingest/dictionary/suggestions/apply")]
+    [InlineData("POST", "/ingest/dictionary/suggestions/dismiss")]
+    [InlineData("GET", "/ingest/dictionary/dismissed")]
+    [InlineData("POST", "/ingest/dictionary/dismissed/restore")]
+    // The rest of the ingest surface is recordings - dictation audio and transcripts, which are the
+    // owner's. The add grant opens one route, not the prefix it sits under.
+    [InlineData("GET", "/ingest/recordings")]
+    [InlineData("POST", "/ingest/recording")]
+    [InlineData("GET", "/ingest/recording/r-1/transcript")]
+    [InlineData("DELETE", "/ingest/recording/r-1")]
+    [InlineData("PATCH", "/ingest/recording/r-1/meta")]
+    // The verb decides as much as the path: only POST adds.
+    [InlineData("GET", "/ingest/dictionary/terms")]
+    [InlineData("PUT", "/ingest/dictionary/terms")]
+    [InlineData("DELETE", "/ingest/dictionary/terms")]
+    // And nothing hangs off the add route.
+    [InlineData("POST", "/ingest/dictionary/terms/delete")]
+    [InlineData("DELETE", "/ingest/dictionary/terms/kubernetes")]
+    public void The_dictionary_grant_is_add_only(string method, string path)
+        => Assert.False(SessionKeyGuard.Check(method, path).Allowed, $"{method} {path} must NOT be allowed");
+
     [Theory]
     // Device registration and enrolment. The owner named this one himself: a credential that can enrol a
     // device can admit a NEW device, which is not configuring the product - it is the boundary itself.

--- a/src/CcDirector.Gateway.UnitTests/TenantGlossaryWriterRaceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TenantGlossaryWriterRaceTests.cs
@@ -27,7 +27,15 @@ namespace CcDirector.Gateway.Tests;
 /// person is FOR), and the agent's term may legitimately land on top of the save. What may never happen is
 /// the torn middle, where the agent's word is kept and the person's curation is dropped, because that is
 /// half of each write and no ordering at all. Asserting one fixed winner would be asserting a race.
+///
+/// IN THE "DirectorRoot" COLLECTION because this class redirects the process-wide <c>CC_DIRECTOR_ROOT</c>,
+/// which every test in the process shares. Left out of it, this class ran in parallel with tests that
+/// resolve their storage from that variable, redirected them mid-run, and then deleted the directory from
+/// under them on dispose - surfacing as four UNRELATED tests failing with "unable to open database file".
+/// A test that exercises concurrency is not exempt from the rule about process-global state; it is the
+/// likeliest to break it.
 /// </summary>
+[Collection("DirectorRoot")]
 public sealed class TenantGlossaryWriterRaceTests : IDisposable
 {
     private const int Rounds = 60;

--- a/src/CcDirector.Gateway.UnitTests/TenantGlossaryWriterRaceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TenantGlossaryWriterRaceTests.cs
@@ -179,6 +179,156 @@ public sealed class TenantGlossaryWriterRaceTests : IDisposable
         }
     }
 
+    // ---------- THE GLOSSARY AND ITS PROVENANCE MOVE TOGETHER OR NOT AT ALL ----------
+
+    /// <summary>An agent add exactly as the endpoint composes it: change the glossary and record who did
+    /// it, as one atomic pair.</summary>
+    private static void AgentAdds(TenantId tenant, string sessionId, string term) =>
+        TenantGlossaryWriter.MutateAndRecord(
+            tenant,
+            current =>
+            {
+                var vocab = current.Vocabulary.ToList();
+                var added = new List<string>();
+                if (!vocab.Any(v => string.Equals(v, term, StringComparison.OrdinalIgnoreCase)))
+                {
+                    vocab.Add(term);
+                    added.Add(term);
+                }
+                return (new DictationDictionary(vocab, current.CommonMistranscriptions, current.Profiles),
+                        (IReadOnlyList<string>)added);
+            },
+            sessionId,
+            "director-race",
+            new DateTime(2026, 8, 7, 12, 0, 0, DateTimeKind.Utc));
+
+    /// <summary>
+    /// EVERY SURVIVING TERM HAS ITS TRAIL ENTRY - the invariant the first round of racing tests was
+    /// structurally blind to.
+    ///
+    /// Those tests asserted glossary state only, and the glossary was perfectly correct in every run while
+    /// the provenance write sat outside the lock, appended unlocked, and swallowed its own failure. So two
+    /// sessions could both land their terms with one session's trail entries lost, and
+    /// `dictionary additions` would then be unable to find that session's bad batch - which is the whole
+    /// purpose of the record. A term nobody can attribute is un-sweepable.
+    /// </summary>
+    [Fact]
+    public void Two_racing_sessions_each_keep_their_provenance()
+    {
+        for (var round = 0; round < Rounds; round++)
+        {
+            var tenant = TenantFor(round);
+            var sessionOne = $"11111111-0000-0000-0000-{round:D12}";
+            var sessionTwo = $"22222222-0000-0000-0000-{round:D12}";
+
+            RaceTwo(
+                () => AgentAdds(tenant, sessionOne, "Kubernetes"),
+                () => AgentAdds(tenant, sessionTwo, "Helm"));
+
+            var glossary = TenantGlossary.Load(tenant);
+            var trail = GlossaryAdditionLog.Read(tenant);
+
+            // Neither add is a replace, so both words must be there...
+            Assert.Contains("Kubernetes", glossary.Vocabulary);
+            Assert.Contains("Helm", glossary.Vocabulary);
+
+            // ...and every one of them must be attributable, which is the half that used to be losable.
+            foreach (var term in glossary.Vocabulary)
+                Assert.True(trail.Any(e => e.Term == term),
+                    $"round {round}: '{term}' is in the glossary with NO trail entry - it cannot be traced " +
+                    $"or swept. Trail holds: [{string.Join(", ", trail.Select(e => e.Term))}]");
+
+            // And the two sessions are still told apart, which is what makes a batch findable.
+            Assert.Equal("Kubernetes", trail.Single(e => e.SessionId == sessionOne).Term);
+            Assert.Equal("Helm", trail.Single(e => e.SessionId == sessionTwo).Term);
+        }
+    }
+
+    /// <summary>Eight at once. Two writers can miss a narrow window by luck; this is the version that fails
+    /// loudly when the trail append is unlocked, because concurrent appends to one file lose lines.</summary>
+    [Fact]
+    public void Many_racing_sessions_lose_no_provenance()
+    {
+        const int writers = 8;
+        for (var round = 0; round < 15; round++)
+        {
+            var tenant = TenantFor(round);
+            using var gate = new ManualResetEventSlim(false);
+            Exception? failure = null;
+
+            var threads = Enumerable.Range(0, writers).Select(i => new Thread(() =>
+            {
+                try
+                {
+                    gate.Wait();
+                    AgentAdds(tenant, $"session-{i}", $"term-{i}");
+                }
+                catch (Exception ex) { Interlocked.CompareExchange(ref failure, ex, null); }
+            })).ToList();
+
+            foreach (var t in threads) t.Start();
+            gate.Set();
+            foreach (var t in threads) t.Join();
+
+            if (failure is not null)
+                throw new Xunit.Sdk.XunitException($"round {round}: a concurrent writer threw: {failure}");
+
+            var glossary = TenantGlossary.Load(tenant);
+            var trail = GlossaryAdditionLog.Read(tenant);
+
+            Assert.Equal(writers, glossary.Vocabulary.Count);
+            for (var i = 0; i < writers; i++)
+            {
+                Assert.Contains($"term-{i}", glossary.Vocabulary);
+                Assert.True(trail.Any(e => e.Term == $"term-{i}" && e.SessionId == $"session-{i}"),
+                    $"round {round}: term-{i} landed in the glossary but its provenance was LOST - " +
+                    $"trail has {trail.Count} of {writers} entries");
+            }
+        }
+    }
+
+    // ---------- A TRAIL THAT CANNOT BE WRITTEN FAILS THE ADD ----------
+
+    /// <summary>
+    /// If the provenance cannot be recorded, the word must NOT be added. The record used to be written after
+    /// the glossary, inside a catch that swallowed the failure and let the add report success - a silent
+    /// loss of exactly the guarantee the owner traded the confirmation step for.
+    ///
+    /// The failure is forced by putting a DIRECTORY where the trail file belongs, so the append cannot
+    /// succeed. What is asserted is not just that it throws, but that the glossary is untouched afterwards:
+    /// throwing while having already added the word would leave the forbidden state behind and merely
+    /// report it.
+    /// </summary>
+    [Fact]
+    public void An_add_whose_provenance_cannot_be_written_fails_and_adds_nothing()
+    {
+        var tenant = TenantFor(0);
+
+        // Make the trail unwritable: a directory sitting exactly where the append expects a file.
+        var trailPath = GlossaryAdditionLog.PathFor(tenant);
+        Directory.CreateDirectory(trailPath);
+
+        Assert.ThrowsAny<Exception>(() => AgentAdds(tenant, "session-one", "Kubernetes"));
+
+        // The word must not be in the glossary. This is the assertion that distinguishes "fails loudly"
+        // from "fails loudly after doing the damage".
+        var glossary = TenantGlossary.Load(tenant);
+        Assert.DoesNotContain("Kubernetes", glossary.Vocabulary);
+    }
+
+    /// <summary>The control for the test above: with the trail writable, the identical call succeeds and
+    /// records. Without this, a bug that made every add throw would pass the failure test.</summary>
+    [Fact]
+    public void The_same_add_succeeds_when_the_provenance_can_be_written()
+    {
+        var tenant = TenantFor(0);
+
+        AgentAdds(tenant, "session-one", "Kubernetes");
+
+        Assert.Contains("Kubernetes", TenantGlossary.Load(tenant).Vocabulary);
+        Assert.Equal("Kubernetes", GlossaryAdditionLog.Read(tenant).Single().Term);
+    }
+
     [Fact]
     public void Many_concurrent_adds_lose_nothing()
     {

--- a/src/CcDirector.Gateway.UnitTests/TenantGlossaryWriterRaceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TenantGlossaryWriterRaceTests.cs
@@ -1,0 +1,222 @@
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// A CONCURRENT HUMAN EDIT MUST SURVIVE AN AGENT ADD, AND VICE VERSA - the invariant the owner's ruling for
+/// issue #2484 rests on, proven by actually racing two writers rather than describing them.
+///
+/// THE DEFECT THESE TESTS PIN. Every glossary writer used to do an unguarded read-modify-write, so a
+/// person's Cockpit save landing between another caller's read and write was erased - wrong-spellings list
+/// and all - and two concurrent additions could lose one of the terms. That makes the sentence the whole
+/// grant was justified by ("worst case is a stray extra word, never the loss of a correction the owner
+/// relies on") FALSE: add-only would be true of the verb and false of the effect.
+///
+/// WHY A SERIAL TEST CANNOT SEE THIS, WHICH IS EXACTLY WHY IT SURVIVED THE FIRST SUITE. Run one writer then
+/// the other and every version of this code passes, including the broken one - the window only exists when
+/// a second writer is inside the first one's read-modify-write. So these tests start both writers together
+/// and repeat the race enough times to hit the window.
+///
+/// WHAT IS ASSERTED IS LINEARIZABILITY, NOT A FIXED ANSWER. Two legal outcomes exist when a person's whole
+/// document save races an agent's add, and which one wins is a genuine race: the person's save may
+/// legitimately overwrite the agent's term (an explicit human save is authoritative - pruning is what the
+/// person is FOR), and the agent's term may legitimately land on top of the save. What may never happen is
+/// the torn middle, where the agent's word is kept and the person's curation is dropped, because that is
+/// half of each write and no ordering at all. Asserting one fixed winner would be asserting a race.
+/// </summary>
+public sealed class TenantGlossaryWriterRaceTests : IDisposable
+{
+    private const int Rounds = 60;
+
+    private readonly string _root;
+    private readonly string? _priorRoot;
+
+    public TenantGlossaryWriterRaceTests()
+    {
+        _priorRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "cc-glossary-race-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _priorRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>A distinct tenant per round, so one round's file cannot carry state into the next and turn a
+    /// lost update into a pass.</summary>
+    private static TenantId TenantFor(int round) => new($"race-tenant-{round}-{Guid.NewGuid():N}");
+
+    /// <summary>The person's curated document: a term with a wrong-spellings list they just edited. Losing
+    /// that list is the exact harm the ruling forbids.</summary>
+    private static DictationDictionary PersonsCuration() => new(
+        new List<string> { "Frederiksen" },
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+        {
+            ["Frederiksen"] = new List<string> { "Fredrickson", "Fredriksson" },
+        },
+        new Dictionary<string, DictationProfile>(StringComparer.Ordinal));
+
+    /// <summary>Release both threads at the same instant. Starting them sequentially would usually let the
+    /// first finish before the second began, which is a serial test wearing a race's clothes.</summary>
+    private static void RaceTwo(Action first, Action second)
+    {
+        using var gate = new ManualResetEventSlim(false);
+        Exception? failure = null;
+
+        void Run(Action action)
+        {
+            try { gate.Wait(); action(); }
+            catch (Exception ex) { Interlocked.CompareExchange(ref failure, ex, null); }
+        }
+
+        var a = new Thread(() => Run(first));
+        var b = new Thread(() => Run(second));
+        a.Start();
+        b.Start();
+        gate.Set();
+        a.Join();
+        b.Join();
+
+        if (failure is not null)
+            throw new Xunit.Sdk.XunitException($"A racing writer threw: {failure}");
+    }
+
+    [Fact]
+    public void A_persons_save_racing_an_agent_add_is_never_half_lost()
+    {
+        for (var round = 0; round < Rounds; round++)
+        {
+            var tenant = TenantFor(round);
+
+            RaceTwo(
+                // The person saves their curated document from the Cockpit editor.
+                () => TenantGlossaryWriter.Replace(tenant, PersonsCuration()),
+                // An agent adds a word at the same moment.
+                () => TenantGlossary.AddTerms(
+                    tenant,
+                    new[] { "Kubernetes" },
+                    new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)));
+
+            var final = TenantGlossary.Load(tenant);
+
+            // Both orderings keep the person's term AND its wrong spellings. The broken code produced a
+            // document holding "Kubernetes" with the person's list gone - half of each write.
+            Assert.Contains("Frederiksen", final.Vocabulary);
+            Assert.True(final.CommonMistranscriptions.ContainsKey("Frederiksen"),
+                $"round {round}: the person's wrong-spellings list was ERASED by a concurrent agent add - " +
+                "this is the loss the owner's ruling forbids");
+            Assert.Equal(
+                new[] { "Fredrickson", "Fredriksson" },
+                final.CommonMistranscriptions["Frederiksen"].ToArray());
+
+            // And the result is one of the two legal serial orderings, never a third thing.
+            var agentWordSurvived = final.Vocabulary.Contains("Kubernetes");
+            var legal = agentWordSurvived
+                ? final.Vocabulary.Count == 2   // person's save, then the add landed on top
+                : final.Vocabulary.Count == 1;  // the add, then the person's save replaced it - also legal
+            Assert.True(legal, $"round {round}: final vocabulary is no serial ordering: [{string.Join(", ", final.Vocabulary)}]");
+        }
+    }
+
+    [Fact]
+    public void Two_concurrent_agent_adds_both_survive()
+    {
+        for (var round = 0; round < Rounds; round++)
+        {
+            var tenant = TenantFor(round);
+            var empty = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+
+            RaceTwo(
+                () => TenantGlossary.AddTerms(tenant, new[] { "Kubernetes" }, empty),
+                () => TenantGlossary.AddTerms(tenant, new[] { "Helm" }, empty));
+
+            var final = TenantGlossary.Load(tenant);
+
+            // Neither add is a replace, so there is no ordering in which one is lost. Unguarded, the second
+            // writer's stale copy overwrote the first's word.
+            Assert.Contains("Kubernetes", final.Vocabulary);
+            Assert.Contains("Helm", final.Vocabulary);
+            Assert.Equal(2, final.Vocabulary.Count);
+        }
+    }
+
+    [Fact]
+    public void A_wrong_spellings_edit_racing_an_add_keeps_both()
+    {
+        // The suggestion-apply path writes a term AND its wrong spellings, and an agent add races it. Both
+        // are additive, so both must be present afterwards - this is the writer that used to share one
+        // <path>.tmp staging file with everything else.
+        for (var round = 0; round < Rounds; round++)
+        {
+            var tenant = TenantFor(round);
+
+            RaceTwo(
+                () => TenantGlossary.AddTerms(
+                    tenant,
+                    new[] { "mindzie" },
+                    new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+                    {
+                        ["mindzie"] = new List<string> { "Mindsee" },
+                    }),
+                () => TenantGlossary.AddTerms(
+                    tenant,
+                    new[] { "Kubernetes" },
+                    new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)));
+
+            var final = TenantGlossary.Load(tenant);
+
+            Assert.Contains("mindzie", final.Vocabulary);
+            Assert.Contains("Kubernetes", final.Vocabulary);
+            Assert.True(final.CommonMistranscriptions.ContainsKey("mindzie"), $"round {round}: wrong spellings lost");
+            Assert.Contains("Mindsee", final.CommonMistranscriptions["mindzie"]);
+        }
+    }
+
+    [Fact]
+    public void Many_concurrent_adds_lose_nothing()
+    {
+        // Two writers can miss a narrow window by luck. Eight at once, repeatedly, is the version that fails
+        // loudly on an unguarded read-modify-write.
+        const int writers = 8;
+        for (var round = 0; round < 15; round++)
+        {
+            var tenant = TenantFor(round);
+            var empty = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+            using var gate = new ManualResetEventSlim(false);
+            Exception? failure = null;
+
+            // Every writer's exception is CAUGHT and reported. An exception escaping a raw thread kills the
+            // whole test host - the run aborts instead of failing, which hides every test after it and
+            // reports nothing useful about this one. (The unguarded version really does throw here: two
+            // writers collide on the shared <path>.tmp staging file.)
+            var threads = Enumerable.Range(0, writers).Select(i => new Thread(() =>
+            {
+                try
+                {
+                    gate.Wait();
+                    TenantGlossary.AddTerms(tenant, new[] { $"term-{i}" }, empty);
+                }
+                catch (Exception ex) { Interlocked.CompareExchange(ref failure, ex, null); }
+            })).ToList();
+
+            foreach (var t in threads) t.Start();
+            gate.Set();
+            foreach (var t in threads) t.Join();
+
+            if (failure is not null)
+                throw new Xunit.Sdk.XunitException($"round {round}: a concurrent writer threw: {failure}");
+
+            var final = TenantGlossary.Load(tenant);
+            for (var i = 0; i < writers; i++)
+                Assert.True(final.Vocabulary.Contains($"term-{i}"),
+                    $"round {round}: term-{i} was lost - {writers} concurrent adds produced {final.Vocabulary.Count}");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -302,9 +302,11 @@ internal static class RecordingEndpoints
                 if (dto is null)
                     return Results.BadRequest(new { error = "dictionary body required" });
 
-                var path = GlossaryPathFor(t.Value);
-                DictionaryLoader.WriteToDisk(path, FromDto(dto));
-                var reread = DictionaryLoader.LoadFromDisk(path);
+                // Through TenantGlossaryWriter, taking the SAME per-tenant lock the additive path takes.
+                // A whole-document save needs no read of its own, but if it can land in the MIDDLE of
+                // somebody else's read-modify-write then their stale copy is written back over it and this
+                // person's save vanishes - which was the human-edit-lost case found reviewing #2484.
+                var reread = TenantGlossaryWriter.Replace(t.Value, FromDto(dto));
                 return Results.Json(ToDto(reread));
             }
             catch (JsonException ex)
@@ -362,46 +364,57 @@ internal static class RecordingEndpoints
                     }, statusCode: StatusCodes.Status403Forbidden);
                 }
 
-                var path = GlossaryPathFor(t.Value);
-                var current = ToDto(DictionaryLoader.LoadFromDisk(path));
-
-                // The terms that are ACTUALLY new, so the trail below names a session that changed
-                // something. Matched case-insensitively for the same reason TenantGlossary.AddTerms does:
-                // "kubernetes" beside "Kubernetes" is two entries for one word, and the existing one wins.
+                // The terms that were ACTUALLY new, so the trail below names a session that changed
+                // something. Filled INSIDE the lock, from the document the writer hands over - deciding
+                // "is this term already there?" against a copy read outside the lock is the stale read
+                // that made a concurrent human edit losable in the first place.
                 var added = new List<string>();
-                foreach (var term in add.Terms ?? new())
-                {
-                    var trimmed = term?.Trim();
-                    if (!string.IsNullOrWhiteSpace(trimmed) &&
-                        !current.Vocabulary.Any(v => string.Equals(v, trimmed, StringComparison.OrdinalIgnoreCase)))
-                    {
-                        current.Vocabulary.Add(trimmed);
-                        added.Add(trimmed);
-                    }
-                }
 
-                foreach (var kv in add.Mistranscriptions ?? new())
+                var reread = TenantGlossaryWriter.Mutate(t.Value, current =>
                 {
-                    var term = kv.Key?.Trim();
-                    if (string.IsNullOrWhiteSpace(term) || kv.Value is null)
-                        continue;
-                    if (!current.CommonMistranscriptions.TryGetValue(term, out var variants))
-                    {
-                        variants = new List<string>();
-                        current.CommonMistranscriptions[term] = variants;
-                    }
-                    foreach (var v in kv.Value)
-                    {
-                        var vv = v?.Trim();
-                        if (!string.IsNullOrWhiteSpace(vv) && !variants.Contains(vv))
-                            variants.Add(vv);
-                    }
-                }
+                    // The writer calls this once inside the lock; cleared anyway so that if it ever gains a
+                    // retry, a second pass cannot report a term twice.
+                    added.Clear();
+                    var document = ToDto(current);
 
-                DictionaryLoader.WriteToDisk(path, FromDto(current));
+                    // Matched case-insensitively for the same reason TenantGlossary.Merge does:
+                    // "kubernetes" beside "Kubernetes" is two entries for one word, and the existing wins.
+                    foreach (var term in add.Terms ?? new())
+                    {
+                        var trimmed = term?.Trim();
+                        if (!string.IsNullOrWhiteSpace(trimmed) &&
+                            !document.Vocabulary.Any(v => string.Equals(v, trimmed, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            document.Vocabulary.Add(trimmed);
+                            added.Add(trimmed);
+                        }
+                    }
+
+                    foreach (var kv in add.Mistranscriptions ?? new())
+                    {
+                        var term = kv.Key?.Trim();
+                        if (string.IsNullOrWhiteSpace(term) || kv.Value is null)
+                            continue;
+                        if (!document.CommonMistranscriptions.TryGetValue(term, out var variants))
+                        {
+                            variants = new List<string>();
+                            document.CommonMistranscriptions[term] = variants;
+                        }
+                        foreach (var v in kv.Value)
+                        {
+                            var vv = v?.Trim();
+                            if (!string.IsNullOrWhiteSpace(vv) && !variants.Contains(vv))
+                                variants.Add(vv);
+                        }
+                    }
+
+                    return FromDto(document);
+                });
 
                 // Record WHICH SESSION added the word. There is no confirmation step by the owner's ruling,
-                // so this trail is the only thing that lets a bad entry be traced and swept later.
+                // so this trail is the only thing that lets a bad entry be traced and swept later. Outside
+                // the glossary lock on purpose: it writes a different file, and holding a lock across two
+                // files is how two writers that each want both end up deadlocked.
                 if (callingSession is not null)
                     GlossaryAdditionLog.Record(
                         t.Value,
@@ -410,7 +423,7 @@ internal static class RecordingEndpoints
                         added,
                         DateTime.UtcNow);
 
-                return Results.Json(ToDto(DictionaryLoader.LoadFromDisk(path)));
+                return Results.Json(ToDto(reread));
             }
             catch (JsonException ex)
             {

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -317,6 +317,23 @@ internal static class RecordingEndpoints
         // Additive convenience endpoint so an agent in a session can add a term
         // (and optional mistranscription spellings) without round-tripping the
         // whole document. Existing entries are preserved; duplicates are ignored.
+        //
+        // THE ONE ROUTE UNDER /ingest A SESSION KEY MAY CALL (issue #2484, the owner's ruling of
+        // 2026-08-07). SessionKeyGuard opens POST /ingest/dictionary/terms and nothing else here, so an
+        // agent adds a word with no confirmation step in the way. THIS handler enforces the half of that
+        // grant a path cannot express: the same route carries a term AND a wrong-spellings map, and only a
+        // reader of the body can tell them apart. For a SESSION caller:
+        //
+        //   * 'terms' is accepted - a new word goes in, a word already present is skipped, nothing is
+        //     removed or renamed. Worst case is a stray extra word, which is exactly the worst case the
+        //     ruling weighed and accepted;
+        //   * 'mistranscriptions' is REFUSED. A wrong-spellings entry rewrites what the transcriber HEARS,
+        //     so a careless one ("the" -> "Kubernetes") corrupts dictation everywhere rather than leaving a
+        //     stray word, and on an existing term the ruling forbids touching that list outright. Refusing
+        //     the field wholesale is what makes "worst case is a stray extra word" a true sentence rather
+        //     than an approximate one.
+        //
+        // A person in the Cockpit, or a device key, is unchanged and may still send both.
         app.MapPost("/dictionary/terms", async (HttpContext ctx) =>
         {
             var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
@@ -330,14 +347,37 @@ internal static class RecordingEndpoints
                 if (add is null || (!hasTerms && !hasPatterns))
                     return Results.BadRequest(new { error = "provide 'terms' and/or 'mistranscriptions'" });
 
+                // Read the caller from the identity the auth gate resolved, never from the raw request -
+                // see AuthMiddleware.CallingSession. Null means the caller is not a session (the Cockpit,
+                // the phone, a Director), and the add-only narrowing does not apply to them.
+                var callingSession = Util.AuthMiddleware.CallingSession(ctx);
+                if (callingSession is not null && hasPatterns)
+                {
+                    FileLog.Write($"[RecordingEndpoints] dictionary add REFUSED wrong spellings from session {callingSession.SessionId}");
+                    return Results.Json(new
+                    {
+                        error = "a session key may add vocabulary 'terms' only; 'mistranscriptions' " +
+                                "(the wrong-spellings list) is edited by a person in the Cockpit dictionary editor",
+                        code = "session_key_add_only",
+                    }, statusCode: StatusCodes.Status403Forbidden);
+                }
+
                 var path = GlossaryPathFor(t.Value);
                 var current = ToDto(DictionaryLoader.LoadFromDisk(path));
 
+                // The terms that are ACTUALLY new, so the trail below names a session that changed
+                // something. Matched case-insensitively for the same reason TenantGlossary.AddTerms does:
+                // "kubernetes" beside "Kubernetes" is two entries for one word, and the existing one wins.
+                var added = new List<string>();
                 foreach (var term in add.Terms ?? new())
                 {
                     var trimmed = term?.Trim();
-                    if (!string.IsNullOrWhiteSpace(trimmed) && !current.Vocabulary.Contains(trimmed))
+                    if (!string.IsNullOrWhiteSpace(trimmed) &&
+                        !current.Vocabulary.Any(v => string.Equals(v, trimmed, StringComparison.OrdinalIgnoreCase)))
+                    {
                         current.Vocabulary.Add(trimmed);
+                        added.Add(trimmed);
+                    }
                 }
 
                 foreach (var kv in add.Mistranscriptions ?? new())
@@ -359,6 +399,17 @@ internal static class RecordingEndpoints
                 }
 
                 DictionaryLoader.WriteToDisk(path, FromDto(current));
+
+                // Record WHICH SESSION added the word. There is no confirmation step by the owner's ruling,
+                // so this trail is the only thing that lets a bad entry be traced and swept later.
+                if (callingSession is not null)
+                    GlossaryAdditionLog.Record(
+                        t.Value,
+                        callingSession.SessionId.ToString(),
+                        callingSession.DirectorId,
+                        added,
+                        DateTime.UtcNow);
+
                 return Results.Json(ToDto(DictionaryLoader.LoadFromDisk(path)));
             }
             catch (JsonException ex)

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -370,7 +370,12 @@ internal static class RecordingEndpoints
                 // that made a concurrent human edit losable in the first place.
                 var added = new List<string>();
 
-                var reread = TenantGlossaryWriter.Mutate(t.Value, current =>
+                // MutateAndRecord, not Mutate: the glossary change and the provenance record are ONE atomic
+                // pair inside one per-tenant lock, with the record written first. The record used to happen
+                // out here, after the lock was released, appending unlocked and swallowing its own failure -
+                // so two sessions could both land their terms while one session's trail entries vanished,
+                // and a word with no trail entry is un-traceable and therefore un-sweepable.
+                var reread = TenantGlossaryWriter.MutateAndRecord(t.Value, current =>
                 {
                     // The writer calls this once inside the lock; cleared anyway so that if it ever gains a
                     // retry, a second pass cannot report a term twice.
@@ -408,20 +413,11 @@ internal static class RecordingEndpoints
                         }
                     }
 
-                    return FromDto(document);
-                });
-
-                // Record WHICH SESSION added the word. There is no confirmation step by the owner's ruling,
-                // so this trail is the only thing that lets a bad entry be traced and swept later. Outside
-                // the glossary lock on purpose: it writes a different file, and holding a lock across two
-                // files is how two writers that each want both end up deadlocked.
-                if (callingSession is not null)
-                    GlossaryAdditionLog.Record(
-                        t.Value,
-                        callingSession.SessionId.ToString(),
-                        callingSession.DirectorId,
-                        added,
-                        DateTime.UtcNow);
+                    return (FromDto(document), (IReadOnlyList<string>)added);
+                },
+                callingSession?.SessionId.ToString(),
+                callingSession?.DirectorId ?? "",
+                DateTime.UtcNow);
 
                 return Results.Json(ToDto(reread));
             }
@@ -429,6 +425,32 @@ internal static class RecordingEndpoints
             {
                 FileLog.Write($"[RecordingEndpoints] dictionary add bad JSON: {ex.Message}");
                 return Results.BadRequest(new { error = "invalid JSON" });
+            }
+            catch (IOException ex)
+            {
+                // The glossary lock could not be taken, or the provenance record could not be written. Both
+                // mean NOTHING was added, and both are reported as a failure rather than a success - an add
+                // that silently lost its provenance would silently lose the traceability the owner traded
+                // the confirmation step for.
+                FileLog.Write($"[RecordingEndpoints] dictionary add FAILED: {ex.Message}");
+                return Results.Json(new
+                {
+                    error = "the term was NOT added: the dictation glossary could not be written together " +
+                            "with the record of which session added it, and adding a word without that " +
+                            "record would leave an entry nobody could trace or sweep. " + ex.Message,
+                    code = "glossary_write_failed",
+                }, statusCode: StatusCodes.Status500InternalServerError);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                FileLog.Write($"[RecordingEndpoints] dictionary add FAILED: {ex.Message}");
+                return Results.Json(new
+                {
+                    error = "the term was NOT added: the dictation glossary could not be written together " +
+                            "with the record of which session added it, and adding a word without that " +
+                            "record would leave an entry nobody could trace or sweep. " + ex.Message,
+                    code = "glossary_write_failed",
+                }, statusCode: StatusCodes.Status500InternalServerError);
             }
         });
 

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -419,6 +419,35 @@ internal static class RecordingEndpoints
             }
         });
 
+        // WHAT AGENTS ADDED, AND WHICH ONE ADDED IT - the READ half of the traceability the owner's
+        // ruling asks for (issue #2484). Newest first.
+        //
+        // WHY THIS ROUTE HAD TO EXIST. The ruling says a bad entry must be able to be "traced AND swept".
+        // Writing the trail satisfies only the first verb: a record nothing can read is a file somebody has
+        // to go and find on disk, which is not a sweep, and the traceability the ruling traded the
+        // confirmation step for would have been nominal.
+        //
+        // WHY A SESSION KEY MAY READ IT, WHEN IT MAY NOT READ THE GLOSSARY. This serves the addition trail
+        // ONLY, and the trail contains exactly one thing: what AGENTS wrote. A person adding a term through
+        // the Cockpit is not a session and leaves no entry (asserted in AgentDictionaryAddTests), so the
+        // owner's own curation - his hand-added terms and every wrong-spellings list - is not in this file
+        // and is not reachable through this route. Letting agents read back what agents wrote exposes none
+        // of the owner's material, which is why this is not the widening that opening GET /ingest/dictionary
+        // would be. That route stays refused.
+        //
+        // Removal is still the person's, in the Cockpit editor. This route makes a bad batch FINDABLE; it
+        // deliberately offers no way to act on what it finds.
+        app.MapGet("/dictionary/additions", (HttpContext ctx) =>
+        {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (t is null) return TenantRequired();
+            var entries = GlossaryAdditionLog.Read(t.Value)
+                .Reverse()
+                .Select(e => new GlossaryAdditionDto(e.AddedAtUtc, e.Term, e.SessionId, e.DirectorId))
+                .ToList();
+            return Results.Json(new GlossaryAdditionsResponse(entries, entries.Count));
+        });
+
         // ===== Dictionary suggestions API (devthrottle #2075) ================
         // The server mines this tenant's stored transcripts for terms the model keeps getting wrong that are
         // not yet in the glossary, and offers them for one-press addition. Everything the Dictionary page does
@@ -970,6 +999,17 @@ internal sealed record DictionaryProfileDto(bool CleanupEnabled);
 internal sealed record DictionaryAddRequest(
     List<string>? Terms,
     Dictionary<string, List<string>>? Mistranscriptions);
+
+/// <summary>One entry of GET /ingest/dictionary/additions - a word an agent added, and which one (#2484).</summary>
+internal sealed record GlossaryAdditionDto(
+    DateTime AddedAtUtc,
+    string Term,
+    string SessionId,
+    string DirectorId);
+
+/// <summary>GET /ingest/dictionary/additions - what agents added to this tenant's glossary, newest first,
+/// plus the count (the client never re-derives it - rule 7).</summary>
+internal sealed record GlossaryAdditionsResponse(List<GlossaryAdditionDto> Additions, int Count);
 
 // ===== Dictionary suggestions DTOs (devthrottle #2075) ==================================================
 

--- a/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
+++ b/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
@@ -131,6 +131,38 @@ An unregistered name fails loudly, and a name matching two Directors fails listi
 falls back to another Director - if you get one of those errors, run `director list` and pick, rather
 than dropping the flag and spawning wherever.
 
+## Teaching dictation a word: `cc-devthrottle dictionary add`
+
+DevThrottle cleans up what it hears against a per-account glossary of words the person cares about -
+product names, surnames, repositories, tools. When the person says a word the transcriber keeps
+getting wrong, or when you notice one, add it:
+
+```
+cc-devthrottle dictionary add "Kubernetes"
+cc-devthrottle dictionary add "mindzie" "DevThrottle" "Frederiksen"
+```
+
+There is no confirmation step and you do not need to ask. The owner ruled on 2026-08-07 that being
+asked to confirm every addition is worse than the occasional stray entry, so just add the word.
+
+**SPELL IT THE WAY IT IS WRITTEN DOWN.** This is the one thing that can go wrong here, and it is
+yours to get right. The spelling you add becomes the CANONICAL one - it is what dictation will
+correct other spellings *to*. A word that reached you THROUGH dictation may already be mangled, and
+adding that mangled spelling as canonical teaches the transcriber the error instead of the fix. So
+take the spelling from something you can SEE: the repository in front of you, the code, the file
+name, the product's own page. Never add a spelling you only heard. If you are not sure how a word is
+written, look it up before adding it, or do not add it.
+
+**ADD ONLY - and that is deliberate, not a gap.** You can add a term. You CANNOT remove one, rename
+one, overwrite one, or touch the wrong-spellings list attached to an existing term. The Gateway
+refuses every one of those to a session key, so the worst you can do here is leave a stray extra
+word, and a correction the person relies on can never be lost. The person prunes the list in the
+Cockpit dictionary editor, where anything you added looks exactly like a word they typed themselves.
+
+**Which session added which word is recorded.** Because nothing confirms an addition at the time,
+the Gateway notes the adding session beside that account's glossary, so a bad entry can be traced
+back and swept later. Add carefully - the note says who did it.
+
 ## Closing a session - yours and the ones you started
 
 A session can close itself. When an agent has finished its work and nothing is waiting on the
@@ -196,8 +228,14 @@ use the identity the preamble gave you. If no user is named (nobody signed in), 
 - It does not replace the **fleet-comms** skill, which is the full reference for `cc-devthrottle`.
 
 
-**Skill Version:** 6.0 (no Director listener)
-**Last Updated:** 2026-08-03
+**Skill Version:** 6.1 (an agent can teach dictation a word)
+**Last Updated:** 2026-08-07
+**Changes in 6.1:** Added "Teaching dictation a word" - `cc-devthrottle dictionary add`, the owner's
+ruling of 2026-08-07 (issue #2484). An agent may add words to the dictation dictionary with no
+confirmation step; the grant is ADD ONLY (no delete, rename, overwrite, or wrong-spellings edit) and
+the adding session is recorded. The spelling instruction lives here rather than in a runtime prompt,
+because a rule an agent reads before it acts is the only kind that can stop a mangled word being
+added as canonical.
 **Changes in 6.0:** The remove-the-network-port mission deleted the Director's listener entirely.
 There is no loopback floor, no `/healthz`, no `/fleet/*` relay, no `/reconnect`, no local settings
 routes, and no `CC_DIRECTOR_API` or `CC_DIRECTOR_TOKEN` in any session's environment. Agents reach

--- a/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
+++ b/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
@@ -159,9 +159,19 @@ refuses every one of those to a session key, so the worst you can do here is lea
 word, and a correction the person relies on can never be lost. The person prunes the list in the
 Cockpit dictionary editor, where anything you added looks exactly like a word they typed themselves.
 
-**Which session added which word is recorded.** Because nothing confirms an addition at the time,
-the Gateway notes the adding session beside that account's glossary, so a bad entry can be traced
-back and swept later. Add carefully - the note says who did it.
+**Which session added which word is recorded, and you can read it back.** Because nothing confirms
+an addition at the time, the Gateway notes the adding session beside that account's glossary:
+
+```
+cc-devthrottle dictionary additions
+cc-devthrottle dictionary additions --session 9b2f     # one session's batch
+```
+
+That is how a bad entry gets traced and swept - find the session that added it, see the rest of what
+that session added, and hand the batch to the person to prune. Add carefully: the note says who did
+it. The trail shows only what AGENTS added; the person's own terms and every wrong-spellings list
+are not in it, which is why you can read this while the dictionary itself stays closed to you. You
+can find a bad batch; you cannot remove one.
 
 ## Closing a session - yours and the ones you started
 
@@ -230,12 +240,14 @@ use the identity the preamble gave you. If no user is named (nobody signed in), 
 
 **Skill Version:** 6.1 (an agent can teach dictation a word)
 **Last Updated:** 2026-08-07
-**Changes in 6.1:** Added "Teaching dictation a word" - `cc-devthrottle dictionary add`, the owner's
-ruling of 2026-08-07 (issue #2484). An agent may add words to the dictation dictionary with no
-confirmation step; the grant is ADD ONLY (no delete, rename, overwrite, or wrong-spellings edit) and
-the adding session is recorded. The spelling instruction lives here rather than in a runtime prompt,
-because a rule an agent reads before it acts is the only kind that can stop a mangled word being
-added as canonical.
+**Changes in 6.1:** Added "Teaching dictation a word" - `cc-devthrottle dictionary add` and
+`dictionary additions`, the owner's ruling of 2026-08-07 (issue #2484). An agent may add words to the
+dictation dictionary with no confirmation step; the grant is ADD ONLY (no delete, rename, overwrite,
+or wrong-spellings edit), the adding session is recorded, and that trail is readable so a bad entry
+can be traced and its batch swept - the ruling asks for both verbs, and writing a record nothing can
+read would satisfy only the first. The spelling instruction lives here rather than in a runtime
+prompt, because a rule an agent reads before it acts is the only kind that can stop a mangled word
+being added as canonical.
 **Changes in 6.0:** The remove-the-network-port mission deleted the Director's listener entirely.
 There is no loopback floor, no `/healthz`, no `/fleet/*` relay, no `/reconnect`, no local settings
 routes, and no `CC_DIRECTOR_API` or `CC_DIRECTOR_TOKEN` in any session's environment. Agents reach

--- a/src/CcDirector.Gateway/Transcription/GlossaryAdditionLog.cs
+++ b/src/CcDirector.Gateway/Transcription/GlossaryAdditionLog.cs
@@ -22,9 +22,12 @@ namespace CcDirector.Gateway.Transcription;
 /// itself being deleted, so the trail outlives what it describes. It also keeps the glossary schema
 /// untouched, which matters because the desktop, the phone and the Cockpit all read that schema.
 ///
-/// WHAT IT IS NOT. It is not an audit log and nothing enforces anything from it - it is a trail for a person
-/// (or a later sweep) to read. A failure to write it must never fail the addition: the word going in is the
-/// thing the owner asked for, and losing the note is a smaller harm than losing the word.
+/// A FAILURE TO WRITE IT FAILS THE ADDITION. This file originally said the opposite - that losing the note
+/// was a smaller harm than losing the word - and that was wrong. The owner traded away the confirmation step
+/// FOR this record, so a word added with nothing saying who added it cannot be traced and cannot be swept,
+/// which is the state the whole grant was justified against. <see cref="TenantGlossaryWriter.MutateAndRecord"/>
+/// therefore writes this INSIDE the glossary's per-tenant lock and BEFORE the glossary itself, so a throw
+/// here leaves nothing added and nothing recorded rather than a word with no provenance.
 /// </summary>
 public static class GlossaryAdditionLog
 {
@@ -66,19 +69,16 @@ public static class GlossaryAdditionLog
                 SessionId: sessionId,
                 DirectorId: directorId))).Append('\n');
 
-        // Entry point for a side effect that must never take the addition down with it: the word is in the
-        // glossary by the time this runs, and a disk that refused the note is not a reason to tell the agent
-        // its word did not land. Logged loudly so a trail that has stopped being written is visible.
-        try
-        {
-            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-            File.AppendAllText(path, builder.ToString());
-            FileLog.Write($"[GlossaryAdditionLog] Record: tenant={tenant.Value}, session={sessionId}, terms={terms.Count}");
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[GlossaryAdditionLog] Record FAILED (the terms were still added): {ex.Message}");
-        }
+        // NO CATCH HERE, AND THAT IS THE POINT. This used to swallow its own failure and let the addition
+        // report success, on the reasoning that losing the note was a smaller harm than losing the word.
+        // That reasoning was wrong (second review finding on #2484): the owner traded away the confirmation
+        // step FOR this record, so a word added with no trace of who added it is un-sweepable, and an add
+        // that returns success having silently lost the guarantee is worse than an add that fails. The
+        // caller writes this INSIDE the glossary lock and BEFORE the glossary itself, so a throw here leaves
+        // nothing added and nothing recorded.
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.AppendAllText(path, builder.ToString());
+        FileLog.Write($"[GlossaryAdditionLog] Record: tenant={tenant.Value}, session={sessionId}, terms={terms.Count}");
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Transcription/GlossaryAdditionLog.cs
+++ b/src/CcDirector.Gateway/Transcription/GlossaryAdditionLog.cs
@@ -1,0 +1,120 @@
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// WHICH SESSION ADDED WHICH WORD to a tenant's dictation glossary. Append-only, one line of JSON per term,
+/// beside that tenant's own <c>dictionary.yaml</c> (issue #2484).
+///
+/// WHY IT EXISTS. The owner ruled that an agent may add a word with NO confirmation step, because being
+/// asked every time is worse than the occasional bad entry. Remove the confirmation and nothing catches a
+/// bad entry AT WRITE TIME, so the only way a bad one is ever cleaned up is if the person can see where it
+/// came from: one stray word is a shrug, and "some agent, some time last week, added forty" is a sweep. That
+/// is the trade the ruling asks for and this file is the half that makes it payable.
+///
+/// WHY IT IS A SIDECAR AND NOT A FIELD IN THE GLOSSARY. The Cockpit dictionary editor saves the WHOLE
+/// document (<c>PUT /ingest/dictionary</c>), so provenance stored inside <c>dictionary.yaml</c> would be
+/// erased by the next hand-edit - it would be a record that vanished exactly when someone started curating,
+/// which is the moment it is wanted. A separate file survives every glossary write, and it survives the term
+/// itself being deleted, so the trail outlives what it describes. It also keeps the glossary schema
+/// untouched, which matters because the desktop, the phone and the Cockpit all read that schema.
+///
+/// WHAT IT IS NOT. It is not an audit log and nothing enforces anything from it - it is a trail for a person
+/// (or a later sweep) to read. A failure to write it must never fail the addition: the word going in is the
+/// thing the owner asked for, and losing the note is a smaller harm than losing the word.
+/// </summary>
+public static class GlossaryAdditionLog
+{
+    /// <summary>The file name that sits beside a tenant's <c>dictionary.yaml</c>.</summary>
+    internal const string FileName = "dictionary-additions.jsonl";
+
+    private static readonly JsonSerializerOptions Json = new() { PropertyNameCaseInsensitive = true };
+
+    /// <summary>This tenant's addition trail - always the directory its glossary lives in, so a per-tenant
+    /// glossary carries a per-tenant trail and one account's additions are never written into another's.</summary>
+    public static string PathFor(TenantId tenant)
+        => Path.Combine(Path.GetDirectoryName(TenantGlossary.PathFor(tenant))!, FileName);
+
+    /// <summary>
+    /// Note that <paramref name="sessionId"/> added <paramref name="terms"/> to this tenant's glossary.
+    /// Call it with the terms that were ACTUALLY new - a term already present was not added, and recording
+    /// it would put the reader onto a session that changed nothing.
+    /// </summary>
+    /// <param name="tenant">The tenant whose glossary was written. Required and valid.</param>
+    /// <param name="sessionId">The calling session, from the credential the auth gate resolved.</param>
+    /// <param name="directorId">The Director that session belongs to; may be empty.</param>
+    /// <param name="terms">The terms that were newly added. An empty list writes nothing.</param>
+    /// <param name="nowUtc">The time to stamp, so a test does not depend on the clock.</param>
+    public static void Record(
+        TenantId tenant,
+        string sessionId,
+        string directorId,
+        IReadOnlyList<string> terms,
+        DateTime nowUtc)
+    {
+        if (terms.Count == 0) return;
+
+        var path = PathFor(tenant);
+        var builder = new StringBuilder();
+        foreach (var term in terms)
+            builder.Append(JsonSerializer.Serialize(new GlossaryAddition(
+                AddedAtUtc: nowUtc,
+                Term: term,
+                SessionId: sessionId,
+                DirectorId: directorId))).Append('\n');
+
+        // Entry point for a side effect that must never take the addition down with it: the word is in the
+        // glossary by the time this runs, and a disk that refused the note is not a reason to tell the agent
+        // its word did not land. Logged loudly so a trail that has stopped being written is visible.
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.AppendAllText(path, builder.ToString());
+            FileLog.Write($"[GlossaryAdditionLog] Record: tenant={tenant.Value}, session={sessionId}, terms={terms.Count}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GlossaryAdditionLog] Record FAILED (the terms were still added): {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Read this tenant's addition trail, oldest first. An unreadable or malformed line is skipped rather
+    /// than throwing: this is a trail, and one corrupt line must not hide the rest of it.
+    /// </summary>
+    public static IReadOnlyList<GlossaryAddition> Read(TenantId tenant)
+    {
+        var path = PathFor(tenant);
+        if (!File.Exists(path)) return Array.Empty<GlossaryAddition>();
+
+        var entries = new List<GlossaryAddition>();
+        foreach (var line in File.ReadAllLines(path))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            try
+            {
+                if (JsonSerializer.Deserialize<GlossaryAddition>(line, Json) is { } entry)
+                    entries.Add(entry);
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[GlossaryAdditionLog] skipping unreadable line: {ex.Message}");
+            }
+        }
+        return entries;
+    }
+}
+
+/// <summary>One word, and who put it there.</summary>
+/// <param name="AddedAtUtc">When the term was added.</param>
+/// <param name="Term">The term as it went into the glossary.</param>
+/// <param name="SessionId">The session whose key made the call.</param>
+/// <param name="DirectorId">The Director that session belongs to; empty when unknown.</param>
+public sealed record GlossaryAddition(
+    DateTime AddedAtUtc,
+    string Term,
+    string SessionId,
+    string DirectorId);

--- a/src/CcDirector.Gateway/Transcription/TenantGlossary.cs
+++ b/src/CcDirector.Gateway/Transcription/TenantGlossary.cs
@@ -48,9 +48,25 @@ public static class TenantGlossary
         IReadOnlyList<string> vocabulary,
         IReadOnlyDictionary<string, IReadOnlyList<string>> mistranscriptions)
     {
-        var path = PathFor(tenant);
-        var current = DictionaryLoader.LoadFromDisk(path);
+        // Through TenantGlossaryWriter, so the read and the write are ONE step no other writer can
+        // interleave with. Unguarded, this could load the document, be overtaken by the person's Cockpit
+        // save, and write its now-stale copy back over it - erasing a wrong-spellings list they had just
+        // edited (found reviewing #2484).
+        return TenantGlossaryWriter.Mutate(tenant, current => Merge(current, vocabulary, mistranscriptions));
+    }
 
+    /// <summary>
+    /// The pure merge - existing document in, updated document out. Split from the write so the additive
+    /// rule can be read and tested without a file system, and so the ONLY thing left around the file access
+    /// is the lock. It must derive everything from <paramref name="current"/>: it runs inside the lock and
+    /// possibly after a wait, so a value captured before the wait is exactly the stale copy that caused the
+    /// defect.
+    /// </summary>
+    internal static DictationDictionary Merge(
+        DictationDictionary current,
+        IReadOnlyList<string> vocabulary,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> mistranscriptions)
+    {
         var vocab = current.Vocabulary.ToList();
         foreach (var term in vocabulary)
         {
@@ -79,9 +95,7 @@ public static class TenantGlossary
                 patterns[term] = variants;
         }
 
-        var updated = new DictationDictionary(vocab, patterns, current.Profiles);
-        DictionaryLoader.WriteToDisk(path, updated);
-        return DictionaryLoader.LoadFromDisk(path);
+        return new DictationDictionary(vocab, patterns, current.Profiles);
     }
 
     /// <summary>A filesystem-safe folder name for a tenant partition - identical to the sanitiser

--- a/src/CcDirector.Gateway/Transcription/TenantGlossaryWriter.cs
+++ b/src/CcDirector.Gateway/Transcription/TenantGlossaryWriter.cs
@@ -31,11 +31,22 @@ namespace CcDirector.Gateway.Transcription;
 /// HOW. Two gates, because there are two ways to race:
 ///   * a per-tenant monitor, for two requests inside THIS Gateway process - the common case, and the cheap
 ///     one;
-///   * an exclusive per-tenant LOCK FILE, for two Gateway processes over one shared file share. That is not
-///     hypothetical here: a hosted deploy has run two containers against one share, and a lock that lived
-///     only in memory would be silently useless in exactly the window a deploy opens.
+///   * an exclusive per-tenant LOCK FILE, for two Gateway PROCESSES writing the same glossary directory.
 /// Both are held across the whole read-modify-write, which is the point - a lock taken only around the
 /// write would still lose the update, because the loss happens between the read and the write.
+///
+/// EXACTLY WHAT THE FILE LOCK IS PROVEN TO DO, and nothing wider. It serialises two processes against a
+/// LOCAL file system: <c>CrossProcessGlossaryLockTests</c> races a real second operating-system process
+/// against this one, forty writes each, and without the file lock half of them vanish (80 terms expected,
+/// 40 actual). That is measured, and it is the whole of the claim.
+///
+/// IT IS NOT PROVEN on the hosted deployment's NETWORK FILE SHARE. Whether the operating system's file
+/// locking is honoured there is unknown and unreachable from this repository's test rig, so a Gateway
+/// running two containers against one share is NOT covered by evidence here - only by the assumption that
+/// the share honours the lock. That gap is tracked as its own issue rather than papered over. The reason
+/// this paragraph exists at all: the in-process monitor makes single-process tests pass whether the file
+/// lock works or not, so a claim about processes could sit here indefinitely with nothing checking it - as
+/// this one did until review asked.
 ///
 /// The critical section is deliberately SYNCHRONOUS end to end. An await inside it would let the
 /// continuation resume on another thread while the monitor was held by the first, which is the standard way

--- a/src/CcDirector.Gateway/Transcription/TenantGlossaryWriter.cs
+++ b/src/CcDirector.Gateway/Transcription/TenantGlossaryWriter.cs
@@ -83,6 +83,63 @@ public static class TenantGlossaryWriter
         => Mutate(tenant, _ => replacement);
 
     /// <summary>
+    /// Change this tenant's glossary AND record which session added what, as ONE atomic pair - the whole
+    /// point being that neither half can be observed without the other.
+    ///
+    /// WHY THIS EXISTS SEPARATELY FROM <see cref="Mutate"/> (second review finding on #2484). The provenance
+    /// write used to sit in the endpoint, OUTSIDE this lock, appending unlocked and swallowing its own
+    /// failure to return success. So two sessions could both land their terms while one session's trail
+    /// entries vanished - and a word in the glossary with no trail entry is exactly the state the owner's
+    /// grant was justified against, because it is un-traceable and therefore un-sweepable. Racing tests over
+    /// glossary state could not see it: the glossary was perfectly correct in every one of those runs.
+    ///
+    /// THE ORDER IS THE GUARANTEE, and it is chosen for which failure is survivable. The trail is written
+    /// BEFORE the glossary, so:
+    ///   * trail write fails -> it throws, the glossary is never written, and the caller is told the add
+    ///     failed. Nothing was added and nothing was recorded - consistent;
+    ///   * glossary write fails -> it throws after a trail entry exists. That over-reports: the trail names
+    ///     a word that is not in the dictionary, which a person reading it can see is absent and which
+    ///     removes nothing;
+    ///   * both succeed -> correct.
+    /// The one state that is UNREACHABLE is the forbidden one - a term present with no record of who added
+    /// it. Writing the glossary first would have made that the common failure instead.
+    ///
+    /// There is no swallowing catch anywhere on this path, deliberately. A silent provenance failure is a
+    /// silent loss of the guarantee the owner traded the confirmation step for, and an add that returns
+    /// success having lost it is worse than an add that fails.
+    /// </summary>
+    /// <param name="tenant">The tenant whose glossary is being written. Required and valid.</param>
+    /// <param name="change">Given the CURRENT document, returns the document to store and the terms that
+    /// were ACTUALLY new. Runs inside the lock.</param>
+    /// <param name="sessionId">The calling session, or null when the caller is a person - a person's own
+    /// edit records nothing, so there is nothing to keep atomic and the pair collapses to the glossary write.</param>
+    /// <param name="directorId">The Director that session belongs to; may be empty.</param>
+    /// <param name="nowUtc">The time to stamp, so a test does not depend on the clock.</param>
+    public static DictationDictionary MutateAndRecord(
+        TenantId tenant,
+        Func<DictationDictionary, (DictationDictionary Updated, IReadOnlyList<string> Added)> change,
+        string? sessionId,
+        string directorId,
+        DateTime nowUtc)
+    {
+        var path = TenantGlossary.PathFor(tenant);
+        lock (Gates.GetOrAdd(tenant.Value, _ => new object()))
+        {
+            using var crossProcess = AcquireFileLock(path);
+            var current = DictionaryLoader.LoadFromDisk(path);
+            var (updated, added) = change(current);
+
+            // Inside the lock, and BEFORE the glossary write. Any failure here propagates and the glossary
+            // is left untouched.
+            if (sessionId is not null)
+                GlossaryAdditionLog.Record(tenant, sessionId, directorId, added, nowUtc);
+
+            DictionaryLoader.WriteToDisk(path, updated);
+            return DictionaryLoader.LoadFromDisk(path);
+        }
+    }
+
+    /// <summary>
     /// Hold an exclusive OS lock for this tenant's glossary, so two Gateway PROCESSES over one file share
     /// cannot both be inside a read-modify-write. A dedicated <c>.lock</c> file rather than the glossary
     /// itself, because the write path replaces the glossary by rename - locking a file that is about to be

--- a/src/CcDirector.Gateway/Transcription/TenantGlossaryWriter.cs
+++ b/src/CcDirector.Gateway/Transcription/TenantGlossaryWriter.cs
@@ -1,0 +1,124 @@
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// THE ONLY PLACE A TENANT'S GLOSSARY IS WRITTEN, and the reason every write to it is atomic.
+///
+/// THE DEFECT THIS EXISTS TO CLOSE (found in review of issue #2484). Every writer used to do an
+/// unguarded read-modify-write: <c>LoadFromDisk</c>, change the document in memory, <c>WriteToDisk</c>.
+/// Nothing serialised those three steps, so a person's Cockpit save landing between another caller's read
+/// and write was silently ERASED - including a wrong-spellings list they had just edited - and two
+/// concurrent additions could lose one of the terms. The writers even shared one <c>&lt;path&gt;.tmp</c>
+/// staging file, so two in flight at once could tear each other's bytes.
+///
+/// WHY THAT WAS A CORRECTNESS BUG AND NOT A TIDINESS ONE. The owner's ruling lets an agent add a word with
+/// NO confirmation step, and it is justified by one sentence: the worst an agent can do is leave a stray
+/// extra word, never lose a correction the person relies on. An add that can erase a concurrent human edit
+/// makes that sentence FALSE - add-only would be true of the verb and false of the effect - so the whole
+/// grant would rest on a premise the code did not honour. The guard and the handler decide WHAT may be
+/// written; this class is what makes the result of writing it survivable.
+///
+/// THE INVARIANT: every outcome equals some SERIAL ordering of the writes that raced. A person's whole
+/// document save may legitimately overwrite an agent's term (an explicit human save is authoritative, and
+/// pruning is exactly what the person is for), and an agent's add may legitimately land on top of a save.
+/// What may never happen is the torn middle - the agent's word kept while the person's curation is dropped -
+/// because that is a half of each write, which is no ordering at all.
+///
+/// HOW. Two gates, because there are two ways to race:
+///   * a per-tenant monitor, for two requests inside THIS Gateway process - the common case, and the cheap
+///     one;
+///   * an exclusive per-tenant LOCK FILE, for two Gateway processes over one shared file share. That is not
+///     hypothetical here: a hosted deploy has run two containers against one share, and a lock that lived
+///     only in memory would be silently useless in exactly the window a deploy opens.
+/// Both are held across the whole read-modify-write, which is the point - a lock taken only around the
+/// write would still lose the update, because the loss happens between the read and the write.
+///
+/// The critical section is deliberately SYNCHRONOUS end to end. An await inside it would let the
+/// continuation resume on another thread while the monitor was held by the first, which is the standard way
+/// a lock like this stops meaning anything.
+/// </summary>
+public static class TenantGlossaryWriter
+{
+    /// <summary>How long to keep trying for the cross-process lock before giving up. Generous, because the
+    /// work inside it is a small file read and write - reaching this means another process is wedged, which
+    /// is worth failing loudly over rather than writing anyway.</summary>
+    private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>The in-process gate, one per tenant. Keyed by the tenant's own identifier rather than by
+    /// path, so it cannot be defeated by two spellings of the same file.</summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, object> Gates = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Read this tenant's glossary, apply <paramref name="change"/>, and write the result - as ONE step that
+    /// no other writer can interleave with. Returns the re-read document.
+    /// </summary>
+    /// <param name="tenant">The tenant whose glossary is being written. Required and valid.</param>
+    /// <param name="change">Given the CURRENT document, returns the document to store. Called INSIDE the
+    /// lock and possibly after a wait, so it must derive its result from the document it is handed and never
+    /// from one the caller read earlier - reading outside and mutating inside is the very race this closes.</param>
+    public static DictationDictionary Mutate(TenantId tenant, Func<DictationDictionary, DictationDictionary> change)
+    {
+        var path = TenantGlossary.PathFor(tenant);
+        lock (Gates.GetOrAdd(tenant.Value, _ => new object()))
+        {
+            using var crossProcess = AcquireFileLock(path);
+            var current = DictionaryLoader.LoadFromDisk(path);
+            DictionaryLoader.WriteToDisk(path, change(current));
+            return DictionaryLoader.LoadFromDisk(path);
+        }
+    }
+
+    /// <summary>
+    /// Replace this tenant's whole glossary - the Cockpit editor's save. It takes the SAME lock as
+    /// <see cref="Mutate"/>, which is the half that is easy to miss: a replace needs no read of its own, but
+    /// if it can land in the middle of somebody else's read-modify-write then that writer's stale copy is
+    /// written back over it and the person's save vanishes. Serialising only the read-modify-writes against
+    /// each other would leave exactly the human-edit-lost case the review found.
+    /// </summary>
+    public static DictationDictionary Replace(TenantId tenant, DictationDictionary replacement)
+        => Mutate(tenant, _ => replacement);
+
+    /// <summary>
+    /// Hold an exclusive OS lock for this tenant's glossary, so two Gateway PROCESSES over one file share
+    /// cannot both be inside a read-modify-write. A dedicated <c>.lock</c> file rather than the glossary
+    /// itself, because the write path replaces the glossary by rename - locking a file that is about to be
+    /// atomically replaced locks the wrong inode the moment it succeeds.
+    /// </summary>
+    private static FileStream AcquireFileLock(string glossaryPath)
+    {
+        var lockPath = glossaryPath + ".lock";
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(lockPath))!);
+
+        var deadline = DateTime.UtcNow + LockTimeout;
+        var delayMilliseconds = 5;
+        while (true)
+        {
+            try
+            {
+                return new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch (IOException) when (DateTime.UtcNow < deadline)
+            {
+                // Somebody else is mid-write. Back off and try again - this is the lock doing its job, not
+                // an error, so it is not logged per attempt.
+                Thread.Sleep(delayMilliseconds);
+                delayMilliseconds = Math.Min(delayMilliseconds * 2, 100);
+            }
+            catch (IOException ex)
+            {
+                // Past the deadline. Fail loudly rather than writing anyway: writing without the lock is
+                // precisely the data loss this class exists to prevent, and a silent unlocked write would
+                // reintroduce it at the worst possible moment.
+                FileLog.Write($"[TenantGlossaryWriter] AcquireFileLock FAILED after {LockTimeout.TotalSeconds}s: {lockPath} - {ex.Message}");
+                throw new IOException(
+                    $"Could not take the dictation glossary lock at '{lockPath}' within {LockTimeout.TotalSeconds} seconds. " +
+                    "Another process is holding it. The glossary was NOT written - writing without the lock " +
+                    "would risk erasing a concurrent edit.", ex);
+            }
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Util/SessionKeyGuard.cs
+++ b/src/CcDirector.Gateway/Util/SessionKeyGuard.cs
@@ -39,7 +39,9 @@ public readonly record struct SessionKeyVerdict(bool Allowed, string Reason)
 /// to end a session (<c>request-deletion</c>), and this one is flagged to the owner as a line he may want
 /// moved. Also still refused, for the separate reason that they are not configuration at all: the
 /// diagnostics surface, and voice, dictation and transcription DATA - note the distinction from the voice
-/// SETTINGS above, which say how the product should behave and are therefore allowed.
+/// SETTINGS above, which say how the product should behave and are therefore allowed. There is exactly ONE
+/// opening in that dictation surface, <c>POST /ingest/dictionary/terms</c>, and it is an ADD ONLY grant -
+/// see <see cref="IsDictionaryAdd"/>.
 ///
 /// WHAT CHANGED, AND WHY THIS PARAGRAPH WAS REWRITTEN RATHER THAN AMENDED. Phase 1b refused the whole
 /// <c>/directors</c> surface bar two sub-paths, and said so here in prose. The owner's ruling reverses that
@@ -76,6 +78,17 @@ public static class SessionKeyGuard
 
         if (IsAllowed(verb, segments))
             return SessionKeyVerdict.Allow;
+
+        // A refusal on the dictation surface gets its OWN sentence, because the general one would send the
+        // reader somewhere the truth is not. An agent that tried to replace the glossary has not run into
+        // the admission boundary, and telling it about device enrollment and billing would have it hunting a
+        // credential problem instead of reading the one line that answers it: the grant here is add only.
+        if (segments.Length >= 2 && segments[0] == "ingest" && segments[1] == "dictionary")
+            return SessionKeyVerdict.Refuse(
+                $"a session key may not call {verb} {p}; the dictation dictionary is ADD ONLY for an agent - " +
+                "POST /ingest/dictionary/terms with a 'terms' list adds words, and nothing else on this " +
+                "surface is open to a session key, so an agent can never delete, rename or overwrite a term " +
+                "the person relies on. Prune in the Cockpit dictionary editor");
 
         return SessionKeyVerdict.Refuse(
             $"a session key may not call {verb} {p}; it may run the fleet's agent routes and configure the " +
@@ -206,6 +219,9 @@ public static class SessionKeyGuard
             // Write a handover. This is the one that makes moving a session possible without the owner
             // opening the interface, which is the whole point of the ruling.
             if (IsHandoverWrite(s)) return true;
+
+            // Add a word to the dictation dictionary.
+            if (IsDictionaryAdd(verb, s)) return true;
 
             return false;
         }
@@ -348,6 +364,37 @@ public static class SessionKeyGuard
     /// <summary>Creating or removing a handover, both at <c>/directors/{id}/handovers</c> exactly.</summary>
     private static bool IsHandoverWrite(string[] s)
         => s.Length == 3 && s[0] == "directors" && s[2] == "handovers";
+
+    /// <summary>
+    /// ADDING A WORD TO THE DICTATION DICTIONARY - <c>POST /ingest/dictionary/terms</c>, and nothing else
+    /// anywhere under <c>/ingest</c>. The owner's ruling of 2026-08-07 (issue #2484).
+    ///
+    /// WHY THIS ONE ROUTE AND NOT THE SURFACE IT SITS ON. The rest of <c>/ingest</c> is the owner's dictation
+    /// audio and his transcripts, which stay refused for the reason the class comment gives. The glossary is
+    /// different in kind: it says how the product should hear a word, which is configuration, and an agent
+    /// that has just read a product name off the repository in front of it is the best-placed thing on the
+    /// machine to teach the transcriber that word. The owner ruled that asking him to confirm every such
+    /// addition is worse than the occasional stray one.
+    ///
+    /// ADD ONLY, AND WHY THAT IS THE WHOLE OF THE GRANT. A session key may add a term. It may NOT delete,
+    /// rename or overwrite an existing term, and it may not touch the wrong-spellings list attached to one -
+    /// so the worst an agent can do here is leave a stray extra word, never remove a correction the owner
+    /// relies on. That is why <c>PUT /ingest/dictionary</c> (the editor's whole-document save, which can drop
+    /// or empty anything) and the suggestion routes (apply writes a term AND its wrong spellings; dismiss and
+    /// restore change what the owner is shown) are all still refused. The person keeps the pruning shears:
+    /// anything an agent adds is removable in the Cockpit dictionary editor like any hand-added term.
+    ///
+    /// THE ROUTE IS HALF THE GRANT; THE HANDLER IS THE OTHER HALF. This guard can only see a method and a
+    /// path, and the same path carries both a term and a wrong-spellings map. So the narrowing that a path
+    /// cannot express - a session key may send <c>terms</c> and may not send <c>mistranscriptions</c> - is
+    /// enforced in the handler, in <c>RecordingEndpoints</c>, which is the one place that can read a body.
+    /// Neither half is sufficient alone, and both are pinned by tests.
+    ///
+    /// Matched by structure and by exact length, so a sibling somebody hangs off the add route later is
+    /// refused until it is classified here on purpose.
+    /// </summary>
+    private static bool IsDictionaryAdd(string verb, string[] s)
+        => verb == "POST" && s.Length == 3 && s[0] == "ingest" && s[1] == "dictionary" && s[2] == "terms";
 
     /// <summary>The read shapes of the shared skill/workflow catalogue.</summary>
     private static bool IsCatalogueRead(string[] s)

--- a/src/CcDirector.Gateway/Util/SessionKeyGuard.cs
+++ b/src/CcDirector.Gateway/Util/SessionKeyGuard.cs
@@ -86,9 +86,10 @@ public static class SessionKeyGuard
         if (segments.Length >= 2 && segments[0] == "ingest" && segments[1] == "dictionary")
             return SessionKeyVerdict.Refuse(
                 $"a session key may not call {verb} {p}; the dictation dictionary is ADD ONLY for an agent - " +
-                "POST /ingest/dictionary/terms with a 'terms' list adds words, and nothing else on this " +
-                "surface is open to a session key, so an agent can never delete, rename or overwrite a term " +
-                "the person relies on. Prune in the Cockpit dictionary editor");
+                "POST /ingest/dictionary/terms with a 'terms' list adds words, and GET " +
+                "/ingest/dictionary/additions reads back what agents added. Nothing else on this surface is " +
+                "open to a session key, so an agent can never delete, rename or overwrite a term the person " +
+                "relies on. Prune in the Cockpit dictionary editor");
 
         return SessionKeyVerdict.Refuse(
             $"a session key may not call {verb} {p}; it may run the fleet's agent routes and configure the " +
@@ -151,6 +152,10 @@ public static class SessionKeyGuard
             // The automation browsers on one Director's machine. See IsBrowserRoute for how the /directors
             // surface is split between configuration and admission.
             if (IsBrowserRoute(verb, s)) return true;
+
+            // What agents added to the dictation dictionary, and which one added it. See
+            // IsDictionaryAdditionTrail for why this ONE read is open while the glossary itself is not.
+            if (IsDictionaryAdditionTrail(verb, s)) return true;
 
             // Configuration, read side. A Director's settings, the application's own settings, and the
             // handovers on a Director - all three by the owner's ruling that an agent configures the product.
@@ -395,6 +400,31 @@ public static class SessionKeyGuard
     /// </summary>
     private static bool IsDictionaryAdd(string verb, string[] s)
         => verb == "POST" && s.Length == 3 && s[0] == "ingest" && s[1] == "dictionary" && s[2] == "terms";
+
+    /// <summary>
+    /// READING BACK WHAT AGENTS ADDED - <c>GET /ingest/dictionary/additions</c>, and nothing else.
+    ///
+    /// WHY A READ IS OPEN HERE WHEN <c>GET /ingest/dictionary</c> IS REFUSED. These are not the same kind of
+    /// thing, and the difference is whose material each one holds. The glossary is the OWNER's: his
+    /// hand-added terms, his wrong-spellings lists, the corrections he curates. The addition trail holds
+    /// exactly one thing - what AGENTS wrote - because a person adding a term through the Cockpit is not a
+    /// session and leaves no entry at all. So this route lets agents read back agents' own writes, and
+    /// reaches none of the owner's material; opening the glossary would reach all of it.
+    ///
+    /// WHY IT IS NOT OPTIONAL. The owner's ruling asks that a bad entry can be "traced AND swept". Writing
+    /// the trail satisfies only the first verb. A record no tooling can read is a file somebody has to go
+    /// and find on disk, and the traceability that was traded for removing the confirmation step would have
+    /// been nominal - which is the whole reason the ruling asked for it.
+    ///
+    /// FINDING IS NOT ACTING. There is no verb here to remove what this read finds, and there deliberately
+    /// is not one: pruning stays the person's, in the Cockpit editor. This route makes a bad batch
+    /// FINDABLE and stops there.
+    ///
+    /// Matched by exact length so a sibling hung off it later is refused until classified on purpose.
+    /// </summary>
+    private static bool IsDictionaryAdditionTrail(string verb, string[] s)
+        => verb is "GET" or "HEAD"
+           && s.Length == 3 && s[0] == "ingest" && s[1] == "dictionary" && s[2] == "additions";
 
     /// <summary>The read shapes of the shared skill/workflow catalogue.</summary>
     private static bool IsCatalogueRead(string[] s)

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -12,6 +12,7 @@ from rich.table import Table
 from . import __version__
 from . import browser_ops
 from . import diag_ops
+from . import dictionary_ops
 from . import email_ops
 from . import mission_ops
 from . import schedule_ops
@@ -93,6 +94,14 @@ autostart_app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
 )
+dictionary_app = typer.Typer(
+    # ADD is the only verb, and the help says so, because the Gateway refuses a session key on every
+    # other shape of this surface. A command list that offered "remove" and then failed with 403 would
+    # read as a broken tool rather than as the line the owner deliberately drew (issue #2484).
+    help="Add words to the dictation dictionary. ADD ONLY - a person prunes it in the Cockpit editor.",
+    add_completion=False,
+    no_args_is_help=True,
+)
 browser_app = typer.Typer(
     # The verb stays "browser": it is the resource name agents already hold, in the actions registry
     # and in the attach command baked into the fold. The HELP says "profile", which is what the thing
@@ -117,6 +126,7 @@ app.add_typer(email_app, name="email")
 app.add_typer(diag_app, name="diag")
 app.add_typer(autostart_app, name="autostart")
 app.add_typer(browser_app, name="browser")
+app.add_typer(dictionary_app, name="dictionary")
 console = Console()
 
 _ACTIONS = [
@@ -741,6 +751,18 @@ _ACTIONS = [
         "mutatesState": True,
         "args": [],
     },
+    {
+        "id": "dictionary-add",
+        "description": (
+            "Add a word to the dictation dictionary so dictation stops getting it wrong. ADD ONLY: "
+            "an agent cannot remove, rename or overwrite a term, and the person prunes the list in "
+            "the Cockpit editor. Add a spelling you can SEE WRITTEN DOWN - a word that reached you "
+            "through dictation may already be mangled, and the spelling you add becomes canonical."
+        ),
+        "command": 'cc-devthrottle dictionary add "Kubernetes"',
+        "mutatesState": True,
+        "args": [{"name": "terms", "required": True}],
+    },
 ]
 
 
@@ -823,6 +845,23 @@ def browser_remove(
 ) -> None:
     """Stop the browser, delete its folder, and drop it from the registry."""
     browser_ops.remove_browser(name, json_output)
+
+
+@dictionary_app.command("add")
+def dictionary_add(
+    terms: List[str] = typer.Argument(..., help="One or more words or phrases to add."),
+) -> None:
+    """Add words to this account's dictation dictionary, so dictation stops getting them wrong.
+
+    SPELL IT THE WAY IT IS WRITTEN DOWN. The spelling you add becomes the canonical one, and a word
+    that reached you THROUGH dictation may already be mangled - adding that is the failure this
+    warning exists for. Take the spelling from the repository, the code, or the product name in
+    front of you, never from something you only heard.
+
+    ADD ONLY. You cannot remove, rename or overwrite a term, and you cannot touch the wrong-spellings
+    list attached to one. The person prunes the dictionary in the Cockpit editor.
+    """
+    dictionary_ops.add_command(terms)
 
 
 @app.callback()

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -763,6 +763,21 @@ _ACTIONS = [
         "mutatesState": True,
         "args": [{"name": "terms", "required": True}],
     },
+    {
+        "id": "dictionary-additions",
+        "description": (
+            "List every word an AGENT added to the dictation dictionary - when, and which session "
+            "added it - so a bad entry can be traced and its whole batch found. Shows only what "
+            "agents added, never the person's own terms. Finding is not removing: the person prunes "
+            "in the Cockpit editor."
+        ),
+        "command": "cc-devthrottle dictionary additions [--session <id>] [--json]",
+        "mutatesState": False,
+        "args": [
+            {"name": "session", "required": False},
+            {"name": "json", "required": False},
+        ],
+    },
 ]
 
 
@@ -862,6 +877,24 @@ def dictionary_add(
     list attached to one. The person prunes the dictionary in the Cockpit editor.
     """
     dictionary_ops.add_command(terms)
+
+
+@dictionary_app.command("additions")
+def dictionary_additions(
+    session: str = typer.Option(
+        "", "--session", help="Only terms added by this session (full id or an id prefix)."
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON."),
+) -> None:
+    """List every word an AGENT added to the dictionary - when, and which session added it.
+
+    This is how a bad entry gets traced and swept: find the session that added it, see the rest of
+    that session's batch, and hand it to the person to prune in the Cockpit editor. It shows only
+    what agents added - the person's own terms and the wrong-spellings lists are not in this trail.
+
+    You can find a bad batch here. You cannot remove one - that stays the person's.
+    """
+    dictionary_ops.additions_command(session, json_output)
 
 
 @app.callback()

--- a/tools/cc-devthrottle/src/dictionary_ops.py
+++ b/tools/cc-devthrottle/src/dictionary_ops.py
@@ -7,12 +7,21 @@ true: no command existed, and the Gateway refused a session key on the term endp
 The owner ruled on 2026-08-07 that agents MAY add words, with no confirmation step in the way -
 being asked to confirm every time is worse than the occasional stray entry.
 
-ADD ONLY, AND THAT IS THE WHOLE VERB. There is deliberately no `dictionary remove`, no
-`dictionary set`, and no `dictionary list` here, because the Gateway refuses a session key on
-every one of those. A session key may add a term and nothing else: it can never delete, rename or
-overwrite an existing term, and it can never touch the wrong-spellings list attached to one. So
-the worst an agent can do is leave a stray extra word, and the person prunes in the Cockpit
-dictionary editor exactly as they would a word they typed in themselves.
+TWO VERBS: `add`, and `additions` to read back what agents added. There is deliberately no
+`dictionary remove`, no `dictionary set`, and no `dictionary list` of the glossary itself, because
+the Gateway refuses a session key on every one of those. A session key may add a term and read the
+addition trail: it can never delete, rename or overwrite an existing term, and it can never touch
+the wrong-spellings list attached to one. So the worst an agent can do is leave a stray extra word,
+and the person prunes in the Cockpit dictionary editor exactly as they would a word they typed in
+themselves.
+
+WHY `additions` EXISTS. The owner's ruling asks that a bad entry can be traced AND SWEPT. A record
+that nothing can read is a file somebody would have to go and find on disk, which satisfies the
+first verb and not the second. `additions` names every word an agent added, when, and which session
+added it - so one session's bad batch can be picked out and handed to the person to prune, rather
+than the person having to distrust the whole list. Note what it does NOT show: the person's own
+terms, and every wrong-spellings list, are not in the trail at all (a person's edit leaves no
+entry), which is exactly why this read could be opened while the glossary itself stays closed.
 
 SPELL IT THE WAY IT IS WRITTEN DOWN. The spelling you add becomes the canonical one, and the
 failure mode the owner named is a word that arrived through dictation ALREADY MANGLED being added
@@ -28,7 +37,9 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import typer
+from rich import box
 from rich.console import Console
+from rich.table import Table
 
 # Make cc_shared importable when running from source, matching the existing cc-* tools.
 _tools_dir = str(Path(__file__).resolve().parent.parent.parent)
@@ -114,4 +125,68 @@ def add_command(terms: List[str]) -> None:
     console.print(
         "[dim]The person prunes this list in the Cockpit dictionary editor. You can add words; "
         "you cannot remove or change one.[/dim]"
+    )
+
+
+ADDITIONS_PATH = "/ingest/dictionary/additions"
+
+
+def read_additions() -> List[Dict[str, Any]]:
+    """Every word an agent added to this account's glossary, newest first."""
+    result = gateway.get_json(ADDITIONS_PATH)
+    if not isinstance(result, dict):
+        return []
+    entries = result.get("additions")
+    return entries if isinstance(entries, list) else []
+
+
+def additions_command(session: str = "", json_output: bool = False) -> None:
+    """`cc-devthrottle dictionary additions [--session <id>] [--json]`.
+
+    The sweep half of the traceability. `--session` matches a full id or an id prefix, which is how
+    the fleet addresses a session everywhere else - somebody chasing a bad batch has the short id
+    from the roster, not the full one.
+    """
+    try:
+        entries = read_additions()
+    except GatewayError as err:
+        err_console.print(f"[red]{err}[/red]")
+        raise typer.Exit(code=1)
+
+    wanted = (session or "").strip().lower()
+    if wanted:
+        entries = [e for e in entries if str(e.get("sessionId", "")).lower().startswith(wanted)]
+
+    if json_output:
+        import json as _json
+
+        console.print_json(_json.dumps(entries))
+        return
+
+    # Say the empty case in words rather than printing an empty table. "No agent has added a word"
+    # and "the filter matched nothing" are different facts, and a reader chasing a bad entry needs
+    # to know which one they are looking at.
+    if not entries:
+        if wanted:
+            console.print(f"No agent-added terms from a session matching '{session}'.")
+        else:
+            console.print("No agent has added a term to this account's dictation dictionary.")
+        return
+
+    table = Table(box=box.SIMPLE, header_style="bold")
+    table.add_column("Added (UTC)")
+    table.add_column("Term")
+    table.add_column("Session")
+    table.add_column("Director")
+    for entry in entries:
+        table.add_row(
+            str(entry.get("addedAtUtc", ""))[:19].replace("T", " "),
+            str(entry.get("term", "")),
+            str(entry.get("sessionId", ""))[:8],
+            str(entry.get("directorId", "")),
+        )
+    console.print(table)
+    console.print(
+        "[dim]Newest first. To remove a bad entry, the person deletes it in the Cockpit dictionary "
+        "editor - an agent can find a bad batch here but cannot sweep it.[/dim]"
     )

--- a/tools/cc-devthrottle/src/dictionary_ops.py
+++ b/tools/cc-devthrottle/src/dictionary_ops.py
@@ -1,0 +1,117 @@
+"""Add words to the dictation dictionary from a session (issue #2484).
+
+WHY THIS COMMAND EXISTS. DevThrottle's dictation cleans up what it hears against a glossary of
+words the person cares about - product names, surnames, tools. The documentation promised that
+"add Kubernetes to my dictionary" was a single instruction to any connected agent, and it was not
+true: no command existed, and the Gateway refused a session key on the term endpoint outright.
+The owner ruled on 2026-08-07 that agents MAY add words, with no confirmation step in the way -
+being asked to confirm every time is worse than the occasional stray entry.
+
+ADD ONLY, AND THAT IS THE WHOLE VERB. There is deliberately no `dictionary remove`, no
+`dictionary set`, and no `dictionary list` here, because the Gateway refuses a session key on
+every one of those. A session key may add a term and nothing else: it can never delete, rename or
+overwrite an existing term, and it can never touch the wrong-spellings list attached to one. So
+the worst an agent can do is leave a stray extra word, and the person prunes in the Cockpit
+dictionary editor exactly as they would a word they typed in themselves.
+
+SPELL IT THE WAY IT IS WRITTEN DOWN. The spelling you add becomes the canonical one, and the
+failure mode the owner named is a word that arrived through dictation ALREADY MANGLED being added
+as though it were correct. Add a spelling you can SEE - from the repository, the code, the product
+name in front of you - never one you only heard. `add` refuses a term that is obviously not a
+written word for that reason; everything else is your judgement.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import typer
+from rich.console import Console
+
+# Make cc_shared importable when running from source, matching the existing cc-* tools.
+_tools_dir = str(Path(__file__).resolve().parent.parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from cc_shared import gateway  # noqa: E402
+
+console = Console()
+err_console = Console(stderr=True)
+
+#: The same class the shared transport raises, never a look-alike beside it - see mission_ops.py
+#: for the trap that aliasing avoids.
+GatewayError = gateway.GatewayError
+
+TERMS_PATH = "/ingest/dictionary/terms"
+
+
+def validate_terms(terms: List[str]) -> List[str]:
+    """The terms to send, trimmed - or a message saying why one of them cannot be a dictionary word.
+
+    Deliberately a THIN check. It rejects only what could not be a written word under any reading
+    (empty, or carrying a line break, which means a block of prose was pasted where a term goes).
+    It does NOT try to judge spelling: a checker that guessed would reject real product names, and
+    the owner's instruction puts spelling on the agent, backed by looking at the written source,
+    not on a rule in this file that cannot see the repository.
+    """
+    cleaned: List[str] = []
+    for term in terms:
+        trimmed = (term or "").strip()
+        if not trimmed:
+            raise ValueError("A dictionary term cannot be empty.")
+        if "\n" in trimmed or "\r" in trimmed:
+            raise ValueError(
+                f"A dictionary term cannot span lines: {trimmed.splitlines()[0][:40]!r}... "
+                "Add one word or phrase per term."
+            )
+        cleaned.append(trimmed)
+    if not cleaned:
+        raise ValueError("Give at least one term to add.")
+    return cleaned
+
+
+def add_terms(terms: List[str]) -> Dict[str, Any]:
+    """POST the terms to this session's Gateway and return the glossary it answers with."""
+    body = {"terms": terms}
+    result = gateway.post_json(TERMS_PATH, body)
+    return result if isinstance(result, dict) else {}
+
+
+def add_command(terms: List[str]) -> None:
+    """`cc-devthrottle dictionary add <term> [<term> ...]` - the command-line entry point."""
+    try:
+        cleaned = validate_terms(terms)
+    except ValueError as err:
+        err_console.print(f"[red]{err}[/red]")
+        raise typer.Exit(code=1)
+
+    try:
+        glossary = add_terms(cleaned)
+    except GatewayError as err:
+        err_console.print(f"[red]{err}[/red]")
+        raise typer.Exit(code=1)
+
+    vocabulary = glossary.get("vocabulary") or []
+    lowered = {str(word).lower() for word in vocabulary}
+    missing = [term for term in cleaned if term.lower() not in lowered]
+
+    for term in cleaned:
+        if term.lower() in lowered:
+            console.print(f"[green]In the dictation dictionary:[/green] {term}")
+
+    # Say so rather than reporting a success the answer does not support. A term the Gateway
+    # accepted but did not return is not "added" - and a command that printed success anyway is the
+    # kind of report that has to be discovered by dictating the word and hearing it come out wrong.
+    if missing:
+        err_console.print(
+            "[red]The Gateway accepted the request but these terms are not in the glossary it "
+            f"returned: {', '.join(missing)}[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    console.print(
+        "[dim]The person prunes this list in the Cockpit dictionary editor. You can add words; "
+        "you cannot remove or change one.[/dim]"
+    )

--- a/tools/cc-devthrottle/tests/test_dictionary_ops.py
+++ b/tools/cc-devthrottle/tests/test_dictionary_ops.py
@@ -1,0 +1,159 @@
+"""Tests for `cc-devthrottle dictionary add` (issue #2484).
+
+The owner ruled that an agent may add words to the dictation dictionary with NO confirmation step,
+and that the grant is ADD ONLY. These cases pin the decisions that would otherwise be reversed by a
+later well-meaning edit:
+
+  * add sends exactly `terms`, and never `mistranscriptions` - the Gateway refuses a session key on
+    the wrong-spellings list, and a command that sent one would fail every call with a 403;
+  * `remove` and `set` are NOT verbs on this command, so the tool never offers something the
+    Gateway will refuse;
+  * a Gateway refusal reaches the reader as the Gateway's own sentence, not a traceback;
+  * a term the answer does not contain is reported as a failure, not as a success.
+
+No HTTP happens: the Gateway post is stubbed.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import typer
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from typer.testing import CliRunner  # noqa: E402
+
+from src import dictionary_ops  # noqa: E402
+from src.cli import app  # noqa: E402
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def posted(monkeypatch):
+    """Capture what the command sends, and answer with a glossary containing every term sent."""
+    calls = []
+
+    def fake_post(path, body=None, timeout=30):
+        calls.append({"path": path, "body": body})
+        terms = (body or {}).get("terms") or []
+        return {"vocabulary": list(terms), "commonMistranscriptions": {}, "profiles": {}}
+
+    monkeypatch.setattr(dictionary_ops.gateway, "post_json", fake_post)
+    return calls
+
+
+def test_add_sends_the_terms_to_the_term_endpoint(posted):
+    result = runner.invoke(app, ["dictionary", "add", "Kubernetes"])
+
+    assert result.exit_code == 0
+    assert posted == [{"path": "/ingest/dictionary/terms", "body": {"terms": ["Kubernetes"]}}]
+
+
+def test_add_sends_several_terms_in_one_call(posted):
+    result = runner.invoke(app, ["dictionary", "add", "Kubernetes", "Helm", "mindzie"])
+
+    assert result.exit_code == 0
+    assert posted[0]["body"] == {"terms": ["Kubernetes", "Helm", "mindzie"]}
+
+
+def test_add_never_sends_wrong_spellings(posted):
+    """The narrowing that makes the grant safe. A session key may add a term and may NOT touch the
+    wrong-spellings list, so this command must never put one in the body - if it did, every call
+    would come back 403 and the feature would be dead on arrival."""
+    result = runner.invoke(app, ["dictionary", "add", "Kubernetes"])
+
+    assert result.exit_code == 0
+    assert "mistranscriptions" not in posted[0]["body"]
+
+
+def test_there_is_no_remove_or_set_verb():
+    """ADD ONLY, said by the command surface itself. Offering a verb the Gateway refuses would read
+    as a broken tool rather than as the line the owner drew."""
+    for verb in ("remove", "delete", "set", "replace", "list"):
+        result = runner.invoke(app, ["dictionary", verb, "Kubernetes"])
+        assert result.exit_code != 0, f"'dictionary {verb}' must not be a command"
+
+
+def test_the_help_says_add_only_and_warns_about_spelling(plain):
+    result = runner.invoke(app, ["dictionary", "add", "--help"])
+
+    text = plain(result.output).lower()
+    assert "add only" in text
+    assert "written down" in text
+
+
+def test_a_gateway_refusal_is_reported_as_its_own_sentence(monkeypatch):
+    """A 403 from the guard carries a sentence written for the agent that hit it. It must arrive
+    intact - a traceback here would send the reader hunting a credential problem."""
+    def refuse(path, body=None, timeout=30):
+        raise dictionary_ops.GatewayError(
+            "a session key may not call PUT /ingest/dictionary; the dictation dictionary is ADD ONLY"
+        )
+
+    monkeypatch.setattr(dictionary_ops.gateway, "post_json", refuse)
+
+    result = runner.invoke(app, ["dictionary", "add", "Kubernetes"])
+
+    assert result.exit_code == 1
+    assert "ADD ONLY" in result.output
+
+
+def test_a_term_missing_from_the_answer_is_a_failure(monkeypatch):
+    """A 200 is not proof the word went in. Reporting success from the status code alone is the kind
+    of false green that is only discovered by dictating the word and hearing it come out wrong."""
+    def answer_without_it(path, body=None, timeout=30):
+        return {"vocabulary": ["something else"], "commonMistranscriptions": {}, "profiles": {}}
+
+    monkeypatch.setattr(dictionary_ops.gateway, "post_json", answer_without_it)
+
+    result = runner.invoke(app, ["dictionary", "add", "Kubernetes"])
+
+    assert result.exit_code == 1
+    assert "Kubernetes" in result.output
+
+
+def test_an_empty_term_is_refused_before_any_call(posted):
+    result = runner.invoke(app, ["dictionary", "add", "   "])
+
+    assert result.exit_code == 1
+    assert posted == []
+
+
+def test_a_pasted_block_of_prose_is_refused_before_any_call(posted):
+    """One word or phrase per term. A multi-line paste is prose that landed in the wrong argument,
+    and adding it would put a paragraph into the glossary as though it were a word."""
+    result = runner.invoke(app, ["dictionary", "add", "Kubernetes\nis a container orchestrator"])
+
+    assert result.exit_code == 1
+    assert posted == []
+
+
+def test_terms_are_trimmed(posted):
+    result = runner.invoke(app, ["dictionary", "add", "  Kubernetes  "])
+
+    assert result.exit_code == 0
+    assert posted[0]["body"] == {"terms": ["Kubernetes"]}
+
+
+def test_validate_terms_rejects_an_empty_list():
+    with pytest.raises(ValueError):
+        dictionary_ops.validate_terms([])
+
+
+def test_the_action_is_discoverable():
+    """An agent finds this through `cc-devthrottle actions`, which is the front door the fleet
+    preamble points at. A capability nothing lists is a capability nobody uses."""
+    import json
+
+    result = runner.invoke(app, ["actions", "--json"])
+
+    assert result.exit_code == 0
+    actions = {a["id"]: a for a in json.loads(result.output)["actions"]}
+    assert "dictionary-add" in actions
+    assert actions["dictionary-add"]["mutatesState"] is True
+    # The spelling instruction travels with the action, because the actions list is read by agents
+    # that never open the skill.
+    assert "written down" in actions["dictionary-add"]["description"].lower()

--- a/tools/cc-devthrottle/tests/test_dictionary_ops.py
+++ b/tools/cc-devthrottle/tests/test_dictionary_ops.py
@@ -77,6 +77,93 @@ def test_there_is_no_remove_or_set_verb():
         assert result.exit_code != 0, f"'dictionary {verb}' must not be a command"
 
 
+# ---------- the read half: tracing and sweeping a bad entry ----------
+
+
+TRAIL = [
+    {"addedAtUtc": "2026-08-07T10:02:00Z", "term": "Kuberentes",
+     "sessionId": "bbbbbbbb-2222-3333-4444-555555555555", "directorId": "director-b"},
+    {"addedAtUtc": "2026-08-07T10:01:00Z", "term": "Kubernetees",
+     "sessionId": "bbbbbbbb-2222-3333-4444-555555555555", "directorId": "director-b"},
+    {"addedAtUtc": "2026-08-07T10:00:00Z", "term": "Kubernetes",
+     "sessionId": "aaaaaaaa-1111-2222-3333-444444444444", "directorId": "director-a"},
+]
+
+
+@pytest.fixture
+def trail(monkeypatch):
+    """Answer the additions read with a trail holding one good term and one session's bad batch."""
+    calls = []
+
+    def fake_get(path, timeout=30):
+        calls.append(path)
+        return {"additions": list(TRAIL), "count": len(TRAIL)}
+
+    monkeypatch.setattr(dictionary_ops.gateway, "get_json", fake_get)
+    return calls
+
+
+def test_additions_reads_the_trail_endpoint(trail, plain):
+    result = runner.invoke(app, ["dictionary", "additions"])
+
+    assert result.exit_code == 0
+    assert trail == ["/ingest/dictionary/additions"]
+    text = plain(result.output)
+    assert "Kubernetes" in text
+    assert "Kuberentes" in text
+
+
+def test_additions_filters_to_one_session_by_id_prefix(trail, plain):
+    """The sweep. Somebody chasing a bad entry has the short id from the roster, so a prefix has to
+    work - and filtering must leave the OTHER session's good term out."""
+    result = runner.invoke(app, ["dictionary", "additions", "--session", "bbbbbbbb"])
+
+    assert result.exit_code == 0
+    text = plain(result.output)
+    assert "Kuberentes" in text
+    assert "Kubernetees" in text
+    assert "Kubernetes " not in text.replace("Kubernetees", "").replace("Kuberentes", "")
+
+
+def test_additions_says_when_a_filter_matched_nothing(trail, plain):
+    """'No agent has added anything' and 'your filter matched nothing' are different facts, and a
+    reader chasing a bad entry needs to know which one they are looking at."""
+    result = runner.invoke(app, ["dictionary", "additions", "--session", "ffffffff"])
+
+    assert result.exit_code == 0
+    assert "matching" in plain(result.output)
+
+
+def test_additions_says_when_no_agent_has_added_anything(monkeypatch, plain):
+    monkeypatch.setattr(dictionary_ops.gateway, "get_json",
+                        lambda path, timeout=30: {"additions": [], "count": 0})
+
+    result = runner.invoke(app, ["dictionary", "additions"])
+
+    assert result.exit_code == 0
+    assert "No agent has added a term" in plain(result.output)
+
+
+def test_additions_tells_the_reader_it_cannot_remove(trail, plain):
+    """Finding is not acting, said where the person reading the output will see it - otherwise the
+    obvious next question ('so how do I delete it?') has no answer on screen."""
+    result = runner.invoke(app, ["dictionary", "additions"])
+
+    assert "Cockpit" in plain(result.output)
+
+
+def test_additions_reports_a_gateway_refusal_as_its_sentence(monkeypatch):
+    def refuse(path, timeout=30):
+        raise dictionary_ops.GatewayError("the dictation dictionary is ADD ONLY for an agent")
+
+    monkeypatch.setattr(dictionary_ops.gateway, "get_json", refuse)
+
+    result = runner.invoke(app, ["dictionary", "additions"])
+
+    assert result.exit_code == 1
+    assert "ADD ONLY" in result.output
+
+
 def test_the_help_says_add_only_and_warns_about_spelling(plain):
     result = runner.invoke(app, ["dictionary", "add", "--help"])
 
@@ -153,7 +240,9 @@ def test_the_action_is_discoverable():
     assert result.exit_code == 0
     actions = {a["id"]: a for a in json.loads(result.output)["actions"]}
     assert "dictionary-add" in actions
+    assert "dictionary-additions" in actions
     assert actions["dictionary-add"]["mutatesState"] is True
+    assert actions["dictionary-additions"]["mutatesState"] is False
     # The spelling instruction travels with the action, because the actions list is read by agents
     # that never open the skill.
     assert "written down" in actions["dictionary-add"]["description"].lower()


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1788

## The ruling this implements

Quoted in full, from the owner's comment of 2026-08-07 on the issue:

> yes - allow agents to add words to the dictation dictionary, and do NOT put a confirmation step in the way (being asked to confirm every time is worse than the occasional bad entry).
>
> Shape to build:
>
> - ADD ONLY. A session key may add a term. It may not delete, rename or overwrite an existing term, and it may not touch the wrong-spellings list attached to an existing term. Worst case is therefore a stray extra word, never the loss of a correction the owner relies on.
> - The person keeps the pruning shears: anything an agent adds is removable in the Cockpit dictionary editor exactly like a hand-added term.
> - Spelling is the agent's responsibility. The owner's caveat: a term captured through dictation can arrive already mangled, and adding that spelling as canonical is the failure mode to avoid. Agents should add a spelling they can see written down - from the repository, the code, the product name in front of them - rather than one they only heard. Put that instruction where agents will read it (the dictionary or fleet skill), not as a runtime prompt.
> - Default for the implementer, owner may override at review: record which session added a term so a bad entry can be traced and swept, since there is no confirmation step to catch it at write time.

## The refusal, verified before anything was changed

The issue's claim is that `SessionKeyGuard` does not allow the ingest routes, so a session key gets 403 on the dictionary term endpoint. I wrote the regression tests first and ran them against unchanged code:

```
[FAIL] SessionKeyGuardTests.A_session_may_add_a_dictionary_term
Failed! - Failed: 1, Passed: 161, Skipped: 0, Total: 162
```

One assertion failed - the new "an agent may add" case - and all sixteen new refusal assertions passed on the unchanged guard. So the 403 was real, and everything that must stay refused already was.

## What changed

The grant has two halves, because a path cannot express all of it.

**`SessionKeyGuard`** opens exactly `POST /ingest/dictionary/terms` and nothing else anywhere under `/ingest`. Replacing the glossary (`PUT /ingest/dictionary`, the Cockpit editor's whole-document save), reading it, deleting from it, and the entire suggestion surface all stay refused - each of those is a way to LOSE a correction. A refusal on this surface now returns its own sentence naming the add-only line, instead of the generic admission-boundary sentence, which would have sent an agent hunting a credential problem that does not exist.

**The handler in `RecordingEndpoints`** enforces the half a path cannot see: for a SESSION caller the `mistranscriptions` field is refused with 403 `session_key_add_only`. A wrong-spellings entry rewrites what the transcriber HEARS, so a careless one (`"the" -> "Kubernetes"`) corrupts dictation everywhere rather than leaving a stray word - and on an existing term the ruling forbids touching that list at all. Refusing the field wholesale is what makes "worst case is a stray extra word" a true sentence rather than an approximate one. A person in the Cockpit, or a device key, is unchanged and may still send both fields.

Neither half is sufficient alone, and both are pinned by tests.

**Which session added which word** is recorded in `GlossaryAdditionLog` - an append-only file of one JSON line per term, beside that tenant's own `dictionary.yaml`. This is the implementer default the ruling invites the owner to override at review. It is a sidecar rather than a field inside the glossary because the Cockpit editor saves the whole document, so provenance stored in the YAML would be erased by the next hand-edit - it would vanish exactly when someone started curating, which is the moment it is wanted. A failure to write the note never fails the addition.

**The read path - `cc-devthrottle dictionary additions`** (added in review, second commit). The ruling asks that a bad entry can be traced **and swept**, and writing the trail satisfied only the first verb - a record nothing can read is a file somebody has to find on disk. `GET /ingest/dictionary/additions` serves every word an agent added, newest first, with the time, the session and the Director; `--session` takes an id *prefix*, because whoever is chasing a bad entry has the short id off the roster.

A session key may read that while `GET /ingest/dictionary` stays refused, and the boundary is drawn on **what the trail contains**, not on who is asking: the trail holds only what AGENTS wrote, because a person adding through the Cockpit is not a session and leaves no entry at all (asserted). So agents read back agents' own writes and reach none of the owner's curation - his terms, and every wrong-spellings list, are not in that file. Opening the glossary would reach all of it, so it stays shut.

Finding is not acting. There is no verb to remove what the trail finds; `POST`/`PUT`/`DELETE` on it are all refused, and the command says on screen that pruning happens in the Cockpit editor.

**The agent-facing surface**: `cc-devthrottle dictionary add "Kubernetes"`, listed in the actions registry agents discover through. `add` is the only verb, deliberately - offering `remove` and then failing every call with 403 would read as a broken tool rather than as the line the owner drew.

**The spelling guidance** is in the `dev-throttle` skill - both copies, the Gateway's shipped body and the repo's in-tree skills copy, whose bodies are byte-identical after this change - and in the action's own description, and in the command's help. Not in a runtime prompt, as the ruling directs: the spelling you add becomes canonical, a word that reached you through dictation may already be mangled, so add a spelling you can SEE WRITTEN DOWN and never one you only heard.

## Two concurrency defects found in review, and fixed

Neither was cosmetic: both broke the premise the owner's ruling rests on, so a serial-only suite would have shipped a grant whose justification the code did not honour.

**1. A glossary write was not atomic.** Every writer did an unguarded read-modify-write, so a person's Cockpit save landing between another caller's read and write was erased - wrong-spellings list included - and two concurrent adds could lose one. The three writers even shared one `<path>.tmp` staging file, so two in flight tore each other's bytes. That made *add-only* true of the verb and false of the effect.

`TenantGlossaryWriter` is now the only place a tenant's glossary is written, holding a per-tenant monitor **and** an exclusive per-tenant lock file across the whole read-modify-write. (What the file lock is and is not proven to do is scoped below - the claim is narrower than "safe on the hosted share".) All three writers go through it, including the editor's whole-document save - the half that is easy to miss, since a replace landing inside someone else's read-modify-write gets their stale copy written back over it. A lock around only the write would have changed nothing, because the loss happens *between* the read and the write.

**2. The provenance write was outside that lock.** It ran after the lock released, appended unlocked, and swallowed its own failure to return success - so two sessions could both land their terms with one session's trail entries lost, making that batch unfindable, which is the entire purpose of the record.

`MutateAndRecord` now writes both inside one lock, **trail first**. The order is the guarantee, chosen for which failure is survivable: a trail failure throws with the glossary untouched (nothing added, nothing recorded); a glossary failure leaves a trail entry naming a word that is not there (over-reports, visible, removes nothing). The forbidden state - a term present with nothing saying who added it - is unreachable. Writing the glossary first would have made that state the *common* failure. The swallowing catch is gone: if the trail cannot be written the add fails with a 500 naming why, because an add that reports success having silently lost the traceability is worse than one that fails.

**Both were proven by reverting, not by green.** A serial test passes on both broken versions - which is exactly why the first suite missed defect 1, and why my own racing tests (which assert *glossary* state) were structurally blind to defect 2. With the pre-fix behaviour restored the tests failed with the precise harm:

```
round 0: term-3 landed in the glossary but its provenance was LOST - trail has 5 of 8 entries
round 0: 'Kubernetes' is in the glossary with NO trail entry - it cannot be traced
         or swept. Trail holds: [Helm]
Assert.ThrowsAny() Failure: No exception was thrown        (the silent-success case)
```

An earlier revert of defect 1 also produced an unhandled `dictionary.yaml.tmp` collision that aborted the test host, confirming the shared temp file tore bytes as well as losing updates. The eight concurrency tests live in `Gateway.UnitTests` - the **fast** suite - so this proof runs on every default gate without needing the machine lock.

## The file lock: exactly what is proven, and what is not

Review challenged this and was right to. Every race test runs inside one process, where the static per-tenant monitor already serialises everything - so **with `AcquireFileLock` deleted outright, all eight still passed.** A guard whose removal changes no test is a guard nothing is holding, and the cross-process claim rested entirely on reading the code.

**Proven.** `CrossProcessGlossaryLockTests` starts a real second operating-system process (this assembly re-entered by `dotnet test` with a filter selecting an otherwise-inert helper) and races it against the parent, forty writes each, released together by a file signal:

| | result |
|---|---|
| with the file lock | passes, 80 terms, each with its trail entry (three runs, no flake) |
| without it | **fails - Expected: 80, Actual: 40** |

Half the writes vanish silently across processes. That is the lost update the in-process monitor cannot prevent, and no single-process test could ever show it.

**NOT proven, and deliberately not claimed.** This shows the lock serialises two processes against a **local** file system. It does **not** show that operating-system file locking is honoured by the hosted deployment's **network file share**, which nothing in this repository can reach. A hosted Gateway running two containers against one share therefore rests on an assumption, not on this evidence. The code comment now says exactly this rather than the wider claim it carried before, and the gap is tracked as its own issue on the product repository.

**A trap worth carrying forward:** a cross-process test that races nothing still passes. The first version of this test reported a child that "wrote nothing" - it had written all forty terms into its *own* redirected root, because the assembly's start-up points `CC_DIRECTOR_ROOT` at a per-run isolated directory and overwrote what the parent passed. Had the parent not verified that both sides actually wrote, it would have raced only itself, passed, and certified a lock it never exercised. The child now re-asserts the parent's root from a variable the redirect does not touch, writes a diagnostics file the parent quotes on failure, and the parent asserts both sides wrote before judging anything.

## How this agrees with issue 2482

The sibling seat is making hosted live dictation READ the tenant glossary. I read its branch (`origin/fix-2482-tenant-glossary-dictation`, commit `1c1876388`) rather than guessing.

The two agree by construction: **both resolve through `TenantGlossary`, and neither hand-injects a path.** 2482 changes `GatewayTranscriptionService` to take a `Func<TenantId, DictationDictionary>` defaulting to `TenantGlossary.Load`, and removes the hand-injected `glossaryPath` from `RecordingEndpoints.BuildService`. My write path goes to `TenantGlossary.PathFor(tenant)` for the tenant the request resolved. `Load` and `PathFor` are the same class and the same file, so a word an agent adds is a word the next dictation on that account reads.

They also do not conflict textually - I test-merged the branch into this one and the merge is clean (`Auto-merging RecordingEndpoints.cs / Automatic merge went well`). The two touch different parts of that file: 2482 is in `BuildService` at the bottom, this is the term handler at the top. `GlossaryPathFor` stays in use after 2482 removes its own caller, so nothing is orphaned either way.

## Regression coverage

Everything the brief asked to be pinned, is:

| Pinned | Where |
| --- | --- |
| Add succeeds with a session key | `AgentDictionaryAddTests.A_session_key_adds_a_term` (real hosted Gateway, real session key) |
| Delete and overwrite still refused with a session key | `The_destructive_verbs_are_refused_for_a_session_key` (8 routes), `A_refused_replacement_leaves_the_glossary_untouched`, `A_session_key_may_not_touch_the_wrong_spellings_list` |
| A term lands in the requesting tenant's glossary and nowhere else | `A_term_added_by_one_tenants_agent_reaches_no_other_tenant` - two fully enrolled accounts, checked through the HTTP read AND on disk |
| The adding session is recorded | `The_session_that_added_a_term_is_recorded`, plus `A_term_that_was_already_there_records_no_second_adder` and `A_person_adding_a_term_writes_no_session_trail` |

| The trail can be read, and separates one session's batch from another's | `An_agent_can_read_back_what_agents_added`, `The_trail_separates_one_sessions_batch_from_anothers` |
| Reading the trail does not expose the person's own terms | `The_trail_does_not_expose_the_persons_own_terms`, `One_tenants_trail_is_invisible_to_another` |
| Finding is not acting | `The_trail_cannot_be_written_or_swept_by_an_agent` |
| A human edit survives a concurrent agent add | `A_persons_save_racing_an_agent_add_is_never_half_lost` + 3 more (fast suite), `A_persons_save_racing_an_agent_add_over_http_never_loses_the_persons_corrections` |
| Every surviving term keeps its provenance under race | `Two_racing_sessions_each_keep_their_provenance`, `Many_racing_sessions_lose_no_provenance`, `Racing_sessions_over_http_keep_every_terms_provenance` |
| A trail that cannot be written fails the add | `An_add_whose_provenance_cannot_be_written_fails_and_adds_nothing` (+ its control), `An_add_whose_provenance_cannot_be_written_fails_over_http` |

Plus `SessionKeyGuardTests` (20 new cases: two allows, eighteen refusals covering the verb, the siblings, and the rest of the `/ingest` prefix - including the pair that carries the whole shape, `GET .../additions` allowed while `GET /ingest/dictionary` is refused), and `test_dictionary_ops.py` (19 cases on the command line, including that `add` never sends `mistranscriptions`, that there is no `remove`/`set`/`list` verb, and that an empty trail distinguishes "no agent has added anything" from "your filter matched nothing").

The proof is HTTP and hosted, not a call to the guard, because a test against either half of the grant alone would pass while the other half was wrong.

## What was run

`.\scripts\test-local.ps1 -Parked` - `-Parked` because the change lands in Gateway code, which adds the two suites the default run skips: `CcDirector.Gateway.Tests` (host-bound, machine-wide lock, where the new end-to-end tests live) and `CcDirector.Core.Tests`.

**10 of 11 projects green. One red, and it is not this change.**

| | |
| --- | --- |
| `CcDirector.Gateway.UnitTests` | 3000 passed at the time of that run; **3012 on the final re-run**, which adds the nine concurrency tests |
| `CcDirector.Gateway.Tests` | 2278 passed, **1 failed**, 4 skipped - the failure is the pre-existing Postgres one below |
| `CcDirector.Core.Tests` | 4265 passed |
| the other 8 projects | all green |

**Final state, after the read path and both concurrency fixes** (re-run once the machine-wide lock freed):

| suite | result |
| --- | --- |
| `CcDirector.Gateway.Tests` filtered to `AgentDictionaryAddTests` | **27 passed, 0 failed** (57s) |
| `CcDirector.Gateway.UnitTests` full | **3012 passed**, 2 skipped - green on three consecutive runs |
| `CcDirector.Core.UnitTests` | 153 passed |
| `tools/cc-devthrottle` pytest | 250 passed |
| `tools/test_shipped_tools_contract.py` | 36 passed |

Nothing on this pull request is marked unproven. Review status is a separate matter - see the comments.

The one failure is `PostgresProviderProofTests.Collation_ExplicitC_OnExactlyTheDeclaredNaturalKeys_OnRealPostgres`.

**Judged against the parent, not assumed.** I reproduced it on a detached worktree of clean `origin/main` at `68f48c1f1cf343632ed0d605fef7560ff346e9b7`, tree clean, filtered to that one test: `Failed! - Failed: 1, Passed: 0, Total: 1`. So it is red on untouched `main` and pre-existing.

The cause, read out of `origin/main` with `git show` rather than a working tree: `GatewayDbContext` declares **20** `UseCollation("C")` columns including `session_keys.SessionId` and `session_keys.KeyHash`, while the test's expected list enumerates **18** and contains no `session_keys` at all - exactly the two columns the failure names. The schema is correct; the hand-maintained list in the test is stale. It survived because these classes skip without `CC_GATEWAY_TEST_PG_CONNECTION`, which `ci.yml` never sets (it mentions Postgres zero times) and `test-local.ps1` never sets either - so no gate this project runs has ever executed it. Filed as devthrottle_internal thefrederiksen/devthrottle_internal#773, cross-referenced with thefrederiksen/devthrottle#1426. The Release 2.0.1 Architect has recorded it as a known red rather than a blocker.

Also run:

- `python -m pytest tests` in `tools/cc-devthrottle` - **250 passed**, re-run after the read path was added.
- `python -m pytest test_shipped_tools_contract.py` in `tools` - 36 passed.
- `CcDirector.Gateway.UnitTests` in full, after both concurrency fixes - **3010 passed**, including the eight new race tests.
- `CcDirector.Core.UnitTests` - 153 passed.

## What was NOT verified

- Nothing was driven through a real running Director or a real microphone. The proof is at the HTTP boundary with real session keys and real tenants, which is where the grant lives; whether a freshly added word audibly improves a dictation is downstream of issue 2482 and is that seat's ground to cover.
- The tutorial text the issue mentions ("the docs now describe the shipped truth" - that the flow is human-only) is not in this repository, so it is now out of date in the other direction. Flagging it rather than chasing it into another repository unasked.




