### PR TITLE
Let a session key change a mission it can already create and read

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/SessionKeyGuardTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionKeyGuardTests.cs
@@ -56,6 +56,10 @@ public sealed class SessionKeyGuardTests
     [InlineData("PATCH", "/sessions/11111111-1111-1111-1111-111111111111")]
     [InlineData("POST", "/fanout")]
     [InlineData("POST", "/missions")]
+    // The third verb on a record a session key can already create and read: rename it, set its WHY,
+    // and end it (complete / removed) or reopen it. An agent that can open a mission but can never
+    // end one is how the mission list grows forever.
+    [InlineData("PATCH", "/missions/m-123")]
     [InlineData("POST", "/machines/SOREN_NORTH/sessions")]
     [InlineData("POST", "/machines/SOREN_NORTH/launch")]
     [InlineData("POST", "/gateway/skills/move-session/publish")]

--- a/src/CcDirector.Gateway/Util/SessionKeyGuard.cs
+++ b/src/CcDirector.Gateway/Util/SessionKeyGuard.cs
@@ -229,6 +229,21 @@ public static class SessionKeyGuard
         // Rename a session (PATCH /sessions/{sid}).
         if (verb == "PATCH" && s.Length == 2 && s[0] == "sessions") return true;
 
+        // Change a mission a session key can already CREATE and READ: its name, its WHY, and whether it
+        // is still live (complete / removed / reopened). PATCH /missions/{mid}.
+        //
+        // This sits exactly alongside the session rename above, and for the same reason: a mission is the
+        // unit of work an agent is on, and an agent that can open one but can never rename it or END it
+        // leaves the mission list growing forever - which is the state the fleet was found in, eleven
+        // missions with several finished days earlier and no way out.
+        //
+        // No wider than what a session key already has. POST /missions (create) and GET /missions (read)
+        // are both allowed above; this is the third verb on the same record, resolved inside the caller's
+        // own tenant by the route itself, which answers 404 for another account's mission exactly as the
+        // read does. It is nowhere near the admission surface this guard exists to protect - device
+        // enrollment, account identity, Director registration.
+        if (verb == "PATCH" && s.Length == 2 && s[0] == "missions") return true;
+
         if (verb == "DELETE")
         {
             // Delete an automation browser.

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -199,7 +199,10 @@ _ACTIONS = [
     },
     {
         "id": "mission-list",
-        "description": "List the Missions on the Gateway - the named bodies of work sessions attach to.",
+        "description": (
+            "List the ACTIVE Missions on the Gateway - the named bodies of work sessions attach to. "
+            "Add --all (or --state complete|removed) to include ones that have been ended."
+        ),
         "command": "cc-devthrottle mission list",
         "mutatesState": False,
         "args": [],
@@ -234,6 +237,49 @@ _ACTIONS = [
         "command": "cc-devthrottle mission detach <session>",
         "mutatesState": True,
         "args": [{"name": "session", "required": True}],
+    },
+    {
+        # Discoverable for the same reason attach is. An agent that finishes a body of work and cannot
+        # find the verb to END it leaves the mission list growing forever, which is exactly the state
+        # the owner found it in: eleven missions, several finished days earlier, with no way out.
+        "id": "mission-rename",
+        "description": (
+            "Rename a Mission. Its id does not change, so every attached session stays attached and "
+            "its WHY is kept."
+        ),
+        "command": 'cc-devthrottle mission rename <mission> "<new name>"',
+        "mutatesState": True,
+        "args": [
+            {"name": "mission", "required": True},
+            {"name": "name", "required": True},
+        ],
+    },
+    {
+        "id": "mission-complete",
+        "description": (
+            "Mark a Mission as FINISHED. It leaves the default list and is kept as a record - this is "
+            "the ending to use when the work is done."
+        ),
+        "command": "cc-devthrottle mission complete <mission>",
+        "mutatesState": True,
+        "args": [{"name": "mission", "required": True}],
+    },
+    {
+        "id": "mission-remove",
+        "description": (
+            "Remove a Mission that should not exist - a duplicate, a mistake, an abandoned idea. NOT "
+            "an outcome: use complete for finished work. Soft, so the record is kept and can be reopened."
+        ),
+        "command": "cc-devthrottle mission remove <mission>",
+        "mutatesState": True,
+        "args": [{"name": "mission", "required": True}],
+    },
+    {
+        "id": "mission-reopen",
+        "description": "Return a completed or removed Mission to active.",
+        "command": "cc-devthrottle mission reopen <mission>",
+        "mutatesState": True,
+        "args": [{"name": "mission", "required": True}],
     },
     {
         "id": "machine-list",
@@ -1227,20 +1273,70 @@ def spawn(
 @mission_app.command("create")
 def mission_create(
     name: str = typer.Argument(..., help="Human-friendly name for the Mission."),
-    parent: Optional[str] = typer.Option(
-        None, "--parent", help="Parent Mission id to nest this Mission under (a tree of Missions)."
-    ),
 ) -> None:
     """Create a Mission record on the Gateway and print its id."""
-    mission_ops.create_mission(name, parent)
+    mission_ops.create_mission(name)
 
 
 @mission_app.command("list")
 def mission_list(
     json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON."),
+    show_all: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help="Include missions that have been completed or removed. Off by default: the question "
+        "this command answers is 'what am I working on', and finished work is the wrong answer to it.",
+    ),
+    state: Optional[str] = typer.Option(
+        None,
+        "--state",
+        help="Show only this state: active, complete, or removed. Overrides --all.",
+    ),
 ) -> None:
-    """List every Mission record on the Gateway."""
-    mission_ops.list_missions(json_output)
+    """List the Missions on the Gateway (active ones by default)."""
+    mission_ops.list_missions(json_output, state=state or ("all" if show_all else None))
+
+
+@mission_app.command("rename")
+def mission_rename(
+    mission: str = typer.Argument(
+        ..., help="The Mission to rename: its id, an id prefix, or part of its name."
+    ),
+    name: str = typer.Argument(..., help="The new display name."),
+) -> None:
+    """Rename a Mission. Its id does not change, so every attached session stays attached."""
+    mission_ops.rename_mission(mission, name)
+
+
+@mission_app.command("complete")
+def mission_complete(
+    mission: str = typer.Argument(
+        ..., help="The Mission to complete: its id, an id prefix, or part of its name."
+    ),
+) -> None:
+    """Mark a Mission as finished. It leaves the default list but is kept - this is the outcome."""
+    mission_ops.end_mission(mission, "complete")
+
+
+@mission_app.command("remove")
+def mission_remove(
+    mission: str = typer.Argument(
+        ..., help="The Mission to remove: its id, an id prefix, or part of its name."
+    ),
+) -> None:
+    """Remove a Mission that should not exist (a duplicate, a mistake). Soft: the record is kept."""
+    mission_ops.end_mission(mission, "removed")
+
+
+@mission_app.command("reopen")
+def mission_reopen(
+    mission: str = typer.Argument(
+        ..., help="The Mission to reopen: its id, an id prefix, or part of its name."
+    ),
+) -> None:
+    """Return a completed or removed Mission to active."""
+    mission_ops.reopen_mission(mission)
 
 
 @mission_app.command("attach")

--- a/tools/cc-devthrottle/src/mission_ops.py
+++ b/tools/cc-devthrottle/src/mission_ops.py
@@ -136,15 +136,25 @@ class MissionClient:
             return gateway.parse_json_body(resp, self.base_url)
         raise GatewayError(self._gateway_message(resp))
 
-    def create(self, name: str, parent: Optional[str]) -> Dict[str, Any]:
-        body: Dict[str, Any] = {"missionName": name}
-        if parent:
-            body["parentMissionId"] = parent
-        return self._ok_or_raise(self._request("POST", "/missions", body))
+    def create(self, name: str) -> Dict[str, Any]:
+        # Missions are FLAT. The parent link was removed on 2026-08-07 after never being used once;
+        # see docs/new_architecture/mission-as-first-class-unit-of-work.md.
+        return self._ok_or_raise(self._request("POST", "/missions", {"missionName": name}))
 
-    def list_all(self) -> List[Dict[str, Any]]:
-        data = self._ok_or_raise(self._request("GET", "/missions"))
+    def list_all(self, state: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Missions from the Gateway. ACTIVE ONLY unless `state` asks otherwise ("all" for every state).
+
+        The default matches the Gateway's: "what am I working on" is the question nearly every caller
+        is asking, and a list padded with finished work is the wrong answer to it.
+        """
+        path = "/missions" if not state else f"/missions?state={state}"
+        data = self._ok_or_raise(self._request("GET", path))
         return list(data) if isinstance(data, list) else []
+
+    def patch(self, mission_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Change a mission: its why, its name, or its state. Returns MissionPatchResultDto."""
+        resp = self._ok_or_raise(self._request("PATCH", f"/missions/{mission_id}", body))
+        return resp if isinstance(resp, dict) else {}
 
 
 def _resolve_mission(query: str) -> Dict[str, Any]:
@@ -155,8 +165,12 @@ def _resolve_mission(query: str) -> Dict[str, Any]:
     full one from the caller's OWN mission list, and the Gateway resolves it inside the caller's own
     tenant regardless of what was typed here.
     """
+    # EVERY state, not just active. A mission that has been completed or removed still has to be
+    # addressable - reopening one, or correcting its name, is exactly when you reach for it, and
+    # resolving against the default active-only list would answer "no mission matches" for a record
+    # that is plainly there.
     try:
-        missions = MissionClient().list_all()
+        missions = MissionClient().list_all(state="all")
     except GatewayError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
@@ -203,10 +217,10 @@ def _short_id(value: Optional[str]) -> str:
     return value.split("-")[0] if "-" in value else value
 
 
-def create_mission(name: str, parent: Optional[str]) -> None:
+def create_mission(name: str) -> None:
     """Create a Mission record on the Gateway and print its id."""
     try:
-        resp = MissionClient().create(name, parent)
+        resp = MissionClient().create(name)
     except GatewayError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
@@ -224,10 +238,10 @@ def create_mission(name: str, parent: Optional[str]) -> None:
     )
 
 
-def list_missions(json_output: bool) -> None:
-    """List every Mission record on the Gateway."""
+def list_missions(json_output: bool, state: Optional[str] = None) -> None:
+    """List the Missions on the Gateway - active ones unless `state` asks for otherwise."""
     try:
-        missions = MissionClient().list_all()
+        missions = MissionClient().list_all(state=state)
     except GatewayError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
@@ -237,22 +251,115 @@ def list_missions(json_output: bool) -> None:
         return
 
     if not missions:
-        console.print(
-            "No missions on the Gateway yet. Create one with 'cc-devthrottle mission create <name>'."
-        )
+        if state and state != "active":
+            # Say WHICH list is empty. "No missions" under a filter would read as "you have none at
+            # all", which is a different and much more alarming statement.
+            console.print(f"No missions with state '{state}'.")
+        else:
+            console.print(
+                "No active missions on the Gateway. "
+                "Create one with 'cc-devthrottle mission create <name>', "
+                "or see finished ones with 'cc-devthrottle mission list --all'."
+            )
         return
 
     table = Table(show_header=True, header_style="bold", box=box.ASCII)
     table.add_column("Id")
     table.add_column("Name")
-    table.add_column("Parent")
+    table.add_column("State")
+    table.add_column("Why")
 
     for mission in missions:
         mid = _field(mission, "missionId", "MissionId")
         name = _field(mission, "missionName", "MissionName") or "-"
-        parent = _field(mission, "parentMissionId", "ParentMissionId") or "-"
-        table.add_row(_short_id(mid) if mid else "-", name, parent)
+        mstate = _field(mission, "state", "State") or "active"
+        why = _field(mission, "why", "Why") or ""
+        # A mission with no WHY is FLAGGED, not blank - the same rule the Cockpit card follows. A
+        # mission whose reason nobody wrote down is the thing worth noticing in this list.
+        why_cell = why if why else "[yellow]no why set[/yellow]"
+        table.add_row(_short_id(mid) if mid else "-", name, mstate, why_cell)
     console.print(table)
+
+
+def _patch_mission(mission_query: str, body: Dict[str, Any], command_name: str) -> Dict[str, Any]:
+    """Resolve a mission, apply a patch, and surface anything the Gateway had to say about it."""
+    mission = _resolve_mission(mission_query)
+    mission_id = _field(mission, "missionId", "MissionId")
+    if not mission_id:
+        console.print("[red]Error:[/red] the Gateway returned a mission with no id.")
+        raise typer.Exit(1)
+
+    try:
+        resp = MissionClient().patch(mission_id, body)
+    except GatewayError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
+    resp["_before"] = mission
+    return resp
+
+
+def _patched_mission(resp: Dict[str, Any]) -> Dict[str, Any]:
+    inner = resp.get("mission", resp.get("Mission"))
+    return inner if isinstance(inner, dict) else {}
+
+
+def _print_patch_note(resp: Dict[str, Any]) -> None:
+    """Print the Gateway's sentence about anything that happened alongside the change.
+
+    Passed through verbatim, exactly like the attach seat note: what happened to the workflow run is
+    decided at the Gateway, and a client that re-worded it would be writing its own account of a
+    decision it did not make.
+    """
+    note = _field(resp, "note", "Note")
+    if note:
+        console.print(f"[yellow]Note:[/yellow] {note}")
+
+
+def rename_mission(mission_query: str, new_name: str) -> None:
+    """Rename a Mission. Its id does not change, so nothing attached to it moves."""
+    if not new_name.strip():
+        console.print("[red]Error:[/red] a mission name cannot be blank.")
+        raise typer.Exit(1)
+
+    resp = _patch_mission(mission_query, {"missionName": new_name}, "rename")
+    before = _field(resp.get("_before", {}), "missionName", "MissionName") or "(unnamed)"
+    after = _field(_patched_mission(resp), "missionName", "MissionName") or new_name.strip()
+
+    # NAME THE OLD NAME. A rename that reports only the new one hides which mission moved, which is
+    # the same failure the attach command avoids by naming the mission a session LEFT.
+    console.print(f'[green]Renamed[/green] "{before}" to "{after}".')
+    console.print("Its id is unchanged, so every attached session stays attached.")
+    _print_patch_note(resp)
+
+
+def end_mission(mission_query: str, state: str) -> None:
+    """Complete or remove a Mission (both are endings; both are reversible)."""
+    resp = _patch_mission(mission_query, {"state": state}, state)
+    mission = _patched_mission(resp)
+    name = _field(mission, "missionName", "MissionName") or "(unnamed)"
+    mid = _field(mission, "missionId", "MissionId") or ""
+
+    verb = "Completed" if state == "complete" else "Removed"
+    console.print(f"[green]{verb}[/green] mission {name} ({_short_id(mid)}).")
+    _print_patch_note(resp)
+
+    # SAY WHERE IT WENT, and how to get it back. An ending that reports only success leaves the owner
+    # unable to find the record afterwards - and the Cockpit has no archive view yet, so the command
+    # line is currently the ONLY way to see it again.
+    console.print(
+        f"It is out of the default list. See it with 'cc-devthrottle mission list --state {state}', "
+        f"or bring it back with 'cc-devthrottle mission reopen {_short_id(mid)}'."
+    )
+
+
+def reopen_mission(mission_query: str) -> None:
+    """Return an ended Mission to active - the way back from a mistaken ending."""
+    resp = _patch_mission(mission_query, {"state": "active"}, "reopen")
+    mission = _patched_mission(resp)
+    name = _field(mission, "missionName", "MissionName") or "(unnamed)"
+    console.print(f"[green]Reopened[/green] mission {name}. It is back in the default list.")
+    _print_patch_note(resp)
 
 
 # ===== Attach and detach (issue #2387) =====================================================

--- a/tools/cc-devthrottle/tests/test_mission_lifecycle.py
+++ b/tools/cc-devthrottle/tests/test_mission_lifecycle.py
@@ -1,0 +1,194 @@
+"""Tests for `cc-devthrottle mission rename | complete | remove | reopen | list --all` (Phase 3).
+
+These are the verbs that let an AGENT end a body of work, not just the owner from the Cockpit. The
+gap they close is the state the owner actually found the fleet in: eleven missions, several finished
+days earlier, with no way out of the list - because nothing anywhere could end one.
+
+The cases assert the decisions, because each was settled deliberately:
+
+  * a rename NAMES THE OLD NAME, so it is visible WHICH mission moved;
+  * a rename keeps the id, and the message says so - that is why attached sessions do not move;
+  * complete and remove are DIFFERENT ENDINGS, and each says where the record went and how to get
+    it back, because the Cockpit has no archive view yet and this is the only way to see it;
+  * resolution sees ENDED missions, or a completed mission could never be reopened;
+  * the Gateway's note about the workflow run is passed through VERBATIM, never re-worded here.
+
+No HTTP happens: the Gateway calls are stubbed.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import typer
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src import mission_ops  # noqa: E402
+
+
+def flowed(text: str) -> str:
+    """Collapse Rich's wrapping so an assertion is about WORDS, not column width."""
+    return " ".join(text.split())
+
+
+ACTIVE_ID = "aaaaaaaa-1111-2222-3333-444444444444"
+DONE_ID = "cccccccc-5555-6666-7777-888888888888"
+
+ACTIVE = {"missionId": ACTIVE_ID, "missionName": "Release 2.0.0", "state": "active", "why": "ship it"}
+DONE = {"missionId": DONE_ID, "missionName": "Remove the network port", "state": "complete", "why": ""}
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Stub the mission list and the PATCH; record every patch call."""
+    patches = []
+    listed_states = []
+
+    def fake_list_all(self, state=None):
+        listed_states.append(state)
+        # The Gateway's own default is active-only; "all" is what includes an ended mission.
+        return [ACTIVE, DONE] if state == "all" else [ACTIVE]
+
+    def fake_patch(self, mission_id, body):
+        patches.append({"missionId": mission_id, **body})
+        before = ACTIVE if mission_id == ACTIVE_ID else DONE
+        updated = dict(before)
+        if "missionName" in body:
+            updated["missionName"] = body["missionName"].strip()
+        if "state" in body:
+            updated["state"] = body["state"]
+        return {"mission": updated, "note": None, "attachedSessionCount": 0}
+
+    monkeypatch.setattr(mission_ops.MissionClient, "__init__", lambda self, base_url=None: None)
+    monkeypatch.setattr(mission_ops.MissionClient, "list_all", fake_list_all)
+    monkeypatch.setattr(mission_ops.MissionClient, "patch", fake_patch)
+    return {"patches": patches, "listed_states": listed_states}
+
+
+# ---- rename ----------------------------------------------------------------------------------
+
+
+def test_rename_sends_the_new_name_and_reports_the_old_one(wired, capsys):
+    mission_ops.rename_mission(ACTIVE_ID, "  Release 2.0.1  ")
+
+    assert wired["patches"] == [{"missionId": ACTIVE_ID, "missionName": "  Release 2.0.1  "}]
+
+    out = flowed(capsys.readouterr().out)
+    # Both names, so it is visible WHICH mission moved - the same reason attach names what a session left.
+    assert '"Release 2.0.0" to "Release 2.0.1"' in out
+    # And the reassurance that matters: renaming does not detach anything.
+    assert "id is unchanged" in out
+
+
+def test_rename_refuses_a_blank_name_without_calling_the_gateway(wired):
+    with pytest.raises(typer.Exit):
+        mission_ops.rename_mission(ACTIVE_ID, "   ")
+
+    assert wired["patches"] == []
+
+
+# ---- the two endings -------------------------------------------------------------------------
+
+
+def test_complete_sends_complete_and_says_where_the_record_went(wired, capsys):
+    mission_ops.end_mission(ACTIVE_ID, "complete")
+
+    assert wired["patches"] == [{"missionId": ACTIVE_ID, "state": "complete"}]
+
+    out = flowed(capsys.readouterr().out)
+    assert "Completed" in out
+    # An ending that reports only success leaves the owner unable to find the record afterwards.
+    assert "mission list --state complete" in out
+    assert "mission reopen" in out
+
+
+def test_remove_sends_removed_and_is_a_different_ending(wired, capsys):
+    mission_ops.end_mission(ACTIVE_ID, "removed")
+
+    assert wired["patches"] == [{"missionId": ACTIVE_ID, "state": "removed"}]
+
+    out = flowed(capsys.readouterr().out)
+    assert "Removed" in out
+    assert "Completed" not in out
+
+
+def test_reopen_returns_a_mission_to_active(wired, capsys):
+    mission_ops.reopen_mission(DONE_ID)
+
+    assert wired["patches"] == [{"missionId": DONE_ID, "state": "active"}]
+    assert "Reopened" in flowed(capsys.readouterr().out)
+
+
+# ---- resolution has to see ended missions ----------------------------------------------------
+
+
+def test_an_ended_mission_can_still_be_resolved(wired, capsys):
+    """The regression this guards: resolving against the ACTIVE-only list would answer 'no mission
+    matches' for a completed mission that is plainly there - making reopen impossible."""
+    mission_ops.reopen_mission("Remove the network port")
+
+    assert wired["patches"] == [{"missionId": DONE_ID, "state": "active"}]
+    # It asked for every state, not the default.
+    assert "all" in wired["listed_states"]
+
+
+# ---- the Gateway's note is passed through ----------------------------------------------------
+
+
+def test_the_gateways_note_is_printed_verbatim(monkeypatch, capsys):
+    note = "The mission was ended, but its workflow run could not be closed with it."
+
+    monkeypatch.setattr(mission_ops.MissionClient, "__init__", lambda self, base_url=None: None)
+    monkeypatch.setattr(mission_ops.MissionClient, "list_all", lambda self, state=None: [ACTIVE])
+    monkeypatch.setattr(
+        mission_ops.MissionClient, "patch",
+        lambda self, mission_id, body: {"mission": dict(ACTIVE, state="complete"), "note": note},
+    )
+
+    mission_ops.end_mission(ACTIVE_ID, "complete")
+
+    # Verbatim. Only the Gateway knows what happened to the run; a client that re-worded it would be
+    # writing its own account of a decision it did not make.
+    assert note in flowed(capsys.readouterr().out)
+
+
+# ---- listing ---------------------------------------------------------------------------------
+
+
+def test_list_is_active_only_by_default(wired, capsys):
+    mission_ops.list_missions(json_output=False)
+
+    assert wired["listed_states"] == [None]
+    out = flowed(capsys.readouterr().out)
+    assert "Release 2.0.0" in out
+    assert "Remove the network port" not in out
+
+
+def test_list_all_includes_ended_missions(wired, capsys):
+    mission_ops.list_missions(json_output=False, state="all")
+
+    assert wired["listed_states"] == ["all"]
+    out = flowed(capsys.readouterr().out)
+    assert "Release 2.0.0" in out
+    assert "Remove the network port" in out
+
+
+def test_a_mission_with_no_why_is_flagged_not_blank(wired, capsys):
+    mission_ops.list_missions(json_output=False, state="all")
+
+    # The same rule the Cockpit card follows: a mission whose reason nobody wrote down is the thing
+    # worth noticing in this list, so it is flagged rather than shown as an empty cell.
+    assert "no why set" in flowed(capsys.readouterr().out)
+
+
+def test_an_empty_filtered_list_says_which_list_is_empty(monkeypatch, capsys):
+    monkeypatch.setattr(mission_ops.MissionClient, "__init__", lambda self, base_url=None: None)
+    monkeypatch.setattr(mission_ops.MissionClient, "list_all", lambda self, state=None: [])
+
+    mission_ops.list_missions(json_output=False, state="removed")
+
+    # "No missions" under a filter would read as "you have none at all" - a different and much more
+    # alarming statement than the truth.
+    assert "state 'removed'" in flowed(capsys.readouterr().out)

--- a/tools/cc-devthrottle/tests/test_mission_ops.py
+++ b/tools/cc-devthrottle/tests/test_mission_ops.py
@@ -83,7 +83,10 @@ def wired(monkeypatch):
             "previousMissionName": "Voice cleanup",
         }
 
-    monkeypatch.setattr(mission_ops.MissionClient, "list_all", lambda self: list(MISSIONS))
+    # list_all now takes a state filter (missions can be completed or removed); the resolver asks
+    # for "all" so an ended mission can still be renamed or reopened.
+    monkeypatch.setattr(mission_ops.MissionClient, "list_all",
+                        lambda self, state=None: list(MISSIONS))
     monkeypatch.setattr(mission_ops.MissionClient, "__init__", lambda self, base_url=None: None)
     monkeypatch.setattr(session_ops.gateway, "get_fleet", lambda: (list(ROSTER), True, None, None))
     monkeypatch.setattr(session_ops.gateway, "post_json", fake_post_json)
@@ -201,7 +204,10 @@ def test_a_remote_attach_still_reports_the_mission_it_left(monkeypatch, capsys, 
     # about that session, so nothing on the return path knows what the session left. The roster row
     # the caller was just resolved against does, so the move is still visible rather than silently
     # reported as a plain attach.
-    monkeypatch.setattr(mission_ops.MissionClient, "list_all", lambda self: list(MISSIONS))
+    # list_all now takes a state filter (missions can be completed or removed); the resolver asks
+    # for "all" so an ended mission can still be renamed or reopened.
+    monkeypatch.setattr(mission_ops.MissionClient, "list_all",
+                        lambda self, state=None: list(MISSIONS))
     monkeypatch.setattr(mission_ops.MissionClient, "__init__", lambda self, base_url=None: None)
     monkeypatch.setattr(
         session_ops.gateway, "get_fleet",
@@ -231,7 +237,10 @@ def test_a_remote_attach_still_reports_the_mission_it_left(monkeypatch, capsys, 
 
 
 def _wire(monkeypatch, response):
-    monkeypatch.setattr(mission_ops.MissionClient, "list_all", lambda self: list(MISSIONS))
+    # list_all now takes a state filter (missions can be completed or removed); the resolver asks
+    # for "all" so an ended mission can still be renamed or reopened.
+    monkeypatch.setattr(mission_ops.MissionClient, "list_all",
+                        lambda self, state=None: list(MISSIONS))
     monkeypatch.setattr(mission_ops.MissionClient, "__init__", lambda self, base_url=None: None)
     monkeypatch.setattr(session_ops.gateway, "get_fleet", lambda: (list(ROSTER), True, None, None))
     monkeypatch.setattr(


### PR DESCRIPTION
**Found by driving the live Gateway rather than trusting the merge.** `PATCH /missions/{mid}` answered:

```
403 {"code":"session_key_out_of_scope"}
```

Every mission verb just shipped for agents — `rename`, `complete`, `remove`, `reopen` — would have failed for every agent session, on a Gateway that had *just* been deployed with them. The command line was correct, the routes were correct, and nothing could call them.

## Why it happened

A session key could already **create** a mission (`POST /missions`) and **read** one (`GET /missions`, `GET /missions/{mid}`). It could not change one, because the guard's `PATCH` branch only knew about session rename — the mission PATCH route did not exist when that branch was written, and adding the route did not add it here.

## Why this is safe

No wider than what a session key already holds:

- It is the **third verb on the same record** it can already create and read.
- The route resolves the mission **inside the caller's own tenant** and answers 404 for another account's mission, exactly as the read does.
- It is nowhere near the admission surface this guard exists to protect — device enrollment, account identity, Director registration, force-killing a Director.

It sits deliberately beside the session-rename line above it, for the same reason: a mission is the unit of work an agent is on, and an agent that can open one but never end one leaves the mission list growing forever — the state the fleet was actually found in.

## Testing

- `SessionKeyGuardTests`: 144 passed, with `PATCH /missions/m-123` added to the allowed table.
- `SessionKey*` filter: 179 passed.
- Solution builds clean.