### PR TITLE
Hosted dictation reads the tenant's own glossary, and an unresolved tenant is refused

### DIFF
--- a/docs/public/release-notes/v2.0.1.md
+++ b/docs/public/release-notes/v2.0.1.md
@@ -1,0 +1,56 @@
+# DevThrottle v2.0.1
+
+A hardening release. Everything here is a defect found during and just after
+v2.0.0 - several of them by walking the product on a clean machine as a new user
+would, which is how the worst ones surface.
+
+## Your dictionary now affects your own dictation
+
+If you use DevThrottle in the cloud, the words you add to your dictionary were not
+reaching your dictation. The correction pass was reading a shared dictionary file
+rather than yours, so adding a term you say all day changed nothing, and the
+promise that your dictionary follows you everywhere quietly failed.
+
+Your dictation now reads **your** glossary. Two details worth stating plainly,
+because both could have been got wrong:
+
+- If you have not written a dictionary, you get no correction at all - never
+  somebody else's terms.
+- Running DevThrottle on your own machine is unchanged.
+
+## A broken dictionary no longer costs you the transcription
+
+If your dictionary file was malformed or unreadable, it could fail the whole
+transcription instead of stepping aside. That is backwards: the dictionary is there
+to improve a transcript, so when it cannot be read the right answer is the plain
+transcript, not an error.
+
+A dictionary that cannot be read is now skipped, and you get your raw text.
+
+## The usage page stops hiding a service
+
+The account usage page showed cards for three services while a fourth - the wingman
+- was being recorded the whole time and never shown. Its activity was collected and
+invisible, so the page did not add up to what you were actually using.
+
+Every recorded service now gets a card.
+
+<!--
+DRAFT - Architect, Release 2.0.1. Sections above cover Phase 1 (issues 2482, 2483
+and 2487) and are settled. Still to be written as their phases land:
+
+  Phase 2 - the member usage page naming upstream model ids (1368), the retired
+            brand on /account/keys (1379), and the clean install that reported
+            success while the fleet tool was unreachable (1255).
+  Phase 3 - the dead vocabulary-bias path (2481), the raw Win32 error when there is
+            no microphone (1377), and spoken replies that could go unmetered (1367).
+  Phase 4 - the release script guards (1365). Internal only; not user-facing, so it
+            probably earns a line under "Also in this release" at most.
+
+Not in this release, by the owner's decision: the agent dictionary command (2484).
+It is being built and will land after this cut.
+
+House style, from v2.0.0: lead with what was broken FOR THE USER, in their words,
+then what is now true. No issue numbers. No internal component names. Nothing that
+names a provider.
+-->

--- a/docs/public/release-notes/v2.0.1.md
+++ b/docs/public/release-notes/v2.0.1.md
@@ -1,56 +1,58 @@
 # DevThrottle v2.0.1
 
-A hardening release. Everything here is a defect found during and just after
-v2.0.0 - several of them by walking the product on a clean machine as a new user
-would, which is how the worst ones surface.
+A hardening release. Every item here is a defect found during or just after v2.0.0,
+several of them by walking the product on a clean machine as a new user would, and
+several more by an independent review that sent the work back before it shipped.
 
-## Your dictionary now affects your own dictation
+## Your dictionary now reaches your own dictation
 
 If you use DevThrottle in the cloud, the words you add to your dictionary were not
-reaching your dictation. The correction pass was reading a shared dictionary file
-rather than yours, so adding a term you say all day changed nothing, and the
-promise that your dictionary follows you everywhere quietly failed.
+affecting your dictation at all. The correction pass read a shared dictionary rather
+than yours, so adding a term you say all day changed nothing, and the promise that
+your dictionary follows you everywhere quietly failed.
 
 Your dictation now reads **your** glossary. Two details worth stating plainly,
-because both could have been got wrong:
+because either could have been got wrong and both were checked:
 
-- If you have not written a dictionary, you get no correction at all - never
-  somebody else's terms.
+- If you have written no dictionary, you get **no** correction - never somebody
+  else's terms.
 - Running DevThrottle on your own machine is unchanged.
 
 ## A broken dictionary no longer costs you the transcription
 
 If your dictionary file was malformed or unreadable, it could fail the whole
-transcription instead of stepping aside. That is backwards: the dictionary is there
-to improve a transcript, so when it cannot be read the right answer is the plain
-transcript, not an error.
+transcription instead of stepping aside. That is backwards: the dictionary exists to
+improve a transcript, so when it cannot be read the right answer is the plain
+transcript.
 
-A dictionary that cannot be read is now skipped, and you get your raw text.
+A dictionary that cannot be read is now skipped and you get your raw text. It does
+not fall back to anyone else's terms either - failing open means your own words, not
+a stranger's spelling.
 
-## The usage page stops hiding a service
+## The dictionary never did bias speech recognition, and now says so
 
-The account usage page showed cards for three services while a fourth - the wingman
-- was being recorded the whole time and never shown. Its activity was collected and
-invisible, so the page did not add up to what you were actually using.
+The product told you, in the app and on the phone, that your terms were "biased into
+speech-to-text". They were not, and the code path that would have done it had no
+caller - your audio goes to speech recognition untouched, and your terms are applied
+afterwards to the finished transcript.
 
-Every recorded service now gets a card.
+The wording is now what actually happens, everywhere it appeared: the app, the phone,
+the agent-facing help, and the dead path itself is gone. This changes no behaviour -
+it stops the product describing a design it does not have.
 
-<!--
-DRAFT - Architect, Release 2.0.1. Sections above cover Phase 1 (issues 2482, 2483
-and 2487) and are settled. Still to be written as their phases land:
+## A request we cannot place is now refused rather than guessed at
 
-  Phase 2 - the member usage page naming upstream model ids (1368), the retired
-            brand on /account/keys (1379), and the clean install that reported
-            success while the fleet tool was unreachable (1255).
-  Phase 3 - the dead vocabulary-bias path (2481), the raw Win32 error when there is
-            no microphone (1377), and spoken replies that could go unmetered (1367).
-  Phase 4 - the release script guards (1365). Internal only; not user-facing, so it
-            probably earns a line under "Also in this release" at most.
+On the hosted service, one voice route would accept a request whose account could not
+be resolved and quietly treat it as a local, single-machine request - reading the
+shared dictionary and filing the transcript in the wrong place. Every comparable
+route already refused. This one now refuses too.
 
-Not in this release, by the owner's decision: the agent dictionary command (2484).
-It is being built and will land after this cut.
+## Also in this release
 
-House style, from v2.0.0: lead with what was broken FOR THE USER, in their words,
-then what is now true. No issue numbers. No internal component names. Nothing that
-names a provider.
--->
+- The Missions board groups sessions by the mission they belong to, hides missions
+  with nothing in them, and always tells you how many there are.
+- Dictation no longer carries a finished recording into a session you have since
+  moved on from - the guard now arms from both ways of starting to speak.
+- The root folders caption says what actually happens: discovery is the local scan.
+- `workflow run` accepts the short run id it prints to you, and a web page answer is
+  never mistaken for data.

--- a/src/CcDirector.Gateway.Tests/GatewayTranscriptionServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTranscriptionServiceTests.cs
@@ -261,7 +261,7 @@ public sealed class GatewayTranscriptionServiceTests : IDisposable
 
         var service = new GatewayTranscriptionService(
             new KeyVault(_vaultPath),
-            dictionaryProvider: () => throw new InvalidDataException("dictionary file is malformed"),
+            dictionaryProvider: _ => throw new InvalidDataException("dictionary file is malformed"),
             http: new HttpClient(new StatusHandler(HttpStatusCode.OK, "{\"text\":\"the raw words\"}")),
             audioArchive: ScratchArchive());
 
@@ -279,10 +279,10 @@ public sealed class GatewayTranscriptionServiceTests : IDisposable
         // dictionary provider must yield the raw text there too, never an exception.
         var service = new GatewayTranscriptionService(
             new KeyVault(_vaultPath),
-            dictionaryProvider: () => throw new InvalidDataException("dictionary file is malformed"),
+            dictionaryProvider: _ => throw new InvalidDataException("dictionary file is malformed"),
             audioArchive: ScratchArchive());
 
-        var outcome = await service.CleanupAsync("the raw words", CancellationToken.None);
+        var outcome = await service.CleanupAsync("the raw words", ct: CancellationToken.None);
 
         Assert.Equal("the raw words", outcome.Text);
         Assert.False(outcome.Applied);

--- a/src/CcDirector.Gateway.Tests/HostedWingmanTranscribeTenantRefusalTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedWingmanTranscribeTenantRefusalTests.cs
@@ -1,0 +1,255 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using CcDirector.Core;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// THE MAPPED ROUTE, DRIVEN. <c>POST /wingman/transcribe</c> on a hosted Gateway must REFUSE a caller whose
+/// tenant does not resolve, never serve it - and this test is the only thing in the repository that drives
+/// that route at all.
+///
+/// WHY THIS EXISTS RATHER THAN ANOTHER SERVICE-LEVEL TEST. The route used to pass the nullable result of
+/// <c>GatewayEndpoints.ResolveReadTenant</c> straight into
+/// <see cref="GatewayTranscriptionService.TranscribeAsync"/>. That resolver's own documentation says null is a
+/// REFUSAL; the service's contract says null means the self-host single tenant. Handing one to the other
+/// turned the refusal into <see cref="TenantId.Local"/> three layers down, with three consequences on a
+/// hosted request - the SHARED FLAT GLOSSARY biased the caller's words, the shared history took their turn,
+/// and their transcript evidence landed in the Local partition.
+///
+/// Every existing test of that behaviour constructs <see cref="GatewayTranscriptionService"/> DIRECTLY and
+/// never maps the route, so all of them passed with this route wide open. A guard written the same way would
+/// be worth exactly as much. So this one boots a real <see cref="GatewayHost"/>, authenticates with a real
+/// device key through the real host-wide auth gate, and posts real multipart audio at the real path.
+///
+/// HOW THE UNRESOLVABLE TENANT IS PRODUCED, STATED EXACTLY, BECAUSE IT IS NOT THE OBVIOUS ONE.
+/// <c>ResolveReadTenant</c> answers null on hosted in two documented cases: a key with no bound tenant, and
+/// A BOUNDARY THAT IS NOT HOSTED-WIRED. The first is NOT reachable through a hosted host's front door - on
+/// hosted, <c>DeviceRegistry.ResolveCredential</c> classifies a device row with no tenant binding as REVOKED,
+/// so the auth gate answers 401 before any route runs (that is what
+/// <see cref="HostedContentReadDenyTests.Every_family_is_refused_to_a_caller_carrying_no_tenant_at_all"/>
+/// pins). The second is: the host is constructed while the process is not hosted, so its boundary is built
+/// over the single-tenant context, and hosted mode - which is read LIVE from the environment - is on by the
+/// time the request arrives. <c>ResolveReadTenant</c> then returns null WITHOUT consulting the boundary, and
+/// the caller is authenticated, which is precisely the shape the guard has to answer.
+///
+/// WHAT THIS PROVES AND WHAT IT DOES NOT. It proves that when the route's tenant resolution answers null for
+/// an authenticated hosted caller, the route refuses and NOTHING downstream runs. It does not claim the
+/// unbound-device-key route into that null is reachable on the production hosted Gateway - it is not, today,
+/// because authentication refuses it first. The guard is the contract's own floor, and the second half of
+/// this file is what makes the floor load bearing.
+///
+/// THE STORE RECEIPT IS THE POINT, NOT THE STATUS CODE. A vault key IS configured here on purpose. Without
+/// one the route answers 503 at its own key check before ever reaching the transcription owner, and every
+/// "nothing was written" assertion below would be green whether the guard existed or not - decorative, not
+/// load bearing. With the key set, removing the guard drives the request all the way into
+/// <see cref="GatewayTranscriptionService.TranscribeAsync"/>, and the shared transcription history takes a
+/// record. That receipt changes colour when the guard is removed, which is the only thing that makes it
+/// evidence rather than decoration.
+///
+/// WHICH ASSERTIONS ARE PROVEN ABLE TO FAIL, AND WHICH ARE NOT. Stated because the difference is the whole
+/// value of the file:
+///   PROVEN able to fail - the refusal body and status, and the SHARED/LOCAL TRANSCRIPTION HISTORY being
+///   empty. Both were watched going red with the guard removed, on this branch.
+///   NOT proven able to fail - the transcript store's Local row count, and the flat glossary's terms being
+///   absent from the answer. Both of those consequences sit behind a SUCCESSFUL provider transcription: the
+///   store append is skipped when the provider produced no text, and the glossary is only read on the
+///   success path. This route builds its own transcription service against a compile-time base URL, so a
+///   test cannot stub the provider, and a success cannot be produced here. They are asserted because they
+///   are the right things to assert and they are cheap - but this file does NOT claim to have watched them
+///   redden. What IS established is upstream of all three: the service is never entered.
+///   DELIBERATELY ABSENT - "the clip was not archived". <see cref="TranscriptionAudioArchive.TrySave"/>
+///   skips every write on hosted by its own gate, so that assertion could never fail in either direction. An
+///   assertion that cannot fail reads as proof and is not; it was removed rather than left in.
+///
+/// REVERT-PROOF RECIPE (run it; do not take the assertion on trust):
+///   1. In <c>GatewayWingmanVoiceEndpoint.cs</c>, delete the <c>reqTenant is null</c> refusal at the top of
+///      the <c>/wingman/transcribe</c> handler (and restore the old
+///      <c>tenant: GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary)</c> argument).
+///   2. Run this class. It goes RED on the refusal - the answer becomes the transcription service's own
+///      provider error - and, with the refusal assertions temporarily moved aside so the receipt fails
+///      first, RED on the history being non-empty. Both were observed on this branch.
+///   3. Restore. Green again.
+/// Note that step 2 makes ONE outbound provider call with a fake key, for the reason given above. The
+/// committed, guarded test makes no network call at all - it is refused before the service is entered.
+/// </summary>
+[Collection("GatewayHostedMode")]
+public sealed class HostedWingmanTranscribeTenantRefusalTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    /// <summary>The exact refusal every sibling route on this surface returns for an unresolved tenant.</summary>
+    private const string Refusal = "no tenant is bound to this request";
+
+    /// <summary>A term only the SHARED FLAT glossary carries, so its presence anywhere would name that file.</summary>
+    private const string FlatGlossaryTerm = "zqxjvflatglossary";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string _key = "";
+
+    /// <summary>The clip posted at the route - real bytes in a real multipart part, so the request is the
+    /// shape the phone actually sends and not a body the handler rejects before the guard is reached.</summary>
+    private readonly byte[] _clip = Encoding.UTF8.GetBytes("zqxjv-clip-" + Guid.NewGuid().ToString("N"));
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-transcribe-refusal-" + Guid.NewGuid().ToString("N"));
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private string? _priorHosted;
+
+    public HostedWingmanTranscribeTenantRefusalTests()
+    {
+        // The isolated storage root. Everything the refused request could have written - the glossary it
+        // would have read, the audio archive, the transcription history - resolves under here, so a write
+        // that should not happen is observable rather than lost in the developer's own folders.
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-transcribe-refusal-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Hosted mode is OFF while the host is constructed, ON before the request. See the class comment:
+        // this is what produces an authenticated caller whose tenant does not resolve.
+        _priorHosted = Environment.GetEnvironmentVariable(GatewayHostedMode.HostedEnvVar);
+        Environment.SetEnvironmentVariable(GatewayHostedMode.HostedEnvVar, null);
+
+        // A key for the configured transcription mode, so the route's own no-key check cannot be what
+        // answers. Without this the receipts below prove nothing - see the class comment.
+        var vaultPath = Path.Combine(_root, "keyvault.json");
+        TranscriptionModeConfig.Set(TranscriptionMode.DevThrottle);
+        new KeyVault(vaultPath).Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_live_notarealkey");
+
+        // The SHARED FLAT glossary - the Local tenant's file, the one a null tenant reads. Seeded so it
+        // exists and carries a term nothing else in this test could produce.
+        var flat = GatewayTranscriptionService.DictionaryPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(flat)!);
+        File.WriteAllText(flat, $"common_mistranscriptions:\n  {FlatGlossaryTerm}: [somethingelse]\n");
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            keyVaultPath: vaultPath,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+        // A real, active device key. It authenticates: the registry was built while this process was not
+        // hosted, so it does not apply the hosted binding check that would revoke it.
+        _key = _gateway.Devices.Register("dev-a", "MA").DeviceKey;
+
+        // PRECONDITION, asserted rather than assumed: nothing has been written yet, so a non-empty receipt
+        // after the request can only have come from the request.
+        Assert.Empty(HistoryFiles());
+        Assert.Equal(0, _gateway.Transcripts.Count(TenantId.Local));
+
+        // And now the process is hosted.
+        Environment.SetEnvironmentVariable(GatewayHostedMode.HostedEnvVar, "1");
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable(GatewayHostedMode.HostedEnvVar, _priorHosted);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Hosted_transcribe_with_no_resolvable_tenant_is_refused_and_reaches_nothing()
+    {
+        var resp = await PostClipAsync();
+
+        // 1. THE REFUSAL, body first. The status is asserted after the fingerprint deliberately: the Cockpit
+        //    single-page-app fallback answers any unclaimed path, so a status-first assertion would redden on
+        //    "404 is not 403" if the route were renamed, which proves a route moved rather than proving this
+        //    test can tell the guard's answer from a masking route's.
+        var root = await ContentFingerprint.AsJsonObjectAsync(resp, "POST wingman/transcribe");
+        Assert.Equal(new[] { "error" }, root.EnumerateObject().Select(p => p.Name).ToArray());
+        Assert.Equal(Refusal, ContentFingerprint.Text(root, "error", "POST wingman/transcribe"));
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+
+        // 2. THE TRANSCRIPTION OWNER WAS NEVER ENTERED - THE ONE RECEIPT THAT IS PROVEN ABLE TO FAIL.
+        //    RecordHistory runs on EVERY TranscribeAsync outcome, including a failed provider call, and with a
+        //    null tenant it selects the injected shared history - which is the Local directory. So an empty
+        //    history is the receipt that the service was not reached at all, and therefore that the glossary
+        //    read and the transcript write below could not have happened either. Watched going red with the
+        //    guard removed; see the recipe in the class comment.
+        Assert.Empty(HistoryFiles());
+
+        // 3. THE OTHER LOCAL STORE. The Local partition of the transcript store is where a null tenant's
+        //    transcript evidence lands. NOT proven able to fail here - the append is skipped when the provider
+        //    produced no text, and this test cannot produce a successful transcription. Asserted anyway,
+        //    because it is the right thing to assert and it is free; not offered as proof.
+        Assert.Equal(0, _gateway.Transcripts.Count(TenantId.Local));
+
+        // 4. THE SHARED FLAT GLOSSARY WAS NOT APPLIED. A refusal carries no transcript at all, so there is no
+        //    text for the flat file's terms to have altered - and the file is still exactly as seeded, so
+        //    nothing rewrote it. Also NOT proven able to fail, for the same reason as 3: the glossary is read
+        //    only on the success path. Receipt 2 is what actually rules the read out, by proving the code
+        //    that performs it never ran.
+        Assert.DoesNotContain(FlatGlossaryTerm, await resp.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+        Assert.Contains(FlatGlossaryTerm, File.ReadAllText(GatewayTranscriptionService.DictionaryPath()));
+    }
+
+    /// <summary>
+    /// THE SELF-HOST CONTROL, and it is not optional: a guard that refused everybody would satisfy the test
+    /// above perfectly. Off hosted mode, <c>ResolveReadTenant</c> answers <see cref="TenantId.Local"/> for
+    /// every authenticated caller, so the SAME request on the SAME host must get past the guard.
+    ///
+    /// It is proved by the answer that comes from FURTHER IN than the guard - the route's own bad-body
+    /// message, which nothing else in the Gateway emits and which is reached only after the tenant check.
+    /// A body-shape refusal is used rather than a full transcription because completing one would mean a
+    /// real provider call: this route builds its own transcription service, so there is no client to stub.
+    /// </summary>
+    [Fact]
+    public async Task Self_host_transcribe_is_not_refused_by_the_tenant_guard()
+    {
+        Environment.SetEnvironmentVariable(GatewayHostedMode.HostedEnvVar, null);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "wingman/transcribe");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        req.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+        var resp = await _http.SendAsync(req);
+
+        var root = await ContentFingerprint.AsJsonObjectAsync(resp, "POST wingman/transcribe (self-host)");
+        var error = ContentFingerprint.Text(root, "error", "POST wingman/transcribe (self-host)");
+        Assert.Equal("send the recording as multipart form-data with an 'audio' file", error);
+        Assert.NotEqual(Refusal, error);
+    }
+
+    private Task<HttpResponseMessage> PostClipAsync()
+    {
+        var form = new MultipartFormDataContent();
+        var file = new ByteArrayContent(_clip);
+        file.Headers.ContentType = new MediaTypeHeaderValue("audio/webm");
+        form.Add(file, "audio", "clip.webm");
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "wingman/transcribe")
+        {
+            Content = form,
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _key);
+        return _http.SendAsync(req);
+    }
+
+    /// <summary>Every file the shared (Local) transcription history holds. Empty is the receipt.</summary>
+    private static string[] HistoryFiles()
+    {
+        var dir = TranscriptionHistoryLog.DefaultDirectory();
+        return Directory.Exists(dir)
+            ? Directory.GetFiles(dir, "*", SearchOption.AllDirectories)
+            : Array.Empty<string>();
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TenantGlossaryDictationCleanupTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantGlossaryDictationCleanupTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using CcDirector.Core;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Regression tests for issue #2482: hosted live dictation must read the REQUESTING TENANT's
+/// glossary - the file the Cockpit dictionary editor writes via <see cref="TenantGlossary.PathFor"/> -
+/// and never the global flat file. Before the fix, <c>POST /transcription</c> constructed
+/// <see cref="GatewayTranscriptionService"/> without a tenant dictionary provider, so cleanup loaded
+/// the flat <see cref="GatewayTranscriptionService.DictionaryPath"/> for every tenant and a hosted
+/// user's dictionary edits did not affect their next dictation.
+///
+/// These tests build the service exactly as the endpoints do - with the DEFAULT dictionary provider,
+/// nothing injected - so they prove the default itself is tenant-aware. The transcription provider is
+/// a stubbed HttpClient (cleanup is deterministic and in-process, so no network is needed for the
+/// correction). Uses CC_DIRECTOR_ROOT for the glossary locations - in the "DirectorRoot" collection
+/// because it sets CC_DIRECTOR_ROOT.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class TenantGlossaryDictationCleanupTests : IDisposable
+{
+    private static readonly TenantId HostedTenant = new("11111111-2222-3333-4444-555555555555");
+
+    private readonly string? _prevRoot;
+    private readonly string _root;
+    private readonly string _vaultPath;
+
+    public TenantGlossaryDictationCleanupTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-glossary-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        _vaultPath = Path.Combine(_root, "keyvault.json");
+
+        TranscriptionModeConfig.Set(TranscriptionMode.DevThrottle);
+        new KeyVault(_vaultPath).Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_live_abc");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>The raw transcript the stubbed provider returns; both glossaries list "glotword"
+    /// as a wrong form, each mapping it to a DIFFERENT canonical term, so the corrected output
+    /// names exactly which file the cleanup read.</summary>
+    private const string RawTranscript = "please spell glotword now";
+
+    private static void WriteGlossary(string path, string canonicalTerm)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, $"common_mistranscriptions:\n  {canonicalTerm}: [glotword]\n");
+    }
+
+    private void WriteGlobalFlatFile() => WriteGlossary(GatewayTranscriptionService.DictionaryPath(), "GlobalCanonical");
+
+    private void WriteTenantGlossary(TenantId tenant) => WriteGlossary(TenantGlossary.PathFor(tenant), "TenantCanonical");
+
+    /// <summary>A service built the way the endpoints build it: default dictionary provider, stubbed
+    /// transcription POST, and a scratch archive/history under this test's own root so an omitted
+    /// default can never write into the real user's folders.</summary>
+    private GatewayTranscriptionService Service()
+        => new(
+            new KeyVault(_vaultPath),
+            http: new HttpClient(new StatusHandler(HttpStatusCode.OK, "{\"text\":\"" + RawTranscript + "\"}")),
+            history: new TranscriptionHistoryLog(Path.Combine(_root, "history-scratch")),
+            audioArchive: new TranscriptionAudioArchive(Path.Combine(_root, "archive-scratch")));
+
+    private sealed class StatusHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+        public StatusHandler(HttpStatusCode status, string body) { _status = status; _body = body; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            });
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_HostedTenant_ReadsThatTenantsGlossary_NeverTheGlobalFile()
+    {
+        // THE regression (issue #2482). The global flat file and the tenant's own glossary both list
+        // the same wrong form with different corrections; the corrected text must carry the TENANT's
+        // correction, proving the cleanup read the file the Cockpit dictionary editor writes.
+        WriteGlobalFlatFile();
+        WriteTenantGlossary(HostedTenant);
+
+        var result = await Service().TranscribeAsync(
+            new byte[] { 1, 2, 3 }, "clip.webm", "audio/webm", applyCorrection: true, CancellationToken.None,
+            tenant: HostedTenant, source: "batch");
+
+        Assert.Equal(TranscriptionOutcome.Ok, result.Outcome);
+        Assert.Equal("please spell TenantCanonical now", result.Text);
+        Assert.DoesNotContain("GlobalCanonical", result.Text);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_HostedTenantWithNoGlossary_DoesNotFallBackToTheGlobalFile()
+    {
+        // A tenant that has written no glossary gets NO correction - never the global file's terms.
+        // A miss must stay a miss (tenancy law: no aggregate or global fallback that hides one).
+        WriteGlobalFlatFile();
+
+        var result = await Service().TranscribeAsync(
+            new byte[] { 1, 2, 3 }, "clip.webm", "audio/webm", applyCorrection: true, CancellationToken.None,
+            tenant: HostedTenant, source: "batch");
+
+        Assert.Equal(TranscriptionOutcome.Ok, result.Outcome);
+        Assert.Equal(RawTranscript, result.Text);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_LocalTenant_StillReadsTheFlatFile()
+    {
+        // Self-host unchanged: the single Local tenant's glossary IS the flat file, exactly as before.
+        WriteGlobalFlatFile();
+
+        var result = await Service().TranscribeAsync(
+            new byte[] { 1, 2, 3 }, "clip.webm", "audio/webm", applyCorrection: true, CancellationToken.None,
+            tenant: TenantId.Local, source: "batch");
+
+        Assert.Equal(TranscriptionOutcome.Ok, result.Outcome);
+        Assert.Equal("please spell GlobalCanonical now", result.Text);
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_NoTenant_StillReadsTheFlatFile()
+    {
+        // A caller that carries no tenant is the self-host single tenant - same flat file as before.
+        WriteGlobalFlatFile();
+
+        var result = await Service().TranscribeAsync(
+            new byte[] { 1, 2, 3 }, "clip.webm", "audio/webm", applyCorrection: true, CancellationToken.None);
+
+        Assert.Equal(TranscriptionOutcome.Ok, result.Outcome);
+        Assert.Equal("please spell GlobalCanonical now", result.Text);
+    }
+
+    [Fact]
+    public async Task CleanupAsync_TenantScoped_ReadsThatTenantsGlossary()
+    {
+        // The phone Notes assemble-then-clean path: GatewayServiceRecordingTranscriber passes its
+        // tenant into CleanupAsync, so the assembled transcript is corrected against that tenant's
+        // own glossary through the same one mechanism.
+        WriteGlobalFlatFile();
+        WriteTenantGlossary(HostedTenant);
+
+        var outcome = await Service().CleanupAsync(RawTranscript, HostedTenant);
+
+        Assert.True(outcome.Applied);
+        Assert.Equal("please spell TenantCanonical now", outcome.Text);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TenantGlossaryDictationCleanupTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantGlossaryDictationCleanupTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Text;
 using CcDirector.Core;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Recording;
 using CcDirector.Core.Tenancy;
 using CcDirector.Gateway.Transcription;
 using Xunit;
@@ -201,6 +202,31 @@ public sealed class TenantGlossaryDictationCleanupTests : IDisposable
         Assert.Equal(TranscriptionOutcome.Ok, result.Outcome);
         Assert.Equal(RawTranscript, result.Text);
         Assert.DoesNotContain("GlobalCanonical", result.Text);
+    }
+
+    [Fact]
+    public async Task RecordingTranscriber_CarriesItsOwnTenantIntoCleanup_NotTheGlobalFile()
+    {
+        // The wiring #2482 changed but nothing guarded. RecordingEndpoints builds ONE
+        // GatewayServiceRecordingTranscriber per tenant and that adapter is the only thing that knows
+        // which tenant the phone Notes assemble-then-clean path belongs to - it holds the tenant and
+        // supplies it to CleanupAsync, because IRecordingTranscriber.CleanupAsync carries no tenant of
+        // its own. Drop the tenant at that one call site and every hosted recording silently corrects
+        // against the global file again, with no other test noticing.
+        //
+        // So this drives the ADAPTER, through its IRecordingTranscriber contract, rather than calling
+        // the service directly - calling the service directly is what the test above already does, and
+        // it is exactly the check that cannot see this regression.
+        WriteGlobalFlatFile();
+        WriteTenantGlossary(HostedTenant);
+
+        IRecordingTranscriber transcriber = new GatewayServiceRecordingTranscriber(Service(), HostedTenant);
+
+        var outcome = await transcriber.CleanupAsync(RawTranscript, CancellationToken.None);
+
+        Assert.True(outcome.Applied);
+        Assert.Equal("please spell TenantCanonical now", outcome.Text);
+        Assert.DoesNotContain("GlobalCanonical", outcome.Text);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/TenantGlossaryDictationCleanupTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantGlossaryDictationCleanupTests.cs
@@ -65,6 +65,17 @@ public sealed class TenantGlossaryDictationCleanupTests : IDisposable
 
     private void WriteTenantGlossary(TenantId tenant) => WriteGlossary(TenantGlossary.PathFor(tenant), "TenantCanonical");
 
+    /// <summary>A genuinely corrupt glossary for this tenant - an unterminated YAML flow sequence, which
+    /// makes the real loader's parse throw rather than quietly returning an empty dictionary. Written
+    /// through the same <see cref="TenantGlossary.PathFor"/> the Cockpit dictionary editor writes, so the
+    /// fault is raised by the PRODUCTION read path and not by a test stub standing in for it.</summary>
+    private static void WriteMalformedTenantGlossary(TenantId tenant)
+    {
+        var path = TenantGlossary.PathFor(tenant);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "common_mistranscriptions:\n  TenantCanonical: [glotword\n");
+    }
+
     /// <summary>A service built the way the endpoints build it: default dictionary provider, stubbed
     /// transcription POST, and a scratch archive/history under this test's own root so an omitted
     /// default can never write into the real user's folders.</summary>
@@ -160,5 +171,50 @@ public sealed class TenantGlossaryDictationCleanupTests : IDisposable
 
         Assert.True(outcome.Applied);
         Assert.Equal("please spell TenantCanonical now", outcome.Text);
+    }
+
+    // ---- The COMBINED contract: issues #2482 and #2483 together ----
+    //
+    // These two belong to neither issue alone, which is why neither branch carried them. 2482 makes the
+    // read tenant-keyed; 2483 makes the read fail open. Only together do they answer the question a
+    // hosted user actually poses: MY glossary is corrupt - what happens to my dictation? All three parts
+    // of the answer are asserted, because each can regress on its own:
+    //   1. the request still succeeds (2483 - a dictionary fault must not fail transcribed text),
+    //   2. the text comes back RAW (2483 - fail open, not fail closed),
+    //   3. and it is NOT corrected from the global file (2482 - a fault must not become a global fallback,
+    //      which is the tenancy defect wearing a different hat).
+    //
+    // The fault is raised by the REAL loader on a REAL corrupt file through the DEFAULT provider - the
+    // service is built exactly as the endpoints build it - so this proves the production path fails open,
+    // not merely that the guard catches a stub that was told to throw.
+
+    [Fact]
+    public async Task TranscribeAsync_HostedTenantWithMalformedGlossary_FailsOpenToRawText_AndNeverTheGlobalFile()
+    {
+        WriteGlobalFlatFile();
+        WriteMalformedTenantGlossary(HostedTenant);
+
+        var result = await Service().TranscribeAsync(
+            new byte[] { 1, 2, 3 }, "clip.webm", "audio/webm", applyCorrection: true, CancellationToken.None,
+            tenant: HostedTenant, source: "batch");
+
+        Assert.Equal(TranscriptionOutcome.Ok, result.Outcome);
+        Assert.Equal(RawTranscript, result.Text);
+        Assert.DoesNotContain("GlobalCanonical", result.Text);
+    }
+
+    [Fact]
+    public async Task CleanupAsync_HostedTenantWithMalformedGlossary_FailsOpenToRawText_AndNeverTheGlobalFile()
+    {
+        // The same combined contract on the phone Notes assemble-then-clean path.
+        WriteGlobalFlatFile();
+        WriteMalformedTenantGlossary(HostedTenant);
+
+        var outcome = await Service().CleanupAsync(RawTranscript, HostedTenant);
+
+        Assert.False(outcome.Applied);
+        Assert.Equal(RawTranscript, outcome.Text);
+        Assert.DoesNotContain("GlobalCanonical", outcome.Text);
+        Assert.Contains("dictionary unavailable", outcome.Reason);
     }
 }

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -637,6 +637,27 @@ internal static class GatewayWingmanVoiceEndpoint
         // Returns { transcript }.
         app.MapPost("/wingman/transcribe", async (HttpContext ctx, CancellationToken ct) =>
         {
+            // THE REQUESTING TENANT IS RESOLVED FIRST, AND NULL IS A REFUSAL. This is the contract
+            // GatewayEndpoints.ResolveReadTenant states in its own documentation: on hosted, a key with no
+            // bound tenant - and a boundary that is not hosted-wired - resolve to null, and null means the
+            // caller is DENIED, never served the Local partition.
+            //
+            // This route used to pass that nullable STRAIGHT into TranscribeAsync, which is where the refusal
+            // became the self-host tenant three layers down. All three of GatewayTranscriptionService's
+            // null-means-Local substitutions then fired on a hosted request: CleanupCoreAsync read the SHARED
+            // FLAT GLOSSARY, so another account's terms could alter their words; RecordHistory took the
+            // injected shared history; and the transcript store wrote their transcript evidence into the Local
+            // partition. Refusing here is also the first defect fixed - an unbound hosted caller should get a
+            // refusal, not a transcription.
+            //
+            // Same shape and the same body as every sibling route on this surface (and as
+            // GatewayDictationEndpoint.NoTenantResult): no new error shape is invented. Self-host is unchanged -
+            // there ResolveReadTenant answers TenantId.Local for every authenticated caller, exactly as the
+            // nullable did before.
+            var reqTenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (reqTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
+
             if (!ctx.Request.HasFormContentType)
                 return Results.Json(new { error = "send the recording as multipart form-data with an 'audio' file" },
                     statusCode: StatusCodes.Status400BadRequest);
@@ -671,7 +692,7 @@ internal static class GatewayWingmanVoiceEndpoint
             // Transcribe WITH the validated dictionary correction applied (the SAME engine every other
             // surface uses; fails open to the raw transcript in local mode or on any cleanup error).
             var result = await transcription.TranscribeAsync(bytes, fileName, contentType, applyCorrection: true, ct,
-                tenant: GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary), source: "voice");
+                tenant: reqTenant.Value, source: "voice");
             // Out of credits / monthly cap (issue #939): map to the shared 402 state (branch by code)
             // instead of flattening it into a generic 502 - so the client shows the consistent
             // add-credits message and keeps the recording, not "transcription failed".

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -833,9 +833,6 @@ internal static class RecordingEndpoints
         var root = RootForTenant(tenant);
         // Promotion target: the vault transcripts collection (permanent copy), per tenant.
         var collectionDir = CollectionForTenant(tenant);
-        // The glossary the cleanup pass reads to correct the finished transcript - this tenant's own
-        // (issue #2060). It never reaches the speech-to-text provider (issue 2481).
-        var glossaryPath = GlossaryPathFor(tenant);
         // This tenant's transcription-health history. The single Local tenant uses the host's shared log
         // (self-host, unchanged); every other tenant writes to its own partition so a recording's history
         // contribution is never fleet-global. (The Transcription Health READ surface is issue #2059.)
@@ -858,14 +855,24 @@ internal static class RecordingEndpoints
         // provider-compatible batch endpoint for hosted mode. So switching the mode in the Cockpit
         // changes how the recording is transcribed with no Gateway restart, and on-device mode now
         // works for recordings too - the same single audio-to-text path every other batch caller uses.
+        //
+        // The transcriber carries THIS tenant into the cleanup call, so the corrector reads this
+        // tenant's own glossary (issue #2060) through the one TenantGlossary owner - the same
+        // mechanism every live-dictation caller uses (issue #2482), no hand-injected path here.
+        //
+        // The glossary is still only ever applied to the FINISHED transcript and is never sent to the
+        // speech-to-text provider (issue 2481). That sentence used to sit on the hand-injected
+        // glossaryPath this site no longer has; it is kept here, at the construction site, because
+        // deleting the injection must not delete the ruling that came with it. The same claim is on
+        // GlossaryPathFor, which is now the only place a glossary path is composed.
         return new RecordingIngestService(
             root,
             transcriberFactory: () => new GatewayServiceRecordingTranscriber(
                 new GatewayTranscriptionService(
                     keyVault ?? new KeyVault(),
                     history: tenantHistory,
-                    audioArchive: audioArchive,
-                    dictionaryProvider: () => DictionaryLoader.LoadFromDisk(glossaryPath))),
+                    audioArchive: audioArchive),
+                tenant),
             filer,
             collectionDir);
     }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -462,6 +462,13 @@ public sealed class GatewayHost : IAsyncDisposable
     internal Tenancy.HostedTenantBoundary TenantBoundary => _tenantBoundary;
 
     /// <summary>
+    /// The per-tenant transcript store this host injects into every transcription path. Exposed to the test
+    /// assembly so a refusal test can ask the store ITSELF whether a partition was written, rather than
+    /// inferring it from a status code - a refused request must leave the Local partition at zero rows.
+    /// </summary>
+    internal Transcription.TranscriptStore Transcripts => _transcripts;
+
+    /// <summary>
     /// The account-to-tenant resolver (Hosted Multi-Tenancy increment 1): owns the tenants mapping table and
     /// mints or looks up a tenant from a verified account subject. Exposed so the hosted enrollment boundary
     /// can resolve a tenant once, at the point the account token is validated. Unused on the single-tenant

--- a/src/CcDirector.Gateway/Transcription/GatewayServiceRecordingTranscriber.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayServiceRecordingTranscriber.cs
@@ -1,5 +1,6 @@
 using CcDirector.Core.Dictation;
 using CcDirector.Core.Recording;
+using CcDirector.Core.Tenancy;
 
 namespace CcDirector.Gateway.Transcription;
 
@@ -12,19 +13,26 @@ namespace CcDirector.Gateway.Transcription;
 /// Each finalized one-minute segment is transcribed RAW (no per-segment correction); the assembled
 /// concatenation runs through the validated dictionary corrector ONCE, so the assembled transcript is
 /// provably the per-segment raw concatenation plus dictionary edits only.
+///
+/// The adapter is built per tenant (by <see cref="Api.RecordingEndpoints"/>) and carries that tenant
+/// into the cleanup call, so the corrector reads THAT tenant's glossary through the one
+/// <see cref="TenantGlossary"/> owner - the same mechanism every live-dictation caller uses
+/// (issue #2482).
 /// </summary>
 internal sealed class GatewayServiceRecordingTranscriber : IRecordingTranscriber
 {
     private readonly GatewayTranscriptionService _service;
+    private readonly TenantId _tenant;
 
-    public GatewayServiceRecordingTranscriber(GatewayTranscriptionService service)
+    public GatewayServiceRecordingTranscriber(GatewayTranscriptionService service, TenantId tenant)
     {
         _service = service ?? throw new ArgumentNullException(nameof(service));
+        _tenant = tenant;
     }
 
     public Task<string> TranscribeChunkAsync(byte[] audio, string contentType, string fileName, CancellationToken ct = default)
         => _service.TranscribeSegmentRawAsync(audio, fileName, contentType, ct);
 
     public Task<CleanupOutcome> CleanupAsync(string rawTranscript, CancellationToken ct = default)
-        => _service.CleanupAsync(rawTranscript, ct);
+        => _service.CleanupAsync(rawTranscript, _tenant, ct);
 }

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -352,7 +352,6 @@ public sealed class GatewayTranscriptionService
             return new CleanupOutcome(raw, Applied: false, Reason: "dictionary unavailable: " + ex.Message);
         }
 
-
         if (dictionary.Vocabulary.Count == 0 && dictionary.CommonMistranscriptions.Count == 0)
             return new CleanupOutcome(raw, Applied: false, Reason: "empty dictionary");
 

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -34,7 +34,7 @@ namespace CcDirector.Gateway.Transcription;
 public sealed class GatewayTranscriptionService
 {
     private readonly KeyVault _vault;
-    private readonly Func<DictationDictionary> _dictionaryProvider;
+    private readonly Func<CcDirector.Core.Tenancy.TenantId, DictationDictionary> _dictionaryProvider;
     private readonly Func<TranscriptionMode> _modeProvider;
     private readonly HttpClient? _http;
     private readonly string _cleanupModel;
@@ -43,9 +43,12 @@ public sealed class GatewayTranscriptionService
     private readonly TranscriptStore? _transcripts;
 
     /// <param name="vault">The Gateway key vault - the single store for the transcription key.</param>
-    /// <param name="dictionaryProvider">Supplies the live dictation dictionary the corrector uses;
-    /// invoked fresh per cleanup so a glossary edit takes effect on the next transcription. Defaults
-    /// to loading the shared dictionary file from disk.</param>
+    /// <param name="dictionaryProvider">Supplies the live dictation dictionary the corrector uses FOR
+    /// A GIVEN TENANT; invoked fresh per cleanup so a glossary edit takes effect on the next
+    /// transcription. Defaults to <see cref="TenantGlossary.Load"/>, the single owner of where a
+    /// tenant's glossary lives - the Local tenant reads the shared flat file (self-host, unchanged)
+    /// and every other tenant reads its own per-tenant file, so a hosted user's dictionary edits bias
+    /// THEIR next dictation and nobody else's (issue #2482).</param>
     /// <param name="modeProvider">Supplies the current transcription mode; invoked fresh per resolve
     /// so a mode change in the Cockpit takes effect with no restart. Defaults to
     /// <see cref="TranscriptionModeConfig.Get"/>.</param>
@@ -66,7 +69,7 @@ public sealed class GatewayTranscriptionService
     /// diagnostic aid and never gates a turn.</param>
     public GatewayTranscriptionService(
         KeyVault vault,
-        Func<DictationDictionary>? dictionaryProvider = null,
+        Func<CcDirector.Core.Tenancy.TenantId, DictationDictionary>? dictionaryProvider = null,
         Func<TranscriptionMode>? modeProvider = null,
         HttpClient? http = null,
         string? cleanupModel = null,
@@ -75,7 +78,7 @@ public sealed class GatewayTranscriptionService
         TranscriptStore? transcripts = null)
     {
         _vault = vault ?? throw new ArgumentNullException(nameof(vault));
-        _dictionaryProvider = dictionaryProvider ?? (() => DictionaryLoader.LoadFromDisk(DictionaryPath()));
+        _dictionaryProvider = dictionaryProvider ?? TenantGlossary.Load;
         _modeProvider = modeProvider ?? TranscriptionModeConfig.Get;
         _http = http;
         _cleanupModel = string.IsNullOrWhiteSpace(cleanupModel) ? CleanupOrchestrator.DefaultModel : cleanupModel;
@@ -188,7 +191,7 @@ public sealed class GatewayTranscriptionService
         CleanupOutcome? cleanup = null;
         var swCleanup = Stopwatch.StartNew();
         if (applyCorrection)
-            cleanup = await CleanupCoreAsync(raw, ct);
+            cleanup = await CleanupCoreAsync(raw, tenant, ct);
         swCleanup.Stop();
         var text = cleanup?.Text ?? raw;
 
@@ -287,11 +290,17 @@ public sealed class GatewayTranscriptionService
     /// outcome. Fails open (CodingStyle section 16 / issue #190): on an empty dictionary or any cleanup
     /// error, the raw transcript comes back byte-identical. Deterministic and in-process - needs no key.
     /// </summary>
-    public async Task<CleanupOutcome> CleanupAsync(string rawTranscript, CancellationToken ct = default)
+    /// <param name="rawTranscript">The assembled raw transcript to correct.</param>
+    /// <param name="tenant">The tenant whose glossary biases the correction - the requesting tenant,
+    /// resolved by the calling endpoint (issue #2482). Null means the self-host single tenant (Local),
+    /// which reads the shared flat file exactly as before.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task<CleanupOutcome> CleanupAsync(
+        string rawTranscript, CcDirector.Core.Tenancy.TenantId? tenant = null, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(rawTranscript))
             return new CleanupOutcome(rawTranscript ?? "", Applied: false, Reason: "empty transcript");
-        return await CleanupCoreAsync(rawTranscript, ct);
+        return await CleanupCoreAsync(rawTranscript, tenant, ct);
     }
 
     /// <summary>
@@ -311,9 +320,14 @@ public sealed class GatewayTranscriptionService
 
     /// <summary>
     /// The validated dictionary correction core, shared by the optional <c>correct</c> flag and the
-    /// Notes assemble-then-clean path. Fails open to the raw transcript.
+    /// Notes assemble-then-clean path. Fails open to the raw transcript. The correction reads the
+    /// REQUESTING TENANT's glossary (issue #2482): the tenant the endpoint resolved for the request,
+    /// or the self-host single tenant (Local) when the caller carries none - the same null-means-Local
+    /// convention <see cref="RecordHistory"/> uses, never a hosted tenant silently reading the
+    /// global file.
     /// </summary>
-    private async Task<CleanupOutcome> CleanupCoreAsync(string raw, CancellationToken ct)
+    private async Task<CleanupOutcome> CleanupCoreAsync(
+        string raw, CcDirector.Core.Tenancy.TenantId? tenant, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(raw))
             return new CleanupOutcome(raw ?? "", Applied: false, Reason: "empty transcript");
@@ -325,16 +339,19 @@ public sealed class GatewayTranscriptionService
         // The dictionary read shares the corrector's fail-open contract (issue #2483): a malformed or
         // unreadable dictionary file must never fail a transcription that already produced text, so a
         // provider fault degrades to the raw transcript exactly like a fault inside CleanAsync does.
+        // The read is THIS TENANT's glossary (issue #2482), so the fail-open covers a fault reading a
+        // per-tenant glossary exactly as it covers one reading the shared flat file.
         DictationDictionary dictionary;
         try
         {
-            dictionary = _dictionaryProvider();
+            dictionary = _dictionaryProvider(tenant ?? CcDirector.Core.Tenancy.TenantId.Local);
         }
         catch (Exception ex)
         {
             FileLog.Write($"[GatewayTranscriptionService] dictionary read FAILED (fail-open, returning raw text): {ex.Message}");
             return new CleanupOutcome(raw, Applied: false, Reason: "dictionary unavailable: " + ex.Message);
         }
+
 
         if (dictionary.Vocabulary.Count == 0 && dictionary.CommonMistranscriptions.Count == 0)
             return new CleanupOutcome(raw, Applied: false, Reason: "empty dictionary");
@@ -346,8 +363,9 @@ public sealed class GatewayTranscriptionService
     }
 
     /// <summary>
-    /// The single shared dictation glossary file used by both the recording transcriber and the
-    /// dictionary editor endpoints, so the path is defined in exactly one place.
+    /// The shared flat dictation glossary file - the Local (self-host single) tenant's glossary, and
+    /// the base location <see cref="TenantGlossary.PathFor"/> derives every per-tenant glossary from,
+    /// so the path is defined in exactly one place.
     /// </summary>
     /// <remarks>The Director composes this same path via AgentOptions.ResolveDictationDictionaryPath;
     /// both now go through CcStorage so the two cannot drift apart.</remarks>


### PR DESCRIPTION
Release 2.0.1, Phase 1 and 1b. Built by one seat, inspected by a different agent family, and the inspection sent it back before this was opened.

Closes thefrederiksen/devthrottle_internal#1786

## What this changes for a user

If you use DevThrottle in the cloud, the words you add to your dictionary now actually reach your dictation. They were being ignored: the correction pass read a shared file rather than yours, so adding a term you say all day changed nothing.

Two details that could each have been got wrong, and were checked:

- A tenant with **no** glossary gets **no** correction - never somebody else's terms. Proven by a negative control, not assumed.
- A **malformed** tenant glossary returns your raw text rather than failing the transcription, and does not fall back to the global dictionary. Failing open means raw text, not another tenant's words.

Self-host behaviour is unchanged, and that is asserted rather than assumed.

## Why it is one pull request and not two

Issues thefrederiksen/devthrottle_internal#1786 and thefrederiksen/devthrottle_internal#1787 **do not compose**. Whichever landed second broke the build: half a git conflict on the dictionary read, half a silent compile break - thefrederiksen/devthrottle_internal#1786 changes the provider delegate to take a tenant, and thefrederiksen/devthrottle_internal#1787's tests were written against the zero-argument form, failing in a file neither diff touches (CS1593 twice, CS1503).

That was found by BUILDING both together, not by reading them. thefrederiksen/devthrottle_internal#1787 has since merged alone as thefrederiksen/devthrottle#2493, so this branch was rebased onto it, its own copy dropped, and the composition re-established on **main's** copy of the fail-open guard - diffed rather than assumed identical. **Every proof was re-run from scratch on the new base**; the pre-rebase ones were treated as void.

## What the inspection found, and what it changed

An independent Codex inspection of the frozen artifact returned RED with two blockers. Both are closed here.

**1. `/wingman/transcribe` served an unresolved tenant as Local.** `ResolveReadTenant` documents that on hosted "null is a REFUSAL"; that route passed the nullable straight into transcription with no check, so a request with an unresolvable tenant was served, read the shared glossary, and wrote transcript evidence into the Local partition. Every sibling route refuses first. It now refuses too, with a byte-identical body to the twelve other refusals in the same file.

**A severity correction, because the first telling was too strong.** This was described as reachable by an authenticated but unbound hosted key. It is not: `DeviceRegistry.ResolveCredential` classifies an unbound row as revoked, so auth answers 401 before the route runs. The reachable null is the other documented case - a boundary that is not hosted-wired, a wiring fault rather than an attacker-reachable one. The defect and the fix are real; the reachability claim was overstated and is corrected here rather than quietly softened.

**2. The internal branch would have regressed main.** It carried an older, weaker money-surfaces script than main already has. Its three website files are now byte-identical to main by object hash, so the internal side lands mission records only.

## The guard is the point

All 25 pre-existing tests passed with `/wingman/transcribe` wide open, because they construct the transcription service directly and never map the route. The new test is **the only thing in the repository that drives that route at all**: real host, real device key through the real auth gate, real multipart audio. Revert-proven twice - deleting the guard turns the 403 into the service's own error, and with the refusal assertions moved aside it also reddens on a shared history write that a refused request must never make.

A fourth assertion was written, found **incapable of failing** - the audio archive skips every write on hosted by its own gate - and deleted rather than left as a green that reads as proof.

## Stated honestly: what is NOT proven

- **The full local gate was not run on this branch**; focused classes only (61 of 61 in the affected neighbourhood). CI runs the whole solution, which is why this pull request is the control that was missing - CI had only ever run main.
- The transcript-store and glossary assertions are **not** revert-proven: both sit behind a successful provider transcription, so what is proven is upstream of them - the service is never entered.
- **A known order-dependency risk in the new test class.** It mutates `CC_GATEWAY_HOSTED` and `CC_DIRECTOR_ROOT` and flips hosted on mid-setup. It sits in a `DisableParallelization` collection and restores both variables in `DisposeAsync` including the null case, but containment is **reasoned, and observed only in runs of at most six classes - never in the full 2276**. If CI shows a new red anywhere in `Gateway.Tests`, look here first even if the failing test appears unrelated.
- Two reds are already known and accounted for on this repo: the Postgres collation proof (red on clean main; CI never runs it) and an order-dependent `CreateMission` 500 whose victim moves between runs.
- Hosted mission attach remains **unverified** - its isolation assertions never execute, because the test dies in setup. A green there would mean "we stopped hitting the setup failure", not "isolation is proven".