### PR TITLE
The explicit-C collation list acknowledges the two session_keys columns

### DIFF
--- a/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
@@ -129,7 +129,13 @@ public sealed class PostgresProviderProofTests
             "ORDER BY c.relname, a.attname");
 
         // One entry per UseCollation("C") declaration in GatewayDbContext, read back from the live catalog.
-        // 18 declarations, 18 columns - verified one-to-one against the model on 2026-07-31 (#1191).
+        // 20 declarations, 20 columns - verified one-to-one against the model on 2026-08-08.
+        // It went stale a second time between 2026-07-31 and now: the two session_keys columns arrived with
+        // the remove-the-network-port change (#2450) and this list was not updated, so the suite was red on
+        // main from 2026-08-05 and stayed red through the v2.0.0 and v2.0.1 tags. Being environment-gated is
+        // no longer the explanation - this suite runs in the parked gate, which a release is required to run.
+        // The model is the correct side of that disagreement in both cases; this enumeration is the side that
+        // has to be acknowledged, which is exactly what it is for.
         var expected = new[]
         {
             ("account_trials", "subject"),
@@ -142,6 +148,8 @@ public sealed class PostgresProviderProofTests
             ("push_subscriptions", "Endpoint"),
             ("session_history", "SessionId"),
             ("session_history_rollups", "RepoKey"),
+            ("session_keys", "KeyHash"),
+            ("session_keys", "SessionId"),
             ("session_spend", "SessionId"),
             ("skill_tenant_overrides", "SkillId"),
             ("skills", "Id"),


### PR DESCRIPTION
Found by the v2.0.2 release gate, which is the first parked run since the two columns landed.

## The failure

`PostgresProviderProofTests.Collation_ExplicitC_OnExactlyTheDeclaredNaturalKeys_OnRealPostgres` reads the live PostgreSQL catalog for every gateway column carrying an explicit `C` collation and compares it against a hand-maintained enumeration. The catalog returned two the enumeration did not list:

```
Expected: ..., (session_history_rollups, RepoKey), (session_spend, SessionId), ...
Actual:   ..., (session_history_rollups, RepoKey), (session_keys, KeyHash), (session_keys, SessionId), (session_spend, SessionId), ...
```

The model declares 20 `UseCollation("C")` columns; the list enumerated 18. The `session_keys` pair arrived with #2450 on 2026-08-05, which means the Gateway suite has been red on main since that day - **through the v2.0.0 and v2.0.1 tags**. The test's own comment warned this list had gone stale once before (#1191) and blamed being environment-gated; that excuse is spent, because this suite is in the parked gate a release is required to run.

## The resolution

The model is the correct side of the disagreement. `session_keys.KeyHash` is the authentication lookup: if Postgres collated it by locale rather than byte, two different hashes could compare equal - a refused registration on the unique index, or the wrong session authenticated on a read. #2450 declared it deliberately and for that reason. The enumeration is the side that has to acknowledge it, which is what the enumeration is for.

## Proof, in both directions, same tree, Release configuration

- Unchanged list: `Failed: 1, Passed: 2280, Skipped: 4, Total: 2285` - the failure naming exactly those two columns.
- Corrected list: `Passed: 1` on the same test.

The first half matters as much as the second: the check was run against a known-bad input and did fail, so the pass is a pass and not an empty instrument.

## Review

Reviewed by an independent cross-family reviewer, asked specifically whether adding the entries papers over a genuine model-versus-database defect. VERDICT: CLEAN - the declarations are correct, the ordering matches the query's ORDER BY, and the comment is consistent.