### PR TITLE
release: v2.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.


### PR DESCRIPTION
Version bump for v2.0.1. The release notes are already on main at `docs/public/release-notes/v2.0.1.md`.

The tag is created only after this merges, so it can never point at a commit that is not on main - the v1.9.2 lesson.

**Cut by hand rather than by `scripts/new-release.ps1`**, deliberately. That script has two open defects (internal #1365) and one that is not filed: it tags even when the merge-back fails, because its only guard re-reads a version out of a FILE when the failure that actually happened was about git STATE; it does not refuse a pre-existing remote release branch; and it is fully interactive with no parameters, so it cannot be driven non-interactively at all. Both of its missing guards were applied manually before this branch was created - no `release/*` branch existed on the remote, and no `v2.0.1` tag existed - and the git-state check will be applied before the tag is pushed.