### PR TITLE
A mission can be renamed, completed, or removed

### DIFF
--- a/packages/client-core/src/missions/missions.ts
+++ b/packages/client-core/src/missions/missions.ts
@@ -25,6 +25,12 @@ export interface MissionDto {
   why?: string | null;
   /** When the WHY was last set (ISO-8601 UTC), or null if never. */
   whyUpdatedAt?: string | null;
+  /** "active", "complete", or "removed". Absent from an older Gateway, which reads as active.
+   *  `listMissions` returns only active missions unless asked otherwise, so this is "active" on every
+   *  mission the default view draws - it matters when asking for the archive. */
+  state?: string | null;
+  /** When the state last changed (ISO-8601 UTC), or null while it has only ever been active. */
+  stateChangedAt?: string | null;
 }
 
 /**

--- a/src/CcDirector.Core.Tests/MissionStoreTests.cs
+++ b/src/CcDirector.Core.Tests/MissionStoreTests.cs
@@ -330,4 +330,182 @@ public class MissionStoreTests
                 File.Delete(tempFile);
         }
     }
+
+    // ---- rename and ending a mission (Phase 2) -------------------------------------------------------
+
+    [Fact]
+    public void Rename_ChangesTheDisplayName_AndKeepsIdAndWhy()
+    {
+        var tempFile = TempPath();
+        try
+        {
+            var store = NewStore(tempFile);
+            var mission = store.Create(TenantId.Local, "Release 2.0.0");
+            store.SetWhy(TenantId.Local, mission.MissionId, "the reason", DateTimeOffset.UtcNow);
+
+            var renamed = store.Rename(TenantId.Local, mission.MissionId, "  Release 2.0.1  ");
+
+            Assert.NotNull(renamed);
+            Assert.Equal("Release 2.0.1", renamed.MissionName);
+            // The identity does not move, and neither does the WHY - which is the whole reason the WHY had
+            // to stop being keyed by name before rename existed.
+            Assert.Equal(mission.MissionId, renamed.MissionId);
+            Assert.Equal("the reason", renamed.Why);
+
+            var reopened = NewStore(tempFile);
+            Assert.Equal("Release 2.0.1", reopened.Get(TenantId.Local, mission.MissionId)!.MissionName);
+            Assert.Equal("the reason", reopened.Get(TenantId.Local, mission.MissionId)!.Why);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void Rename_BlankThrows_AndUnknownReturnsNull()
+    {
+        var tempFile = TempPath();
+        try
+        {
+            var store = NewStore(tempFile);
+            var mission = store.Create(TenantId.Local, "Release");
+
+            Assert.Throws<ArgumentException>(() => store.Rename(TenantId.Local, mission.MissionId, "  "));
+            Assert.Null(store.Rename(TenantId.Local, Guid.NewGuid(), "Anything"));
+            // The refused rename changed nothing.
+            Assert.Equal("Release", store.Get(TenantId.Local, mission.MissionId)!.MissionName);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void A_new_mission_is_active_and_listed()
+    {
+        var tempFile = TempPath();
+        try
+        {
+            var store = NewStore(tempFile);
+            var mission = store.Create(TenantId.Local, "Release 2.0.1");
+
+            Assert.Equal(MissionStates.Active, mission.State);
+            Assert.True(mission.IsActive);
+            Assert.Null(mission.StateChangedAt);
+            Assert.Single(store.List(TenantId.Local));
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Theory]
+    [InlineData(MissionStates.Complete)]
+    [InlineData(MissionStates.Removed)]
+    public void An_ended_mission_leaves_the_default_list_but_is_still_there(string ending)
+    {
+        var tempFile = TempPath();
+        try
+        {
+            var store = NewStore(tempFile);
+            var mission = store.Create(TenantId.Local, "Remove the network port");
+            var now = DateTimeOffset.UtcNow;
+
+            var ended = store.SetState(TenantId.Local, mission.MissionId, ending, now);
+
+            Assert.NotNull(ended);
+            Assert.Equal(ending, ended.State);
+            Assert.Equal(now, ended.StateChangedAt);
+            Assert.False(ended.IsActive);
+
+            // Gone from the default view...
+            Assert.Empty(store.List(TenantId.Local));
+            // ...but NOT gone. Removed is a soft delete: the record stays, and the id still resolves.
+            Assert.NotNull(store.Get(TenantId.Local, mission.MissionId));
+            Assert.Single(store.List(TenantId.Local, includeEnded: true));
+            Assert.Single(store.List(TenantId.Local, state: ending));
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void An_ended_mission_can_be_reopened()
+    {
+        var tempFile = TempPath();
+        try
+        {
+            var store = NewStore(tempFile);
+            var mission = store.Create(TenantId.Local, "Ended by mistake");
+            store.SetState(TenantId.Local, mission.MissionId, MissionStates.Complete, DateTimeOffset.UtcNow);
+            Assert.Empty(store.List(TenantId.Local));
+
+            var reopened = store.SetState(TenantId.Local, mission.MissionId, MissionStates.Active,
+                DateTimeOffset.UtcNow);
+
+            Assert.NotNull(reopened);
+            Assert.True(reopened.IsActive);
+            Assert.Single(store.List(TenantId.Local));
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void SetState_RejectsAnythingElse_AndUnknownReturnsNull()
+    {
+        var tempFile = TempPath();
+        try
+        {
+            var store = NewStore(tempFile);
+            var mission = store.Create(TenantId.Local, "Release");
+
+            Assert.Throws<ArgumentException>(() =>
+                store.SetState(TenantId.Local, mission.MissionId, "archived", DateTimeOffset.UtcNow));
+            Assert.Null(store.SetState(TenantId.Local, Guid.NewGuid(), MissionStates.Complete,
+                DateTimeOffset.UtcNow));
+            Assert.True(store.Get(TenantId.Local, mission.MissionId)!.IsActive);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void A_record_written_before_states_existed_reads_as_active()
+    {
+        var tempFile = TempPath();
+        try
+        {
+            // No State property at all - exactly what every missions.json on disk holds today.
+            File.WriteAllText(tempFile,
+                "[{\"MissionId\":\"" + Guid.NewGuid() + "\",\"MissionName\":\"Older Mission\"," +
+                "\"CreatedAt\":\"2026-01-01T00:00:00+00:00\",\"TenantId\":null}]");
+
+            var store = NewStore(tempFile);
+            var listed = store.List(TenantId.Local);
+
+            Assert.Single(listed);
+            Assert.True(listed[0].IsActive);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
 }

--- a/src/CcDirector.Core/Sessions/Mission.cs
+++ b/src/CcDirector.Core/Sessions/Mission.cs
@@ -1,6 +1,37 @@
 namespace CcDirector.Core.Sessions;
 
 /// <summary>
+/// The states a Mission can be in. Stored as a string rather than an enum so an unrecognised value from a
+/// newer writer round-trips instead of deserialising to whatever happens to be zero.
+///
+/// There are exactly three, and the two endings are DIFFERENT ENDINGS rather than one with a flag:
+/// COMPLETE means the work finished and is worth keeping - "what did we ship in July" is a real question.
+/// REMOVED means the mission should not have existed - a duplicate, a mistake, an abandoned idea. It is
+/// not an outcome, and lumping it in with completed work would quietly corrupt the answer to that question.
+/// </summary>
+public static class MissionStates
+{
+    /// <summary>Live work. The ordinary state, and what a mission is created in.</summary>
+    public const string Active = "active";
+
+    /// <summary>The work finished. Kept forever; out of the default view.</summary>
+    public const string Complete = "complete";
+
+    /// <summary>This should not exist. Soft-deleted: the record stays, out of every default view.</summary>
+    public const string Removed = "removed";
+
+    /// <summary>The states that are an ENDING - a mission in one of these is no longer live work.</summary>
+    public static readonly string[] Ended = { Complete, Removed };
+
+    /// <summary>Normalize a caller-supplied state, or null when it is not one of the three.</summary>
+    public static string? Normalize(string? value)
+    {
+        var v = (value ?? string.Empty).Trim().ToLowerInvariant();
+        return v == Active || v == Complete || v == Removed ? v : null;
+    }
+}
+
+/// <summary>
 /// A Mission: the named unit of work a pod of sessions is collectively chartered to accomplish
 /// (see docs/new_architecture/mission-as-first-class-unit-of-work.md). A Mission is its OWN persisted
 /// record - not merely an attachment field on a session - so it survives a Director/Manager restart and
@@ -39,6 +70,23 @@ public sealed class Mission
 
     /// <summary>When <see cref="Why"/> was last set (UTC), or null if it has never been set.</summary>
     public DateTimeOffset? WhyUpdatedAt { get; set; }
+
+    /// <summary>
+    /// One of <see cref="MissionStates"/>. Defaults to Active, which is also what a record written before
+    /// this field existed reads as - every mission that predates it was, by definition, never ended.
+    ///
+    /// A mission can be ended while sessions are still attached to it, and that is deliberate. Refusing
+    /// would make ending hardest exactly when a mission has sprawled, which is when it most needs ending,
+    /// and a single idle-but-alive session would block it for no reason. The contradiction is shown rather
+    /// than prevented - see the Cockpit's mission card.
+    /// </summary>
+    public string State { get; set; } = MissionStates.Active;
+
+    /// <summary>When <see cref="State"/> last changed (UTC), or null while it has only ever been Active.</summary>
+    public DateTimeOffset? StateChangedAt { get; set; }
+
+    /// <summary>True when this mission is still live work - the ordinary case, and what the default view shows.</summary>
+    public bool IsActive => MissionStates.Normalize(State) is null or MissionStates.Active;
 
     /// <summary>UTC timestamp the Mission was created. Used for stable list ordering.</summary>
     public DateTimeOffset CreatedAt { get; set; }

--- a/src/CcDirector.Core/Sessions/MissionStore.cs
+++ b/src/CcDirector.Core/Sessions/MissionStore.cs
@@ -113,12 +113,33 @@ public sealed class MissionStore
             return LoadAll().FirstOrDefault(m => m.MissionId == missionId && OwnedBy(m, tenant));
     }
 
-    /// <summary>Return every Mission <paramref name="tenant"/> owns, oldest first.</summary>
-    public IReadOnlyList<Mission> List(TenantId tenant)
+    /// <summary>
+    /// Return the Missions <paramref name="tenant"/> owns, oldest first.
+    ///
+    /// ACTIVE ONLY BY DEFAULT. A mission that has been completed or removed is history, and every caller
+    /// that wants "what am I working on" wants it left out - which is all of them, until something asks for
+    /// the archive. Pass <paramref name="state"/> to ask for one specific state, or
+    /// <paramref name="includeEnded"/> to get everything.
+    ///
+    /// The default is the safe direction to be wrong in: a caller that has not been taught about states
+    /// shows a shorter, correct list rather than a longer one full of finished work.
+    /// </summary>
+    /// <param name="state">One of <see cref="MissionStates"/> to return only that state, or null.</param>
+    /// <param name="includeEnded">True to return every state. Ignored when <paramref name="state"/> is given.</param>
+    public IReadOnlyList<Mission> List(TenantId tenant, string? state = null, bool includeEnded = false)
     {
         RequireValid(tenant);
+        var wanted = MissionStates.Normalize(state);
         lock (_lock)
-            return LoadAll().Where(m => OwnedBy(m, tenant)).OrderBy(m => m.CreatedAt).ToList();
+        {
+            var mine = LoadAll().Where(m => OwnedBy(m, tenant));
+            if (wanted is not null)
+                mine = mine.Where(m => string.Equals(
+                    MissionStates.Normalize(m.State) ?? MissionStates.Active, wanted, StringComparison.Ordinal));
+            else if (!includeEnded)
+                mine = mine.Where(m => m.IsActive);
+            return mine.OrderBy(m => m.CreatedAt).ToList();
+        }
     }
 
     /// <summary>
@@ -143,6 +164,79 @@ public sealed class MissionStore
             mission.Why = trimmed;
             // A cleared WHY carries no "last set" time - the field is unset, not set-to-empty-at-a-moment.
             mission.WhyUpdatedAt = trimmed.Length == 0 ? null : nowUtc;
+            SaveAll(missions);
+            return mission;
+        }
+    }
+
+    /// <summary>
+    /// Rename <paramref name="tenant"/>'s Mission. Returns the updated Mission, or null when this tenant has
+    /// no such mission - indistinguishable from another tenant's, like every accessor here.
+    ///
+    /// Renaming is SAFE because nothing keys off the name: sessions attach by <see cref="Mission.MissionId"/>,
+    /// the Cockpit groups by it, and the WHY is a field on this record. That was not true until the WHY moved
+    /// here - it used to live in a table keyed by the lower-cased name, and this method would have silently
+    /// orphaned it. The name is display text, and this is the method that makes that literal.
+    /// </summary>
+    /// <exception cref="ArgumentException">The new name is null, empty, or whitespace.</exception>
+    public Mission? Rename(TenantId tenant, Guid missionId, string missionName)
+    {
+        RequireValid(tenant);
+        if (string.IsNullOrWhiteSpace(missionName))
+            throw new ArgumentException("missionName is required", nameof(missionName));
+
+        var trimmed = missionName.Trim();
+        FileLog.Write($"[MissionStore] Rename: tenant={tenant.ToLogString()} mission={missionId} " +
+                      $"name=\"{trimmed}\"");
+        lock (_lock)
+        {
+            var missions = LoadAll();
+            var mission = missions.FirstOrDefault(m => m.MissionId == missionId && OwnedBy(m, tenant));
+            if (mission is null)
+                return null;
+
+            mission.MissionName = trimmed;
+            SaveAll(missions);
+            return mission;
+        }
+    }
+
+    /// <summary>
+    /// End (or reopen) <paramref name="tenant"/>'s Mission by setting its <see cref="Mission.State"/> to one
+    /// of <see cref="MissionStates"/>. Returns the updated Mission, or null when this tenant has no such
+    /// mission.
+    ///
+    /// REMOVED IS A SOFT DELETE - the record stays on disk. Two concrete reasons, not squeamishness: a
+    /// mission number must never be reused, so the row has to keep holding its number; and sessions may
+    /// still carry this mission id, so a vanished record would leave clients showing an attachment they
+    /// cannot resolve. Actually erasing rows is a separate purge, not this verb.
+    ///
+    /// Setting the state it already has is a no-op that still returns the mission, so a caller repeating
+    /// itself gets a success rather than a confusing failure.
+    /// </summary>
+    /// <exception cref="ArgumentException">The state is not one of the three.</exception>
+    public Mission? SetState(TenantId tenant, Guid missionId, string state, DateTimeOffset nowUtc)
+    {
+        RequireValid(tenant);
+        var normalized = MissionStates.Normalize(state)
+            ?? throw new ArgumentException(
+                $"state must be one of: {MissionStates.Active}, {MissionStates.Complete}, {MissionStates.Removed}",
+                nameof(state));
+
+        FileLog.Write($"[MissionStore] SetState: tenant={tenant.ToLogString()} mission={missionId} " +
+                      $"state={normalized}");
+        lock (_lock)
+        {
+            var missions = LoadAll();
+            var mission = missions.FirstOrDefault(m => m.MissionId == missionId && OwnedBy(m, tenant));
+            if (mission is null)
+                return null;
+
+            if (string.Equals(mission.State, normalized, StringComparison.Ordinal))
+                return mission;
+
+            mission.State = normalized;
+            mission.StateChangedAt = nowUtc;
             SaveAll(missions);
             return mission;
         }

--- a/src/CcDirector.Gateway.Contracts/MissionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/MissionDto.cs
@@ -31,6 +31,12 @@ public sealed class MissionDto
     /// <summary>When the WHY was last set (UTC), or null if it has never been set.</summary>
     public DateTimeOffset? WhyUpdatedAt { get; set; }
 
+    /// <summary>"active", "complete", or "removed". Older Gateways send nothing, which reads as active.</summary>
+    public string State { get; set; } = "active";
+
+    /// <summary>When the state last changed (UTC), or null while it has only ever been active.</summary>
+    public DateTimeOffset? StateChangedAt { get; set; }
+
     /// <summary>ADDITIVE (Workflows mission, phase 4, issue #1771): the workflow run opened beside
     /// this Mission when it was created through the Gateway - a mission is a run of the built-in
     /// "mission" workflow. Null on reads that do not resolve it and on missions predating the spine.
@@ -57,9 +63,40 @@ public sealed class NewMissionRequest
 public sealed class MissionPatchRequest
 {
     /// <summary>The mission's WHY. An empty or whitespace value CLEARS it, returning the card to its "no
-    /// why set" flag. Null means "do not change the why" - and, until other fields exist here, is rejected
-    /// as an empty request rather than treated as a silent no-op.</summary>
+    /// why set" flag. Null means "do not change the why".</summary>
     public string? Why { get; set; }
+
+    /// <summary>The mission's display name. Null means "do not rename"; blank is REJECTED rather than
+    /// treated as a clear, because a mission with no name cannot be referred to.</summary>
+    public string? MissionName { get; set; }
+
+    /// <summary>"active", "complete", or "removed". Null means "do not change the state". Setting "active"
+    /// on an ended mission REOPENS it, which is the way back from a mistaken ending.</summary>
+    public string? State { get; set; }
+}
+
+/// <summary>
+/// The result of PATCH /missions/{mid}: the updated Mission, plus anything the caller needs TOLD that the
+/// mission record alone does not say.
+/// </summary>
+public sealed class MissionPatchResultDto
+{
+    /// <summary>The mission after the change.</summary>
+    public MissionDto? Mission { get; set; }
+
+    /// <summary>
+    /// A plain sentence about something that happened alongside the change and that the caller cannot see
+    /// from the mission itself - a workflow run that could not be advanced, or an ending applied while
+    /// sessions were still attached. Null when the outcome speaks for itself.
+    ///
+    /// Returned rather than left to be inferred, for the same reason MissionAttachResultDto returns its
+    /// seat note: only the Gateway knows what happened to the run, and a caller told nothing would report a
+    /// clean ending it has no basis for.
+    /// </summary>
+    public string? Note { get; set; }
+
+    /// <summary>How many sessions were still attached when the mission was ended. Zero otherwise.</summary>
+    public int AttachedSessionCount { get; set; }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
+++ b/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
@@ -132,11 +132,11 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
 
         var setA = await Json(await Send("PATCH", $"missions/{idA}", _keyA, WhyBody(whyA)),
             HttpStatusCode.OK, "SEED    PATCH /missions/{A} (tenant A)");
-        Assert.Equal(whyA, Str(setA, "why"));
+        Assert.Equal(whyA, Str(Obj(setA, "mission"), "why"));
 
         var setB = await Json(await Send("PATCH", $"missions/{idB}", _keyB, WhyBody(whyB)),
             HttpStatusCode.OK, "SEED    PATCH /missions/{B} (tenant B)");
-        Assert.Equal(whyB, Str(setB, "why"));
+        Assert.Equal(whyB, Str(Obj(setB, "mission"), "why"));
 
         // Each tenant reads back EXACTLY its own why - not the other's, and not overwritten by it.
         var readA = await Json(await Send("GET", $"missions/{idA}", _keyA, null),
@@ -164,7 +164,7 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
         // B's untouched. Without this, the reads above could be an inert route rather than a partitioned one.
         var clearA = await Json(await Send("PATCH", $"missions/{idA}", _keyA, WhyBody("")),
             HttpStatusCode.OK, "CONTROL PATCH /missions/{A} (tenant A clears its OWN why)");
-        Assert.Equal("", Str(clearA, "why"));
+        Assert.Equal("", Str(Obj(clearA, "mission"), "why"));
 
         var survivingBAgain = await Json(await Send("GET", $"missions/{idB}", _keyB, null),
             HttpStatusCode.OK, "AFTER   GET /missions/{B} (after A cleared its own)");

--- a/src/CcDirector.Gateway.Tests/MissionWhyEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionWhyEndpointTests.cs
@@ -200,4 +200,145 @@ public sealed class MissionWhyEndpointTests : IAsyncLifetime
         using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
         return doc.RootElement.TryGetProperty("why", out var why) ? why.GetString() ?? "" : "";
     }
+
+    // ---- rename and ending (Phase 2) ------------------------------------------------------------------
+
+    [Fact]
+    public async Task Rename_changes_the_name_and_keeps_the_why()
+    {
+        var mission = await CreateMission("Release 2.0.0");
+        await PatchWhy(mission, "the reason");
+
+        using var res = await Patch(mission, new { missionName = "  Release 2.0.1  " });
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+
+        var listed = await GetMission(mission);
+        Assert.Equal("Release 2.0.1", listed.GetProperty("missionName").GetString());
+        // The WHY survives the rename. Under the old name-keyed store it would simply have vanished.
+        Assert.Equal("the reason", listed.GetProperty("why").GetString());
+    }
+
+    [Fact]
+    public async Task A_blank_name_is_rejected_rather_than_stored()
+    {
+        var mission = await CreateMission("Release 2.0.1");
+
+        using var res = await Patch(mission, new { missionName = "   " });
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+
+        var listed = await GetMission(mission);
+        Assert.Equal("Release 2.0.1", listed.GetProperty("missionName").GetString());
+    }
+
+    [Theory]
+    [InlineData("complete")]
+    [InlineData("removed")]
+    public async Task Ending_a_mission_takes_it_out_of_the_default_list_but_keeps_the_record(string ending)
+    {
+        var mission = await CreateMission("Remove the network port");
+
+        using var res = await Patch(mission, new { state = ending });
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+
+        Assert.DoesNotContain(mission, await ListMissionIds(null));
+        Assert.Contains(mission, await ListMissionIds("all"));
+        Assert.Contains(mission, await ListMissionIds(ending));
+
+        // Soft: the record is still addressable by id.
+        var listed = await GetMission(mission);
+        Assert.Equal(ending, listed.GetProperty("state").GetString());
+    }
+
+    [Fact]
+    public async Task An_ended_mission_can_be_reopened()
+    {
+        var mission = await CreateMission("Ended by mistake");
+        await Patch(mission, new { state = "complete" });
+        Assert.DoesNotContain(mission, await ListMissionIds(null));
+
+        using var res = await Patch(mission, new { state = "active" });
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        Assert.Contains(mission, await ListMissionIds(null));
+    }
+
+    // The run store refuses created -> succeeded, and EVERY mission run on this fleet is still at created
+    // because nothing has ever advanced one. So the ordinary case is the one needing two steps, and this is
+    // the test that would catch it silently not happening.
+    [Fact]
+    public async Task Completing_a_mission_drives_its_workflow_run_to_a_terminal_state()
+    {
+        var mission = await CreateMission("Release 2.0.1");
+        Assert.Equal("created", await RunStatusFor(mission));
+
+        using var res = await Patch(mission, new { state = "complete" });
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+
+        Assert.Equal("succeeded", await RunStatusFor(mission));
+    }
+
+    [Fact]
+    public async Task Removing_a_mission_abandons_its_workflow_run()
+    {
+        var mission = await CreateMission("A duplicate");
+
+        using var res = await Patch(mission, new { state = "removed" });
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+
+        Assert.Equal("abandoned", await RunStatusFor(mission));
+    }
+
+    [Fact]
+    public async Task An_unrecognised_state_is_rejected()
+    {
+        var mission = await CreateMission("Release 2.0.1");
+        using var res = await Patch(mission, new { state = "archived" });
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_state_filter_the_route_does_not_know_is_rejected()
+    {
+        using var res = await Authed(HttpMethod.Get, "/missions?state=parked");
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+    }
+
+    // ---- Phase 2 helpers -----------------------------------------------------------------------------
+
+    private async Task<HttpResponseMessage> Patch(string missionId, object body)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Patch, $"/missions/{missionId}")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        return await _http.SendAsync(req);
+    }
+
+    private async Task<JsonElement> GetMission(string missionId)
+    {
+        using var res = await Authed(HttpMethod.Get, $"/missions/{missionId}");
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        return JsonDocument.Parse(await res.Content.ReadAsStringAsync()).RootElement.Clone();
+    }
+
+    private async Task<List<string>> ListMissionIds(string? state)
+    {
+        var route = state is null ? "/missions" : $"/missions?state={state}";
+        using var res = await Authed(HttpMethod.Get, route);
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        return doc.RootElement.EnumerateArray()
+            .Select(e => e.GetProperty("missionId").GetString()!)
+            .ToList();
+    }
+
+    private async Task<string> RunStatusFor(string missionId)
+    {
+        using var res = await Authed(HttpMethod.Get, $"/gateway/workflow-runs?missionId={missionId}&limit=1");
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        var runs = doc.RootElement.TryGetProperty("runs", out var r) ? r : doc.RootElement;
+        var first = runs.EnumerateArray().FirstOrDefault();
+        return first.ValueKind == JsonValueKind.Undefined ? "(no run)" : first.GetProperty("status").GetString()!;
+    }
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -330,14 +330,30 @@ internal static class GatewayEndpoints
             // #1039: the list is the caller's OWN missions. It used to be missions.List() - every account's
             // missions, served to every account, on one shared hosted store. A request that resolves to no
             // tenant is DENIED (403), never served the Local partition.
-            app.MapGet("/missions", (HttpContext ctx) =>
+            // ACTIVE ONLY by default. ?state=complete|removed|active returns exactly that state, and
+            // ?state=all returns every one. An existing caller that knows nothing about states gets a
+            // shorter, correct list rather than one padded with finished work - the safe direction to be
+            // wrong in, and what every current caller actually wants.
+            app.MapGet("/missions", (HttpContext ctx, string? state) =>
             {
                 var tenant = ResolveReadTenant(ctx, tenantBoundary);
                 if (tenant is null)
                     return Results.Json(new { error = "no tenant is bound to this request" },
                         statusCode: StatusCodes.Status403Forbidden);
 
-                return Results.Json(missions.List(tenant.Value).Select(ToMissionDto).ToList());
+                var wanted = (state ?? "").Trim().ToLowerInvariant();
+                var all = wanted == "all";
+                if (!all && wanted.Length > 0 && Core.Sessions.MissionStates.Normalize(wanted) is null)
+                    return Results.BadRequest(new
+                    {
+                        error = "state must be one of: active, complete, removed, all",
+                    });
+
+                var list = missions.List(
+                    tenant.Value,
+                    state: all || wanted.Length == 0 ? null : wanted,
+                    includeEnded: all);
+                return Results.Json(list.Select(ToMissionDto).ToList());
             });
 
             // #1039: resolve INSIDE the caller's own tenant. A mission id that belongs to another account
@@ -399,19 +415,74 @@ internal static class GatewayEndpoints
 
                 // Nothing to change is a client mistake worth naming, not a silent success that looks like
                 // the edit was applied.
-                if (req?.Why is null)
-                    return Results.BadRequest(new { error = "why is required" });
+                if (req is null || (req.Why is null && req.MissionName is null && req.State is null))
+                    return Results.BadRequest(new { error = "one of why, missionName or state is required" });
 
-                var updated = missions.SetWhy(tenant.Value, missionId, req.Why, DateTimeOffset.UtcNow);
+                // Reject a blank NAME up front rather than storing one: a mission nobody can refer to is
+                // not a rename, it is a broken record. (A blank WHY is different - that is the clear path.)
+                if (req.MissionName is not null && string.IsNullOrWhiteSpace(req.MissionName))
+                    return Results.BadRequest(new { error = "missionName cannot be blank" });
+
+                var wantedState = req.State is null ? null : Core.Sessions.MissionStates.Normalize(req.State);
+                if (req.State is not null && wantedState is null)
+                    return Results.BadRequest(new
+                    {
+                        error = "state must be one of: active, complete, removed",
+                    });
+
+                var now = DateTimeOffset.UtcNow;
+                Core.Sessions.Mission? updated = null;
+
+                if (req.Why is not null)
+                    updated = missions.SetWhy(tenant.Value, missionId, req.Why, now);
+
+                if (req.MissionName is not null)
+                    updated = missions.Rename(tenant.Value, missionId, req.MissionName) ?? updated;
+
+                if (wantedState is not null)
+                    updated = missions.SetState(tenant.Value, missionId, wantedState, now) ?? updated;
+
+                // Every accessor above answers null for BOTH an unknown mission and another tenant's, so a
+                // null here is a 404 - the same answer either way, and the id cannot be probed.
                 if (updated is null)
                 {
                     FileLog.Write($"[GatewayEndpoints] PATCH /missions/{mid}: unknown to this tenant");
                     return Results.NotFound(new { error = "mission not found" });
                 }
 
-                FileLog.Write($"[GatewayEndpoints] PATCH /missions/{mid}: why " +
-                              (updated.Why.Length == 0 ? "cleared" : "set"));
-                return Results.Json(ToMissionDto(updated));
+                var result = new MissionPatchResultDto { Mission = ToMissionDto(updated) };
+
+                // ===== ENDING A MISSION ALSO ENDS ITS WORKFLOW RUN =====
+                //
+                // A Mission is also a RUN of the built-in "mission" workflow. Leaving the run open while the
+                // mission is finished would leave the fleet governed by conduct for work that is over, and
+                // would keep it in every "what is still running" answer the run store gives.
+                //
+                // THE TRANSITION TABLE IS REAL AND HAS TO BE OBEYED. A run goes
+                // created -> active -> succeeded, so "complete" cannot be applied to a run still sitting at
+                // created in one move. Every mission run on this fleet IS still at created, because nothing
+                // has ever advanced one - so the common case is precisely the one that needs two steps. The
+                // intermediate move is not a fiction: sessions really were seated on that run and it really
+                // was in use; the transition was simply never recorded.
+                //
+                // A run that cannot be advanced does NOT block the ending. The mission's own state is the
+                // primary fact and it is already stored; the run is a second store. But the caller is TOLD,
+                // in the same shape MissionAttachResultDto reports a seat, because only the Gateway can see
+                // what happened here and a caller told nothing would report a clean ending it cannot vouch for.
+                if (wantedState is Core.Sessions.MissionStates.Complete or Core.Sessions.MissionStates.Removed
+                    && workflowRuns is not null)
+                {
+                    var terminal = wantedState == Core.Sessions.MissionStates.Complete
+                        ? WorkflowRunStatus.Succeeded
+                        : WorkflowRunStatus.Abandoned;
+                    result.Note = EndMissionRun(workflowRuns, missionId, terminal);
+                }
+
+                FileLog.Write($"[GatewayEndpoints] PATCH /missions/{mid}: " +
+                              $"why={(req.Why is null ? "unchanged" : updated.Why.Length == 0 ? "cleared" : "set")} " +
+                              $"name={(req.MissionName is null ? "unchanged" : "renamed")} " +
+                              $"state={updated.State}");
+                return Results.Json(result);
             });
 
             FileLog.Write("[GatewayEndpoints] mapped Gateway-native /missions routes");
@@ -3963,7 +4034,51 @@ internal static class GatewayEndpoints
         MissionName = m.MissionName,
         Why = m.Why,
         WhyUpdatedAt = m.WhyUpdatedAt,
+        State = Core.Sessions.MissionStates.Normalize(m.State) ?? Core.Sessions.MissionStates.Active,
+        StateChangedAt = m.StateChangedAt,
     };
+
+    /// <summary>
+    /// Drive a mission's workflow run to <paramref name="terminal"/> when its mission ends. Returns a
+    /// sentence for the caller when there is something to say, or null when the outcome speaks for itself.
+    ///
+    /// Walks created -> active -> terminal where needed, because the run store enforces its transition
+    /// table and refuses to jump straight from created to succeeded. That is the ordinary case here, not an
+    /// edge one: no mission run on this fleet has ever left created.
+    ///
+    /// Never throws. Ending the mission is the primary fact and is already persisted by the time this runs;
+    /// a run that will not advance is reported, not escalated into a failed request that would leave the
+    /// caller believing the ending did not happen when it did.
+    /// </summary>
+    private static string? EndMissionRun(Workflows.WorkflowRunStore workflowRuns, Guid missionId, string terminal)
+    {
+        try
+        {
+            var run = workflowRuns.List(missionId: missionId, limit: 1).FirstOrDefault();
+            if (run is null)
+                return "This mission has no workflow run of its own, so there was no run to end.";
+
+            if (WorkflowRunStatus.Terminal.Contains(run.Status, StringComparer.Ordinal))
+                return null;   // already ended; nothing to say
+
+            // The table allows created -> active and active -> succeeded/abandoned, but not created ->
+            // succeeded. Step through when we have to.
+            if (string.Equals(run.Status, WorkflowRunStatus.Created, StringComparison.Ordinal)
+                && !string.Equals(terminal, WorkflowRunStatus.Abandoned, StringComparison.Ordinal))
+            {
+                workflowRuns.Patch(run.Id, new PatchWorkflowRunRequest { Status = WorkflowRunStatus.Active });
+            }
+
+            workflowRuns.Patch(run.Id, new PatchWorkflowRunRequest { Status = terminal });
+            return null;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayEndpoints] EndMissionRun({missionId} -> {terminal}) FAILED: {ex.Message}");
+            return "The mission was ended, but its workflow run could not be closed with it - "
+                 + "it will still appear among the running workflow runs.";
+        }
+    }
 
     /// <summary>
     /// The hosted refusal payload for POST /shutdown (production-readiness B2). Validated on construction, so a


### PR DESCRIPTION
Phase 2: the Gateway verbs behind the three things you asked for. The Cockpit menu is Phase 4; the command line is Phase 3.

## Rename

`MissionStore.Rename` plus `missionName` on `PATCH /missions/{mid}`.

This is **only safe because nothing keys off the name any more** — sessions attach by `MissionId`, the Cockpit groups by it, and the WHY became a field on the record in the previous change. Renaming before that would have silently orphaned every WHY. A blank name is **rejected**, not stored: a mission nobody can refer to is a broken record, not a rename. (A blank WHY is different, and still clears.)

## Two endings, not one

`Mission.State` is `active | complete | removed`.

- **Complete** — the work finished and is worth keeping. "What did we ship in July" is a real question.
- **Removed** — the mission should not have existed: a duplicate, a mistake, an abandoned idea. Not an outcome, and folding it in with completed work would quietly corrupt that answer.

**Removed is a soft delete.** The record stays, for two concrete reasons: a mission number must never be reused, so the row has to keep holding it; and sessions may still carry the id, so a vanished record would leave clients showing an attachment they cannot resolve. Erasing rows is a separate purge.

An ended mission can be **reopened** by setting it back to active — the way back from a mistaken ending.

**Ending is allowed while sessions are still attached**, per your ruling. Refusing would make ending hardest exactly when a mission has sprawled, which is when it most needs ending, and one idle-but-alive session would block it for nothing.

## Ending a mission ends its workflow run

The transition table is obeyed rather than worked around. A run goes `created → active → succeeded`, so "complete" **cannot** be applied in one move to a run still at `created` — which is **every mission run on this fleet**, because nothing has ever advanced one. The ordinary case is the one needing two steps, and there is a test that would catch it silently not happening.

A run that will not advance does **not** block the ending. The mission's own state is the primary fact and is already stored by then. The caller is told instead, through `MissionPatchResultDto.Note` — the same shape `MissionAttachResultDto` uses for its seat, and for the same reason: only the Gateway can see what happened, and a caller told nothing would report a clean ending it cannot vouch for.

## GET /missions is active-only by default

`?state=complete|removed|active|all` for the rest. An existing caller that knows nothing about states gets a shorter, correct list rather than one padded with finished work — the safe direction to be wrong in. A record written before this field existed reads as active, which is true of every mission on disk today, and there is a test seeding exactly that shape.

## Known gap, deliberately left until Phase 4

**Completing a mission will make it disappear from the Cockpit**, which has no archive view yet. Phase 3's `mission list --all` can still see it and nothing is lost — but there is a window here where ending a mission is a one-way trip as far as the screen is concerned.

## Testing

- Solution builds clean; root typecheck clean.
- `Core.Tests` mission filter: 52 passed (rename keeps id and WHY, both endings, reopen, invalid state rejected, and a record with no `State` field reading as active).
- `Gateway.Tests` mission + census filter: 51 passed, including the two-step run transition for both endings.
- Web: cockpit 282, client-core 905, mobile 3.
- **Honest note on flakiness:** that Gateway filter reported 2 failures and then 51/51 on identical code, and the same suite did the same thing (36/1 then 37/0) on the previous change. Those reds were flaky, not fixed — I am not presenting the green as a resolution of them.