### PR TITLE
release: v2.0.2 - a mission can be ended, and agents can call the verbs that end it

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v2.0.2.md
+++ b/docs/public/release-notes/v2.0.2.md
@@ -1,0 +1,56 @@
+# DevThrottle v2.0.2
+
+A small release that finishes the mission lifecycle. Missions could be started but
+never ended, and the fleet was found in exactly that state - eleven missions, several
+of them finished days earlier, with no way out of the list. You can now end one.
+
+## A mission can be ended, renamed, or brought back
+
+A mission is the body of work a session belongs to. Until now nothing anywhere could
+end one, so the list only ever grew, and finished work sat beside live work with no
+way to tell them apart.
+
+Five commands now do the whole lifecycle:
+
+```
+cc-devthrottle mission rename <mission> "<new name>"
+cc-devthrottle mission complete <mission>
+cc-devthrottle mission remove <mission>
+cc-devthrottle mission reopen <mission>
+cc-devthrottle mission list [--all | --state active|complete|removed]
+```
+
+All of them are in the agent-discoverable actions list, not just the help text, so an
+agent that finishes a body of work can find the verb that ends it.
+
+The wording is most of the work here, because these commands are the only surface for
+this until the Cockpit gets an archive view:
+
+- A rename names the old name too, so it is visible which mission moved, and says the
+  identifier is unchanged - because "will this detach my sessions" is the first thing
+  anyone wonders.
+- Ending a mission says where the record went and how to get it back, naming both the
+  list command and `reopen`. There is no other way to see an ended mission yet, so a
+  bare "done" would leave you unable to find it.
+- An empty filtered list says which list is empty. A bare "no missions" under a filter
+  reads as "you have none at all", which is a different and much more alarming thing.
+- A mission with no stated reason for existing is flagged rather than shown as an empty
+  cell, the same rule the Cockpit card follows.
+
+## Your agents can actually use those commands
+
+The commands above reached a service that refused them. Every mission verb answered
+`403` for an agent session, on a service that had just been given the routes: a session
+key could create a mission and read one, but not change one.
+
+An agent may now change a mission it can already create and read. This is no wider than
+what it already held - the mission is resolved inside the caller's own account, and
+another account's mission answers "not found" exactly as a read does.
+
+## Also in this release
+
+- `mission create --parent` is gone. Missions are flat now, and the flag was still
+  sending a parent identifier to a service that no longer has the field.
+- Resolving a mission by name or short identifier now looks at every mission rather than
+  only the active ones. Without that, `reopen` was impossible, and `rename` failed on
+  exactly the missions most likely to need correcting.


### PR DESCRIPTION
Cuts v2.0.2 from the two changes merged after the v2.0.1 tag - #2506 (the mission lifecycle verbs) and #2507 (the permission that made them callable).

## What is in it

- `cc-devthrottle mission rename / complete / remove / reopen`, and a state-filtered `mission list`, all in the agent-discoverable actions list.
- A session key may now change a mission it can already create and read. Every one of the verbs above answered 403 before this.

## What is deliberately NOT in it

Both open pull requests were reviewed by an independent cross-family reviewer for this release and both came back BLOCK. Findings are posted on each:

- #2496 - five defects, the worst being that the add route returns the whole glossary, so a session key reads the dictionary it is refused on GET.
- #2379 - five defects, the worst being that the erasure watermark is judged by read time, so a second Gateway can re-insert derived text after the delete reports success.

Neither belongs in a release. They are held for fixing.

## Gate

Local gate green on the release base (72781cd08): nine projects, 4266 tests, every TRX outcome Completed. The release gate - `.\scripts\test-local.ps1 -Parked -Configuration Release` - runs on merged main at the exact commit to be tagged, before the tag is pushed.

## Accuracy check on the notes

Every claim verified against origin/main, not against the pull request bodies: the five verbs exist in `tools/cc-devthrottle/src/cli.py`, `SessionKeyGuard.cs:245` allows `PATCH /missions/{id}`, `mission create --parent` is gone, and resolution reads `state=all`.