### PR TITLE
The mission lifecycle tests assert on words, not on Rich's colour

### DIFF
--- a/tools/cc-devthrottle/tests/test_mission_lifecycle.py
+++ b/tools/cc-devthrottle/tests/test_mission_lifecycle.py
@@ -16,6 +16,7 @@ The cases assert the decisions, because each was settled deliberately:
 No HTTP happens: the Gateway calls are stubbed.
 """
 
+import re
 import sys
 from pathlib import Path
 
@@ -27,10 +28,21 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from src import mission_ops  # noqa: E402
 
+# Rich emits colour when its console decides the destination can take it, and that decision differs
+# between a developer's machine and continuous integration. The escapes land INSIDE the sentences
+# asserted on here, so a substring a reader plainly sees on screen is absent from the captured
+# string. That is what made these three tests pass locally and fail in continuous integration.
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
 
 def flowed(text: str) -> str:
-    """Collapse Rich's wrapping so an assertion is about WORDS, not column width."""
-    return " ".join(text.split())
+    """Strip Rich's colour and collapse its wrapping, so an assertion is about WORDS.
+
+    Two pieces of presentation come out, for one reason: neither is the message. Colour varies with
+    where the output is going and the wrap column varies with console width, so an assertion that
+    fails on either is testing the terminal rather than what was said.
+    """
+    return " ".join(ANSI.sub("", text).split())
 
 
 ACTIVE_ID = "aaaaaaaa-1111-2222-3333-444444444444"


### PR DESCRIPTION
Main is red in the Tool contracts (Python) job, and has been since the mission lifecycle verbs merged (#2506). This is the fix.

## The failure

```
FAILED tests/test_mission_lifecycle.py::test_rename_sends_the_new_name_and_reports_the_old_one
FAILED tests/test_mission_lifecycle.py::test_complete_sends_complete_and_says_where_the_record_went
FAILED tests/test_mission_lifecycle.py::test_an_empty_filtered_list_says_which_list_is_empty
3 failed, 240 passed
```

All three for one reason - Rich colours its output when it judges the destination can take it, that judgement differs between a developer's console and a continuous integration runner, and the escape sequences land INSIDE the sentence being asserted on:

```
assert "state 'removed'" in "No missions with state \x1b[32m'removed'\x1b[0m."
```

The words are all there on screen. The substring is not in the captured string.

## The fix

These assertions already go through a `flowed` helper whose whole job is removing presentation that is not the message - it collapsed Rich's line wrapping, for exactly the reason that a wrap column is the terminal's business and not the sentence's. Colour is the same kind of noise, so it comes out in the same place. One change fixes all three.

## Proof, both directions, colour forced on

- Pristine file from main: `3 failed, 8 passed` - the same three tests with the same messages, so the local run reproduces what continuous integration saw rather than guessing at it.
- With the fix: `11 passed`.
- Whole toolbelt suite: `243 passed` with colour forced, `243 passed` without.

## Why this reached main

The local gate runs no Python tests at all, so this job is the only place these run. That is working as designed - the trade is merge on local green and chase the red afterwards - and this is the chase.