### PR TITLE
Delete the dead speech-to-text bias path and record the ruling at the deletion site

### DIFF
--- a/apps/cockpit/src/dictionary/DictionaryView.tsx
+++ b/apps/cockpit/src/dictionary/DictionaryView.tsx
@@ -23,8 +23,10 @@ import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { ConfirmDialog } from "../components";
 
 // The dictation Dictionary editor (issue #977, epic #967) - the React port of the Blazor Cockpit
-// Dictionary.razor (#183). The human edits the vocabulary chips biased into speech-to-text and the
-// common-mistranscriptions term-to-variant map fed to the cleanup pass, with a dirty-state Save that
+// Dictionary.razor (#183). The human edits the vocabulary chips and the common-mistranscriptions
+// term-to-variant map. BOTH are fed to the cleanup pass and NEITHER is ever sent to the
+// speech-to-text provider: the transcriber gets audio only, and the listed words are substituted
+// afterwards on the finished transcript (issue 2481). Edited with a dirty-state Save that
 // PUTs the whole glossary and re-renders the returned dictionary. It reads and writes same-origin
 // through the Gateway front door (client-core) - never a Director address.
 //
@@ -567,7 +569,7 @@ export function DictionaryView() {
             {/* ---- Vocabulary ---- */}
             <div className="dc-section">
               <h2>Vocabulary</h2>
-              <p className="dc-hint">Terms biased into speech-to-text.</p>
+              <p className="dc-hint">Terms corrected to this spelling after transcription.</p>
               <div className="dc-chips">
                 {dict.vocabulary.map((term, i) => (
                   <span className="dc-chip" key={`${term}/${i}`}>

--- a/docs/architecture/transcription-quality-loop.md
+++ b/docs/architecture/transcription-quality-loop.md
@@ -101,9 +101,17 @@ Findings (full report saved separately). Our approach is the standard one; we ar
     Metaphone. Add per-term precomputed IPA rather than a runtime dependency if possible.
   - Borrow Microsoft.PhoneticMatching's `EnHybridDistance` design (phonetic blended with edit distance)
     as the scoring template, swapping its English engine for the multilingual one.
-- **Orthogonal wins:** use the transcription provider's own biasing channel (Whisper `initial_prompt`,
-  Deepgram keywords, AssemblyAI word_boost, Speechmatics `sounds_like`) so fewer errors reach cleanup;
-  and consider an optional per-term `sounds_like`/pronunciation field (every serious product offers it).
+- **RULED OUT - the provider's own biasing channel.** This bullet used to propose exactly that
+  (Whisper `initial_prompt`, Deepgram keywords, AssemblyAI word_boost, Speechmatics `sounds_like`,
+  plus a per-term pronunciation field) so fewer errors would reach cleanup. The owner ruled against
+  it on 2026-08-07 (issue 2481) and the dead code for it has been deleted. **Do not propose it
+  again.** Nothing - no vocabulary, no keyword list, no pronunciation hint - is ever sent to the
+  speech-to-text provider; it gets audio only. Priming the transcriber makes it steer toward the
+  suggested words, changing wording and sentence structure rather than just spelling, and that
+  corrupts the record of what was actually said. Meaning preservation outranks the error rate: a
+  faithful transcript with a wrong spelling beats a fluent one with altered meaning, and the wrong
+  spelling is what the cleanup pass exists to fix. This constrains the whole section - every recall
+  improvement has to come from the cleanup matcher, which is why that is where the work goes.
 
 ## 6. Continuous improvement + always-deploy-best - PROCESS
 

--- a/docs/architecture/transcription-quality-loop.md
+++ b/docs/architecture/transcription-quality-loop.md
@@ -47,7 +47,9 @@ We already have `tools/harnesses/transcription-eval-harness/` (audio -> transcri
 recall) and 5 recorded English fixtures. Transcription is now third-party, so the new harness focuses on
 the DICTIONARY CLEANUP step, holds transcription constant, and is multilingual. The design is lifted from
 established ASR-customization / contextual-biasing methodology (GenSEC/HyPoradise, LibriSpeech biasing),
-NOT invented.
+NOT invented. To be clear about what is borrowed: the MEASUREMENT method (the B-WER / U-WER split
+below), not the technique. We do not do contextual biasing - nothing is sent to the transcriber but
+audio (issue 2481). Transcription is held constant and only the cleanup step is measured.
 
 Central design decision - hold transcription constant (text-in / text-out). Each fixture is:
 `{ language (BCP-47), raw_transcript (frozen mishearing), term_list (targets + distractors),

--- a/docs/features/dictation/PLAN.md
+++ b/docs/features/dictation/PLAN.md
@@ -101,6 +101,9 @@ GitHub repo, no separate package, no multi-vendor abstraction.
 1. **Phase 0, proof of fact.** No code commitment. Record a 30 second
    clip of representative speech with company terms. Send it through
    OpenAI gpt-4o-transcribe both with and without the prompt parameter.
+   > CORRECTION, 2026-08-07 (owner ruling, issue 2481): the "with the prompt parameter"
+   > arm was REJECTED. Nothing is ever sent to the transcriber but audio. The script that
+   > ran this experiment is tombstoned and will not run.
    Run both transcripts through a Haiku cleanup pass that knows the term
    list. Compare. Only proceed if the dictionary mechanism works
    reliably enough on your real voice and real terms.

--- a/docs/features/dictation/PLAN.md
+++ b/docs/features/dictation/PLAN.md
@@ -17,6 +17,12 @@ GitHub repo, no separate package, no multi-vendor abstraction.
    ways. As a soft prior via the OpenAI prompt parameter, and as a strong
    corrector via the Haiku cleanup pass with the term list in the system
    prompt.
+   > CORRECTION, 2026-08-07 (owner ruling, issue 2481): the first of those two ways was
+   > REJECTED and its code deleted. The dictionary is applied ONE way only - as a
+   > correction pass over the finished transcript. Nothing is ever sent to the
+   > speech-to-text provider as a prior, a prompt, or any other steering hint, because
+   > priming the transcriber changes wording and sentence structure and corrupts the
+   > record of what was said.
 3. Post-process cleanup. A small Claude model runs on the final transcript
    with the dictionary as context to repair mistakes and apply style.
 4. Cross-platform consumers. Same library serves Windows desktop today,
@@ -75,6 +81,9 @@ GitHub repo, no separate package, no multi-vendor abstraction.
 - **DictionaryLoader.** Parses the YAML. Watches the file for changes.
   Packs the keyterm list for OpenAI prompts and for the Haiku cleanup
   system prompt.
+  > CORRECTION, 2026-08-07 (owner ruling, issue 2481): the packing-for-OpenAI-prompts half
+  > was `BuildSttPrompt`, and it is DELETED. DictionaryLoader today only loads, watches and
+  > writes the dictionary; nothing in it builds a prompt for the transcriber.
 - **ProviderClient.** Speaks the OpenAI Realtime API over WebSocket.
   Streams audio chunks. Surfaces partial and final transcripts.
 - **AudioBuffer.** Ring buffer with disk spill, used during offline

--- a/docs/features/dictation/STATUS.md
+++ b/docs/features/dictation/STATUS.md
@@ -66,6 +66,14 @@ Expected end-to-end latencies on a typical sentence:
 
 ## Phase 0: PASS
 
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): the half of this experiment that used
+> the transcription **prompt parameter** was later REJECTED and the code deleted. Vocabulary
+> and steering hints are never sent to the speech-to-text provider - it gets audio only -
+> because priming the transcriber makes it steer toward the suggested words, changing wording
+> and sentence structure and corrupting the record of what was said. The listed words are
+> substituted afterwards by a separate pass over the finished transcript. The result below is
+> left as the dated record of what was tried.
+
 The proof-of-fact experiment in `docs/features/dictation/phase0/` validated
 that OpenAI `gpt-4o-transcribe` with the prompt parameter, followed by a
 Claude Haiku cleanup pass that has the vocabulary and known mistranscription
@@ -171,6 +179,9 @@ The browser-facing surface is in place:
   default of `%LOCALAPPDATA%/cc-director/dictation/dictionary.yaml`.
   Missing file means "no vocabulary bias, no cleanup glossary" without
   breaking the pipeline.
+  > CORRECTION, 2026-08-07 (owner ruling, issue 2481): there is no "vocabulary bias" and
+  > there never will be - nothing from this file reaches the transcriber. A missing file
+  > means no cleanup glossary, so transcripts come back uncorrected.
 - **Three integration tests** in
   `src/CcDirector.Gateway.Tests/DictationEndpointTests.cs`. Two pure
   protocol checks plus one full end-to-end roundtrip: client opens a

--- a/docs/features/dictation/phase0/REPORT.md
+++ b/docs/features/dictation/phase0/REPORT.md
@@ -4,6 +4,15 @@ Verdict: PASS (9/9 expected company-term occurrences recovered in the final vari
 
 ## Method
 
+> **CORRECTION, 2026-08-07 (owner ruling, issue 2481).** The variants below that use the
+> transcription **prompt parameter** describe an approach that was REJECTED, and the code for it
+> has been deleted. Read the `with_prompt` results as a record of an experiment, NOT as a reason
+> to build it: vocabulary and steering hints are never sent to the speech-to-text provider,
+> because priming it makes the model steer toward the suggested words, changing wording and
+> sentence structure and corrupting the record of what was actually said. Meaning preservation
+> outranks term recall. What ships is the `no_prompt` transcript plus a correction pass over the
+> finished text.
+
 Generated 3 synthetic clips with OpenAI tts-1 (voice=alloy).
 Each clip transcribed with gpt-4o-transcribe in three variants:
 
@@ -14,6 +23,10 @@ Each clip transcribed with gpt-4o-transcribe in three variants:
 Pass criterion: every expected company term appears in the variant 3 transcript for every clip (case-insensitive substring match).
 
 ## Results
+
+> **CORRECTION (issue 2481):** the `with_prompt` rows below are the REJECTED approach. A better
+> score there is not an argument for it - priming the transcriber changes wording and sentence
+> structure, which these clip-level term checks do not measure. See the note at the top.
 
 ### Clip 1
 
@@ -70,6 +83,13 @@ Expected company terms: acmeflow, CenCon, cc-director
 > Tell acmeflow that the CenCon report is ready and ping the cc-director gateway team.
 
 ## Interpretation
+
+> **CORRECTION (issue 2481):** the conclusion below rests on the transcription **prompt
+> parameter**, which the owner REJECTED on 2026-08-07; the code for it is deleted. Nothing is
+> sent to the transcriber but audio, and the listed words are substituted afterwards on the
+> finished transcript - priming it changes wording and sentence structure and corrupts the
+> record of what was said. Any follow-up here that tunes a transcription prompt, or that reaches
+> for a provider's keyterm boosting, is closed. Only the cleanup pass is open.
 
 OpenAI gpt-4o-transcribe with the prompt parameter, followed by a Claude Haiku cleanup pass that has the term list in its system prompt, reliably recovers all expected company terms across the synthetic test clips.
 

--- a/docs/features/dictation/phase0/REPORT_v1.md
+++ b/docs/features/dictation/phase0/REPORT_v1.md
@@ -4,6 +4,15 @@ Verdict: FAIL (8/9 expected company-term occurrences recovered in the final vari
 
 ## Method
 
+> **CORRECTION, 2026-08-07 (owner ruling, issue 2481).** The variants below that use the
+> transcription **prompt parameter** describe an approach that was REJECTED, and the code for it
+> has been deleted. Read the `with_prompt` results as a record of an experiment, NOT as a reason
+> to build it: vocabulary and steering hints are never sent to the speech-to-text provider,
+> because priming it makes the model steer toward the suggested words, changing wording and
+> sentence structure and corrupting the record of what was actually said. Meaning preservation
+> outranks term recall. What ships is the `no_prompt` transcript plus a correction pass over the
+> finished text.
+
 Generated 3 synthetic clips with OpenAI tts-1 (voice=alloy).
 Each clip transcribed with gpt-4o-transcribe in three variants:
 
@@ -14,6 +23,10 @@ Each clip transcribed with gpt-4o-transcribe in three variants:
 Pass criterion: every expected company term appears in the variant 3 transcript for every clip (case-insensitive substring match).
 
 ## Results
+
+> **CORRECTION (issue 2481):** the `with_prompt` rows below are the REJECTED approach. A better
+> score there is not an argument for it - priming the transcriber changes wording and sentence
+> structure, which these clip-level term checks do not measure. See the note at the top.
 
 ### Clip 1
 
@@ -70,6 +83,13 @@ Expected company terms: acmeflow, CenCon, cc-director
 > Tell acmeflow that the CenCon report is ready and ping the cc-director gateway team.
 
 ## Interpretation
+
+> **CORRECTION (issue 2481):** the conclusion below rests on the transcription **prompt
+> parameter**, which the owner REJECTED on 2026-08-07; the code for it is deleted. Nothing is
+> sent to the transcriber but audio, and the listed words are substituted afterwards on the
+> finished transcript - priming it changes wording and sentence structure and corrupts the
+> record of what was said. Any follow-up here that tunes a transcription prompt, or that reaches
+> for a provider's keyterm boosting, is closed. Only the cleanup pass is open.
 
 Variant 3 did not recover every expected company term. Inspect transcripts.json. Possible follow-ups before committing to Phase 1:
 

--- a/docs/features/dictation/phase0/REPORT_v2.md
+++ b/docs/features/dictation/phase0/REPORT_v2.md
@@ -4,6 +4,15 @@ Verdict: FAIL (8/9 expected company-term occurrences recovered in the final vari
 
 ## Method
 
+> **CORRECTION, 2026-08-07 (owner ruling, issue 2481).** The variants below that use the
+> transcription **prompt parameter** describe an approach that was REJECTED, and the code for it
+> has been deleted. Read the `with_prompt` results as a record of an experiment, NOT as a reason
+> to build it: vocabulary and steering hints are never sent to the speech-to-text provider,
+> because priming it makes the model steer toward the suggested words, changing wording and
+> sentence structure and corrupting the record of what was actually said. Meaning preservation
+> outranks term recall. What ships is the `no_prompt` transcript plus a correction pass over the
+> finished text.
+
 Generated 3 synthetic clips with OpenAI tts-1 (voice=alloy).
 Each clip transcribed with gpt-4o-transcribe in three variants:
 
@@ -14,6 +23,10 @@ Each clip transcribed with gpt-4o-transcribe in three variants:
 Pass criterion: every expected company term appears in the variant 3 transcript for every clip (case-insensitive substring match).
 
 ## Results
+
+> **CORRECTION (issue 2481):** the `with_prompt` rows below are the REJECTED approach. A better
+> score there is not an argument for it - priming the transcriber changes wording and sentence
+> structure, which these clip-level term checks do not measure. See the note at the top.
 
 ### Clip 1
 
@@ -70,6 +83,13 @@ Expected company terms: acmeflow, CenCon, cc-director
 > Tell acmeflow that the CenCon report is ready and ping the cc-director gateway team.
 
 ## Interpretation
+
+> **CORRECTION (issue 2481):** the conclusion below rests on the transcription **prompt
+> parameter**, which the owner REJECTED on 2026-08-07; the code for it is deleted. Nothing is
+> sent to the transcriber but audio, and the listed words are substituted afterwards on the
+> finished transcript - priming it changes wording and sentence structure and corrupts the
+> record of what was said. Any follow-up here that tunes a transcription prompt, or that reaches
+> for a provider's keyterm boosting, is closed. Only the cleanup pass is open.
 
 Variant 3 did not recover every expected company term. Inspect transcripts.json. Possible follow-ups before committing to Phase 1:
 

--- a/docs/features/dictation/phase0/run_phase0.py
+++ b/docs/features/dictation/phase0/run_phase0.py
@@ -1,22 +1,59 @@
 """
-Phase 0 proof of fact for the cc-director dictation library.
+TOMBSTONE - THIS SCRIPT IS RETIRED AND WILL NOT RUN. DO NOT REVIVE IT.
 
-Verifies that OpenAI gpt-4o-transcribe with the prompt parameter, plus a
-Claude Haiku cleanup pass, correctly transcribes company-specific terms.
+It is kept as the dated record of the Phase 0 experiment (2026-05), not as a
+tool. It verified OpenAI gpt-4o-transcribe WITH THE PROMPT PARAMETER, plus a
+Claude Haiku cleanup pass - and the prompt-parameter half of that design was
+REJECTED by the owner on 2026-08-07 (issue 2481).
 
-PASS if all expected company terms appear correctly in the cleaned
-transcript for every test clip. FAIL otherwise.
+DevThrottle never sends vocabulary, glossaries, or any other steering hint to
+the speech-to-text provider. Dictation is two strict stages: transcribe the raw
+audio as faithfully as possible, audio only, then run a separate code-driven
+correction pass that replaces the listed words on the finished transcript.
+Priming the transcriber makes it steer toward the suggested words, which changes
+wording and sentence structure and corrupts the record of what was actually
+said. Meaning preservation is paramount; this was learned from real problems.
 
-Outputs to docs/features/dictation/phase0/:
+So the STT_PROMPT below is a rejected approach, not a missing feature. The
+matching C# code (DictionaryLoader.BuildSttPrompt) has been deleted. Being off
+the build path is not safety while the file is still executable and its own
+docstring claims it verifies the design - hence the hard exit below.
+
+The original outputs it produced are beside it and are still the record:
   clip{N}.mp3       generated TTS audio
   transcripts.json  raw and cleaned transcripts for all variants
   REPORT.md         human-readable summary with verdict
 """
 
+import sys
+
+print(
+    "run_phase0.py is a TOMBSTONE and does not run.\n"
+    "\n"
+    "It exercised the speech-to-text prompt/bias parameter, which the owner\n"
+    "rejected on 2026-08-07 (issue 2481). Vocabulary and steering hints are\n"
+    "never sent to the transcriber: transcribe the raw audio faithfully, then\n"
+    "substitute the listed words on the finished transcript in a separate pass.\n"
+    "Priming the transcriber changes wording and sentence structure and\n"
+    "corrupts the record of what was said.\n"
+    "\n"
+    "The code below is kept only as the dated record of the experiment.\n"
+    "Do not re-enable it. If you need transcription quality work, it belongs\n"
+    "in the cleanup pass - see docs/architecture/transcription-quality-loop.md.",
+    file=sys.stderr,
+)
+sys.exit(2)
+
+
+# ===========================================================================
+# EVERYTHING BELOW THIS LINE IS THE ORIGINAL EXPERIMENT, RETAINED AS THE
+# RECORD OF WHAT WAS RUN IN MAY 2026. IT IS UNREACHABLE - the sys.exit above
+# stops the module before any of it executes. Do not "fix" that.
+# ===========================================================================
+
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 from openai import OpenAI

--- a/docs/goals/GOAL_DICTATION_LIBRARY.md
+++ b/docs/goals/GOAL_DICTATION_LIBRARY.md
@@ -41,6 +41,15 @@ result.
      cleanup pass whose system prompt contains the term list as
      "known company terms, fix any obvious mistranscriptions."
 
+   > CORRECTION, 2026-08-07 (owner ruling, issue 2481): of the three variants above, the
+   > two that put the term list in the **prompt parameter** describe an approach that was
+   > REJECTED, and the code for it has been deleted. The term list is never sent to the
+   > speech-to-text provider in any form: the transcriber gets audio only, and the listed
+   > words are substituted afterwards on the finished transcript. Priming the transcriber
+   > makes it steer toward the suggested words, changing wording and sentence structure and
+   > corrupting the record of what was said. This experiment plan is left as written,
+   > because it is the dated record of what was tried.
+
 3. For each clip and each variant, record the raw output. Save the audio
    files and the JSON of all transcripts under
    `docs/features/dictation/phase0/`.

--- a/docs/goals/GOAL_DICTATION_LIBRARY.md
+++ b/docs/goals/GOAL_DICTATION_LIBRARY.md
@@ -161,6 +161,9 @@ Stop and ask the user in any of these situations:
 - You hit an OpenAI or Anthropic API behavior that contradicts what
   PLAN.md assumes (for example, the Realtime API does not actually
   support the prompt parameter the way we expect).
+  > CORRECTION, 2026-08-07 (owner ruling, issue 2481): whether the provider supports a
+  > prompt parameter is moot - we do not use one. Nothing but audio is sent to the
+  > transcriber.
 - Something requires the user's microphone to verify. This is Phase 2
   territory.
 - You are unsure whether a change is in scope. Ask first.

--- a/docs/plans/phone-recorder-otter-replacement.md
+++ b/docs/plans/phone-recorder-otter-replacement.md
@@ -54,7 +54,7 @@ that feeds existing code.
 | `DictationSession` facade | `src/CcDirector.Core/Dictation/DictationSession.cs` | Drive transcription of each uploaded chunk |
 | `OpenAiTranscriptionProvider` (batch) | `src/CcDirector.Core/Dictation/Providers/OpenAiTranscriptionProvider.cs` | Transcribe a finalized audio file via `/v1/audio/transcriptions`. This is the right provider for file ingest (NOT the realtime one). |
 | `CleanupOrchestrator` | `src/CcDirector.Core/Dictation/CleanupOrchestrator.cs` | gpt-4o-mini cleanup pass with vocabulary + known-mistranscription glossary |
-| `DictionaryLoader` + dictionary YAML | `src/CcDirector.Core/Dictation/` | Company-term vocabulary bias (ConPTY, Avalonia, acmeflow, etc.) |
+| `DictionaryLoader` + dictionary YAML | `src/CcDirector.Core/Dictation/` | Company-term vocabulary bias (ConPTY, Avalonia, acmeflow, etc.) - CORRECTION 2026-08-07 (issue 2481): not a bias. These terms are never sent to the transcriber; they are corrected on the finished transcript. |
 | `AudioBuffer` (disk spill) | `src/CcDirector.Core/Dictation/AudioBuffer.cs` | Reference for the crash-safe / chunked philosophy; the phone mirrors this on-device |
 | Gateway endpoint pattern | `src/CcDirector.Gateway/Api/GatewayEndpoints.cs` | Where the new `/ingest/*` routes are mapped |
 | Gateway auth (token) + Tailscale Serve | `src/CcDirector.Gateway/Tailscale/` | The HTTPS-only remote path the phone uploads over |
@@ -238,6 +238,13 @@ Server-side storage of received chunks + manifest:
 existing dictation buffer convention).
 
 ### D. Server pipeline (reuses existing code)
+
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): step 1 below is wrong about how the
+> dictionary is used, and always was. The dictionary is NOT passed to the transcriber as
+> "vocabulary bias" - no vocabulary and no steering hint is ever sent to the speech-to-text
+> provider, because priming it changes wording and sentence structure and corrupts the
+> record of what was said. The transcriber gets audio only; the dictionary is applied
+> afterwards, in the cleanup step. The plan is left as written as a dated record.
 
 1. Each received chunk -> `OpenAiTranscriptionProvider` (batch) with the
    loaded dictionary as vocabulary bias -> per-chunk raw transcript stored

--- a/docs/plans/voice-dictionary-page.md
+++ b/docs/plans/voice-dictionary-page.md
@@ -117,6 +117,12 @@ definition of the path (extract a small helper, e.g.
 
 ## Dictionary page layout (target)
 
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): the mockup below labels the vocabulary
+> "terms biased into speech-to-text". That was never how it should have read and the shipped
+> page no longer says it. Nothing in the glossary is sent to the speech-to-text provider; the
+> terms are corrected on the finished transcript after it comes back. The mockup is left as
+> the dated record of the design.
+
 ```
 +=======================================================================+
 |  Voice Recorder                                       <- Dashboard     |

--- a/docs/plans/voice-dictionary-page.md
+++ b/docs/plans/voice-dictionary-page.md
@@ -16,6 +16,14 @@ YAML file.
 - File: `%LOCALAPPDATA%\cc-director\dictation\dictionary.yaml`
 - Parsed by `DictionaryLoader` (`src/CcDirector.Core/Dictation/DictionaryLoader.cs`),
   shaped by `DictationDictionary` (`Models/Dictionary.cs`).
+
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): the `vocabulary` description immediately
+> below is wrong about CURRENT behaviour. Nothing is packed into a speech-to-text `prompt`
+> bias - that code (`DictionaryLoader.BuildSttPrompt`) has been deleted. The transcriber is
+> given audio only; the canonical terms are applied by the cleanup pass to the finished
+> transcript, because priming the transcriber changes wording and sentence structure and
+> corrupts the record of what was said.
+
 - Three sections:
   - `vocabulary` - canonical terms, packed into the OpenAI STT `prompt` bias.
   - `common_mistranscriptions` - correct term -> wrong spellings seen in practice,
@@ -132,6 +140,9 @@ definition of the path (extract a small helper, e.g.
 |  desktop voice-to-type. Edits apply on the next recording.  [ Save ]   |
 +-----------------------------------------------------------------------+
 |  VOCABULARY                  terms biased into speech-to-text          |
+|  <-- WRONG COPY, issue 2481. Shipped page reads "Terms corrected to    |
+|      this spelling after transcription." Nothing is sent to the        |
+|      transcriber. Do not copy the line above.                          |
 |  +-----------------------------------------------------------------+  |
 |  |  [ acmeflow x ] [ CenCon x ] [ ConPTY x ] [ cc-director x ]      |  |
 |  |  [ Avalonia x ] [ Example User x ]                        |  |
@@ -163,6 +174,9 @@ definition of the path (extract a small helper, e.g.
   PUT with malformed body returns 400; missing file GET returns empty shape.
 - Manual: edit a term on the page, save, record a phone clip, confirm the new
   term biases the transcript.
+  > CORRECTION, 2026-08-07 (owner ruling, issue 2481): nothing biases the transcript. The
+  > check that applies is that the new term is CORRECTED into the finished transcript by the
+  > cleanup pass; the transcriber never sees it.
 
 ## Risks / notes
 

--- a/docs/problems/voice-dictionary-not-applied-on-mobile.md
+++ b/docs/problems/voice-dictionary-not-applied-on-mobile.md
@@ -49,6 +49,10 @@ Evidence:
    construction and cached in a readonly field. A later vocabulary edit cannot
    change it for this instance.
 
+   > CORRECTION, 2026-08-07 (owner ruling, issue 2481): there is no speech-to-text bias
+   > prompt any more. `BuildSttPrompt` and this `_sttPrompt` field are DELETED, and the
+   > class itself no longer exists. Vocabulary is never sent to the transcriber.
+
 3. `OpenAiRecordingTranscriber.cs:72`
    ```csharp
    => _cleanup.CleanAsync(rawTranscript, _dictionary.Current, "default", ct);
@@ -64,6 +68,9 @@ Evidence:
 
 So the recording transcriber's vocabulary bias AND cleanup glossary are both
 fixed at the moment the Gateway started.
+
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): there is no "vocabulary bias" half of
+> this any more - only the cleanup glossary. Nothing is sent to the transcriber but audio.
 
 ## Why this contradicts the docs (the trap)
 
@@ -99,6 +106,11 @@ repos); a blanket mapping would wrongly rewrite real uses. The correct lever is
 the STT `vocabulary` bias (already contains "acmeflow") plus restarting/reloading
 so it actually applies - not a risky find-replace rule.
 
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): the lever named here DOES NOT EXIST and
+> is not coming back. There is no speech-to-text vocabulary bias. The reasoning about "my
+> repo" still stands - do not add it as a literal mistranscription mapping - but the remedy
+> is the cleanup pass over the finished transcript, not priming the transcriber.
+
 ## What was changed on disk during the session (does NOT fix the bug by itself)
 
 `%LOCALAPPDATA%\cc-director\dictation\dictionary.yaml` - added to the `acmeflow`
@@ -120,6 +132,13 @@ root cause above.
 6. Restart the Gateway, upload the same recording: now the edit applies.
 
 ## Suggested fix (pick one; option A preferred)
+
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): DO NOT IMPLEMENT the `_sttPrompt`
+> bullet in option A. Recomputing a speech-to-text prompt per transcription is exactly the
+> rejected approach - vocabulary and steering hints are never sent to the transcriber,
+> because priming it changes wording and sentence structure and corrupts the record of what
+> was said. `BuildSttPrompt` is deleted. The live-reload point itself is fine; it applies to
+> the cleanup glossary only.
 
 A. Make the recording transcriber reload the dictionary live, the same way
    desktop dictation does:

--- a/docs/problems/voice-dictionary-not-applied-on-mobile.md
+++ b/docs/problems/voice-dictionary-not-applied-on-mobile.md
@@ -163,6 +163,12 @@ After the fix, correct the two stale docs:
 
 ## Acceptance
 
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): the first criterion below names the
+> rejected behaviour as REQUIRED, which would make a tester sign off on the thing that is
+> banned. There is no "vocabulary bias" to confirm and there must never be one. The criterion
+> that applies is that the new CORRECTION is applied to the finished transcript; the
+> transcriber is given audio only.
+
 - Edit the dictionary, do NOT restart the Gateway, upload a phone recording with
   the affected term, and confirm the new correction/vocabulary bias is applied.
 - A regression test that constructs the recording transcriber, changes the

--- a/docs/problems/voice-dictionary-not-applied-on-mobile.md
+++ b/docs/problems/voice-dictionary-not-applied-on-mobile.md
@@ -5,6 +5,15 @@ Reporter: the maintainer (via assistant session in a private workspace)
 Component: CcDirector.Gateway recording/transcription pipeline + dictation dictionary
 Severity: medium (functional - corrections never take effect on the path the user actually uses)
 
+> HISTORICAL RECORD, 2026-05-25. Kept for the history; do not work from it. The class it
+> describes, `OpenAiRecordingTranscriber`, no longer exists, and the parts below that talk
+> about a speech-to-text bias prompt describe an approach the owner has since REJECTED
+> (issue 2481, 2026-08-07). Vocabulary and steering hints are never sent to the transcriber:
+> it gets audio only, and the listed words are substituted afterwards by a separate pass over
+> the finished transcript. `DictionaryLoader.BuildSttPrompt` and its `_sttPrompt` field are
+> deleted. Ignore suggested fix A's second bullet, and the "the correct lever is the STT
+> `vocabulary` bias" line - there is no such lever and there is not going to be one.
+
 ## Symptom (what the user experienced)
 
 The mobile voice unit keeps mishearing the company name "acmeflow" and the user

--- a/docs/research/transcription-speed/FINDINGS.md
+++ b/docs/research/transcription-speed/FINDINGS.md
@@ -70,6 +70,10 @@ Avoid DeepInfra for the latency-critical path (the 4-45s variability already exp
 
 ## 3. Dictionary cleanup WITHOUT an LLM (threads: non-LLM cleanup + ASR biasing)
 
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): the "ASR biasing" thread named in this
+> heading is REJECTED in full - see 3a below. Nothing is sent to the speech-to-text provider
+> but audio. Only the non-LLM cleanup thread survives, and it is the whole approach.
+
 Both research threads converge on the SAME architecture: **no LLM in the hot path.**
 
 ### 3a. Bias the transcriber (nearly free)

--- a/docs/research/transcription-speed/FINDINGS.md
+++ b/docs/research/transcription-speed/FINDINGS.md
@@ -66,6 +66,15 @@ Avoid DeepInfra for the latency-critical path (the 4-45s variability already exp
 Both research threads converge on the SAME architecture: **no LLM in the hot path.**
 
 ### 3a. Bias the transcriber (nearly free)
+
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): this recommendation was REJECTED and the
+> code written for it has been deleted. The vocabulary is never passed to the transcriber in
+> any form, and the engine-comparison table above must not be read as making keyword-biasing
+> strength a selection criterion. Priming the transcriber makes it steer toward the suggested
+> words, changing wording and sentence structure and corrupting the record of what was said.
+> Section 3b - the deterministic matcher on the finished transcript - is the whole approach.
+> The research is left as written, as the dated record of what was considered.
+
 Pass the known vocabulary as a short glossary in the transcription `prompt` parameter so most
 terms come out right at the source. Caveats (OpenAI cookbook): the Whisper/gpt-4o prompt hint
 fixes SOME rare terms but not all, and does not reliably enforce casing (lowercase `mindzie`).

--- a/docs/research/transcription-speed/FINDINGS.md
+++ b/docs/research/transcription-speed/FINDINGS.md
@@ -45,6 +45,13 @@ Speed-first ranking for short dictation clips (~2s-2min), .NET Windows host w/ o
 | **Parakeet-TDT 0.6B (sherpa-onnx)** | Local | <0.05 s GPU / ~0.5 s CPU | $0 | weak | Good (C# NuGet, in-proc) |
 | **Whisper.net (whisper.cpp)** | Local | ~0.1-0.5 s GPU / 1-5 s CPU | $0 | initial_prompt | Best (native C#, Vulkan/CUDA/CPU) |
 
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): ignore the "Custom vocab" column when
+> choosing an engine. DevThrottle does not use any provider's custom-vocabulary channel -
+> no `prompt` hint, no keyterms, no `initial_prompt` - because priming the transcriber
+> changes wording and sentence structure and corrupts the record of what was said. Terms
+> are corrected on the finished transcript instead. Speed, cost and .NET fit are the real
+> selection criteria here; that column is not one.
+
 **Recommendation:**
 - **Fastest win, minimal effort: switch the default to Groq `whisper-large-v3-turbo`.**
   It is an OpenAI-compatible endpoint, so the Gateway proxy changes only base URL + key +
@@ -81,6 +88,10 @@ fixes SOME rare terms but not all, and does not reliably enforce casing (lowerca
 Stronger engines if we ever switch: Deepgram Keyterm / AssemblyAI keyterms_prompt (~90% recall,
 casing preserved) / Speechmatics `sounds_like` (encode the exact mishearings).
 
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): none of these engine features will be
+> used, however strong. Switching engine is a speed and cost decision only; the keyword
+> channel is not a reason to pick one, because we never send words to the transcriber.
+
 ### 3b. Replace the o4-mini cleanup with an in-process deterministic matcher
 The cleanup's only job is fixing a known, finite custom vocabulary - a deterministic
 string-matching problem, not a generative one. The mishearings are phonetic
@@ -98,6 +109,10 @@ proposal mechanism (stage b), catching the NEW variants that currently escape to
 
 **Can biasing alone drop cleanup?** No - no engine guarantees rare-proper-noun spelling/casing.
 Keep a cleanup step, but make it the deterministic matcher above, not an LLM.
+
+> CORRECTION, 2026-08-07 (owner ruling, issue 2481): the question is moot - there is no
+> biasing at all. Nothing is sent to the transcriber but audio, so the cleanup pass is not
+> merely kept, it is the ONLY correction stage there is.
 
 ---
 
@@ -138,6 +153,11 @@ Both are enforced by skipping multi-token windows containing a canonical term or
    and an entire class of network failures; deterministic and unit-testable.
 3. **Bias transcription** with the vocabulary glossary via the `prompt` parameter (nearly free,
    reduces how often cleanup is even needed).
+   > CORRECTION, 2026-08-07 (owner ruling, issue 2481): step 3 is REJECTED and will not be
+   > built. The vocabulary is never passed to the transcriber in any form. Priming it makes it
+   > steer toward the suggested words, changing wording and sentence structure and corrupting
+   > the record of what was said. Steps 1, 2 and 4 are unaffected. Left in place as the dated
+   > record of what was recommended.
 4. **Later / optional:** local Parakeet/Whisper.net backend for GPU machines (offline, free,
    fastest); streaming for live on-screen dictation.
 

--- a/docs/reviews/dictation-dictionary-suggestions-mockup-2026-07-23.html
+++ b/docs/reviews/dictation-dictionary-suggestions-mockup-2026-07-23.html
@@ -83,6 +83,12 @@
   <main class="main">
     <h1>Dictionary</h1>
     <p class="sub">Terms that bias transcription, plus corrections for words the model keeps getting wrong.</p>
+    <!-- CORRECTION, 2026-08-07 (owner ruling, issue 2481): this subhead is WRONG. No term biases
+         transcription. The transcriber is given audio only; these terms correct the FINISHED
+         transcript. Do NOT copy this line. -->
+    <p class="sub" style="color:#c0392b;"><strong>CORRECTION (issue 2481):</strong>
+      nothing biases transcription - the transcriber gets audio only. These terms correct the
+      finished transcript afterwards.</p>
 
     <!-- SUGGESTIONS CARD -->
     <section class="card suggest">
@@ -140,6 +146,19 @@
     <section class="card">
       <div class="card-head"><h2>Vocabulary</h2></div>
       <p class="why">Proper nouns the model is nudged toward. Safe - it only biases, never replaces.</p>
+      <!-- CORRECTION, 2026-08-07 (owner ruling, issue 2481): WRONG, and wrong in the most
+           dangerous way - it argues the rejected approach is the SAFE one. The model is nudged
+           toward nothing; no term is ever sent to the transcriber. And biasing is not the safe
+           option, it is the unsafe one: steering the transcriber changes wording and sentence
+           structure, not just spelling, which corrupts the record of what was actually said.
+           Replacing a listed word on the finished transcript is the safe operation, because it
+           is a known, configured substitution that leaves everything else untouched. Do NOT
+           copy this line or its reasoning. -->
+      <p class="why" style="color:#c0392b;"><strong>CORRECTION (issue 2481):</strong>
+        nothing is nudged - no term reaches the transcriber. And this has the safety argument
+        backwards: biasing is the UNSAFE option, because steering changes wording and sentence
+        structure and corrupts the record of what was said. Substituting a listed word on the
+        finished transcript is the safe one.</p>
       <div class="chips">
         <span class="chip">mindzie</span><span class="chip">Frederiksen</span><span class="chip">Soren</span>
         <span class="chip">Center Consulting</span><span class="chip">DevThrottle</span><span class="chip">ConPty</span>

--- a/docs/reviews/dictation-dictionary-suggestions-mockup-v2-2026-07-24.html
+++ b/docs/reviews/dictation-dictionary-suggestions-mockup-v2-2026-07-24.html
@@ -273,6 +273,15 @@
   <header class="doc-head">
     <p class="eyebrow">Design review - round 1</p>
     <h1>Dictation dictionary suggestions: all five screens</h1>
+    <blockquote style="border-left:4px solid #c0392b; margin:16px 0; padding:8px 14px;">
+      <strong>CORRECTION, 2026-08-07 (owner ruling, issue 2481).</strong>
+      The mockups below show the Vocabulary hint as "Terms biased into speech-to-text."
+      That is wrong and the shipped page no longer says it. Nothing in the dictionary is
+      ever sent to the speech-to-text provider - it is given audio only - because priming
+      the transcriber changes wording and sentence structure and corrupts the record of
+      what was said. The terms are corrected on the finished transcript afterwards. These
+      mockups are left as the dated record of the 2026-07-24 review.
+    </blockquote>
     <p>
       The feature in one sentence: the gateway keeps your dictation transcripts for 30 days,
       notices the words the speech model keeps getting wrong, and offers them as one-press
@@ -395,6 +404,14 @@
               <section class="section">
                 <h2>Vocabulary</h2>
                 <p class="hint">Terms biased into speech-to-text.</p>
+                <!-- CORRECTION, 2026-08-07 (owner ruling, issue 2481): this copy is WRONG and the
+                     shipped page no longer says it. It now reads "Terms corrected to this spelling
+                     after transcription." Nothing in the dictionary is ever sent to the
+                     speech-to-text provider; priming the transcriber changes wording and sentence
+                     structure and corrupts the record of what was said. Do NOT copy this line. -->
+                <p class="hint" style="color:#c0392b;"><strong>CORRECTION (issue 2481):</strong>
+                  wrong copy - the shipped page reads "Terms corrected to this spelling after
+                  transcription." Nothing here is sent to the speech-to-text provider.</p>
                 <div class="chips">
                   <span class="chip">Soren <span class="x">x</span></span>
                   <span class="chip">DevThrottle <span class="x">x</span></span>
@@ -490,6 +507,14 @@
               <section class="section">
                 <h2>Vocabulary</h2>
                 <p class="hint">Terms biased into speech-to-text.</p>
+                <!-- CORRECTION, 2026-08-07 (owner ruling, issue 2481): this copy is WRONG and the
+                     shipped page no longer says it. It now reads "Terms corrected to this spelling
+                     after transcription." Nothing in the dictionary is ever sent to the
+                     speech-to-text provider; priming the transcriber changes wording and sentence
+                     structure and corrupts the record of what was said. Do NOT copy this line. -->
+                <p class="hint" style="color:#c0392b;"><strong>CORRECTION (issue 2481):</strong>
+                  wrong copy - the shipped page reads "Terms corrected to this spelling after
+                  transcription." Nothing here is sent to the speech-to-text provider.</p>
                 <div class="chips">
                   <span class="chip chip-new">mindzie <span class="x">x</span></span>
                   <span class="chip chip-new">ConPty <span class="x">x</span></span>

--- a/docs/reviews/dictation-dictionary-suggestions-mockup-v2-2026-07-24.html
+++ b/docs/reviews/dictation-dictionary-suggestions-mockup-v2-2026-07-24.html
@@ -343,6 +343,13 @@
             <div class="wrap">
               <h1>Dictionary</h1>
               <p class="sub">Terms that steer speech-to-text toward your vocabulary, plus corrections for spellings the model keeps getting wrong.</p>
+              <!-- CORRECTION, 2026-08-07 (owner ruling, issue 2481): this subhead is WRONG. Nothing
+                   steers speech-to-text. The transcriber is given audio only; these terms correct the
+                   FINISHED transcript. Priming the transcriber changes wording and sentence structure
+                   and corrupts the record of what was said. Do NOT copy this line. -->
+              <p class="sub" style="color:#c0392b;"><strong>CORRECTION (issue 2481):</strong>
+                nothing steers speech-to-text - the transcriber gets audio only. These terms correct
+                the finished transcript afterwards.</p>
 
               <section class="section suggest">
                 <div class="suggest-head">
@@ -494,6 +501,13 @@
             <div class="wrap">
               <h1>Dictionary</h1>
               <p class="sub">Terms that steer speech-to-text toward your vocabulary, plus corrections for spellings the model keeps getting wrong.</p>
+              <!-- CORRECTION, 2026-08-07 (owner ruling, issue 2481): this subhead is WRONG. Nothing
+                   steers speech-to-text. The transcriber is given audio only; these terms correct the
+                   FINISHED transcript. Priming the transcriber changes wording and sentence structure
+                   and corrupts the record of what was said. Do NOT copy this line. -->
+              <p class="sub" style="color:#c0392b;"><strong>CORRECTION (issue 2481):</strong>
+                nothing steers speech-to-text - the transcriber gets audio only. These terms correct
+                the finished transcript afterwards.</p>
 
               <section class="section">
                 <div class="quiet-line">
@@ -598,6 +612,13 @@
             <div class="wrap">
               <h1>Dictionary</h1>
               <p class="sub">Terms that steer speech-to-text toward your vocabulary, plus corrections for spellings the model keeps getting wrong.</p>
+              <!-- CORRECTION, 2026-08-07 (owner ruling, issue 2481): this subhead is WRONG. Nothing
+                   steers speech-to-text. The transcriber is given audio only; these terms correct the
+                   FINISHED transcript. Priming the transcriber changes wording and sentence structure
+                   and corrupts the record of what was said. Do NOT copy this line. -->
+              <p class="sub" style="color:#c0392b;"><strong>CORRECTION (issue 2481):</strong>
+                nothing steers speech-to-text - the transcriber gets audio only. These terms correct
+                the finished transcript afterwards.</p>
 
               <section class="section">
                 <h2>Dismissed suggestions</h2>

--- a/packages/client-core/src/dictation/dictionaryClient.ts
+++ b/packages/client-core/src/dictation/dictionaryClient.ts
@@ -18,8 +18,10 @@ export interface DictionaryProfile {
   cleanupEnabled: boolean;
 }
 
-/** The dictation glossary, mirroring the C# DictionaryDto: the vocabulary biased into speech-to-text,
- *  the correct-term -> wrong-spellings map fed to the cleanup pass, and named profiles. */
+/** The dictation glossary, mirroring the C# DictionaryDto: the canonical vocabulary, the
+ *  correct-term -> wrong-spellings map, and named profiles. Nothing in here reaches the
+ *  speech-to-text provider - the transcriber is given audio only, and both the vocabulary and the
+ *  wrong-spellings map are applied by the cleanup pass on the finished transcript (issue 2481). */
 export interface Dictionary {
   vocabulary: string[];
   commonMistranscriptions: Record<string, string[]>;

--- a/packages/client-core/src/dictation/dictionaryEdits.ts
+++ b/packages/client-core/src/dictation/dictionaryEdits.ts
@@ -19,7 +19,9 @@ export type AddEntryResult =
   // The entry was added - `dict` is the new Dictionary the page should adopt.
   | { status: "added"; word: string; dict: Dictionary };
 
-/** Add a word to the vocabulary biased into speech-to-text. Trims first; rejects empty and duplicates. */
+/** Add a word to the canonical vocabulary the cleanup pass corrects towards on the finished
+ *  transcript - it is never sent to the transcriber (issue 2481). Trims first; rejects empty
+ *  and duplicates. */
 export function addVocabularyWord(dict: Dictionary, raw: string): AddEntryResult {
   const word = raw.trim();
   if (word.length === 0) return { status: "empty" };

--- a/phone/CcDirectorClient/DictionaryPage.xaml
+++ b/phone/CcDirectorClient/DictionaryPage.xaml
@@ -46,7 +46,7 @@
                     <VerticalStackLayout Spacing="10">
                         <Label Text="Vocabulary" FontSize="15" FontAttributes="Bold"
                                TextColor="#E6EAF2" />
-                        <Label Text="Terms biased into speech-to-text."
+                        <Label Text="Terms corrected to this spelling after transcription."
                                FontSize="12" TextColor="#8A93A6" />
 
                         <Label x:Name="VocabEmptyLabel" Text="No vocabulary terms yet."

--- a/phone/CcDirectorClient/DictionaryPage.xaml.cs
+++ b/phone/CcDirectorClient/DictionaryPage.xaml.cs
@@ -5,10 +5,12 @@ namespace CcDirectorClient;
 
 /// <summary>
 /// The phone port of the Gateway's Dictionary page (dictionary.html). Edits the one
-/// shared STT dictation glossary used by both phone-recording transcription and
-/// desktop voice-to-type: the vocabulary biased into speech-to-text, the known
-/// mistranscription corrections (correct term -> wrong spellings), and the cleanup
-/// profiles. Loads GET /ingest/dictionary into an in-memory working copy, marks the
+/// shared dictation glossary used by both phone-recording transcription and
+/// desktop voice-to-type: the canonical vocabulary, the known mistranscription
+/// corrections (correct term -> wrong spellings), and the cleanup profiles. None of
+/// it is sent to the speech-to-text provider - the transcriber gets audio only, and
+/// every term here is applied afterwards by the cleanup pass on the finished
+/// transcript (issue 2481). Loads GET /ingest/dictionary into an in-memory working copy, marks the
 /// page dirty on any change, and writes the whole thing back with PUT
 /// /ingest/dictionary on Save. Same surface as dictionary.html.
 /// </summary>

--- a/phone/CcDirectorClient/Voice/GatewayClient.cs
+++ b/phone/CcDirectorClient/Voice/GatewayClient.cs
@@ -81,10 +81,12 @@ public sealed class RecordingItem
 }
 
 /// <summary>
-/// The shared STT dictation glossary, as edited on the Dictionary page. Mirrors
-/// the shape returned by GET /ingest/dictionary: the vocabulary biased into
-/// speech-to-text, the known mistranscription corrections (correct term -> list
-/// of wrong spellings), and the cleanup profiles (name -> cleanupEnabled).
+/// The shared dictation glossary, as edited on the Dictionary page. Mirrors
+/// the shape returned by GET /ingest/dictionary: the canonical vocabulary, the
+/// known mistranscription corrections (correct term -> list of wrong spellings),
+/// and the cleanup profiles (name -> cleanupEnabled). None of it is sent to the
+/// speech-to-text provider; it is all applied by the cleanup pass on the finished
+/// transcript (issue 2481).
 /// </summary>
 public sealed class DictionaryModel
 {

--- a/scripts/sweep-bias-claims.py
+++ b/scripts/sweep-bias-claims.py
@@ -42,6 +42,28 @@ of being wrong is the most useful thing in its header.
    masked its own hits. It is excluded by path, deliberately and visibly: the exclusion is
    printed on every run. It is the only file excluded for this reason.
 
+WHAT THIS DOES NOT CATCH - READ THIS BEFORE TRUSTING A CLEAN RUN.
+
+THIS IS A NET, NOT A PROOF. It matches known wordings and known shapes. It cannot achieve
+perfect recall against natural language and does not try: the chase was CLOSED deliberately,
+by instruction, while each round was still finding something - not because the holes ran out.
+Known and accepted gaps:
+
+  * Paraphrase that uses neither the vocabulary nor the transfer shape. "The engine already
+    knows our product names because we tell it in advance" says the banned thing and matches
+    nothing here.
+  * A claim spread across two sentences or two lines. Every rule is single-line, so "The
+    glossary is loaded at startup. It goes out with each request." is invisible.
+  * An implication carried by a diagram, an image, a table layout, or a screenshot. Nothing
+    here reads pictures, and a table can imply the design purely by what its columns are.
+  * Any wording nobody has thought of yet. Five review rounds each found a real hole; the
+    sixth would have found one too.
+
+So: A CLEAN RUN MEANS NOTHING MATCHED. It does NOT mean nothing is there. Zero here measures
+the patterns, exactly as a zero-instance count measures the strings it searched for and not the
+world. A human reading the change remains the backstop, and this sweep is only there to stop
+the same wordings coming back unnoticed.
+
 Usage:
     python scripts/sweep-bias-claims.py              sweep the tree
     python scripts/sweep-bias-claims.py --self-test  prove the detector catches known-bad input
@@ -88,7 +110,27 @@ STRICT_CONTEXT = re.compile(
 TRANSFER_VERB = re.compile(
     r"\b(includ(e|es|ing)|send(s|ing)?|sent|pass(es|ing|ed)?|giv(e|es|ing)|gave|given"
     r"|receiv(e|es|ing|ed)|attach(es|ing|ed)?|suppl(y|ies|ying|ied)|upload(s|ing|ed)?"
-    r"|feed(s|ing)?|fed|provid(e|es|ing|ed)|add(s|ing|ed)?|inject(s|ing|ed)?)\b",
+    r"|feed(s|ing)?|fed|provid(e|es|ing|ed)|add(s|ing|ed)?|inject(s|ing|ed)?"
+    # a second sweep of my own detector slipped 12 of 15 attacks past it; these are the verbs
+    # those attacks used. Enumerating verbs will never be complete, which is why CODE_SHAPE
+    # below catches the thing by its structure instead.
+    r"|ship(s|ping|ped)?|bundl(e|es|ing|ed)|post(s|ing|ed)?|populat(e|es|ing|ed)"
+    r"|wir(e|es|ing|ed)|configur(e|es|ing|ed)|carr(y|ies|ying)|carried|travels? with"
+    r"|hand(s|ing|ed)?|embed(s|ding|ded)?|plac(e|es|ing|ed)|put)\b",
+    re.I,
+)
+# The code that would actually reintroduce this: a glossary expression bound to the provider's
+# prompt field. `form.Add(new StringContent(glossary), "prompt")` contains no prose at all and
+# slipped past every prose rule. "dictionary" alone is deliberately NOT a glossary token here -
+# C# is full of Dictionary<string, object>, and including it produced 31 false positives.
+GLOSSARY_TOKEN = re.compile(
+    r"vocabular\w*|glossar\w*|keyterms?|term list|word list|sttprompt|buildsttprompt"
+    r"|dictionary\.vocab\w*|dictation dictionary|dictionary terms",
+    re.I,
+)
+PROMPT_FIELD = re.compile(
+    r"\"prompt\"|'prompt'|\bprompt\s*[:=]|\bprompt (field|parameter|param)\b|initial_prompt"
+    r"|\.Prompt\b",
     re.I,
 )
 TRANSFER_OBJECT = re.compile(
@@ -104,6 +146,29 @@ CLAUSE_BREAK = re.compile(r"[;:,]|\b(but|and|while|whereas|however|though|althou
                           re.I)
 
 
+# A negation does not always prohibit. These two shapes ENDORSE the transfer while wearing a
+# negative, and they are how someone actually argues for rebuilding a rejected design:
+#   "Not sending the dictionary to the provider is a bug"   - negated gerund as the subject of
+#                                                             a sentence calling it a defect
+#   "Never fail to pass the term list to the ASR provider"  - negated failure-to-act
+# Both must be read as claims, never exempted.
+DOUBLE_NEGATIVE = re.compile(
+    r"\b(never|not|n't|no)\b[^.;]{0,40}?\b(fail(s|ing|ed)?|omit(s|ting|ted)?|neglect(s|ing|ed)?"
+    r"|forget(s|ting)?|skip(s|ping|ped)?)\b\s+to\b",
+    re.I,
+)
+ENDORSING_VERDICT = re.compile(
+    r"\b(is|was|would be|remains?)\s+(a\s+|an\s+)?(bug|mistake|error|defect|regression|wrong"
+    r"|broken|oversight|problem|failure|the issue)\b",
+    re.I,
+)
+
+
+def endorses_transfer(line):
+    """The line argues FOR the transfer despite carrying a negation."""
+    return bool(DOUBLE_NEGATIVE.search(line) or ENDORSING_VERDICT.search(line))
+
+
 def negated_transfer(line):
     """True only when EVERY transfer verb on the line is itself negated.
 
@@ -113,6 +178,8 @@ def negated_transfer(line):
     is looked for between the start of the verb's own clause and the verb itself. If even one
     transfer verb is positive, the line states the banned behaviour and is a claim.
     """
+    if endorses_transfer(line):
+        return False        # a negation that advocates the transfer exempts nothing
     verbs = list(TRANSFER_VERB.finditer(line))
     if not verbs:
         return False
@@ -125,7 +192,9 @@ def negated_transfer(line):
 TRANSFER_DEST = re.compile(
     r"\b(speech.to.text|stt|transcriber|transcription request|\bprovider\b|audio upload"
     r"|prompt field|prompt parameter|\basr\b|whisper|speech model|speech engine"
-    r"|transcription (call|api|endpoint|payload|body))\b",
+    r"|transcription (call|api|endpoint|payload|body)"
+    # named engines - "send the keyterms to Deepgram" names no generic destination at all
+    r"|deepgram|assembly ?ai|speechmatics|groq|gpt-4o-transcribe|azure speech|google speech)\b",
     re.I,
 )
 
@@ -142,6 +211,9 @@ def is_claim(line):
     # exemption is scoped twice over: to this tier only (an outright "biased into speech-to-text"
     # still counts whatever else is on the line), and to the transfer PREDICATE (a "not"
     # governing some other verb does not excuse a positive transfer sitting beside it).
+    # Code binding a glossary to the provider's prompt field - the literal regression.
+    if GLOSSARY_TOKEN.search(line) and PROMPT_FIELD.search(line):
+        return True
     if negated_transfer(line):
         return False
     return bool(TRANSFER_VERB.search(line)
@@ -173,7 +245,13 @@ UNRELATED = re.compile(
     r"|fix a known custom vocabulary"
     # lazy construction of the dictation transcriber: "a dictation is sent" is the user
     # speaking, not the dictionary being handed over
-    r"|built the first time a dictation is sent",
+    r"|built the first time a dictation is sent"
+    # naming the two pipeline stages in order - transcribe, THEN clean - which is the correct
+    # design, not the transfer
+    r"|transcribes \+ dictionary-cleans"
+    # sharing one path-resolution helper between the editor and the transcriber wiring; what
+    # is shared is where the file lives, not the file's contents going to a provider
+    r"|dictionary-path resolution with the transcriber wiring",
     re.I,
 )
 # A heading is a reader's entry point: markdown headings, HTML h1-h4, and setext rules.
@@ -239,6 +317,30 @@ DETECTOR_CASES = [
      True, "contrastive 'not just' after a positive transfer"),
     ("The dictionary is not only stored locally; it is sent to the provider",
      True, "'not only ... ; it is sent' - the transfer is positive"),
+    # --- a negation that ENDORSES the transfer: how someone argues FOR rebuilding this ---
+    ("Not sending the dictionary to the provider is a bug",
+     True, "negated gerund called a defect"),
+    ("Never fail to pass the term list to the ASR provider",
+     True, "negated failure-to-act"),
+    # --- verbs and shapes that slipped past a self-attack (12 of 15 got through) ---
+    ("ship the glossary alongside the audio to Whisper", True, "verb: ship"),
+    ("bundle the term list with the transcription request", True, "verb: bundle"),
+    ("post the vocabulary to the STT call", True, "verb: post"),
+    ("populate the prompt field with the dictionary terms", True, "prompt field bound to terms"),
+    ("wire the glossary into the transcription call", True, "verb: wire"),
+    ("configure the ASR request with our term list", True, "verb: configure"),
+    ("AssemblyAI gets the word list with each upload", True, "named engine as destination"),
+    ("send the keyterms to Deepgram on every request", True, "named engine as destination"),
+    ("the dictionary travels with the audio to the provider", True, "verb: travels with"),
+    ("the transcription payload carries our glossary", True, "verb: carries"),
+    # the literal regression, in code, with no prose at all
+    ('form.Add(new StringContent(glossary), "prompt");', True, "code: glossary into prompt field"),
+    ('form.Add(new StringContent(DictionaryLoader.BuildSttPrompt(d)), "prompt");',
+     True, "code: the deleted builder wired back in"),
+    ("prompt: dictionary.vocabulary.join(', ')", True, "code: vocabulary as the prompt"),
+    # ...and code that must NOT trip it
+    ('var map = new Dictionary<string, object> { ["provider"] = provider };',
+     False, "C# Dictionary<> beside a provider variable"),
 ]
 
 
@@ -328,6 +430,14 @@ def sweep(root):
     for rel, why in sorted(EXCLUDE.items()):
         print("excluded:       %s (%s)" % (rel, why))
     print("UNANNOTATED CLAIMS: %d" % total)
+    if not total:
+        # Printed on every clean run on purpose: the number is the easiest thing to quote and
+        # the easiest thing to over-read. It measures the patterns, not the repository.
+        print("\nNOTE: this is a NET, not a proof. A clean run means nothing MATCHED - not that")
+        print("nothing is there. It cannot see paraphrase without the known vocabulary or")
+        print("transfer shape, a claim spread across two lines, an implication carried by a")
+        print("diagram or a table, or wording nobody has thought of. A human reading the change")
+        print("is the backstop. See the limits section in this file's header.")
     return 1 if total else 0
 
 

--- a/scripts/sweep-bias-claims.py
+++ b/scripts/sweep-bias-claims.py
@@ -1,0 +1,141 @@
+"""
+Sweep the repository for claims that DevThrottle sends vocabulary or steering hints to the
+speech-to-text provider - the approach the owner rejected in issue 2481.
+
+WHY THIS EXISTS. Deleting the rejected code (DictionaryLoader.BuildSttPrompt) did not delete
+the DESIGN: it stayed asserted in comments, user-visible strings, agent-facing help, a model
+prompt, live architecture recommendations, dated records, and experiment RESULTS that argue
+FOR it. A claim left standing is how a rejected design gets helpfully rebuilt later.
+
+TWO METHOD FAILURES THIS SCRIPT EXISTS TO NOT REPEAT. Both were found by reviewers after an
+earlier version of this sweep reported "clean":
+
+1. SCOPE. The first version listed files from `git diff --name-only origin/main` - only files
+   already touched. It could not find a file never opened, so it reported clean for exactly
+   the files nobody had looked at. It now seeds from `git grep` over the WHOLE tree.
+
+2. REACH. The second version treated a correction within N lines as covering a claim. That
+   let a correction in one section vouch for a claim in the NEXT section - which is how a
+   standalone "Acceptance" criterion requiring "vocabulary bias" passed. A reader does not
+   arrive at the top of a file and read down; they enter at a HEADING. So coverage now means
+   SAME SECTION, where a section runs from one heading to the next. Acceptance criteria,
+   checklists and tables are entry points more often than prose is.
+
+Usage:  python scripts/sweep-bias-claims.py
+Exit 0 if nothing is unannotated, 1 otherwise (so it can gate a build if wanted).
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+# A claim that the transcriber is being steered.
+CLAIM = re.compile(
+    r"bias(es|ed|ing)?\b|prompt parameter|initial_prompt|word_boost|keyterms?\b"
+    r"|nudged toward|packed into the (openai|stt)",
+    re.I,
+)
+# ...but only when it is about transcription, not statistics or CSS.
+CONTEXT = re.compile(r"transcri|speech|stt|vocab|glossar|dictionar|asr|whisper|nudge|prompt", re.I)
+# A correction/annotation that discharges a claim.
+#
+# THIS MUST BE NARROW, AND HERE IS WHY. An earlier version accepted the bare word
+# "correction", any of "never sent", "REJECTED", and so on. That let a CLAIM certify ITSELF:
+# the acceptance criterion "confirm the new correction/vocabulary bias is applied" contains
+# the word "correction", so the sweep read the defect as its own annotation and passed the
+# whole section. A marker has to be something only a deliberate annotation would say, so it
+# is the issue number - every note written for this ruling names it - plus the two headers
+# that stand in for one.
+CORRECTION = re.compile(r"\b2481\b|RULED OUT|TOMBSTONE", re.I)
+# Uses of the word "bias" that have nothing to do with transcription. Verified individually.
+UNRELATED = re.compile(
+    r"unbiased covariance|amber-biased|tail-biased|The bias is deliberate|bias the share"
+    r"|bias this prevents|would bias exactly",
+    re.I,
+)
+# A heading is a reader's entry point: markdown headings, HTML h1-h4, and the ==== / ---- rules.
+HEADING = re.compile(r"^\s{0,3}#{1,6}\s|<h[1-4][\s>]|^\s*={3,}\s*$|^\s*-{3,}\s*$", re.I)
+
+SKIP_EXT = (".png", ".jpg", ".jpeg", ".gif", ".mp3", ".m4a", ".trx", ".pdf", ".ico",
+            ".svg", ".woff", ".woff2", ".zip", ".dll", ".exe", ".pyc")
+
+# Stated exclusions, each with a reason. Anything here is a decision, not an oversight.
+EXCLUDE = {
+    # Tombstoned: hard sys.exit(2) before any import, so the body is unreachable. Its header
+    # carries the ruling; the text below the exit is the retained record of the experiment.
+    "docs/features/dictation/phase0/run_phase0.py":
+        "tombstoned - unreachable behind a hard exit, header carries the ruling",
+}
+# Test fixtures that contain this work's own session NAME ("fix: 2481 delete bias path"),
+# which is not a claim about behaviour.
+EXCLUDE_DIRS = ("apps/cockpit/src/missions/",)
+
+
+def sections(lines):
+    """Yield (start, end) line indices for each heading-delimited section.
+
+    A reader enters at a heading, so a correction only reaches claims under the SAME heading.
+    """
+    starts = [i for i, l in enumerate(lines) if HEADING.search(l)]
+    if not starts or starts[0] != 0:
+        starts = [0] + starts
+    bounds = []
+    for n, s in enumerate(starts):
+        e = starts[n + 1] if n + 1 < len(starts) else len(lines)
+        bounds.append((s, e))
+    return bounds
+
+
+def unannotated(path):
+    """Claims in `path` with no correction in the section a reader would enter at."""
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        lines = fh.read().split("\n")
+    out = []
+    for start, end in sections(lines):
+        block = lines[start:end]
+        # Coverage is per SECTION, not per line-distance. A reader enters at the heading and
+        # reads that section, so a correction anywhere within it is seen - before the claim or
+        # after it. What must NOT count is a correction in a neighbouring section: that is the
+        # leak that let an "Acceptance" criterion requiring "vocabulary bias" pass.
+        if any(CORRECTION.search(l) for l in block):
+            continue
+        for i, line in enumerate(block):
+            if not (CLAIM.search(line) and CONTEXT.search(line)):
+                continue
+            if CORRECTION.search(line) or UNRELATED.search(line):
+                continue
+            out.append((start + i + 1, line.strip()[:100]))
+    return out
+
+
+def main():
+    listed = subprocess.run(
+        ["git", "grep", "-l", "-i", "-E", CLAIM.pattern],
+        capture_output=True, text=True,
+    ).stdout
+    files = sorted({f.strip() for f in listed.split("\n") if f.strip()})
+
+    total, skipped = 0, []
+    for f in files:
+        if f in EXCLUDE:
+            skipped.append((f, EXCLUDE[f]))
+            continue
+        if f.startswith(EXCLUDE_DIRS) or f.endswith(SKIP_EXT) or not os.path.exists(f):
+            continue
+        hits = unannotated(f)
+        if hits:
+            total += len(hits)
+            print("####", f)
+            for n, t in hits:
+                print("    %d: %s" % (n, t))
+
+    print("\nfiles searched: %d" % len(files))
+    for f, why in skipped:
+        print("excluded: %s (%s)" % (f, why))
+    print("UNANNOTATED CLAIMS: %d" % total)
+    return 1 if total else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sweep-bias-claims.py
+++ b/scripts/sweep-bias-claims.py
@@ -80,14 +80,53 @@ STRICT_CONTEXT = re.compile(
     re.I,
 )
 
+# TRANSFER - the banned behaviour stated plainly, with no bias jargon at all: an OBJECT (the
+# dictionary) moving to a DESTINATION (the transcriber) via a VERB. "Include the dictionary in
+# the speech-to-text request" is squarely the ruling and contains not one word the tiers above
+# look for. All three parts must appear on the line, which is what keeps "sends the terms to the
+# cleanup pass" out.
+TRANSFER_VERB = re.compile(
+    r"\b(includ(e|es|ing)|send(s|ing)?|sent|pass(es|ing|ed)?|giv(e|es|ing)|gave|given"
+    r"|receiv(e|es|ing|ed)|attach(es|ing|ed)?|suppl(y|ies|ying|ied)|upload(s|ing|ed)?"
+    r"|feed(s|ing)?|fed|provid(e|es|ing|ed)|add(s|ing|ed)?|inject(s|ing|ed)?)\b",
+    re.I,
+)
+TRANSFER_OBJECT = re.compile(
+    r"\b(dictionar\w*|glossar\w*|vocabular\w*|term list|word list|known terms|keyterms?"
+    r"|spelling hints?|term set|our terms|the terms)\b",
+    re.I,
+)
+NEGATION = re.compile(r"\b(never|nothing|not|n't|no)\b", re.I)
+TRANSFER_DEST = re.compile(
+    r"\b(speech.to.text|stt|transcriber|transcription request|\bprovider\b|audio upload"
+    r"|prompt field|prompt parameter|\basr\b|whisper|speech model|speech engine"
+    r"|transcription (call|api|endpoint|payload|body))\b",
+    re.I,
+)
+
 
 def is_claim(line):
-    """A claim is an unmistakable phrase, or an ordinary verb in transcription context."""
-    return bool(STRONG.search(line) or (WEAK.search(line) and STRICT_CONTEXT.search(line)))
+    """A claim is an unmistakable phrase, an ordinary verb in transcription context, or a
+    plain statement that the dictionary is handed to the transcriber."""
+    if STRONG.search(line):
+        return True
+    if WEAK.search(line) and STRICT_CONTEXT.search(line):
+        return True
+    # A line stating the CORRECT behaviour - "nothing in it is ever sent to the speech model" -
+    # is the transfer shape negated, and must not be reported as the thing it forbids. Applied
+    # to this tier only: an explicit "biased into speech-to-text" still counts even if the line
+    # happens to contain "not", because the strong and weak tiers name the behaviour outright.
+    if NEGATION.search(line):
+        return False
+    return bool(TRANSFER_VERB.search(line)
+                and TRANSFER_OBJECT.search(line)
+                and TRANSFER_DEST.search(line))
 
 
-# Kept so --self-test and callers can seed a file search from one pattern.
-CLAIM = re.compile("%s|%s" % (STRONG.pattern, WEAK.pattern), re.I)
+# Seeds the file search. Wider than is_claim() on purpose: it decides which files to OPEN, and
+# a file skipped here is never examined at all, so it errs toward including too many.
+CLAIM = re.compile(
+    "%s|%s|%s" % (STRONG.pattern, WEAK.pattern, TRANSFER_OBJECT.pattern), re.I)
 # An annotation that discharges a claim. NARROW ON PURPOSE - see failure 3. Every note written
 # for this ruling names the issue; nothing else in ordinary prose does.
 CORRECTION = re.compile(r"\b2481\b|RULED OUT|TOMBSTONE", re.I)
@@ -105,7 +144,10 @@ UNRELATED = re.compile(
     # nudging a WAV cut point to a quiet spot so a word is not sliced
     r"|bounded parts, nudging"
     # naming the cleanup task the deterministic matcher replaces - correction, not biasing
-    r"|fix a known custom vocabulary",
+    r"|fix a known custom vocabulary"
+    # lazy construction of the dictation transcriber: "a dictation is sent" is the user
+    # speaking, not the dictionary being handed over
+    r"|built the first time a dictation is sent",
     re.I,
 )
 # A heading is a reader's entry point: markdown headings, HTML h1-h4, and setext rules.
@@ -128,6 +170,34 @@ EXCLUDE = {
 # Test fixtures holding this work's own session NAME ("fix: 2481 delete bias path"), not a
 # claim about behaviour.
 EXCLUDE_DIRS = ("apps/cockpit/src/missions/",)
+
+
+# Named lines the detector must and must not match, run by --self-test. Every "must match" here
+# is a real line from this repository or a sentence a reviewer showed would sail through.
+DETECTOR_CASES = [
+    # --- transfer language: the ruling stated plainly, with no bias jargon at all ---
+    ("include the dictionary in the speech-to-text request", True, "transfer: include/dictionary/stt"),
+    ("the transcriber receives the glossary with every audio upload", True, "transfer: receives/glossary/transcriber"),
+    ("give the provider the term list as spelling hints", True, "transfer: give/term list/provider"),
+    ("pass known terms in the prompt field", True, "transfer: pass/known terms/prompt field"),
+    # --- real lines that were found in this repository ---
+    ("Terms that steer speech-to-text toward your vocabulary.", True, "v2 mockup subhead"),
+    ("Terms biased into speech-to-text.", True, "shipped Cockpit and phone copy"),
+    ("confirm the new correction/vocabulary bias is applied.", True, "the acceptance criterion"),
+    ("Proper nouns the model is nudged toward. Safe - it only biases.", True, "the safety-argument line"),
+    ("The dictionary biases a speech model toward distinctive terms", True, "the screening model prompt"),
+    ("Bias transcription with the vocabulary glossary via the prompt parameter", True, "findings step 3"),
+    # --- must NOT match: same words, nothing to do with steering a transcriber ---
+    ("// Nudge with Enter. The nudge is safe while the prompt is", False, "terminal submit watchdog"),
+    ('streamingBehavior: "steer"', False, "agent SDK option"),
+    ("car mode end phrase set: length=", False, "log line"),
+    ("norm = win * win / (win * win - 1.0)  # unbiased covariance", False, "statistics"),
+    ("the cleanup pass receives the dictionary and fixes the transcript", False, "cleanup, the CORRECT path"),
+    ("sends the terms to the cleanup pass", False, "cleanup destination, not the provider"),
+    ("nothing in it is ever sent to the speech model", False, "the correct behaviour, stated"),
+    ("the dictionary is never passed to the transcriber", False, "the correct behaviour, stated"),
+    ("we do not send the glossary to the provider", False, "the correct behaviour, stated"),
+]
 
 
 class SweepError(RuntimeError):
@@ -219,40 +289,112 @@ def sweep(root):
     return 1 if total else 0
 
 
-def self_test(root):
-    """Prove the detector catches known-bad input. A check that cannot fail is not a check.
+# The ORIGINAL claim text each file must yield once its annotations are removed. Asserting
+# these exact strings is the point: an earlier self-test only asserted that SOME hit appeared,
+# and passed on the leftover prose of the annotations it had half-stripped - a check passing on
+# the wrong evidence, which is the very defect this sweep exists to find.
+EXPECTED_CLAIMS = {
+    "docs/reviews/dictation-dictionary-suggestions-mockup-v2-2026-07-24.html": [
+        "Terms biased into speech-to-text.",
+        "Terms that steer speech-to-text toward your vocabulary",
+    ],
+    "docs/reviews/dictation-dictionary-suggestions-mockup-2026-07-23.html": [
+        "Terms that bias transcription",
+        "Proper nouns the model is nudged toward",
+    ],
+    "docs/problems/voice-dictionary-not-applied-on-mobile.md": [
+        "confirm the new correction/vocabulary bias is applied",
+        "The speech-to-text bias prompt",
+    ],
+    "docs/research/transcription-speed/FINDINGS.md": [
+        "with the vocabulary glossary via the `prompt` parameter",
+        "Bias the transcriber",
+    ],
+}
 
-    Takes a real annotated file, strips its annotations, and asserts the claims reappear.
+
+def strip_annotation_blocks(text):
+    """Remove WHOLE annotation blocks, not just the lines carrying the marker.
+
+    Stripping only marker lines left the rest of each annotation's prose in place - and that
+    prose is full of claim words, so the detector "caught" annotation remnants and the test
+    passed without ever seeing the original claim. Blocks here are the shapes the annotations
+    actually take: markdown blockquote runs, HTML comments, and the red correction paragraphs.
     """
+    lines = text.split("\n")
+    out, i = [], 0
+    while i < len(lines):
+        line = lines[i]
+        block, end = None, i
+
+        if line.lstrip().startswith(">"):                       # markdown blockquote run
+            end = i
+            while end < len(lines) and lines[end].lstrip().startswith(">"):
+                end += 1
+            block = lines[i:end]
+        elif "<!--" in line:                                    # HTML comment, may span lines
+            end = i
+            while end < len(lines) and "-->" not in lines[end]:
+                end += 1
+            end = min(end + 1, len(lines))
+            block = lines[i:end]
+        elif re.search(r"<p[ >]", line):                        # HTML paragraph, may span lines
+            end = i
+            while end < len(lines) and "</p>" not in lines[end]:
+                end += 1
+            end = min(end + 1, len(lines))
+            block = lines[i:end]
+
+        if block is not None and any(CORRECTION.search(l) for l in block):
+            i = end                                             # drop the whole annotation
+            continue
+        out.append(line)
+        i += 1
+    return "\n".join(out)
+
+
+def self_test(root):
+    """Prove the detector catches known-bad input. A check that cannot fail is not a check."""
     print("SELF-TEST - the detector must FAIL on known-bad input.\n")
-    targets = [
-        "docs/reviews/dictation-dictionary-suggestions-mockup-v2-2026-07-24.html",
-        "docs/problems/voice-dictionary-not-applied-on-mobile.md",
-        "docs/research/transcription-speed/FINDINGS.md",
-    ]
-    tmp = os.path.join(root, ".sweep-selftest.tmp")
     failures = 0
-    for rel in targets:
+
+    print("  [1] named lines the detector must and must not match")
+    for text, want, why in DETECTOR_CASES:
+        got = bool(is_claim(text) and not UNRELATED.search(text))
+        ok = got == want
+        failures += 0 if ok else 1
+        print("      %-5s want=%-5s got=%-5s  %s" % ("ok" if ok else "WRONG", want, got, why))
+
+    print("\n  [2] real files with their annotation BLOCKS removed must yield the ORIGINAL claims")
+    tmp = os.path.join(root, ".sweep-selftest.tmp")
+    for rel, expected in sorted(EXPECTED_CLAIMS.items()):
         path = os.path.join(root, rel)
         if not os.path.exists(path):
-            print("  SKIP %s (missing)" % rel)
+            print("      SKIP %s (missing)" % rel)
+            failures += 1
             continue
         clean = unannotated(path)
         with open(path, encoding="utf-8", errors="replace") as fh:
-            stripped = [l for l in fh.read().split("\n") if not CORRECTION.search(l)]
+            broken_text = strip_annotation_blocks(fh.read())
         with open(tmp, "w", encoding="utf-8", newline="") as fh:
-            fh.write("\n".join(stripped))
+            fh.write(broken_text)
         try:
-            broken = unannotated(tmp)
+            hits = unannotated(tmp)
         finally:
             os.remove(tmp)
-        ok = (not clean) and bool(broken)
+        found = [t for t in hits]
+        missing = [e for e in expected
+                   if not any(e.lower() in text.lower() for _, text in found)]
+        ok = (not clean) and not missing
         failures += 0 if ok else 1
-        print("  %s %s" % ("PASS" if ok else "FAIL", rel))
-        print("      as committed: %d unannotated | annotations removed: %d unannotated"
-              % (len(clean), len(broken)))
-        if broken:
-            print("      example caught: line %d: %s" % (broken[0][0], broken[0][1][:70]))
+        print("      %-5s %s" % ("ok" if ok else "WRONG", rel))
+        print("            as committed: %d unannotated | blocks removed: %d"
+              % (len(clean), len(found)))
+        for e in expected:
+            hit = next((n for n, t in found if e.lower() in t.lower()), None)
+            print("            %s expected claim at line %s: %s"
+                  % ("found" if hit else "MISSING", hit if hit else "-", e[:60]))
+
     print("\nSELF-TEST: %s" % ("PASS" if not failures else "FAIL (%d)" % failures))
     return 0 if not failures else 2
 

--- a/scripts/sweep-bias-claims.py
+++ b/scripts/sweep-bias-claims.py
@@ -96,7 +96,32 @@ TRANSFER_OBJECT = re.compile(
     r"|spelling hints?|term set|our terms|the terms)\b",
     re.I,
 )
-NEGATION = re.compile(r"\b(never|nothing|not|n't|no)\b", re.I)
+NEGATION = re.compile(r"\b(never|nothing|not|n't|no|nor)\b", re.I)
+# Where one clause ends and the next begins. A negation only reaches the verb in ITS OWN clause:
+# in "Do not omit the dictionary; send it to the transcriber" the "not" governs "omit", and the
+# instruction after the semicolon is the banned one, fully positive.
+CLAUSE_BREAK = re.compile(r"[;:,]|\b(but|and|while|whereas|however|though|although|yet|then)\b",
+                          re.I)
+
+
+def negated_transfer(line):
+    """True only when EVERY transfer verb on the line is itself negated.
+
+    The guard used to be line-wide, which meant any "not" anywhere switched the whole detector
+    off - so six different ways of writing the banned instruction with an unrelated or
+    contrastive "not" sailed through. The negation has to govern the transfer PREDICATE, so it
+    is looked for between the start of the verb's own clause and the verb itself. If even one
+    transfer verb is positive, the line states the banned behaviour and is a claim.
+    """
+    verbs = list(TRANSFER_VERB.finditer(line))
+    if not verbs:
+        return False
+    for verb in verbs:
+        breaks = [b.end() for b in CLAUSE_BREAK.finditer(line) if b.end() <= verb.start()]
+        clause = line[(max(breaks) if breaks else 0):verb.end()]
+        if not NEGATION.search(clause):
+            return False        # a positive transfer survives - this is a claim
+    return True                 # every transfer on the line is explicitly negated
 TRANSFER_DEST = re.compile(
     r"\b(speech.to.text|stt|transcriber|transcription request|\bprovider\b|audio upload"
     r"|prompt field|prompt parameter|\basr\b|whisper|speech model|speech engine"
@@ -113,10 +138,11 @@ def is_claim(line):
     if WEAK.search(line) and STRICT_CONTEXT.search(line):
         return True
     # A line stating the CORRECT behaviour - "nothing in it is ever sent to the speech model" -
-    # is the transfer shape negated, and must not be reported as the thing it forbids. Applied
-    # to this tier only: an explicit "biased into speech-to-text" still counts even if the line
-    # happens to contain "not", because the strong and weak tiers name the behaviour outright.
-    if NEGATION.search(line):
+    # is the transfer shape negated, and must not be reported as the thing it forbids. The
+    # exemption is scoped twice over: to this tier only (an outright "biased into speech-to-text"
+    # still counts whatever else is on the line), and to the transfer PREDICATE (a "not"
+    # governing some other verb does not excuse a positive transfer sitting beside it).
+    if negated_transfer(line):
         return False
     return bool(TRANSFER_VERB.search(line)
                 and TRANSFER_OBJECT.search(line)
@@ -197,6 +223,22 @@ DETECTOR_CASES = [
     ("nothing in it is ever sent to the speech model", False, "the correct behaviour, stated"),
     ("the dictionary is never passed to the transcriber", False, "the correct behaviour, stated"),
     ("we do not send the glossary to the provider", False, "the correct behaviour, stated"),
+    ("The dictionary is never sent to the provider, nor given to the ASR engine",
+     False, "two transfers, both negated"),
+    # --- the banned instruction wearing an unrelated or contrastive "not". A line-wide negation
+    # --- guard missed every one of these; the guard is scoped to the transfer predicate now.
+    ("Do not omit the dictionary; send it to the transcriber",
+     True, "negation governs 'omit', the transfer is positive"),
+    ("The transcriber receives the glossary, not the cleanup pass",
+     True, "contrastive 'not' after a positive transfer"),
+    ("Never leave the term list local; pass it to the ASR provider",
+     True, "negation governs 'leave', the transfer is positive"),
+    ("No restart is needed: the transcriber receives the glossary on each request",
+     True, "negation belongs to an unrelated clause"),
+    ("The provider must receive the dictionary, not just audio",
+     True, "contrastive 'not just' after a positive transfer"),
+    ("The dictionary is not only stored locally; it is sent to the provider",
+     True, "'not only ... ; it is sent' - the transfer is positive"),
 ]
 
 

--- a/scripts/sweep-bias-claims.py
+++ b/scripts/sweep-bias-claims.py
@@ -7,22 +7,46 @@ the DESIGN: it stayed asserted in comments, user-visible strings, agent-facing h
 prompt, live architecture recommendations, dated records, and experiment RESULTS that argue
 FOR it. A claim left standing is how a rejected design gets helpfully rebuilt later.
 
-TWO METHOD FAILURES THIS SCRIPT EXISTS TO NOT REPEAT. Both were found by reviewers after an
-earlier version of this sweep reported "clean":
+SIX METHOD FAILURES THIS SCRIPT EXISTS TO NOT REPEAT. Every one was found by a reviewer AFTER
+an earlier version of this sweep reported "clean". They are listed because a checker's history
+of being wrong is the most useful thing in its header.
 
 1. SCOPE. The first version listed files from `git diff --name-only origin/main` - only files
    already touched. It could not find a file never opened, so it reported clean for exactly
-   the files nobody had looked at. It now seeds from `git grep` over the WHOLE tree.
+   the files nobody had looked at. Seeds from `git grep` over the WHOLE tree now.
 
-2. REACH. The second version treated a correction within N lines as covering a claim. That
-   let a correction in one section vouch for a claim in the NEXT section - which is how a
-   standalone "Acceptance" criterion requiring "vocabulary bias" passed. A reader does not
-   arrive at the top of a file and read down; they enter at a HEADING. So coverage now means
-   SAME SECTION, where a section runs from one heading to the next. Acceptance criteria,
-   checklists and tables are entry points more often than prose is.
+2. REACH. The second version treated an annotation within N lines as covering a claim. That
+   let an annotation in one section vouch for a claim in the NEXT - which is how a standalone
+   "Acceptance" criterion requiring "vocabulary bias" passed. Coverage is per SECTION now,
+   heading to heading, because a reader enters at a heading rather than reading top to bottom.
+   Acceptance criteria, checklists and tables are entry points more often than prose is.
 
-Usage:  python scripts/sweep-bias-claims.py
-Exit 0 if nothing is unannotated, 1 otherwise (so it can gate a build if wanted).
+3. SELF-CERTIFYING MARKER. The marker list accepted the bare word "correction". The defect
+   read "confirm the new correction/vocabulary bias is applied" - so the CLAIM contained the
+   marker, was read as its own annotation, and passed its whole section. A marker must be
+   something only a deliberate annotation would write: the issue number.
+
+4. FAILED OPEN - THE WORST ONE. Run by absolute path from outside a repository, `git grep`
+   errored, the return code was ignored, and it printed "files searched: 0 / UNANNOTATED
+   CLAIMS: 0" and exited 0. It certified the repository from any directory while searching
+   NOTHING. Everything is anchored to the repository root now, every git call's return code is
+   checked, and searching zero files is an ERROR, not a pass.
+
+5. DETECTOR HOLE. CLAIM omitted the verb "steer", so "terms that steer speech-to-text toward
+   your vocabulary" evaluated false - if someone deleted the annotations from the v2 mockup
+   this sweep would not have noticed. The vocabulary is wider now and is tested (see
+   --self-test).
+
+6. RED ON ITS OWN HEAD. This file's comments read as headings and its regex prose reads as
+   claims, so it flagged itself - and only "passed" because the issue number in this docstring
+   masked its own hits. It is excluded by path, deliberately and visibly: the exclusion is
+   printed on every run. It is the only file excluded for this reason.
+
+Usage:
+    python scripts/sweep-bias-claims.py              sweep the tree
+    python scripts/sweep-bias-claims.py --self-test  prove the detector catches known-bad input
+
+Exit codes:  0 = clean, 1 = unannotated claims found, 2 = the sweep could not run properly.
 """
 
 import os
@@ -30,78 +54,132 @@ import re
 import subprocess
 import sys
 
-# A claim that the transcriber is being steered.
-CLAIM = re.compile(
-    r"bias(es|ed|ing)?\b|prompt parameter|initial_prompt|word_boost|keyterms?\b"
-    r"|nudged toward|packed into the (openai|stt)",
-    re.I,
-)
-# ...but only when it is about transcription, not statistics or CSS.
-CONTEXT = re.compile(r"transcri|speech|stt|vocab|glossar|dictionar|asr|whisper|nudge|prompt", re.I)
-# A correction/annotation that discharges a claim.
+# Two tiers, because one wide pattern cannot serve both jobs.
 #
-# THIS MUST BE NARROW, AND HERE IS WHY. An earlier version accepted the bare word
-# "correction", any of "never sent", "REJECTED", and so on. That let a CLAIM certify ITSELF:
-# the acceptance criterion "confirm the new correction/vocabulary bias is applied" contains
-# the word "correction", so the sweep read the defect as its own annotation and passed the
-# whole section. A marker has to be something only a deliberate annotation would say, so it
-# is the issue number - every note written for this ruling names it - plus the two headers
-# that stand in for one.
-CORRECTION = re.compile(r"\b2481\b|RULED OUT|TOMBSTONE", re.I)
-# Uses of the word "bias" that have nothing to do with transcription. Verified individually.
-UNRELATED = re.compile(
-    r"unbiased covariance|amber-biased|tail-biased|The bias is deliberate|bias the share"
-    r"|bias this prevents|would bias exactly",
+# STRONG - phrases that can only mean steering a speech-to-text engine. No further context
+# needed; "nudged toward" and "biased into speech-to-text" are real lines from this repository.
+STRONG = re.compile(
+    r"prompt parameter|initial_prompt|word_boost|keyterms?\b|speech adaptation"
+    r"|packed into the (openai|stt)|nudged toward|biased into speech",
     re.I,
 )
-# A heading is a reader's entry point: markdown headings, HTML h1-h4, and the ==== / ---- rules.
+# WEAK - ordinary verbs that mean steering ONLY next to transcription words. Bare "prompt" is
+# deliberately NOT a context word: in this repository a prompt is usually the agent's terminal
+# prompt, and including it made every submit-watchdog "nudge" a hit (15 false positives in one
+# run). Bare "speech" is out for the same reason - Car Mode speaks.
+# "phrase list/set" and "hotword" are provider steering features, but they collide with
+# ordinary strings ("car mode end phrase set: length=..."), so they need context too.
+WEAK = re.compile(
+    r"bias(es|ed|ing)?\b|steer\w*|prim(e|es|ed|ing)\b|nudg(e|es|ed|ing)\b"
+    r"|boost(s|ed|ing)?\b|custom vocab\w*|phrase (list|set)s?\b|hot ?words?\b",
+    re.I,
+)
+STRICT_CONTEXT = re.compile(
+    r"transcri|speech.to.text|speech model|\bstt\b|\basr\b|whisper"
+    r"|vocabular|glossar|dictionar|dictation",
+    re.I,
+)
+
+
+def is_claim(line):
+    """A claim is an unmistakable phrase, or an ordinary verb in transcription context."""
+    return bool(STRONG.search(line) or (WEAK.search(line) and STRICT_CONTEXT.search(line)))
+
+
+# Kept so --self-test and callers can seed a file search from one pattern.
+CLAIM = re.compile("%s|%s" % (STRONG.pattern, WEAK.pattern), re.I)
+# An annotation that discharges a claim. NARROW ON PURPOSE - see failure 3. Every note written
+# for this ruling names the issue; nothing else in ordinary prose does.
+CORRECTION = re.compile(r"\b2481\b|RULED OUT|TOMBSTONE", re.I)
+# Uses of these words that have nothing to do with steering a transcriber. EVERY entry was read
+# in place first - this list is where a false positive goes to be retired with a reason, never a
+# way to quieten a hit that has not been understood.
+UNRELATED = re.compile(
+    # statistical / visual senses of "bias"
+    r"unbiased covariance|amber-biased|tail-biased|The bias is deliberate|bias the share"
+    r"|bias this prevents|would bias exactly"
+    # "steer"/"nudge" about terminal prompts and browser tabs, not audio
+    r"|steers callers|steer it to the target"
+    # priming a shared AudioContext for Car Mode cues, not priming a model
+    r"|Dictation does not prime"
+    # nudging a WAV cut point to a quiet spot so a word is not sliced
+    r"|bounded parts, nudging"
+    # naming the cleanup task the deterministic matcher replaces - correction, not biasing
+    r"|fix a known custom vocabulary",
+    re.I,
+)
+# A heading is a reader's entry point: markdown headings, HTML h1-h4, and setext rules.
 HEADING = re.compile(r"^\s{0,3}#{1,6}\s|<h[1-4][\s>]|^\s*={3,}\s*$|^\s*-{3,}\s*$", re.I)
 
 SKIP_EXT = (".png", ".jpg", ".jpeg", ".gif", ".mp3", ".m4a", ".trx", ".pdf", ".ico",
             ".svg", ".woff", ".woff2", ".zip", ".dll", ".exe", ".pyc")
 
-# Stated exclusions, each with a reason. Anything here is a decision, not an oversight.
+SELF = "scripts/sweep-bias-claims.py"
+
+# Stated exclusions, each with a reason, PRINTED ON EVERY RUN. An exclusion nobody sees is an
+# exclusion nobody can challenge.
 EXCLUDE = {
-    # Tombstoned: hard sys.exit(2) before any import, so the body is unreachable. Its header
-    # carries the ruling; the text below the exit is the retained record of the experiment.
+    SELF:
+        "this sweep itself - its regex prose reads as claims and its comments as headings "
+        "(failure 6); excluded by path rather than by an accident of its own text",
     "docs/features/dictation/phase0/run_phase0.py":
-        "tombstoned - unreachable behind a hard exit, header carries the ruling",
+        "tombstoned - unreachable behind a hard exit at the top, its header carries the ruling",
 }
-# Test fixtures that contain this work's own session NAME ("fix: 2481 delete bias path"),
-# which is not a claim about behaviour.
+# Test fixtures holding this work's own session NAME ("fix: 2481 delete bias path"), not a
+# claim about behaviour.
 EXCLUDE_DIRS = ("apps/cockpit/src/missions/",)
 
 
-def sections(lines):
-    """Yield (start, end) line indices for each heading-delimited section.
+class SweepError(RuntimeError):
+    """The sweep could not run properly. Never reported as a clean result."""
 
-    A reader enters at a heading, so a correction only reaches claims under the SAME heading.
-    """
+
+def repo_root():
+    """The repository this script lives in - NOT the caller's working directory (failure 4)."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    done = subprocess.run(["git", "-C", here, "rev-parse", "--show-toplevel"],
+                          capture_output=True, text=True)
+    if done.returncode != 0:
+        raise SweepError(
+            "cannot find the repository root from %s: %s"
+            % (here, done.stderr.strip() or "git rev-parse failed"))
+    root = done.stdout.strip()
+    if not root or not os.path.isdir(root):
+        raise SweepError("git reported a repository root that is not a directory: %r" % root)
+    return root
+
+
+def candidate_files(root):
+    """Files anywhere in the tree that mention any claim word. Errors are raised, not ignored."""
+    done = subprocess.run(["git", "-C", root, "grep", "-l", "-i", "-E", CLAIM.pattern],
+                          capture_output=True, text=True)
+    # git grep: 0 = matches found, 1 = no matches, anything else = a real failure.
+    if done.returncode > 1:
+        raise SweepError("git grep failed (exit %d): %s"
+                         % (done.returncode, done.stderr.strip() or "no message"))
+    return sorted({f.strip() for f in done.stdout.split("\n") if f.strip()})
+
+
+def sections(lines):
+    """(start, end) line indices per heading-delimited section - the units a reader enters at."""
     starts = [i for i, l in enumerate(lines) if HEADING.search(l)]
     if not starts or starts[0] != 0:
         starts = [0] + starts
-    bounds = []
-    for n, s in enumerate(starts):
-        e = starts[n + 1] if n + 1 < len(starts) else len(lines)
-        bounds.append((s, e))
-    return bounds
+    return [(s, starts[n + 1] if n + 1 < len(starts) else len(lines))
+            for n, s in enumerate(starts)]
 
 
 def unannotated(path):
-    """Claims in `path` with no correction in the section a reader would enter at."""
+    """Claims in `path` with no annotation in the section a reader would enter at."""
     with open(path, encoding="utf-8", errors="replace") as fh:
         lines = fh.read().split("\n")
     out = []
     for start, end in sections(lines):
         block = lines[start:end]
-        # Coverage is per SECTION, not per line-distance. A reader enters at the heading and
-        # reads that section, so a correction anywhere within it is seen - before the claim or
-        # after it. What must NOT count is a correction in a neighbouring section: that is the
-        # leak that let an "Acceptance" criterion requiring "vocabulary bias" pass.
         if any(CORRECTION.search(l) for l in block):
             continue
         for i, line in enumerate(block):
-            if not (CLAIM.search(line) and CONTEXT.search(line)):
+            if not is_claim(line):
                 continue
             if CORRECTION.search(line) or UNRELATED.search(line):
                 continue
@@ -109,33 +187,87 @@ def unannotated(path):
     return out
 
 
-def main():
-    listed = subprocess.run(
-        ["git", "grep", "-l", "-i", "-E", CLAIM.pattern],
-        capture_output=True, text=True,
-    ).stdout
-    files = sorted({f.strip() for f in listed.split("\n") if f.strip()})
+def sweep(root):
+    files = candidate_files(root)
+    if not files:
+        # This repository contains this very script, which is full of claim words, so a match
+        # count of zero means the search did not happen - not that the tree is clean.
+        raise SweepError(
+            "searched 0 files. The claim pattern matches nothing in %s, which cannot be true "
+            "for this repository - the search did not run. Refusing to report clean." % root)
 
-    total, skipped = 0, []
-    for f in files:
-        if f in EXCLUDE:
-            skipped.append((f, EXCLUDE[f]))
+    total, examined = 0, 0
+    for rel in files:
+        if rel in EXCLUDE or rel.startswith(EXCLUDE_DIRS) or rel.endswith(SKIP_EXT):
             continue
-        if f.startswith(EXCLUDE_DIRS) or f.endswith(SKIP_EXT) or not os.path.exists(f):
+        path = os.path.join(root, rel)
+        if not os.path.exists(path):
             continue
-        hits = unannotated(f)
+        examined += 1
+        hits = unannotated(path)
         if hits:
             total += len(hits)
-            print("####", f)
-            for n, t in hits:
-                print("    %d: %s" % (n, t))
+            print("####", rel)
+            for n, text in hits:
+                print("    %d: %s" % (n, text))
 
-    print("\nfiles searched: %d" % len(files))
-    for f, why in skipped:
-        print("excluded: %s (%s)" % (f, why))
+    print("\nrepository:     %s" % root)
+    print("files matched:  %d   examined: %d" % (len(files), examined))
+    for rel, why in sorted(EXCLUDE.items()):
+        print("excluded:       %s (%s)" % (rel, why))
     print("UNANNOTATED CLAIMS: %d" % total)
     return 1 if total else 0
 
 
+def self_test(root):
+    """Prove the detector catches known-bad input. A check that cannot fail is not a check.
+
+    Takes a real annotated file, strips its annotations, and asserts the claims reappear.
+    """
+    print("SELF-TEST - the detector must FAIL on known-bad input.\n")
+    targets = [
+        "docs/reviews/dictation-dictionary-suggestions-mockup-v2-2026-07-24.html",
+        "docs/problems/voice-dictionary-not-applied-on-mobile.md",
+        "docs/research/transcription-speed/FINDINGS.md",
+    ]
+    tmp = os.path.join(root, ".sweep-selftest.tmp")
+    failures = 0
+    for rel in targets:
+        path = os.path.join(root, rel)
+        if not os.path.exists(path):
+            print("  SKIP %s (missing)" % rel)
+            continue
+        clean = unannotated(path)
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            stripped = [l for l in fh.read().split("\n") if not CORRECTION.search(l)]
+        with open(tmp, "w", encoding="utf-8", newline="") as fh:
+            fh.write("\n".join(stripped))
+        try:
+            broken = unannotated(tmp)
+        finally:
+            os.remove(tmp)
+        ok = (not clean) and bool(broken)
+        failures += 0 if ok else 1
+        print("  %s %s" % ("PASS" if ok else "FAIL", rel))
+        print("      as committed: %d unannotated | annotations removed: %d unannotated"
+              % (len(clean), len(broken)))
+        if broken:
+            print("      example caught: line %d: %s" % (broken[0][0], broken[0][1][:70]))
+    print("\nSELF-TEST: %s" % ("PASS" if not failures else "FAIL (%d)" % failures))
+    return 0 if not failures else 2
+
+
+def main(argv):
+    try:
+        root = repo_root()
+        if "--self-test" in argv:
+            return self_test(root)
+        return sweep(root)
+    except SweepError as exc:
+        print("SWEEP ERROR: %s" % exc, file=sys.stderr)
+        print("This is NOT a clean result.", file=sys.stderr)
+        return 2
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/src/CcDirector.ControlApi/VoiceUtteranceRequests.cs
+++ b/src/CcDirector.ControlApi/VoiceUtteranceRequests.cs
@@ -5,7 +5,8 @@ internal sealed record VoiceUtteranceRegisterRequest(string? UtteranceId);
 
 /// <summary>
 /// Body of POST /voice/utterance/{id}/complete. TotalChunks is how many chunks the
-/// client uploaded (indices 0..TotalChunks-1). SessionId lets the server bias the
-/// transcript cleanup to that session's repo dictionary.
+/// client uploaded (indices 0..TotalChunks-1). SessionId picks which repo dictionary
+/// the server's transcript CLEANUP uses - the pass that runs over the finished
+/// transcript. Nothing is sent to the speech-to-text provider (issue 2481).
 /// </summary>
 internal sealed record VoiceUtteranceCompleteRequest(int TotalChunks, string? Mime, string? SessionId);

--- a/src/CcDirector.Core.Tests/Dictation/DictionaryLoaderTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/DictionaryLoaderTests.cs
@@ -128,25 +128,10 @@ public sealed class DictionaryLoaderTests
         Assert.True(dict.CommonMistranscriptions.ContainsKey("acmeflow"));
     }
 
-    [Fact]
-    public void BuildSttPrompt_EmptyVocab_ReturnsEmpty()
-    {
-        Assert.Equal("", DictionaryLoader.BuildSttPrompt(DictationDictionary.Empty));
-    }
-
-    [Fact]
-    public void BuildSttPrompt_PacksTermsCommaSeparated()
-    {
-        var dict = new DictationDictionary(
-            new[] { "acmeflow", "CenCon", "ConPTY" },
-            new Dictionary<string, IReadOnlyList<string>>(),
-            new Dictionary<string, DictationProfile>());
-        var prompt = DictionaryLoader.BuildSttPrompt(dict);
-        Assert.Contains("acmeflow", prompt);
-        Assert.Contains("CenCon", prompt);
-        Assert.Contains("ConPTY", prompt);
-        Assert.Contains("Glossary", prompt);
-    }
+    // The two BuildSttPrompt tests that stood here were deleted with the method itself
+    // (issue 2481). Vocabulary is never packed into a speech-to-text prompt: the transcriber
+    // is given audio only, and the listed words are substituted afterwards by the correction
+    // pass. There is nothing here to test because there is nothing here to build.
 
     [Fact]
     public void Serialize_RoundTrips_Vocabulary_Patterns_AndProfiles()

--- a/src/CcDirector.Core/Configuration/AgentOptions.cs
+++ b/src/CcDirector.Core/Configuration/AgentOptions.cs
@@ -154,8 +154,10 @@ public class AgentOptions
     /// <summary>
     /// Path to the user-editable dictation dictionary YAML. If null, resolves
     /// to <c>%LOCALAPPDATA%/cc-director/dictation/dictionary.yaml</c>. Missing
-    /// file means no vocabulary bias and no cleanup glossary; the rest of the
-    /// dictation pipeline still works.
+    /// file means no cleanup glossary at all - no vocabulary and no known
+    /// mistranscriptions - so transcripts come back uncorrected; the rest of the
+    /// dictation pipeline still works. Nothing in this file is ever sent to the
+    /// speech-to-text provider (issue 2481).
     /// </summary>
     public string? DictationDictionaryPath { get; set; }
 

--- a/src/CcDirector.Core/Dictation/DictionaryLoader.cs
+++ b/src/CcDirector.Core/Dictation/DictionaryLoader.cs
@@ -68,18 +68,19 @@ public sealed class DictionaryLoader : IDisposable
         get { lock (_gate) return _current; }
     }
 
-    /// <summary>
-    /// Packs the vocabulary into a string suitable for the OpenAI
-    /// transcription <c>prompt</c> parameter. Stays under the practical
-    /// ~244 token budget by truncating long lists.
-    /// </summary>
-    public static string BuildSttPrompt(DictationDictionary dict)
-    {
-        if (dict.Vocabulary.Count == 0)
-            return "";
-        return "Glossary of names and terms used by the speaker: "
-               + string.Join(", ", dict.Vocabulary) + ".";
-    }
+    // DO NOT ADD A METHOD HERE THAT PACKS THE VOCABULARY INTO A SPEECH-TO-TEXT PROMPT.
+    //
+    // A dead BuildSttPrompt lived at this spot and was deleted deliberately (issue 2481).
+    // DevThrottle never sends vocabulary, glossaries, or any other steering hint to the
+    // speech-to-text provider. Dictation is two strict stages: transcribe the raw audio as
+    // faithfully as possible, audio only and no hints, and then run a separate code-driven
+    // correction pass that replaces the listed words on the finished transcript. Priming the
+    // transcriber makes it steer toward the suggested words, which changes wording and
+    // sentence structure and corrupts the record of what was actually said. Preserving the
+    // speaker's meaning is paramount, and this was learned from real problems.
+    //
+    // So this is a rejected approach, not a missing feature. The vocabulary is live and is
+    // read by the correction pass; it must never reach the transcriber.
 
     private void OnFileChanged(object _, FileSystemEventArgs __)
     {

--- a/src/CcDirector.Core/Dictation/Models/Dictionary.cs
+++ b/src/CcDirector.Core/Dictation/Models/Dictionary.cs
@@ -3,9 +3,16 @@ namespace CcDirector.Core.Dictation.Models;
 /// <summary>
 /// User-editable dictation dictionary loaded from a YAML file.
 ///
+/// NOTHING IN HERE IS EVER SENT TO THE SPEECH-TO-TEXT PROVIDER. The transcriber
+/// is given audio only, with no vocabulary and no other steering hint, so that it
+/// writes down what was actually said. Everything below is applied afterwards, by
+/// a separate pass over the finished transcript. See the note where
+/// <c>BuildSttPrompt</c> was deleted in <c>DictionaryLoader</c> for why (issue 2481).
+///
 /// Two layers of knowledge:
-/// 1. <see cref="Vocabulary"/> - canonical terms the speaker uses. Packed into
-///    the OpenAI prompt parameter as a soft decode-time bias.
+/// 1. <see cref="Vocabulary"/> - canonical terms the speaker uses. Read by the
+///    correction pass, which restores a term to its correct spelling on the
+///    finished transcript.
 /// 2. <see cref="CommonMistranscriptions"/> - known mistranscription patterns
 ///    the user has observed in practice. Passed to the dictionary-correction
 ///    LLM, which replaces these exact wrong forms with the canonical term and

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -159,8 +159,9 @@ internal static class RecordingEndpoints
         // over its OWN root directory, so one account's recordings/transcripts and its glossary are physically
         // partitioned from another's - the recording directory is now keyed by (tenant, id), not the
         // caller-supplied id alone. Built lazily per tenant on first use; on self-host the single Local tenant
-        // maps to the existing flat root, so nothing moves there. The transcriber reads the SAME tenant's
-        // glossary, so a per-tenant glossary edit biases only that tenant's transcription.
+        // maps to the existing flat root, so nothing moves there. The cleanup pass reads the SAME tenant's
+        // glossary, so a per-tenant glossary edit changes only that tenant's transcripts. (The glossary is
+        // never sent to the speech-to-text provider - it is applied to the finished transcript; issue 2481.)
         var services = new System.Collections.Concurrent.ConcurrentDictionary<string, RecordingIngestService>(StringComparer.Ordinal);
         RecordingIngestService ServiceFor(TenantId tenant)
             => services.GetOrAdd(tenant.Value, _ => BuildService(tenant, keyVault, history, audioArchive));
@@ -749,11 +750,14 @@ internal static class RecordingEndpoints
         DELETE {base}/ingest/recording/{id}
                Delete the transient local transcript. A promoted vault copy is kept.
 
-        ## Dictionary (speech-to-text glossary)
+        ## Dictionary (transcript-correction glossary)
 
-        The shared glossary that biases transcription toward the user's terms.
-        Editing it affects both phone-recording transcription and desktop
-        dictation. Changes apply on the next recording (no restart).
+        The shared glossary used to correct FINISHED transcripts toward the
+        user's terms. It is never sent to the speech-to-text provider: the
+        audio is transcribed as spoken, with no vocabulary and no steering
+        hint, and only then are the listed words substituted. Editing it
+        affects both phone-recording transcription and desktop dictation.
+        Changes apply on the next recording (no restart).
 
         GET    {base}/ingest/dictionary
                The glossary as JSON:
@@ -812,9 +816,10 @@ internal static class RecordingEndpoints
 
     /// <summary>This tenant's dictation glossary file. Local keeps the existing shared file; every other
     /// tenant gets its own glossary. Read by BOTH the dictionary editor routes and this tenant's recording
-    /// transcriber, so a per-tenant edit biases only that tenant's transcription (issue #2060). Delegates to
-    /// <see cref="TenantGlossary.PathFor"/> so the editor routes, the transcriber, and the suggestion "apply"
-    /// path can never disagree on the glossary location (devthrottle #2075).</summary>
+    /// cleanup pass, so a per-tenant edit changes only that tenant's transcripts (issue #2060). It is never
+    /// sent to the speech-to-text provider - it is applied to the finished transcript (issue 2481).
+    /// Delegates to <see cref="TenantGlossary.PathFor"/> so the editor routes, the cleanup pass, and the
+    /// suggestion "apply" path can never disagree on the glossary location (devthrottle #2075).</summary>
     private static string GlossaryPathFor(TenantId tenant) => TenantGlossary.PathFor(tenant);
 
     private static RecordingIngestService BuildService(
@@ -828,7 +833,8 @@ internal static class RecordingEndpoints
         var root = RootForTenant(tenant);
         // Promotion target: the vault transcripts collection (permanent copy), per tenant.
         var collectionDir = CollectionForTenant(tenant);
-        // The glossary the transcriber reads to bias transcription - this tenant's own (issue #2060).
+        // The glossary the cleanup pass reads to correct the finished transcript - this tenant's own
+        // (issue #2060). It never reaches the speech-to-text provider (issue 2481).
         var glossaryPath = GlossaryPathFor(tenant);
         // This tenant's transcription-health history. The single Local tenant uses the host's shared log
         // (self-host, unchanged); every other tenant writes to its own partition so a recording's history

--- a/src/CcDirector.Gateway/Transcription/DictionarySuggestionScreen.cs
+++ b/src/CcDirector.Gateway/Transcription/DictionarySuggestionScreen.cs
@@ -65,8 +65,10 @@ public static class DictionarySuggestionScreen
     {
         var sb = new StringBuilder();
         sb.AppendLine("You are screening candidate terms for a speech-to-text personal dictionary.");
-        sb.AppendLine("The dictionary biases a speech model toward distinctive terms it keeps misspelling:");
-        sb.AppendLine("product names, company names, people's names, and technical jargon.");
+        sb.AppendLine("The dictionary is applied AFTER transcription - it corrects the finished transcript,");
+        sb.AppendLine("and nothing in it is ever sent to the speech model. The terms it holds are the");
+        sb.AppendLine("distinctive ones the speech model keeps misspelling: product names, company names,");
+        sb.AppendLine("people's names, and technical jargon.");
         sb.AppendLine();
         sb.AppendLine("A clustering pass over the user's dictation transcripts produced the candidates below.");
         sb.AppendLine("The clustering is naive: it groups near-identical spellings, so many candidates are");

--- a/src/CcDirector.Gateway/Transcription/TenantGlossary.cs
+++ b/src/CcDirector.Gateway/Transcription/TenantGlossary.cs
@@ -7,9 +7,10 @@ namespace CcDirector.Gateway.Transcription;
 /// <summary>
 /// The single source of truth for WHERE a tenant's dictation glossary lives and how it is loaded and
 /// additively edited on the Gateway. The dictionary editor routes (<c>GET/PUT/POST /ingest/dictionary</c>),
-/// the recording transcriber, and the suggestion "apply" path all resolve the same per-tenant
-/// <c>dictionary.yaml</c> through here, so a term added on one path biases every other path for that tenant -
-/// and one tenant's glossary is physically partitioned from another's.
+/// the recording cleanup pass, and the suggestion "apply" path all resolve the same per-tenant
+/// <c>dictionary.yaml</c> through here, so a term added on one path is seen by every other path for that
+/// tenant - and one tenant's glossary is physically partitioned from another's. The glossary corrects
+/// FINISHED transcripts and is never sent to the speech-to-text provider (issue 2481).
 ///
 /// PER-TENANT PATH: the single Local tenant keeps the existing shared flat file (so a self-host install's
 /// glossary does not move); every other tenant gets its own <c>&lt;tenantFolder&gt;/dictionary.yaml</c> under the

--- a/tools/harnesses/dictionary-cleanup-eval/README.md
+++ b/tools/harnesses/dictionary-cleanup-eval/README.md
@@ -4,6 +4,11 @@ Scientific evaluation of the deterministic dictionary-cleanup step, using establ
 ASR-customization / contextual-biasing methodology (not invented metrics). See
 `docs/architecture/transcription-quality-loop.md` for the design rationale.
 
+Only the MEASUREMENT is borrowed from that literature, not the technique: DevThrottle does no
+contextual biasing and sends nothing but audio to the transcriber (issue 2481). The "biased"
+tokens named below are the standard B-WER term for the target terms being scored - nothing is
+being biased.
+
 ## What it measures
 
 Transcription is held CONSTANT. Each fixture is text-in / text-out: a frozen `raw_transcript`, a

--- a/tools/harnesses/dictionary-cleanup-eval/eval_cleanup.py
+++ b/tools/harnesses/dictionary-cleanup-eval/eval_cleanup.py
@@ -2,7 +2,12 @@
 Multilingual evaluation harness for the deterministic dictionary-cleanup step.
 
 Design (from established ASR-customization / contextual-biasing methodology): hold transcription
-CONSTANT and score ONLY the cleanup. Each fixture is text-in / text-out - a frozen raw transcript, a
+CONSTANT and score ONLY the cleanup. What is borrowed from that literature is the MEASUREMENT - the
+B-WER / U-WER split below - and NOT the technique: DevThrottle does no contextual biasing and sends
+nothing but audio to the transcriber (issue 2481). "Biased tokens" below is the standard B-WER name
+for the target-term tokens being scored; nothing is being biased.
+
+Each fixture is text-in / text-out - a frozen raw transcript, a
 term list (targets + distractors), the gold corrected text, and the gold edits. The harness POSTs each
 fixture to the Gateway's /transcription/cleanup endpoint (the REAL production cleanup) and scores the
 result. No audio, no third-party ASR variance.
@@ -81,7 +86,11 @@ def align(ref, hyp):
 
 
 def biased_surface_tokens(target_terms, lang):
-    """The set of normalized tokens that belong to any target term (the 'biased' vocabulary)."""
+    """The set of normalized tokens that belong to any target term (the 'biased' vocabulary).
+
+    "Biased" is the standard B-WER term for the target-term tokens being scored. Nothing is
+    biased: DevThrottle sends nothing but audio to the transcriber (issue 2481).
+    """
     s = set()
     for term in target_terms:
         for tok in tokenize(term, lang):


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1785

## The ruling this carries out

Quoting the owner ruling on the issue, 2026-08-07:

> the bias path stays dead - and gets deleted. Never send vocabulary or any steering hints to the speech-to-text provider. The dictation architecture is deliberately two strict stages: transcribe the raw audio as faithfully as possible (audio only, no hints), then a separate code-driven correction pass replaces the listed words on the finished transcript. Priming the transcriber makes it steer toward suggested words, changing wording and sentence structure - corrupting the record of what was said. Meaning preservation is paramount; this was learned from real problems before. The unused prompt-building code is a rejected approach, not a missing feature: the fix for this issue is to DELETE the dead path and leave a comment recording this ruling at the deletion site, so it cannot be helpfully wired up later. The docs already describe the shipped cleanup-only truth and need no change.

## Verified before deleting anything, at origin/main

- `DictionaryLoader.BuildSttPrompt` had **no callers in any shipping code**. The only references anywhere were its own two tests and a historical problem document.
- The live speech-to-text request - the one batch POST to `/audio/transcriptions` in `BatchTranscriptionPipeline` - sends `model`, `response_format` and `language`, and **no prompt field**. Nothing was reaching the transcriber, so removing the method changes no behaviour.
- The vocabulary itself is **live and untouched**: `CleanupOrchestrator`, `FuzzyDictionaryMatcher`, `TranscriptEditEngine` and `MistranscriptionMiner` all read it. That is the correction pass working on the finished transcript, which is exactly the stage the ruling keeps.

## What changed

- Deleted `DictionaryLoader.BuildSttPrompt` and its two tests.
- Left a comment at each deletion site recording the ruling in substance - transcribe raw with audio only, substitute the listed words afterwards, priming corrupts the record of what was said, this is a rejected approach and not a missing feature.
- Corrected two stale comments that stated the rejected approach **as the design**, which is what would invite someone to rebuild it:
  - the `DictationDictionary` summary claimed the vocabulary was "Packed into the OpenAI prompt parameter as a soft decode-time bias";
  - the 2026-05-25 problem document `voice-dictionary-not-applied-on-mobile.md`, whose suggested fix told a future reader to recompute that prompt per transcription. Its record is left intact; a dated note at the top marks the bias-prompt parts as rejected and points at this issue. The class it describes, `OpenAiRecordingTranscriber`, no longer exists either.

Behaviour is unchanged. This is a deletion plus comments.

**One deliberate non-change:** `docs/features/dictation/phase0/run_phase0.py` still defines an `STT_PROMPT`. It is a dated phase-0 experiment script under `docs`, on no build path and called by nothing, and the ruling says the docs need no change - so the record of an experiment that already ran is left as it is rather than edited after the fact.

## Tests

- `.\scripts\test-local.ps1` - all nine default suites green, 4265 tests, every TRX `outcome=Completed`.
- That run then flagged a coverage gap: `CcDirector.Core.Tests` is parked and holds the test file edited here. So the parked suites were run too - `.\scripts\test-local.ps1 -Parked -Filter "FullyQualifiedName~Dictation"`: `CcDirector.Core.Tests` 159 passed, `CcDirector.Gateway.Tests` 29 passed, both `outcome=Completed`. Checked in the TRX that 15 `DictionaryLoaderTests` actually executed and that neither `BuildSttPrompt` test remains.
- **What was not run:** the two parked suites in full, unfiltered. `Core.Tests` needs 11 to 33 minutes and the machine is busy with fleet work. The filter covers every test touching the changed code, and the full build of both projects passed with zero warnings, so a compile-level break would have shown. Stating it rather than implying the whole parked gate ran.
