### PR TITLE
Hide empty missions on the Missions board, and always say how many

### DIFF
--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -102,6 +102,26 @@ const CANVAS_PIVOTS: ReadonlySet<Pivot> = new Set<Pivot>(["machine", "director",
 // they left off. Defaults to "By machine" the first time, or when storage is unavailable.
 const PIVOT_STORAGE_KEY = "cockpit.fleetMapPivot";
 
+// Whether the Missions pivot hides the missions nobody is on right now. Sticky per browser like the
+// pivot itself, and ON by default: a mission that has finished keeps its card forever until somebody ends
+// it, and four of those were enough to push the live work off the bottom of the screen.
+//
+// This is a VIEW preference and nothing more. It does not mean the hidden missions are over, and it is
+// not the way to end one - that is a state on the Mission record and a separate piece of work. Whenever
+// this hides anything the board says how many and offers them back, so it can never be confused with
+// there being none.
+const HIDE_EMPTY_MISSIONS_STORAGE_KEY = "cockpit.fleetMapHideEmptyMissions";
+
+function initialHideEmptyMissions(): boolean {
+  try {
+    // Only an explicit "0" turns it off, so a first-time user (null) gets the clean board.
+    return window.localStorage.getItem(HIDE_EMPTY_MISSIONS_STORAGE_KEY) !== "0";
+  } catch {
+    /* storage unavailable (private mode) - fall through to the default */
+  }
+  return true;
+}
+
 function initialPivot(): Pivot {
   try {
     const saved = window.localStorage.getItem(PIVOT_STORAGE_KEY);
@@ -225,6 +245,17 @@ export function FleetMapView() {
   // name cached on the session for a mission id it has no record for.
   const [missions, setMissions] = useState<MissionDto[]>([]);
   const [missionsError, setMissionsError] = useState<string | null>(null);
+
+  // The hide-empties preference, written through on every change exactly like the pivot above.
+  const [hideEmptyMissions, setHideEmptyMissionsState] = useState<boolean>(initialHideEmptyMissions);
+  const setHideEmptyMissions = useCallback((next: boolean) => {
+    setHideEmptyMissionsState(next);
+    try {
+      window.localStorage.setItem(HIDE_EMPTY_MISSIONS_STORAGE_KEY, next ? "1" : "0");
+    } catch {
+      /* storage unavailable (private mode) - the choice still applies this session */
+    }
+  }, []);
   useEffect(() => {
     if (pivot !== "mission") return;
     let cancelled = false;
@@ -271,6 +302,34 @@ export function FleetMapView() {
                 <>
                   <span className="fmap-sep" aria-hidden="true" />
                   <span>{missionStats.standalone} standalone</span>
+                </>
+              )}
+              {/* The hidden count is part of the tally, not a footnote: the header states what EXISTS,
+                  and says in the same breath how much of it is currently not being drawn. */}
+              {hideEmptyMissions && missionStats.empty > 0 && (
+                <>
+                  <span className="fmap-sep" aria-hidden="true" />
+                  <button
+                    type="button"
+                    className="fmap-emptytoggle"
+                    onClick={() => setHideEmptyMissions(false)}
+                    title="Show the missions that have no sessions on them right now"
+                  >
+                    {missionStats.empty} empty hidden
+                  </button>
+                </>
+              )}
+              {!hideEmptyMissions && missionStats.empty > 0 && (
+                <>
+                  <span className="fmap-sep" aria-hidden="true" />
+                  <button
+                    type="button"
+                    className="fmap-emptytoggle"
+                    onClick={() => setHideEmptyMissions(true)}
+                    title="Hide the missions that have no sessions on them right now"
+                  >
+                    hide {missionStats.empty} empty
+                  </button>
                 </>
               )}
             </>
@@ -369,7 +428,16 @@ export function FleetMapView() {
           // case where we know least - no sessions and no mission list - is the case that renders the most
           // confident answer, a silent "no missions at all".
           (list.length > 0 || missions.length > 0 || missionsError !== null) && (
-            <MissionsBoard sessions={list} missions={missions} error={missionsError} />
+            // Hiding and the way back are passed as ONE unit - MissionsBoardProps refuses hideEmpty
+            // without onShowEmpty, so a card can never be hidden with no affordance to bring it back.
+            <MissionsBoard
+              sessions={list}
+              missions={missions}
+              error={missionsError}
+              {...(hideEmptyMissions
+                ? ({ hideEmpty: true, onShowEmpty: () => setHideEmptyMissions(false) } as const)
+                : ({ hideEmpty: false } as const))}
+            />
           )
         : pivot === "list"
         ? flatSessions.length > 0 && (

--- a/apps/cockpit/src/fleet/fleetmap.css
+++ b/apps/cockpit/src/fleet/fleetmap.css
@@ -47,6 +47,25 @@
   color: var(--attention);
 }
 
+/* The empty-missions count in the header, which is also the control that flips it. It reads as one more
+   stat rather than a button, because it IS one - the number of missions that exist but are not being
+   drawn - and clicking it is the obvious thing to do with it. */
+.fmap-emptytoggle {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--text-dim);
+  cursor: pointer;
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+
+.fmap-emptytoggle:hover,
+.fmap-emptytoggle:focus-visible {
+  color: var(--text);
+}
+
 .fmap-controls {
   margin-left: auto;
   display: inline-flex;

--- a/apps/cockpit/src/missions/MissionsBoard.test.tsx
+++ b/apps/cockpit/src/missions/MissionsBoard.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { useState } from "react";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
 import type { MissionDto } from "@devthrottle/client-core/missions/missions";
@@ -126,6 +127,82 @@ describe("MissionsBoard", () => {
 
     expect(screen.getByText("BPM Studio QA cleanup")).toBeTruthy();
     expect(screen.getByText(/not in the mission list/i)).toBeTruthy();
+  });
+
+  it("hides empty missions when asked - and SAYS how many, with a way back", async () => {
+    const onShowEmpty = vi.fn();
+    renderBoard({
+      sessions: [ARCHITECT],
+      missions: [M_RELEASE, { missionId: "m-dead", missionName: "Remove the network port" }],
+      hideEmpty: true,
+      onShowEmpty,
+    });
+
+    // The staffed mission is drawn; the empty one is not.
+    expect(screen.getByText("Release 2.0.1")).toBeTruthy();
+    expect(screen.queryByText("Remove the network port")).toBeNull();
+
+    // ...but the board never hides silently: the count is on screen and it is the way back.
+    const note = screen.getByText(/1 mission with no sessions is hidden/i);
+    expect(note).toBeTruthy();
+    note.click();
+    expect(onShowEmpty).toHaveBeenCalled();
+  });
+
+  it("draws every mission when not hiding, and shows no hidden-count note", async () => {
+    renderBoard({
+      sessions: [ARCHITECT],
+      missions: [M_RELEASE, { missionId: "m-dead", missionName: "Remove the network port" }],
+      hideEmpty: false,
+    });
+
+    expect(screen.getByText("Release 2.0.1")).toBeTruthy();
+    expect(screen.getByText("Remove the network port")).toBeTruthy();
+    expect(screen.queryByText(/hidden/i)).toBeNull();
+  });
+
+  it("pluralises the hidden-count note", async () => {
+    renderBoard({
+      sessions: [],
+      missions: [
+        { missionId: "m1", missionName: "One" },
+        { missionId: "m2", missionName: "Two" },
+      ],
+      hideEmpty: true,
+      onShowEmpty: vi.fn(),
+    });
+
+    expect(screen.getByText(/2 missions with no sessions are hidden/i)).toBeTruthy();
+  });
+
+  // The callback firing is not the promise; the card COMING BACK is. This drives the real round trip
+  // through a stateful parent, so a wiring mistake between the notice and the board cannot pass.
+  it("brings the hidden missions back when the note is clicked", async () => {
+    function Harness() {
+      const [hide, setHide] = useState(true);
+      const props = hide
+        ? ({ hideEmpty: true, onShowEmpty: () => setHide(false) } as const)
+        : ({ hideEmpty: false } as const);
+      return (
+        <MissionsBoard
+          sessions={[ARCHITECT]}
+          missions={[M_RELEASE, { missionId: "m-dead", missionName: "Remove the network port" }]}
+          {...props}
+        />
+      );
+    }
+
+    render(
+      <MemoryRouter>
+        <Harness />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("Remove the network port")).toBeNull();
+    fireEvent.click(screen.getByText(/1 mission with no sessions is hidden/i));
+
+    expect(screen.getByText("Remove the network port")).toBeTruthy();
+    expect(screen.queryByText(/hidden/i)).toBeNull();
   });
 
   it("says so loudly when the mission list could not be loaded", async () => {

--- a/apps/cockpit/src/missions/MissionsBoard.tsx
+++ b/apps/cockpit/src/missions/MissionsBoard.tsx
@@ -5,7 +5,7 @@ import { dotColor, dotHex, effectiveColor, stateLabel } from "@devthrottle/clien
 import { getMissionNotes, setMissionNote } from "@devthrottle/client-core/missions/missionNotes";
 import type { MissionDto } from "@devthrottle/client-core/missions/missions";
 import { repoBasename, relativeTime } from "../fleet/format";
-import { groupByMission, type MissionGroup } from "./missionGrouping";
+import { groupByMission, splitEmptyMissions, type MissionGroup } from "./missionGrouping";
 
 // The Missions board (issue #1405): the same live fleet the Fleet Map draws, seen the way the owner
 // actually thinks about the work - grouped into MISSIONS rather than machines or repos. A mission is the
@@ -45,11 +45,7 @@ function whyKeyFor(missionName: string): string {
   return missionName.trim().toLowerCase();
 }
 
-export function MissionsBoard({
-  sessions,
-  missions = [],
-  error = null,
-}: {
+interface MissionsBoardBaseProps {
   sessions: SessionDto[];
   /** The Gateway's mission records, so a mission with nobody on it still gets a card. Defaults to none,
    *  which renders only the missions at least one session is attached to. */
@@ -58,7 +54,37 @@ export function MissionsBoard({
    *  mission that has a session on it, but not the empty ones, and it must say so rather than present a
    *  short list as the whole truth. */
   error?: string | null;
-}) {
+}
+
+/**
+ * Hiding is only ever offered TOGETHER with the way back, and the type enforces it rather than trusting
+ * every caller to remember. `hideEmpty` without `onShowEmpty` does not compile.
+ *
+ * This is not type ceremony. The first cut of this component took both as independent optional props, and
+ * a caller that hid the empties without supplying the callback rendered a notice saying "1 mission is
+ * hidden - show it" above a button that did nothing. The requirement is that nothing is ever hidden
+ * without a one-click way back; a requirement a caller can silently fail to meet is not enforced, it is
+ * merely written down. One of this file's own tests had already made exactly that mistake.
+ */
+export type MissionsBoardProps = MissionsBoardBaseProps &
+  (
+    | {
+        /** Hide the missions nobody is on right now. A VIEW preference only - it says nothing about
+         *  whether that work is finished. The board always states how many it hid and offers them back. */
+        hideEmpty: true;
+        /** Required when hiding: how the owner asks for the hidden missions back. */
+        onShowEmpty: () => void;
+      }
+    | { hideEmpty?: false; onShowEmpty?: never }
+  );
+
+export function MissionsBoard({
+  sessions,
+  missions = [],
+  error = null,
+  hideEmpty = false,
+  onShowEmpty,
+}: MissionsBoardProps) {
   const navigate = useNavigate();
 
   // The mission WHYs, keyed by the normalized mission key (the same key groupByMission produces). Read
@@ -93,6 +119,12 @@ export function MissionsBoard({
 
   const grouped = useMemo(() => groupByMission(sessions, missions), [sessions, missions]);
 
+  // Split before deciding what to draw, so the count of what is hidden is always available even when it
+  // is being hidden. The board never drops a card without saying how many it dropped.
+  const { staffed, empty } = useMemo(() => splitEmptyMissions(grouped.missions), [grouped.missions]);
+  const shown = hideEmpty ? staffed : grouped.missions;
+  const hiddenCount = hideEmpty ? empty.length : 0;
+
   const openSession = (sid: string | null | undefined) => {
     const id = (sid ?? "").trim();
     if (id.length > 0) navigate(`/session/${encodeURIComponent(id)}`);
@@ -121,7 +153,7 @@ export function MissionsBoard({
         </div>
       )}
 
-      {grouped.missions.map((m) => (
+      {shown.map((m) => (
         <MissionCard
           key={m.key}
           mission={m}
@@ -130,6 +162,16 @@ export function MissionsBoard({
           onOpen={openSession}
         />
       ))}
+
+      {/* Whatever is hidden is COUNTED and offered back, right where the cards would have been. Hiding
+          without saying so would leave the owner unable to tell an empty fleet from a filtered view -
+          and this board is the one that already told him he had two missions when he had eleven. */}
+      {hiddenCount > 0 && (
+        <button type="button" className="msn-hidden-note" onClick={onShowEmpty}>
+          {hiddenCount} mission{hiddenCount === 1 ? "" : "s"} with no sessions{" "}
+          {hiddenCount === 1 ? "is" : "are"} hidden - show {hiddenCount === 1 ? "it" : "them"}
+        </button>
+      )}
 
       {grouped.standalone.length > 0 && (
         <>
@@ -158,9 +200,16 @@ export function MissionsBoard({
 export function missionCounts(
   sessions: SessionDto[],
   missions: MissionDto[] = [],
-): { missions: number; standalone: number } {
+): { missions: number; standalone: number; empty: number } {
   const grouped = groupByMission(sessions, missions);
-  return { missions: grouped.missions.length, standalone: grouped.standalone.length };
+  // `missions` is the TOTAL and stays the total whether or not the empties are being drawn - the header
+  // reports what exists, and reports separately how many of them are currently hidden.
+  const { empty } = splitEmptyMissions(grouped.missions);
+  return {
+    missions: grouped.missions.length,
+    standalone: grouped.standalone.length,
+    empty: empty.length,
+  };
 }
 
 interface MissionCardProps {

--- a/apps/cockpit/src/missions/missionGrouping.test.ts
+++ b/apps/cockpit/src/missions/missionGrouping.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
 import type { MissionDto } from "@devthrottle/client-core/missions/missions";
-import { displayRole, groupByMission } from "./missionGrouping";
+import { displayRole, groupByMission, splitEmptyMissions } from "./missionGrouping";
 
 // The Missions board groups by the mission a session is ATTACHED to (SessionDto.missionId), with the role
 // the Gateway resolved (SessionDto.sessionRole). These tests lock that, and in particular they lock the
@@ -200,5 +200,42 @@ describe("groupByMission", () => {
 
   it("returns an empty fleet unchanged", () => {
     expect(groupByMission([], [])).toEqual({ missions: [], standalone: [] });
+  });
+});
+
+describe("splitEmptyMissions", () => {
+  it("separates the missions with sessions from the ones without", () => {
+    const { missions } = groupByMission(
+      [session({ name: "w", number: 1, sessionId: "a", missionId: "m-release" })],
+      [M_RELEASE, M_EMPTY],
+    );
+
+    const { staffed, empty } = splitEmptyMissions(missions);
+    expect(staffed.map((m) => m.name)).toEqual(["Release 2.0.1"]);
+    expect(empty.map((m) => m.name)).toEqual(["Website truth report"]);
+  });
+
+  it("keeps the caller's order within each side", () => {
+    const { missions } = groupByMission([], [
+      { missionId: "m3", missionName: "Zebra" },
+      { missionId: "m1", missionName: "apple" },
+      { missionId: "m2", missionName: "Banya" },
+    ]);
+
+    const { staffed, empty } = splitEmptyMissions(missions);
+    expect(staffed).toHaveLength(0);
+    expect(empty.map((m) => m.name)).toEqual(["apple", "Banya", "Zebra"]);
+  });
+
+  it("handles both extremes", () => {
+    expect(splitEmptyMissions([])).toEqual({ staffed: [], empty: [] });
+
+    const { missions } = groupByMission(
+      [session({ name: "w", number: 1, sessionId: "a", missionId: "m-release" })],
+      [M_RELEASE],
+    );
+    const { staffed, empty } = splitEmptyMissions(missions);
+    expect(staffed).toHaveLength(1);
+    expect(empty).toHaveLength(0);
   });
 });

--- a/apps/cockpit/src/missions/missionGrouping.ts
+++ b/apps/cockpit/src/missions/missionGrouping.ts
@@ -68,6 +68,28 @@ export interface GroupedFleet {
   standalone: SessionDto[];
 }
 
+/**
+ * Split the missions into the ones with sessions on them and the ones without.
+ *
+ * EMPTY IS NOT THE SAME AS FINISHED, and this function only knows about the first. A mission is empty
+ * because nobody is on it RIGHT NOW - which is equally true of a mission created ten seconds ago and of
+ * one that shipped a week ago. Hiding the empties is therefore a VIEW preference and never a statement
+ * that the work is over; ending a mission is a state on the record, and it is a different feature.
+ *
+ * The caller must show the hidden COUNT whenever it hides any. A card that disappears with no trace is
+ * the same quiet-wrong-answer this screen was rebuilt to stop giving: the owner cannot tell "there are
+ * none" from "you are not being shown them".
+ */
+export function splitEmptyMissions(missions: MissionGroup[]): {
+  staffed: MissionGroup[];
+  empty: MissionGroup[];
+} {
+  const staffed: MissionGroup[] = [];
+  const empty: MissionGroup[] = [];
+  for (const m of missions) (m.members.length > 0 ? staffed : empty).push(m);
+  return { staffed, empty };
+}
+
 // Order roles Architect -> Manager -> Worker within a mission card, so the lead reads first. A role the
 // Gateway sent that is not one of the three, and a session with no role at all, sort last.
 const ROLE_RANK: Record<string, number> = { Architect: 0, Manager: 1, Worker: 2 };

--- a/apps/cockpit/src/missions/missions.css
+++ b/apps/cockpit/src/missions/missions.css
@@ -81,6 +81,28 @@
   color: var(--text-dim);
 }
 
+/* The in-board notice that empty missions are being hidden, and the control that brings them back. It
+   sits where those cards would have been, so the gap in the list is explained at the gap. */
+.msn-hidden-note {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 11px 16px;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  background: none;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+.msn-hidden-note:hover,
+.msn-hidden-note:focus-visible {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
 /* A mission the roster knows about but the Gateway's mission list does not contain. Amber, not red: the
    sessions and their grouping are real and correct - it is the agreement between the two stores that is
    not, and that is worth showing without shouting. */


### PR DESCRIPTION
## Why

Showing every mission the Gateway knows about put four long-finished missions on the board at a full card each - "Remove the network port", "Release convergence - 2 August", and two URGENT ones whose deadlines passed last week - pushing the live work off the bottom of the screen.

## What

A view preference that hides the missions nobody is on right now. On by default, sticky per browser in `localStorage` exactly like the existing pivot preference.

**Empty is not finished, and this is careful not to pretend otherwise.** A mission is empty because nobody is on it *at this moment* - equally true of one created ten seconds ago and one that shipped last week. Hiding is a view preference and says nothing about whether the work is over. Ending a mission is a state on the record and is separate work (phases 1-2). The four cards that prompted this are a *finished* problem; this only stops them being in the way until there is a verb for that.

## Nothing is ever hidden silently

- The header carries the count and **is** the control that flips it: `11 missions · 4 standalone · 4 empty hidden`.
- A notice sits in the list where the hidden cards would have been, offering them back.

The board that told the owner he had two missions when he had eleven does not get to quietly drop cards again.

**The props enforce it.** `hideEmpty` and `onShowEmpty` are a discriminated union, so hiding without a way back does not compile. The first cut had them as two independent optional props and rendered *"1 mission is hidden - show it"* above an inert button - and one of the tests in this very file had already made that mistake without failing. A requirement a caller can silently fail to meet is not enforced, only written down. The type change immediately caught the real call site in `FleetMapView`.

## Testing

- `splitEmptyMissions` - pure, 3 tests.
- Board - hides with the count, draws everything when not hiding, singular and plural notices, and the **full round trip through a stateful parent** so the hidden card genuinely reappears rather than a callback merely firing.
- Suites green: cockpit 281, client-core 905, mobile 3. Root typecheck clean. Production build clean.
- Reviewed by Codex (different agent family). Two findings: the inert-button hole (fixed structurally, above) and the `localStorage` catch blocks. The second is declined deliberately - it matches the sibling pivot preference in the same file line for line, the comment states the fallback behaviour, and diverging for one of two adjacent preferences would be worse than either choice. If we want storage failures reported, both should change together.