### PR TITLE
mobile: sign out, an entry point from the Cockpit, and two accounts on one phone

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -97,6 +97,11 @@ const DOCS_URL = "https://devthrottle.com/docs";
 // /injected-text route still resolves, as a redirect into that tab, so existing bookmarks keep working.
 const NAV_FOOT: ReadonlyArray<NavItem> = [
   { to: "/account", label: "Account", icon: "account" },
+  // Phone (devthrottle_internal #1508): how to get DevThrottle onto a phone. It sits beside Account
+  // because it is about THIS PERSON'S devices rather than about the fleet. A ROUTE, not an external
+  // link: the job is reaching a DIFFERENT device, and a link would only open the narrow layout in this
+  // desktop browser - the one thing that does not help.
+  { to: "/phone", label: "Phone", icon: "phone" },
   { to: "/your-throttle", label: "Your Throttle", icon: "throttle" },
   { to: "/settings", label: "Settings", icon: "settings" },
   { to: "/about", label: "About", icon: "about" },

--- a/apps/cockpit/src/account/AccountView.tsx
+++ b/apps/cockpit/src/account/AccountView.tsx
@@ -10,6 +10,8 @@ import {
   type AccountDevicesResponse,
 } from "@devthrottle/client-core/account/accountClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { AccountsPanel } from "@devthrottle/client-core/auth/AccountsPanel";
+import { useNavigate } from "react-router-dom";
 import { ErrorBanner, LoadingState, PageHeader } from "../components";
 
 // The Account page (issue #978, epic #967) - the React port of the Blazor Cockpit Account.razor
@@ -171,6 +173,11 @@ export function AccountView() {
     beginSignIn();
   };
 
+  // Adding an account to THIS BROWSER is the shared enrollment flow at the Cockpit's own /signin route,
+  // which is a different journey from signing the GATEWAY in above (beginSignIn). client-core must not
+  // hardcode either shell's route, so the shell supplies its own.
+  const navigate = useNavigate();
+
   return (
     <div className="page acct">
       <PageHeader
@@ -180,6 +187,19 @@ export function AccountView() {
           "account. The credential lives on the Gateway; this page never sees the raw token."
         }
       />
+
+      {/* THIS BROWSER's signed-in accounts (devthrottle_internal #1507/#1509) - the same shared panel
+          the phone's Account screen mounts, so the two surfaces cannot drift (rule 8).
+          It sits ABOVE the Gateway credential because the two are easy to confuse and only one of them
+          is about the machine you are sitting at: signing out HERE means this browser forgets its key,
+          while "Log out" further down clears the GATEWAY's own link to a DevThrottle account. Two
+          different actions on two different things, so they are kept apart and worded apart. */}
+      <section className="acct-browser" aria-label="Accounts signed in on this browser">
+        <h2>Signed in on this browser</h2>
+        <AccountsPanel onAddAccount={() => navigate("/signin")} />
+      </section>
+
+      <h2 className="acct-gateway-head">This Gateway's account</h2>
 
       {error !== null ? (
         <ErrorBanner

--- a/apps/cockpit/src/account/account.css
+++ b/apps/cockpit/src/account/account.css
@@ -324,3 +324,24 @@
   border-radius: 6px;
   font-size: 13px;
 }
+
+/* This browser's own signed-in accounts (devthrottle_internal #1507/#1509). Its cards come from the
+   shared stylesheet (client-core/auth/accounts.css); this is only the Cockpit's frame around them, and
+   the heading that separates them from the Gateway credential below - two different things that both
+   answer to the word "account", so the page names each one. */
+.acct-browser {
+  margin-top: 18px;
+  max-width: 520px;
+}
+.acct-browser h2 {
+  margin: 0 0 10px;
+  font-size: 15px;
+  font-weight: 600;
+}
+.acct-gateway-head {
+  margin: 26px 0 12px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border, #2a3242);
+  font-size: 15px;
+  font-weight: 600;
+}

--- a/apps/cockpit/src/components/NavIcon.tsx
+++ b/apps/cockpit/src/components/NavIcon.tsx
@@ -27,6 +27,7 @@ export type NavIconName =
   | "transcription"
   | "network"
   | "account"
+  | "phone"
   | "throttle"
   | "settings"
   | "injected-text"
@@ -140,6 +141,15 @@ const PAINT: Record<NavIconName, JSX.Element> = {
     <>
       <circle cx="12" cy="7" r="4" />
       <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+    </>
+  ),
+  // A handset: getting DevThrottle onto your phone. A tall rounded rectangle with a home bar, which is
+  // the one silhouette in this set that is taller than it is wide - so it is found by outline alone,
+  // even sitting between the person-shape of Account and the gauge of Your Throttle.
+  phone: (
+    <>
+      <rect x="7" y="2" width="10" height="20" rx="2" />
+      <path d="M10.5 18h3" />
     </>
   ),
   // A gauge: your throttle.

--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -29,6 +29,7 @@ import { YourThrottleView } from "./throttle/YourThrottleView";
 import { TranscriptionHealthView } from "./transcription/TranscriptionHealthView";
 import { NetworkDiagnosticsView } from "./network/NetworkDiagnosticsView";
 import { AccountView } from "./account/AccountView";
+import { PhoneView } from "./phone/PhoneView";
 import { AboutView } from "./about/AboutView";
 import { SettingsView } from "./settings/SettingsView";
 import "./styles.css";
@@ -207,6 +208,9 @@ const router = createBrowserRouter(
             { path: "/transcription", element: <TranscriptionHealthView /> },
             { path: "/network", element: <NetworkDiagnosticsView /> },
             { path: "/account", element: <AccountView /> },
+            // Phone (devthrottle_internal #1508): the scannable code, the address, and how to install the
+            // mobile app - the entry point the Cockpit did not have.
+            { path: "/phone", element: <PhoneView /> },
             { path: "/about", element: <AboutView /> },
             // The Settings page (issue #1025): a real React port of the retired Blazor
             // wwwroot/pages/settings.html (the "This machine" gateway-connection tab + the "AI"

--- a/apps/cockpit/src/phone/PhoneView.tsx
+++ b/apps/cockpit/src/phone/PhoneView.tsx
@@ -1,0 +1,107 @@
+// The Phone page (devthrottle_internal #1508): how you get DevThrottle onto your phone.
+//
+// Nothing in the Cockpit used to point at the mobile app. Every other destination was in the rail, but
+// the app a person actually wants on their phone was reachable only by already knowing the address and
+// typing it in - so in practice it was not reachable at all.
+//
+// This is a PAGE rather than a link, because the job is getting the app onto a DIFFERENT device. A link
+// would open the narrow layout in this desktop browser, which is the one thing nobody wanted. So it
+// offers the three ways across the gap - scan it, copy it, or open it here - and says how to install it
+// once it is there.
+import { useEffect, useState } from "react";
+import { PageHeader } from "../components";
+import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { getMobileQrPng, mobileAppUrl } from "@devthrottle/client-core/account/mobileEntry";
+import "./phone.css";
+
+export function PhoneView() {
+  const url = mobileAppUrl();
+  const [qr, setQr] = useState<string | null>(null);
+  // The Gateway's OWN sentence for why there is no code, rendered verbatim. The one case that actually
+  // happens is a Cockpit opened on localhost, where a code would encode an address no phone can reach;
+  // the Gateway refuses rather than rendering one, and says which address it saw.
+  const [qrProblem, setQrProblem] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let objectUrl: string | null = null;
+
+    getMobileQrPng(controller.signal)
+      .then((blob) => {
+        if (controller.signal.aborted) return;
+        objectUrl = URL.createObjectURL(blob);
+        setQr(objectUrl);
+        setQrProblem(null);
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) setQrProblem(gatewayErrorMessage(err));
+      });
+
+    return () => {
+      controller.abort();
+      if (objectUrl !== null) URL.revokeObjectURL(objectUrl);
+    };
+  }, []);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard access denied (an insecure origin, or the permission refused). The address is on
+      // screen and selectable either way, so say nothing was copied rather than claiming it was.
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className="page phone-page">
+      <PageHeader
+        title="Phone"
+        subtitle="Open DevThrottle on your phone - the same fleet, sized for one hand."
+      />
+
+      <section className="phone-card" aria-label="Scan to open on your phone">
+        <h2>Scan this with your phone camera</h2>
+        {qr !== null && <img className="phone-qr" src={qr} alt={`Scannable code for ${url}`} />}
+        {qr === null && qrProblem === null && <div className="phone-qr-pending">Loading...</div>}
+        {qrProblem !== null && (
+          <p className="phone-qr-problem" role="status">
+            {qrProblem}
+          </p>
+        )}
+        <p className="phone-note">
+          Your phone opens the address below. It has to be on a network that can reach this Gateway.
+        </p>
+      </section>
+
+      <section className="phone-card" aria-label="The address">
+        <h2>Or type it in</h2>
+        <div className="phone-url-row">
+          <code className="phone-url">{url}</code>
+          <button type="button" className="phone-btn" onClick={() => void copy()}>
+            {copied ? "Copied" : "Copy link"}
+          </button>
+        </div>
+        <a className="phone-btn phone-btn-wide" href={url}>
+          Open the mobile view in this browser
+        </a>
+      </section>
+
+      <section className="phone-card" aria-label="Installing it">
+        <h2>Install it as an app</h2>
+        <p className="phone-note">
+          Once it is open on the phone, add it to the home screen - "Add to Home Screen" on iPhone,
+          "Install app" on Android. It then opens full screen with no browser bars, keeps you signed in,
+          and can record and send voice from the lock screen.
+        </p>
+        <p className="phone-note">
+          You sign the phone in once, on devthrottle.com. It can hold more than one account, and you
+          switch between them from the phone's own Account screen.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/cockpit/src/phone/phone.css
+++ b/apps/cockpit/src/phone/phone.css
@@ -1,0 +1,105 @@
+/* The Phone page (devthrottle_internal #1508). Narrow measure on purpose: the whole page is three short
+   instructions and a code to scan, and stretching that across a wide monitor would make it look like
+   more work than it is. */
+
+.phone-page {
+  max-width: 620px;
+}
+
+.phone-card {
+  margin-top: 1rem;
+  padding: 1.1rem 1.25rem;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.14));
+  border-radius: 12px;
+  background: var(--surface, rgba(255, 255, 255, 0.03));
+}
+
+.phone-card h2 {
+  margin: 0 0 0.85rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+/* White plate behind the code, always - a QR is read as dark-on-light, and a dark theme painting the
+   transparent PNG onto a dark surface produces a code that will not scan. */
+.phone-qr {
+  display: block;
+  width: 200px;
+  height: 200px;
+  padding: 10px;
+  border-radius: 8px;
+  background: #ffffff;
+  image-rendering: pixelated;
+}
+
+.phone-qr-pending {
+  width: 200px;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--border, rgba(255, 255, 255, 0.2));
+  border-radius: 8px;
+  opacity: 0.6;
+  font-size: 0.85rem;
+}
+
+.phone-qr-problem {
+  margin: 0;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(234, 179, 8, 0.5);
+  border-radius: 8px;
+  background: rgba(234, 179, 8, 0.1);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.phone-note {
+  margin: 0.85rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  opacity: 0.75;
+}
+
+.phone-url-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.phone-url {
+  flex: 1 1 14rem;
+  min-width: 0;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.14));
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.85rem;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.phone-btn {
+  padding: 0.6rem 0.9rem;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.2));
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  text-align: center;
+  cursor: pointer;
+}
+
+.phone-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.phone-btn-wide {
+  display: block;
+  margin-top: 0.75rem;
+}

--- a/apps/mobile/src/components/NavDrawer.tsx
+++ b/apps/mobile/src/components/NavDrawer.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { useAccounts } from "@devthrottle/client-core/auth/useAccounts";
 
 // The hamburger menu button + slide-in nav drawer for the mobile app-bar. Self-contained: it owns its
 // open/closed state and renders the drawer plus a dimming overlay as a fixed layer above the page.
@@ -8,6 +9,7 @@ import { Link } from "react-router-dom";
 export function NavDrawer() {
   const [open, setOpen] = useState(false);
   const close = () => setOpen(false);
+  const { active, many } = useAccounts();
 
   return (
     <>
@@ -26,6 +28,19 @@ export function NavDrawer() {
                 x
               </button>
             </div>
+            {/* WHO IS SIGNED IN, at the top of the menu (devthrottle_internal #1509). With two accounts
+                on one phone the fleet you are looking at is no longer obvious, and the menu is where you
+                are already heading when you want to change something about it. It is a LINK to the
+                Account screen rather than an inline switcher: switching reloads the whole app, so it
+                belongs behind a deliberate tap on a screen that says so, not on a menu row a thumb
+                brushes past on the way to Sessions. */}
+            {active && (
+              <Link className="drawer-account" to="/account" onClick={close}>
+                <span className="drawer-account-label">{active.label}</span>
+                <span className="drawer-account-sub">{many ? "Switch account" : "Signed in"}</span>
+              </Link>
+            )}
+
             <Link className="drawer-item" to="/" onClick={close}>
               Sessions
             </Link>
@@ -45,6 +60,12 @@ export function NavDrawer() {
               Repos
             </Link>
             <div className="drawer-sep" />
+            {/* Account sits with Settings and About - the destinations about the app and this phone
+                rather than about the fleet - and mirrors the Cockpit's own Account rail item, which the
+                phone had no counterpart for at all. */}
+            <Link className="drawer-item" to="/account" onClick={close}>
+              Account
+            </Link>
             {/* One Settings item, not three. "Test microphone" and "Test transcription" were menu
                 entries of their own while they were screens of their own; they are cards on the
                 Transcription tab now, alongside the transcription model and the background microphone
@@ -57,6 +78,15 @@ export function NavDrawer() {
             </Link>
             <Link className="drawer-item" to="/about" onClick={close}>
               About
+            </Link>
+            {/* Sign out, reachable in one tap from any screen, because the menu is the only thing on
+                every screen. It LINKS to the Account screen instead of signing out where it stands:
+                this row sits directly beneath three ordinary navigation rows, and a mis-tap that ends
+                the session is not one you can take back without another round trip through
+                devthrottle.com. The confirmation is on the Account screen, one tap further. */}
+            <div className="drawer-sep" />
+            <Link className="drawer-item drawer-item-signout" to="/account" onClick={close}>
+              Sign out
             </Link>
           </nav>
         </div>

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -14,6 +14,7 @@ import { About } from "./pages/About";
 import { Diagnostics } from "./pages/Diagnostics";
 import { YourThrottle } from "./pages/YourThrottle";
 import { Repos } from "./pages/Repos";
+import { Account } from "./pages/Account";
 import { SignIn } from "@devthrottle/client-core/auth/SignIn";
 import { DeviceCallback } from "@devthrottle/client-core/auth/DeviceCallback";
 import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
@@ -184,6 +185,10 @@ const router = createBrowserRouter(
             { path: "/recorder", element: <Recorder /> },
             { path: "/notes", element: <Navigate to="/recorder" replace /> },
             { path: "/record", element: <Navigate to="/recorder" replace /> },
+            // Account (devthrottle_internal #1507/#1509): who is signed in on this phone, switching
+            // between logins, adding one, and signing out. Mirrors the Cockpit's Account destination -
+            // the phone had none, which is why it had no way to sign out either.
+            { path: "/account", element: <Account /> },
             { path: "/about", element: <About /> },
             // Diagnostics (auto-network-switching mission): a phone-side connection tester - route
             // (direct LAN vs Tailscale relay), latency, and download/upload throughput, with a verdict.

--- a/apps/mobile/src/pages/Account.tsx
+++ b/apps/mobile/src/pages/Account.tsx
@@ -1,0 +1,28 @@
+// The phone's Account screen (devthrottle_internal #1507, #1509). Until this existed the mobile app
+// had no account destination at all and no way to sign out: the only ways off a signed-in phone were
+// clearing browser storage by hand or revoking the device on devthrottle.com.
+//
+// The screen is a FRAME, not a page: everything inside it is the shared AccountsPanel the desktop
+// Cockpit mounts too, so the two surfaces cannot drift (CLAUDE.md rule 8). The phone supplies the back
+// link, the app bar, and the route that "Add account" leads to.
+import { Link, useNavigate } from "react-router-dom";
+import { AccountsPanel } from "@devthrottle/client-core/auth/AccountsPanel";
+
+export function Account() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="screen">
+      <header className="app-bar">
+        <Link className="back-link" to="/">
+          Back
+        </Link>
+        <h1>Account</h1>
+      </header>
+
+      <section className="account-screen" aria-label="Accounts on this phone">
+        <AccountsPanel onAddAccount={() => navigate("/signin")} />
+      </section>
+    </div>
+  );
+}

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import { playClip, playingSid, rowVoiceInputs, stopPlayback, syncVoiceSessions, 
 import { voiceRowState } from "@devthrottle/client-core/voice/voiceRowState";
 import { voiceQueueFor } from "@devthrottle/client-core/voice/voiceQueue";
 import { NavDrawer } from "../components/NavDrawer";
+import { AccountSwitcher } from "@devthrottle/client-core/auth/AccountSwitcher";
 import { SessionFilterPanel } from "../components/SessionFilterPanel";
 import { useSessionFilter } from "../hooks/useSessionFilter";
 import {
@@ -251,6 +252,11 @@ export function Home() {
       <header className="app-bar">
         <NavDrawer />
         <h1>DevThrottle</h1>
+        {/* Which account's fleet this roster belongs to (devthrottle_internal #1509). Renders NOTHING
+            until a second account is enrolled, so a single-login phone sees the bar it always had. It
+            is on the roster specifically: this is the screen that shows a list of sessions, and a list
+            of the wrong account's sessions is indistinguishable from a list of yours. */}
+        <AccountSwitcher onOpen={() => navigate("/account")} />
         {/* The spacer pushes the filter button to the right end of the bar. It used to be two spacers
             with the network status pill centred between them; the pill is gone (see ConnectionBanner). */}
         <div className="app-bar-spacer" />

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2993,6 +2993,55 @@ a.banner-btn {
   background: var(--border);
   margin: 6px 0;
 }
+/* The signed-in identity at the top of the menu (devthrottle_internal #1509). Set apart from the
+   navigation rows beneath it - it answers "who am I", not "where do I go" - and given its own surface
+   so a thumb heading for Sessions does not land on it. */
+.drawer-account {
+  display: block;
+  margin: 4px 12px 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-2);
+  color: var(--text);
+  text-decoration: none;
+}
+.drawer-account:active {
+  background: var(--surface);
+}
+.drawer-account-label {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.drawer-account-sub {
+  display: block;
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 1px;
+}
+/* Sign out is the one menu row that ends something. Dimmed rather than red: it is an everyday action
+   sitting under three ordinary ones, and a red row at the foot of a menu reads as an error state. */
+.drawer-item-signout {
+  color: var(--text-dim);
+}
+
+/* ===== Account screen =====
+   The account CARDS are shared with the Cockpit and carry their own stylesheet
+   (client-core/auth/accounts.css). This is only the phone's frame and touch re-tuning. */
+.account-screen {
+  padding: 14px;
+}
+.account-screen .accts-item {
+  padding: 14px 16px;
+}
+.account-screen .accts-btn {
+  padding: 14px 16px;
+  font-size: 15px;
+}
 
 /* ===== Settings screen =====
    The Settings CARDS are shared with the Cockpit and carry their own stylesheet

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -7,6 +7,8 @@
   "exports": {
     "./auth/SignIn": "./src/auth/SignIn.tsx",
     "./auth/DeviceCallback": "./src/auth/DeviceCallback.tsx",
+    "./auth/AccountsPanel": "./src/auth/AccountsPanel.tsx",
+    "./auth/AccountSwitcher": "./src/auth/AccountSwitcher.tsx",
     "./dictation/DictationDialog": "./src/dictation/DictationDialog.tsx",
     "./dictation/DictationStatusStrip": "./src/dictation/DictationStatusStrip.tsx",
     "./dictation/MicTestPanel": "./src/dictation/MicTestPanel.tsx",

--- a/packages/client-core/src/account/accountClient.ts
+++ b/packages/client-core/src/account/accountClient.ts
@@ -82,6 +82,40 @@ export async function getAccountStatus(signal?: AbortSignal): Promise<AccountSta
   };
 }
 
+/**
+ * GET /account/status authenticated with a SPECIFIC device key instead of the active one
+ * (devthrottle_internal #1509). Used at the end of enrollment to learn which account the key that was
+ * just minted belongs to, so the account switcher labels it with the person's email rather than
+ * "Account 2" - at that moment the new key is not the active one yet, so authHeaders() would ask about
+ * the wrong account.
+ *
+ * On a HOSTED Gateway this answers about the CALLER, folded from the tenant that device key is bound to
+ * (AccountStatusEndpoint.HostedStatus), which is precisely the identity wanted here. On a self-host
+ * Gateway it answers about the Gateway's own single account - the same account by definition there.
+ *
+ * Returns null rather than throwing. A label is a nicety and the enrollment has ALREADY SUCCEEDED by
+ * the time this runs, so a Gateway that cannot resolve an identity must not turn a completed sign-in
+ * into a failure; the account is stored under its positional name and can be renamed.
+ */
+export async function getAccountStatusForKey(deviceKey: string, signal?: AbortSignal): Promise<AccountStatus | null> {
+  try {
+    const res = await fetch("/account/status", {
+      method: "GET",
+      headers: { Accept: "application/json", Authorization: `Bearer ${deviceKey}` },
+      signal,
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as Partial<AccountStatus> | null;
+    return {
+      signedIn: Boolean(body?.signedIn),
+      email: body?.email ?? null,
+      provider: body?.provider ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
 // POST /account/logout - clear the Gateway credential. Returns the post-logout status the Gateway
 // echoes back (signed-out) so the page confirms without a second round-trip. Throws with the server
 // error on failure.

--- a/packages/client-core/src/account/mobileEntry.ts
+++ b/packages/client-core/src/account/mobileEntry.ts
@@ -1,0 +1,45 @@
+// The mobile app's address on this Gateway, and the scannable code for it (devthrottle_internal #1508).
+//
+// Both live in client-core rather than in the Cockpit because they describe the PRODUCT's shape - where
+// the mobile app is served - not one shell's layout, and the mobile app itself may one day want to show
+// the same code to hand the app to a second phone.
+import { authHeaders, GatewayError } from "../api/client";
+
+/** The path the Gateway serves the mobile app at. The old /m mount is 301-redirected to it. */
+export const MOBILE_APP_PATH = "/mobile";
+
+/**
+ * The absolute address of the mobile app on the Gateway this browser is talking to. Built from the
+ * browser's OWN origin, which is the address the person reached the Cockpit on and therefore the one
+ * their phone has to reach too - never a configured hostname that may name a different route in.
+ */
+export function mobileAppUrl(): string {
+  return `${window.location.origin}${MOBILE_APP_PATH}`;
+}
+
+/**
+ * The scannable code for that address, rendered by the Gateway (GET /account/mobile-qr.png).
+ *
+ * @throws GatewayError carrying the Gateway's own sentence. The case that actually happens is a Cockpit
+ *   opened on localhost: a code encoding an address only this machine can reach would scan perfectly and
+ *   then time out on the phone, so the Gateway refuses to render one and says which address it saw. The
+ *   page shows that sentence instead of a code that cannot work.
+ */
+export async function getMobileQrPng(signal?: AbortSignal): Promise<Blob> {
+  const res = await fetch(`/account/mobile-qr.png`, {
+    method: "GET",
+    headers: { ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) {
+    let detail = `${res.status}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body?.error) detail = body.error;
+    } catch {
+      /* not a JSON body - keep the status code */
+    }
+    throw new GatewayError(res.status, detail);
+  }
+  return res.blob();
+}

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -172,6 +172,19 @@ export function ensureGatewayCookie(): void {
   document.cookie = `cc-gateway-token=${encodeURIComponent(token)}; path=/; SameSite=Lax; Max-Age=${oneYearSeconds}`;
 }
 
+// Drop the mirrored cookie when the last account signs out (devthrottle_internal #1507). The cookie is
+// PERSISTENT (Max-Age one year), so without this a signed-out browser keeps a working credential on
+// disk for the cookie-authenticated resource loads - the terminal stream and the bare <img>/<iframe>
+// sources - long after the key it mirrors has been forgotten from storage. Signing out has to take the
+// credential with it everywhere it was put, not just where it was read from.
+//
+// Switching accounts does NOT call this: ensureGatewayCookie overwrites the same name and path with the
+// newly active account's key.
+export function clearGatewayCookie(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = "cc-gateway-token=; path=/; SameSite=Lax; Max-Age=0";
+}
+
 // The redirect target when a credentialed call is rejected (401) mid-session is SHELL-AWARE, because
 // the two shells that share this client re-gate through sign-in entries at different paths: the
 // mobile PWA's enrollment screen lives at /mobile/signin, the desktop Cockpit's at /signin. Shared
@@ -223,6 +236,19 @@ export function resolveSignInTarget(current: SignInLocation): string {
 function onUnauthorized(): void {
   clearDeviceKey();
   if (typeof window === "undefined") return;
+
+  // A revoke takes out ONE account, not the browser (devthrottle_internal #1509). When another account
+  // is still enrolled here, clearDeviceKey has already made it the active one, so the honest landing is
+  // that account's app - re-mirror its key into the cookie and reload in place. Sending a person who
+  // still holds a working login to the sign-in screen would read as "you have been signed out" when
+  // they have not been.
+  if (getDeviceKey()) {
+    ensureGatewayCookie();
+    window.location.reload();
+    return;
+  }
+
+  clearGatewayCookie();
   const target = resolveSignInTarget({
     pathname: window.location.pathname,
     search: window.location.search,

--- a/packages/client-core/src/auth/AccountSwitcher.tsx
+++ b/packages/client-core/src/auth/AccountSwitcher.tsx
@@ -1,0 +1,34 @@
+// The "who am I" chip (devthrottle_internal #1509) - the compact identity marker both shells put in
+// reach of the work, as opposed to the full AccountsPanel which is a destination.
+//
+// It renders NOTHING until this browser holds more than one account. A single-login browser has no
+// question to answer, and a chip that always says the same thing is noise you learn to stop reading -
+// which is exactly the moment it stops protecting you. The chip exists for one specific mistake: with
+// two fleets on one phone, a message typed into what looks like the work fleet and sent to the personal
+// one. So it appears precisely when that mistake becomes possible.
+import { useAccounts } from "./useAccounts";
+import "./accounts.css";
+
+export interface AccountSwitcherProps {
+  /** Open the Accounts screen, where switching actually happens. Routed by the shell. */
+  onOpen: () => void;
+  /** Extra class from the shell, for its own placement (the app bar, the menu header). */
+  className?: string;
+}
+
+export function AccountSwitcher({ onOpen, className }: AccountSwitcherProps) {
+  const { active, many } = useAccounts();
+  if (!many || !active) return null;
+
+  return (
+    <button
+      type="button"
+      className={`accts-chip${className ? ` ${className}` : ""}`}
+      onClick={onOpen}
+      aria-label={`Signed in as ${active.label}. Switch account.`}
+    >
+      <span className="accts-chip-label">{active.label}</span>
+      <span className="accts-chip-caret" aria-hidden="true">v</span>
+    </button>
+  );
+}

--- a/packages/client-core/src/auth/AccountsPanel.test.tsx
+++ b/packages/client-core/src/auth/AccountsPanel.test.tsx
@@ -1,0 +1,164 @@
+// The Accounts panel (devthrottle_internal #1507, #1509) - the screen that finally gives the mobile app
+// a way to sign out, and both surfaces a way to switch between two logins.
+//
+// What these actually guard: that a sign-out is never one tap (the whole reason the menu row links here
+// instead of acting), that the confirmation SAYS which of the two outcomes will happen, and that the
+// panel is honest about a browser holding no account at all.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { AccountsPanel } from "./AccountsPanel";
+import { addAccount, removeAllAccounts } from "./accountStore";
+
+// accountActions ends every path in a hard navigation, which jsdom cannot perform. Stubbing the module
+// keeps these tests about the PANEL - what it offers and what it says - and leaves where it navigates to
+// accountActions itself.
+const switchAccount = vi.fn();
+const signOutAccount = vi.fn();
+const signOutAllAccounts = vi.fn();
+vi.mock("./accountActions", () => ({
+  switchAccount: (id: string) => switchAccount(id),
+  signOutAccount: (id: string) => signOutAccount(id),
+  signOutAllAccounts: () => signOutAllAccounts(),
+}));
+
+let uuidCounter = 0;
+beforeEach(() => {
+  vi.clearAllMocks();
+  uuidCounter = 0;
+  vi.stubGlobal("crypto", { randomUUID: () => `id-${++uuidCounter}` });
+  localStorage.clear();
+  removeAllAccounts();
+});
+
+// This library installs no global testing-library setup, so each rendering test unmounts its own tree -
+// without it the previous test's panel is still in the document and every query matches twice.
+afterEach(cleanup);
+
+describe("a browser with no account", () => {
+  it("says so, and offers to sign in rather than showing an empty list", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    expect(screen.getByText(/not signed in to any account/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeTruthy();
+  });
+});
+
+describe("a browser with one account", () => {
+  beforeEach(() => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: "personal@example.com" });
+  });
+
+  it("names the account and marks it as the one in use", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    expect(screen.getByText("personal@example.com")).toBeTruthy();
+    expect(screen.getByText("Signed in now")).toBeTruthy();
+  });
+
+  it("offers Add account and a sign-out that names the account", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    expect(screen.getByRole("button", { name: "Add account" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Sign out of personal@example.com/ })).toBeTruthy();
+  });
+
+  it("does NOT offer sign out of all - there is only one", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    expect(screen.queryByRole("button", { name: /all accounts/i })).toBeNull();
+  });
+
+  it("NEVER signs out on the first tap - it asks first", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Sign out of personal@example.com/ }));
+
+    expect(signOutAccount).not.toHaveBeenCalled();
+    expect(screen.getByText(/You will need to sign in through devthrottle.com/i)).toBeTruthy();
+  });
+
+  it("signs out on the confirmation, and can be backed out of", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Sign out of personal@example.com/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(signOutAccount).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Sign out of personal@example.com/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    expect(signOutAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("hands Add account back to the shell, which owns the sign-in route", () => {
+    const onAddAccount = vi.fn();
+    render(<AccountsPanel onAddAccount={onAddAccount} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add account" }));
+
+    expect(onAddAccount).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("a browser with two accounts", () => {
+  beforeEach(() => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: "personal@example.com" });
+    addAccount({ deviceKey: "k2", installId: "i2", email: "work@example.com" });
+  });
+
+  it("lists both, with the newest one active", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    expect(screen.getByText("personal@example.com")).toBeTruthy();
+    expect(screen.getByText("work@example.com")).toBeTruthy();
+    expect(screen.getByText("Signed in now")).toBeTruthy();
+  });
+
+  it("switches to the other account on a tap", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    fireEvent.click(screen.getByText("personal@example.com"));
+
+    expect(switchAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("cannot switch to the account already in use", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    fireEvent.click(screen.getByText("work@example.com"));
+
+    expect(switchAccount).not.toHaveBeenCalled();
+  });
+
+  it("says switching needs no password and no connection, because that is not obvious", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    expect(screen.getByText(/works with no connection/i)).toBeTruthy();
+  });
+
+  it("promises the OTHER account survives - the outcome that differs from a single-login sign-out", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Sign out of work@example.com/ }));
+
+    expect(screen.getByText(/You stay signed in to your other account/i)).toBeTruthy();
+  });
+
+  it("offers signing out of all of them, and warns that each needs signing in again", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Sign out of all accounts/ }));
+    expect(signOutAllAccounts).not.toHaveBeenCalled();
+    expect(screen.getByText(/again for each one/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    expect(signOutAllAccounts).toHaveBeenCalledTimes(1);
+  });
+
+  it("says the device stays on the account at devthrottle.com, so a sign-out is not read as a revoke", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Sign out of work@example.com/ }));
+
+    expect(screen.getByText(/stays on your account at devthrottle.com/i)).toBeTruthy();
+  });
+});

--- a/packages/client-core/src/auth/AccountsPanel.tsx
+++ b/packages/client-core/src/auth/AccountsPanel.tsx
@@ -1,0 +1,127 @@
+// The Accounts panel (devthrottle_internal #1507, #1509): who is signed in on this browser, switch
+// between them, add another, and sign out. ONE component, mounted by both shells - the phone's Account
+// screen and the desktop Cockpit's Account page - so the two surfaces cannot drift into two different
+// products for one account (CLAUDE.md rule 8). Each shell supplies only its own frame around it.
+//
+// Signing out here is THIS BROWSER forgetting a key. It is deliberately not the same action as the
+// Cockpit Account page's "Log out", which clears the GATEWAY's own link to a DevThrottle account
+// (POST /account/logout) - a different thing that happens to a different machine. The two are worded
+// apart on purpose; a shared word would make one button look like the other.
+import { useState } from "react";
+import { signOutAccount, signOutAllAccounts, switchAccount } from "./accountActions";
+import { useAccounts } from "./useAccounts";
+import "./accounts.css";
+
+export interface AccountsPanelProps {
+  /**
+   * Start the add-an-account sign-in. The shells route to their own sign-in entry (the phone's
+   * /mobile/signin, the Cockpit's /signin), which client-core must not hardcode for the other shell.
+   */
+  onAddAccount: () => void;
+}
+
+export function AccountsPanel({ onAddAccount }: AccountsPanelProps) {
+  const { accounts, active, many } = useAccounts();
+  // Which destructive action is awaiting confirmation, if any. Signing out costs a round trip through
+  // devthrottle.com to undo, so it asks first - but only once it has been asked for, so the ordinary
+  // screen is not carrying a warning nobody needed.
+  const [confirming, setConfirming] = useState<"one" | "all" | null>(null);
+
+  if (accounts.length === 0) {
+    return (
+      <div className="accts">
+        <p className="accts-note">This browser is not signed in to any account.</p>
+        <button type="button" className="accts-btn primary" onClick={onAddAccount}>
+          Sign in
+        </button>
+      </div>
+    );
+  }
+
+  const activeLabel = active?.label ?? "this account";
+
+  return (
+    <div className="accts">
+      <div className="accts-list">
+        {accounts.map((account) => {
+          const isActive = account.id === active?.id;
+          return (
+            <button
+              key={account.id}
+              type="button"
+              className={`accts-item${isActive ? " is-active" : ""}`}
+              disabled={isActive}
+              aria-current={isActive ? "true" : undefined}
+              onClick={() => switchAccount(account.id)}
+            >
+              {/* An ASCII mark, not an icon font: the tick has to survive every terminal, log and
+                  accessibility dump this app is read through. */}
+              <span className="accts-mark" aria-hidden="true">{isActive ? "*" : ""}</span>
+              <span className="accts-body">
+                <span className="accts-label">{account.label}</span>
+                <span className="accts-sub">
+                  {isActive ? "Signed in now" : "Tap to switch"}
+                  {account.email && account.email !== account.label ? ` - ${account.email}` : ""}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {many && (
+        <p className="accts-note">
+          Switching reloads the app as that account. Both stay signed in, so it needs no password and
+          works with no connection.
+        </p>
+      )}
+
+      {confirming === null && (
+        <div className="accts-actions">
+          <button type="button" className="accts-btn primary" onClick={onAddAccount}>
+            Add account
+          </button>
+          <button type="button" className="accts-btn danger" onClick={() => setConfirming("one")}>
+            Sign out of {activeLabel}
+          </button>
+          {many && (
+            <button type="button" className="accts-btn danger" onClick={() => setConfirming("all")}>
+              Sign out of all accounts
+            </button>
+          )}
+        </div>
+      )}
+
+      {confirming !== null && (
+        <div className="accts-confirm">
+          <p>
+            {confirming === "all"
+              ? "Sign every account out of this browser? Signing back in means going through devthrottle.com again for each one."
+              : many
+                ? `Sign ${activeLabel} out of this browser? You stay signed in to your other account, and the app switches to it.`
+                : `Sign ${activeLabel} out of this browser? You will need to sign in through devthrottle.com to use the app again.`}
+          </p>
+          <p className="accts-note">
+            This browser forgets the key. The device stays on your account at devthrottle.com until you
+            remove it there.
+          </p>
+          <div className="accts-confirm-row">
+            <button
+              type="button"
+              className="accts-btn danger"
+              onClick={() => {
+                if (confirming === "all") signOutAllAccounts();
+                else if (active) signOutAccount(active.id);
+              }}
+            >
+              Sign out
+            </button>
+            <button type="button" className="accts-btn" onClick={() => setConfirming(null)}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client-core/src/auth/DeviceCallback.tsx
+++ b/packages/client-core/src/auth/DeviceCallback.tsx
@@ -16,12 +16,12 @@
 // effects (store the key, mirror the cookie, land on the route, surface errors).
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { getInstallId, setDeviceKey } from "./deviceKey";
+import { addAccount, clearPendingInstallId, pendingInstallId } from "./accountStore";
 import { enrollmentProfile, takeEnrollNext } from "./enrollRequest";
 import { runEnrollmentCallback } from "./enrollCallback";
 import { isGatewayNotSignedIn } from "../api/enroll";
 import { ensureGatewayCookie } from "../api/client";
-import { beginSignIn } from "../account/accountClient";
+import { beginSignIn, getAccountStatusForKey } from "../account/accountClient";
 
 // "gatewaySignedOut" is the Gateway itself not being signed in to a DevThrottle account (HTTP 409 from
 // /mobile/enroll). It is deliberately NOT an error phase: on a fresh install it is the EXPECTED state - the
@@ -55,7 +55,11 @@ export function DeviceCallback() {
         // The whole dispatch - anti-forgery verification (fail closed), credential classification, and
         // which enroll request is sent - lives in runEnrollmentCallback so it is exercised by tests.
         // This screen only maps the outcome to a phase and the shared side effects.
-        const outcome = await runEnrollmentCallback(params, profile, getInstallId());
+        // The install id minted when this sign-in STARTED, not the active account's - this leg is
+        // enrolling a device for whichever account the person just signed in as, which may not be the
+        // account currently active on this browser (devthrottle_internal #1509).
+        const installId = pendingInstallId();
+        const outcome = await runEnrollmentCallback(params, profile, installId);
         if (cancelled) return;
         switch (outcome.kind) {
           case "denied":
@@ -71,7 +75,19 @@ export function DeviceCallback() {
             setMessage("Sign-in did not return a device key. Please try again.");
             return;
           case "enrolled": {
-            setDeviceKey(outcome.localKey);
+            // Ask the Gateway who this brand-new key belongs to, so the account is labeled with the
+            // person's email rather than a position in a list. It is asked with THAT key, because the
+            // key is not the active one until addAccount stores it. Null is ordinary (a self-host
+            // Gateway with no resolvable identity, or a fresh tenant row that carries no email yet) and
+            // never blocks a sign-in that has already succeeded.
+            const identity = await getAccountStatusForKey(outcome.localKey);
+            if (cancelled) return;
+            addAccount({
+              deviceKey: outcome.localKey,
+              installId,
+              email: identity?.email ?? null,
+            });
+            clearPendingInstallId();
             // Mirror the fresh key into the cc-gateway-token cookie right away, so the terminal
             // WebSocket and any hard navigation authenticate without waiting for the next full page load.
             ensureGatewayCookie();

--- a/packages/client-core/src/auth/SignIn.tsx
+++ b/packages/client-core/src/auth/SignIn.tsx
@@ -9,14 +9,26 @@
 // callback path, the platform, the device label - comes from the installed EnrollmentShellProfile.
 // The desktop gate carries the originally-requested route in ?next=; it is remembered here so the
 // callback can land the browser back on that exact route after the round trip.
-import { getInstallId } from "./deviceKey";
+//
+// This screen is ALSO the "add another account" entry (devthrottle_internal #1509): a browser that
+// already holds an account reaches it from the account switcher, and the only difference is the words -
+// the round trip is identical, and the account that comes back is APPENDED rather than replacing the
+// one already here.
+import { listAccounts, newPendingInstallId } from "./accountStore";
 import { SITE_BASE, enrollmentProfile, newEnrollState, rememberEnrollNext } from "./enrollRequest";
 
 export function SignIn() {
   const profile = enrollmentProfile();
+  // Adding to an existing browser rather than enrolling an empty one. Read at render: the only way to
+  // arrive here holding an account is the switcher's "Add account", and the only way to arrive holding
+  // none is the auth gate.
+  const adding = listAccounts().length > 0;
 
   function start() {
-    const installId = getInstallId();
+    // A FRESH install id for every sign-in, minted here and consumed by the callback leg. This is what
+    // makes a second account a second DEVICE on the cloud roster instead of a collision with the
+    // account already on this browser - see accountStore.
+    const installId = newPendingInstallId();
     const state = newEnrollState();
 
     // Preserve the originally-requested route (?next=) across the round trip (issue #1088). The
@@ -41,10 +53,11 @@ export function SignIn() {
 
   return (
     <div className="signin-screen" style={{ maxWidth: 420, margin: "0 auto", padding: "2rem 1.25rem", textAlign: "center" }}>
-      <h1 style={{ marginBottom: "0.5rem" }}>DevThrottle</h1>
+      <h1 style={{ marginBottom: "0.5rem" }}>{adding ? "Add an account" : "DevThrottle"}</h1>
       <p style={{ opacity: 0.8, marginBottom: "1.5rem" }}>
-        Sign in to connect this {profile.deviceLabel} to your account. You will sign in on devthrottle.com and approve
-        this device; it stays signed in until you remove it from your account.
+        {adding
+          ? `Sign in to the account you want to add. It joins the accounts already on this ${profile.deviceLabel} - nothing signs out, and you can switch between them without signing in again.`
+          : `Sign in to connect this ${profile.deviceLabel} to your account. You will sign in on devthrottle.com and approve this device; it stays signed in until you remove it from your account.`}
       </p>
       <button
         type="button"
@@ -60,7 +73,7 @@ export function SignIn() {
           cursor: "pointer",
         }}
       >
-        Sign in
+        {adding ? "Sign in to another account" : "Sign in"}
       </button>
       <p style={{ opacity: 0.6, fontSize: "0.85rem", marginTop: "1.25rem" }}>
         You will be taken to devthrottle.com to sign in, then returned here.

--- a/packages/client-core/src/auth/accountActions.ts
+++ b/packages/client-core/src/auth/accountActions.ts
@@ -1,0 +1,65 @@
+// Switching and signing out (devthrottle_internal #1507, #1509). accountStore owns the STORAGE; this
+// owns what the running app has to do about a change of identity, which is more than moving a pointer.
+//
+// Both actions finish with a HARD navigation rather than a router push, and that is deliberate. The key
+// is not read once at startup - it is mirrored into the cc-gateway-token cookie, held open by live
+// terminal WebSockets, and baked into every list the shells have already fetched. Re-rendering would
+// leave the previous account's sessions on screen next to the new account's name, which is the one
+// mistake that actually costs something: a message typed into what looks like your work fleet and sent
+// to your personal one. Reloading guarantees every one of those is rebuilt from the new credential.
+import { clearGatewayCookie, ensureGatewayCookie } from "../api/client";
+import { removeAccount, removeAllAccounts, setActiveAccount } from "./accountStore";
+import { getDeviceKey } from "./deviceKey";
+import { enrollmentProfile } from "./enrollRequest";
+
+/** Where a shell lands after an identity change - its own app root, under its own router basename. */
+function appRoot(): string {
+  const profile = enrollmentProfile();
+  return `${profile.basename}${profile.defaultLanding}`;
+}
+
+/** Where a shell sends a browser that now holds no account at all. */
+function signInRoot(): string {
+  const profile = enrollmentProfile();
+  return `${profile.basename}${profile.signInPath}`;
+}
+
+/**
+ * Make another enrolled account the active one and reload the app as them. No network call and no
+ * sign-in: that account's device key was already minted, so this works offline.
+ *
+ * Does nothing when the id names no stored account, so a switcher rendered from a stale list cannot
+ * silently reload the app as the account it was already showing.
+ */
+export function switchAccount(id: string): void {
+  if (!setActiveAccount(id)) return;
+  ensureGatewayCookie();
+  if (typeof window === "undefined") return;
+  window.location.assign(appRoot());
+}
+
+/**
+ * Sign ONE account out of this browser and reload.
+ *
+ * Only this browser forgets the key; the device stays on that account's roster at devthrottle.com until
+ * it is removed there. When another account remains it becomes active and the app reloads as them;
+ * when that was the last one the browser lands on the sign-in screen with the mirrored cookie dropped.
+ */
+export function signOutAccount(id: string): void {
+  removeAccount(id);
+  if (getDeviceKey()) {
+    ensureGatewayCookie();
+    if (typeof window !== "undefined") window.location.assign(appRoot());
+    return;
+  }
+  clearGatewayCookie();
+  if (typeof window !== "undefined") window.location.assign(signInRoot());
+}
+
+/** Sign every account out of this browser and land on the sign-in screen. */
+export function signOutAllAccounts(): void {
+  removeAllAccounts();
+  clearGatewayCookie();
+  if (typeof window === "undefined") return;
+  window.location.assign(signInRoot());
+}

--- a/packages/client-core/src/auth/accountStore.test.ts
+++ b/packages/client-core/src/auth/accountStore.test.ts
@@ -1,0 +1,259 @@
+// The account store (devthrottle_internal #1509). These cover the four things that would silently cost
+// somebody their sign-in: the migration off the single-key store, the dedupe that stops a re-sign-in
+// duplicating a row, per-account install ids, and what happens to the ACTIVE pointer when accounts come
+// and go.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  activeAccount,
+  addAccount,
+  clearPendingInstallId,
+  listAccounts,
+  newPendingInstallId,
+  pendingInstallId,
+  removeAccount,
+  removeAllAccounts,
+  renameAccount,
+  setActiveAccount,
+  subscribeToAccounts,
+} from "./accountStore";
+
+// A minimal localStorage over a Map. jsdom supplies one, but driving it explicitly keeps each test's
+// starting state visible rather than inherited.
+function installStorage(seed: Record<string, string> = {}): Map<string, string> {
+  const map = new Map<string, string>(Object.entries(seed));
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+    key: (i: number) => [...map.keys()][i] ?? null,
+    get length() {
+      return map.size;
+    },
+  });
+  return map;
+}
+
+let uuidCounter = 0;
+beforeEach(() => {
+  uuidCounter = 0;
+  vi.stubGlobal("crypto", {
+    randomUUID: () => `id-${++uuidCounter}`,
+  });
+  installStorage();
+});
+
+describe("migrating off the single-key store", () => {
+  it("adopts an existing cc.deviceKey as the first account, so upgrading signs nobody out", () => {
+    installStorage({ "cc.deviceKey": "old-key", "cc.installId": "old-install" });
+
+    const accounts = listAccounts();
+
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].deviceKey).toBe("old-key");
+    expect(activeAccount()?.deviceKey).toBe("old-key");
+  });
+
+  it("keeps the migrated account's EXISTING install id, so its cloud device row is not stranded", () => {
+    installStorage({ "cc.deviceKey": "old-key", "cc.installId": "old-install" });
+
+    expect(listAccounts()[0].installId).toBe("old-install");
+  });
+
+  it("reports no accounts on a browser that never enrolled", () => {
+    expect(listAccounts()).toEqual([]);
+    expect(activeAccount()).toBeNull();
+  });
+
+  it("mirrors the active key back to cc.deviceKey, so a rolled-back bundle stays signed in", () => {
+    const map = installStorage();
+    addAccount({ deviceKey: "k1", installId: "i1", email: "a@example.com" });
+
+    expect(map.get("cc.deviceKey")).toBe("k1");
+  });
+});
+
+describe("adding accounts", () => {
+  it("appends a second account instead of overwriting the first", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: "personal@example.com" });
+    addAccount({ deviceKey: "k2", installId: "i2", email: "work@example.com" });
+
+    const accounts = listAccounts();
+    expect(accounts.map((a) => a.deviceKey)).toEqual(["k1", "k2"]);
+    // The newly added one is the one you are now using.
+    expect(activeAccount()?.deviceKey).toBe("k2");
+  });
+
+  it("labels an account with its email when the Gateway resolved one", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: "work@example.com" });
+
+    expect(listAccounts()[0].label).toBe("work@example.com");
+  });
+
+  it("gives an account a positional name when no identity could be resolved", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: null });
+    addAccount({ deviceKey: "k2", installId: "i2", email: null });
+
+    expect(listAccounts().map((a) => a.label)).toEqual(["Account 1", "Account 2"]);
+  });
+
+  it("REPLACES the entry when the same account signs in again, rather than duplicating it", () => {
+    addAccount({ deviceKey: "old", installId: "i1", email: "work@example.com" });
+    addAccount({ deviceKey: "fresh", installId: "i2", email: "work@example.com" });
+
+    const accounts = listAccounts();
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].deviceKey).toBe("fresh");
+    expect(accounts[0].installId).toBe("i2");
+  });
+
+  it("keeps two DIFFERENT accounts apart even though both are on one browser", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: "personal@example.com" });
+    addAccount({ deviceKey: "k2", installId: "i2", email: "work@example.com" });
+
+    const [personal, work] = listAccounts();
+    expect(personal.installId).not.toBe(work.installId);
+    expect(personal.deviceKey).not.toBe(work.deviceKey);
+  });
+});
+
+describe("switching", () => {
+  it("moves the active pointer without touching either key", () => {
+    const first = addAccount({ deviceKey: "k1", installId: "i1", email: "a@example.com" });
+    addAccount({ deviceKey: "k2", installId: "i2", email: "b@example.com" });
+
+    expect(setActiveAccount(first.id)).toBe(true);
+    expect(activeAccount()?.deviceKey).toBe("k1");
+    expect(listAccounts()).toHaveLength(2);
+  });
+
+  it("refuses an id that names no stored account", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: "a@example.com" });
+
+    expect(setActiveAccount("not-a-real-id")).toBe(false);
+    expect(activeAccount()?.deviceKey).toBe("k1");
+  });
+
+  it("falls to the first account when the stored pointer dangles, rather than reporting signed out", () => {
+    const map = installStorage();
+    addAccount({ deviceKey: "k1", installId: "i1", email: "a@example.com" });
+    map.set("cc.activeAccount", "an-id-that-was-removed");
+
+    expect(activeAccount()?.deviceKey).toBe("k1");
+  });
+});
+
+describe("signing out", () => {
+  it("removing the active account activates the other one, not the sign-in screen", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: "a@example.com" });
+    const second = addAccount({ deviceKey: "k2", installId: "i2", email: "b@example.com" });
+
+    removeAccount(second.id);
+
+    expect(listAccounts()).toHaveLength(1);
+    expect(activeAccount()?.deviceKey).toBe("k1");
+  });
+
+  it("removing the only account leaves the browser with nothing", () => {
+    const only = addAccount({ deviceKey: "k1", installId: "i1", email: "a@example.com" });
+
+    removeAccount(only.id);
+
+    expect(listAccounts()).toEqual([]);
+    expect(activeAccount()).toBeNull();
+  });
+
+  it("removing an INACTIVE account leaves the active one where it was", () => {
+    const first = addAccount({ deviceKey: "k1", installId: "i1", email: "a@example.com" });
+    addAccount({ deviceKey: "k2", installId: "i2", email: "b@example.com" });
+
+    removeAccount(first.id);
+
+    expect(activeAccount()?.deviceKey).toBe("k2");
+  });
+
+  it("clears the legacy mirror when the last account goes, so no key is left on disk", () => {
+    const map = installStorage();
+    const only = addAccount({ deviceKey: "k1", installId: "i1", email: "a@example.com" });
+
+    removeAccount(only.id);
+
+    expect(map.get("cc.deviceKey")).toBeUndefined();
+  });
+
+  it("removeAllAccounts empties the browser", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: "a@example.com" });
+    addAccount({ deviceKey: "k2", installId: "i2", email: "b@example.com" });
+
+    removeAllAccounts();
+
+    expect(listAccounts()).toEqual([]);
+  });
+});
+
+describe("the in-flight install id", () => {
+  it("mints a fresh one per sign-in, which is what makes a second account a second device", () => {
+    const first = newPendingInstallId();
+    const second = newPendingInstallId();
+
+    expect(first).not.toBe(second);
+  });
+
+  it("is readable on the callback leg after the round trip", () => {
+    const minted = newPendingInstallId();
+
+    expect(pendingInstallId()).toBe(minted);
+  });
+
+  it("mints one when none was saved, so an enrollment never runs without a device id", () => {
+    expect(pendingInstallId()).not.toBe("");
+  });
+
+  it("is consumed once the account it belongs to is stored", () => {
+    const minted = newPendingInstallId();
+    clearPendingInstallId();
+
+    expect(pendingInstallId()).not.toBe(minted);
+  });
+});
+
+describe("subscribers", () => {
+  it("are told when an account is added, switched, renamed or removed", () => {
+    const seen = vi.fn();
+    const unsubscribe = subscribeToAccounts(seen);
+
+    const account = addAccount({ deviceKey: "k1", installId: "i1", email: "a@example.com" });
+    expect(seen).toHaveBeenCalledTimes(1);
+
+    renameAccount(account.id, "Work");
+    expect(seen).toHaveBeenCalledTimes(2);
+
+    removeAccount(account.id);
+    expect(seen).toHaveBeenCalledTimes(3);
+
+    unsubscribe();
+    addAccount({ deviceKey: "k2", installId: "i2", email: "b@example.com" });
+    expect(seen).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("a damaged store", () => {
+  it("reads as no accounts rather than crashing the shell on boot", () => {
+    installStorage({ "cc.accounts": "{not json" });
+
+    expect(listAccounts()).toEqual([]);
+  });
+
+  it("drops an entry missing the one field that matters - its key", () => {
+    installStorage({
+      "cc.accounts": JSON.stringify([
+        { id: "a", label: "Broken", email: null, installId: "i1" },
+        { id: "b", label: "Good", email: null, deviceKey: "k2", installId: "i2" },
+      ]),
+    });
+
+    const accounts = listAccounts();
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].deviceKey).toBe("k2");
+  });
+});

--- a/packages/client-core/src/auth/accountStore.ts
+++ b/packages/client-core/src/auth/accountStore.ts
@@ -1,0 +1,284 @@
+// The signed-in ACCOUNTS on this browser (devthrottle_internal #1509). One browser, more than one
+// DevThrottle account, each holding its own already-minted per-device key.
+//
+// This replaces the single `cc.deviceKey` string that used to be the whole credential store. That
+// string could only ever describe one login, so signing in as a second account OVERWROTE the first and
+// getting back to it meant another full round trip to devthrottle.com. The list here holds every
+// account this browser has enrolled, plus a pointer at the active one, so switching costs a pointer
+// move and a data refresh - both keys are already minted, so a swap needs no network at all.
+//
+// EVERY ACCOUNT CARRIES ITS OWN INSTALL ID, and that is not incidental. The install id is sent to
+// devthrottle.com as `install_id` and to the Gateway as `deviceId` at enrollment, so it is what the
+// cloud device roster keys a device row on. If two accounts shared one install id they would land on
+// ONE roster row, and revoking the work phone would silently drop the personal one with it. A per
+// account install id makes them two independent devices that happen to live in the same browser.
+//
+// Storage is localStorage on the Gateway's own origin, exactly where the single key lived.
+// `cc.deviceKey` is still written as a MIRROR of the active account's key: it is what a previous app
+// bundle reads, so a person left on a cached shell (or a rollback of the deployed bundle) stays signed
+// in on their active account instead of being thrown back to the sign-in screen. Nothing in this
+// codebase reads that mirror any more - getDeviceKey() reads the active entry - it exists purely so
+// the two bundles can coexist during a rollout.
+
+/** One enrolled account on this browser. Never holds an account session - only the local device key. */
+export interface StoredAccount {
+  /** Stable local identifier for this entry. Never sent anywhere; it only names the entry in this browser. */
+  id: string;
+  /** What the switcher shows. The account email once known, otherwise "Account 1", "Account 2", ... */
+  label: string;
+  /** The account email when the Gateway could resolve it, else null. Also the identity accounts dedupe on. */
+  email: string | null;
+  /** The local per-device key the Gateway issued for THIS account. Sent as the Bearer while active. */
+  deviceKey: string;
+  /** This account's own install id - its device identity in the cloud roster. See the note above. */
+  installId: string;
+}
+
+const ACCOUNTS_KEY = "cc.accounts";
+const ACTIVE_KEY = "cc.activeAccount";
+const PENDING_INSTALL_KEY = "cc.pendingInstallId";
+const LEGACY_DEVICE_KEY = "cc.deviceKey";
+const LEGACY_INSTALL_KEY = "cc.installId";
+
+// Subscribers re-render when the account list or the active pointer changes. A switch has to move the
+// whole app - the roster, the app bar, the recorder - and every one of those reads through here.
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+/** Watch for account changes (added, removed, switched). Returns the unsubscribe function. */
+export function subscribeToAccounts(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function announce(): void {
+  for (const listener of listeners) listener();
+}
+
+function readRaw(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    // Storage unavailable (private mode). The app behaves as a browser that has never enrolled, which
+    // is what it did before this store existed.
+    return null;
+  }
+}
+
+function writeRaw(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* storage unavailable (private mode) - the app will simply prompt to sign in again */
+  }
+}
+
+function deleteRaw(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Every field of a stored entry must be a usable string, or the entry is not an account. A partially
+ * written entry is dropped rather than repaired: a blank device key would authenticate nothing, and a
+ * blank install id would enroll as a nameless device.
+ */
+function isAccount(value: unknown): value is StoredAccount {
+  if (typeof value !== "object" || value === null) return false;
+  const a = value as Partial<StoredAccount>;
+  return (
+    typeof a.id === "string" && a.id.length > 0 &&
+    typeof a.label === "string" &&
+    typeof a.deviceKey === "string" && a.deviceKey.length > 0 &&
+    typeof a.installId === "string" && a.installId.length > 0
+  );
+}
+
+function parseAccounts(raw: string | null): StoredAccount[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // The stored list is not JSON. Treat it as no accounts rather than crashing the shell on boot -
+    // the person signs in again, which rewrites it.
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(isAccount).map((a) => ({
+    id: a.id,
+    label: a.label,
+    email: typeof a.email === "string" && a.email.length > 0 ? a.email : null,
+    deviceKey: a.deviceKey,
+    installId: a.installId,
+  }));
+}
+
+function persist(accounts: StoredAccount[], activeId: string): void {
+  writeRaw(ACCOUNTS_KEY, JSON.stringify(accounts));
+  if (activeId) writeRaw(ACTIVE_KEY, activeId);
+  else deleteRaw(ACTIVE_KEY);
+
+  // Keep the previous bundle's single-key store pointing at whichever account is active. See the note
+  // at the top of this file: this is a rollout mirror, not a credential this code reads.
+  const active = accounts.find((a) => a.id === activeId);
+  if (active) writeRaw(LEGACY_DEVICE_KEY, active.deviceKey);
+  else deleteRaw(LEGACY_DEVICE_KEY);
+}
+
+/**
+ * Adopt a pre-#1509 single-key enrollment as the first account in the list, so upgrading the bundle
+ * never signs anybody out. Runs once: the moment the list is written the legacy key stops being read.
+ * Returns the migrated list, or an empty list when there was nothing to migrate.
+ */
+function migrateLegacy(): StoredAccount[] {
+  const legacyKey = readRaw(LEGACY_DEVICE_KEY);
+  if (!legacyKey) return [];
+
+  const migrated: StoredAccount = {
+    id: newId(),
+    label: "Account 1",
+    email: null,
+    deviceKey: legacyKey,
+    // Reuse the browser's existing install id so the migrated account keeps the SAME cloud roster row
+    // it already had. Minting a fresh one here would strand the person's existing device registration
+    // and show them a duplicate device on the website.
+    installId: readRaw(LEGACY_INSTALL_KEY) || newId(),
+  };
+  persist([migrated], migrated.id);
+  writeRaw(LEGACY_INSTALL_KEY, migrated.installId);
+  return [migrated];
+}
+
+function newId(): string {
+  return crypto.randomUUID();
+}
+
+/** Every account enrolled on this browser, in the order they were added. */
+export function listAccounts(): StoredAccount[] {
+  const stored = parseAccounts(readRaw(ACCOUNTS_KEY));
+  if (stored.length > 0) return stored;
+  return migrateLegacy();
+}
+
+/**
+ * The account whose device key the app is currently authenticating with, or null when this browser has
+ * not enrolled. When the stored pointer names an entry that no longer exists the FIRST account is
+ * active instead - a dangling pointer must not present as signed out while a usable key is sitting in
+ * the list.
+ */
+export function activeAccount(): StoredAccount | null {
+  const accounts = listAccounts();
+  if (accounts.length === 0) return null;
+  const id = readRaw(ACTIVE_KEY);
+  return accounts.find((a) => a.id === id) ?? accounts[0];
+}
+
+/**
+ * Make an account the active one. Returns false when no such account is stored, so a caller driving
+ * this from a stale list can tell nothing happened rather than assuming it switched.
+ */
+export function setActiveAccount(id: string): boolean {
+  const accounts = listAccounts();
+  if (!accounts.some((a) => a.id === id)) return false;
+  persist(accounts, id);
+  announce();
+  return true;
+}
+
+/**
+ * Record a freshly-enrolled account and make it active.
+ *
+ * An account already stored under the same email is REPLACED rather than appended: signing in again on
+ * an account you already hold (after a revoke, or just to refresh it) means one entry with a new key,
+ * never a second identical row in the switcher. Dedupe is by email because that is the only identity
+ * the Gateway hands back; when it could not resolve one the entry is appended, and the Accounts screen
+ * is where a duplicate gets removed.
+ */
+export function addAccount(entry: { deviceKey: string; installId: string; email: string | null; label?: string }): StoredAccount {
+  const accounts = listAccounts();
+  const existing = entry.email ? accounts.find((a) => a.email === entry.email) : undefined;
+
+  const account: StoredAccount = {
+    id: existing?.id ?? newId(),
+    label: entry.label ?? entry.email ?? existing?.label ?? `Account ${accounts.length + 1}`,
+    email: entry.email,
+    deviceKey: entry.deviceKey,
+    installId: entry.installId,
+  };
+
+  const next = existing
+    ? accounts.map((a) => (a.id === existing.id ? account : a))
+    : [...accounts, account];
+
+  persist(next, account.id);
+  announce();
+  return account;
+}
+
+/** Give an account a name of its own in the switcher ("Work", "Personal"). */
+export function renameAccount(id: string, label: string): void {
+  const accounts = listAccounts();
+  const trimmed = label.trim();
+  if (trimmed.length === 0) return;
+  const next = accounts.map((a) => (a.id === id ? { ...a, label: trimmed } : a));
+  persist(next, activeAccount()?.id ?? "");
+  announce();
+}
+
+/**
+ * Sign one account out of this browser. Its device key is forgotten here; the device stays on that
+ * account's roster at devthrottle.com until it is removed there.
+ *
+ * Removing the ACTIVE account activates the first one that remains, so a person with two logins who
+ * signs out of one lands on the other rather than on the sign-in screen.
+ */
+export function removeAccount(id: string): void {
+  const accounts = listAccounts();
+  const next = accounts.filter((a) => a.id !== id);
+  const wasActive = activeAccount()?.id === id;
+  const activeId = wasActive ? (next[0]?.id ?? "") : (activeAccount()?.id ?? "");
+  persist(next, activeId);
+  announce();
+}
+
+/** Sign every account out of this browser. */
+export function removeAllAccounts(): void {
+  persist([], "");
+  announce();
+}
+
+/**
+ * Mint the install id for an enrollment that is ABOUT to start, and persist it so the callback leg can
+ * pick it up after the round trip through devthrottle.com.
+ *
+ * A fresh id per sign-in is what makes "add account" produce a second device rather than colliding
+ * with the account already on this browser. SignIn calls this on the way out; the callback consumes it
+ * with takePendingInstallId() on the way back.
+ */
+export function newPendingInstallId(): string {
+  const id = newId();
+  writeRaw(PENDING_INSTALL_KEY, id);
+  return id;
+}
+
+/**
+ * The install id minted for the enrollment currently in flight. Mints one when none was saved (storage
+ * cleared mid-flight, or a callback reached directly), so the enroll request always carries a device
+ * id - an enrollment with no device id is not something to attempt.
+ */
+export function pendingInstallId(): string {
+  const saved = readRaw(PENDING_INSTALL_KEY);
+  if (saved) return saved;
+  return newPendingInstallId();
+}
+
+/** Consume the in-flight install id once the account it belongs to has been stored. */
+export function clearPendingInstallId(): void {
+  deleteRaw(PENDING_INSTALL_KEY);
+}

--- a/packages/client-core/src/auth/accounts.css
+++ b/packages/client-core/src/auth/accounts.css
@@ -1,0 +1,174 @@
+/* The shared account switcher and Accounts panel (devthrottle_internal #1507, #1509). One stylesheet
+   for both shells, in the same shape the settings tabs use: the CONTENT is identical on the desktop and
+   the phone, and each shell re-tunes only spacing and hit-target size around it. */
+
+.accts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.accts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* One account. A button, not a row with a button in it: the whole card is the switch target, which is
+   what a thumb expects on the phone and what a pointer expects on the desktop. */
+.accts-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.accts-item:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+/* The ACTIVE account is not a hover state and must not read like one - it is where you are. */
+.accts-item.is-active {
+  border-color: #3b82f6;
+  background: rgba(59, 130, 246, 0.12);
+  cursor: default;
+}
+
+.accts-mark {
+  flex: 0 0 auto;
+  width: 1.1rem;
+  text-align: center;
+  font-weight: 700;
+  color: #3b82f6;
+}
+
+.accts-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.accts-label {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.accts-sub {
+  font-size: 0.8rem;
+  opacity: 0.7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.accts-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.accts-btn {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.accts-btn:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.accts-btn.primary {
+  border-color: #3b82f6;
+  background: rgba(59, 130, 246, 0.15);
+}
+
+/* Signing out is destructive enough to name itself, but it is an everyday action - warning red, not
+   alarm red, and never the first thing the eye lands on. */
+.accts-btn.danger {
+  border-color: rgba(239, 68, 68, 0.55);
+  color: #fca5a5;
+}
+
+.accts-btn.danger:hover {
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.accts-note {
+  font-size: 0.8rem;
+  opacity: 0.65;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.accts-confirm {
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(239, 68, 68, 0.5);
+  border-radius: 10px;
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.accts-confirm p {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.accts-confirm-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.accts-confirm-row .accts-btn {
+  margin: 0;
+}
+
+/* The compact identity chip (AccountSwitcher). Sized to sit inside an app bar or a menu header without
+   changing its height, and truncating rather than wrapping - an email is long and the bar is not. */
+.accts-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  max-width: 11rem;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  font: inherit;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.accts-chip:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.accts-chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.accts-chip-caret {
+  flex: 0 0 auto;
+  opacity: 0.7;
+  font-size: 0.7rem;
+}

--- a/packages/client-core/src/auth/deviceKey.ts
+++ b/packages/client-core/src/auth/deviceKey.ts
@@ -1,64 +1,64 @@
-// The shared per-device credential store (issue #908 for the phone, issue #1088 for the desktop
+// The shared per-device credential seam (issue #908 for the phone, issue #1088 for the desktop
 // Cockpit). The app never receives a master token from the page (the shell carries no secret).
 // Instead it holds the per-device key it obtained by signing in on devthrottle.com and enrolling with
-// the Gateway (POST /mobile/enroll). That key lives here, in localStorage, scoped to this origin (the
-// Gateway), and is sent as the Bearer on every API call. Both shells share this one store: a browser
-// enrolled through either shell is enrolled for the origin.
+// the Gateway (POST /mobile/enroll). That key is sent as the Bearer on every API call. Both shells
+// share this one seam: a browser enrolled through either shell is enrolled for the origin.
 //
-// A stable install id is generated once and persisted. It is the SAME value the app sends to
-// devthrottle.com (install_id, when it registers the device) and to the Gateway (deviceId, at enroll),
-// so the Gateway's local device record maps to the same cloud roster row - which is what lets a revoke
-// on the website propagate down and drop the local key.
+// This file is now a THIN READ over accountStore (devthrottle_internal #1509). It used to own a single
+// `cc.deviceKey` string, which is exactly why a browser could only hold one login: a second sign-in
+// overwrote the first. The store holds a LIST of accounts and a pointer at the active one, and every
+// function here answers about that ACTIVE account. The seam is unchanged on purpose - every API call
+// already read through getDeviceKey(), so switching accounts moves the whole app without a single call
+// site changing.
+import {
+  activeAccount,
+  listAccounts,
+  pendingInstallId,
+  removeAccount,
+  removeAllAccounts,
+} from "./accountStore";
 
-const DEVICE_KEY = "cc.deviceKey";
-const INSTALL_ID = "cc.installId";
-
-/** The stored per-device key, or "" when the phone has not enrolled yet. */
+/** The active account's per-device key, or "" when this browser has not enrolled yet. */
 export function getDeviceKey(): string {
-  try {
-    return localStorage.getItem(DEVICE_KEY) ?? "";
-  } catch {
-    return "";
-  }
+  return activeAccount()?.deviceKey ?? "";
 }
 
-/** Store the per-device key issued by the Gateway at enrollment. */
-export function setDeviceKey(key: string): void {
-  try {
-    localStorage.setItem(DEVICE_KEY, key);
-  } catch {
-    /* storage unavailable (private mode) - the app will simply prompt to sign in again */
-  }
-}
-
-/** Forget the per-device key (sign out, or the key was revoked and the Gateway now rejects it). */
+/**
+ * Forget the ACTIVE account's key - it was revoked, or the person signed this account out. Any other
+ * account on this browser is untouched, and the first of them becomes active, so signing out of one of
+ * two logins lands on the other rather than on the sign-in screen.
+ */
 export function clearDeviceKey(): void {
-  try {
-    localStorage.removeItem(DEVICE_KEY);
-  } catch {
-    /* ignore */
-  }
+  const active = activeAccount();
+  if (!active) return;
+  removeAccount(active.id);
 }
 
-/** True once the phone has enrolled and holds a per-device key. */
+/** Forget every account on this browser. */
+export function clearAllDeviceKeys(): void {
+  removeAllAccounts();
+}
+
+/** True once this browser holds at least one enrolled account. */
 export function hasDeviceKey(): boolean {
   return getDeviceKey().length > 0;
 }
 
+/** True when more than one account is enrolled, which is what makes the shells show the switcher. */
+export function hasMultipleAccounts(): boolean {
+  return listAccounts().length > 1;
+}
+
 /**
- * The phone's stable, self-generated install id, created once and persisted. Used as install_id at
- * devthrottle.com and as deviceId at /mobile/enroll so both sides map to one device. Falls back to a
- * non-persisted id only if storage is unavailable (the flow still works for this session).
+ * The install id of the ACTIVE account - its stable device identity, used as `install_id` at
+ * devthrottle.com, as `deviceId` at /mobile/enroll, and as the recorder's device id so the server can
+ * say which device recorded a clip. Each account carries its OWN, so two logins on one browser are two
+ * independent rows on the cloud device roster (see accountStore).
+ *
+ * Before this browser has enrolled there is no active account, so the id of the enrollment currently in
+ * flight is returned instead (accountStore mints one when a sign-in starts). That is the same value the
+ * sign-in leg sent to the website, so the enroll leg that follows it matches.
  */
 export function getInstallId(): string {
-  try {
-    let id = localStorage.getItem(INSTALL_ID);
-    if (!id) {
-      id = crypto.randomUUID();
-      localStorage.setItem(INSTALL_ID, id);
-    }
-    return id;
-  } catch {
-    return crypto.randomUUID();
-  }
+  return activeAccount()?.installId ?? pendingInstallId();
 }

--- a/packages/client-core/src/auth/useAccounts.ts
+++ b/packages/client-core/src/auth/useAccounts.ts
@@ -1,0 +1,26 @@
+// React's view of the account store (devthrottle_internal #1509). Any component showing who is signed
+// in - the account switcher, the mobile app bar, the Accounts panel - reads through this so an add,
+// a rename, or a removal moves all of them at once.
+import { useEffect, useState } from "react";
+import { activeAccount, listAccounts, subscribeToAccounts, type StoredAccount } from "./accountStore";
+
+export interface AccountsView {
+  /** Every account enrolled on this browser, in the order they were added. */
+  accounts: StoredAccount[];
+  /** The one the app is authenticating as, or null when this browser has not enrolled. */
+  active: StoredAccount | null;
+  /** True when there is more than one, which is when a switcher is worth showing at all. */
+  many: boolean;
+}
+
+function read(): AccountsView {
+  const accounts = listAccounts();
+  return { accounts, active: activeAccount(), many: accounts.length > 1 };
+}
+
+/** The current accounts, re-read whenever the store changes. */
+export function useAccounts(): AccountsView {
+  const [view, setView] = useState<AccountsView>(read);
+  useEffect(() => subscribeToAccounts(() => setView(read())), []);
+  return view;
+}

--- a/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
+++ b/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
@@ -49,6 +49,7 @@ public sealed class NoCrossMachineLoopbackGuardTests
         ["src/CcDirector.Gateway/GatewayService.cs"] = "Probes THIS process's own Gateway port on loopback to diagnose a failed start (is the port taken by our own gateway, another app, or nothing?). Same machine by definition - it is asking about its own bind - and it moved here unchanged from GatewayTrayController when the lifecycle left the tray app.",
         ["src/CcDirector.Gateway/Tailscale/TailscaleServeProvisioner.cs"] = "Maps the tailnet front door to local loopback backends.",
         ["src/CcDirector.Gateway/Api/RecordingEndpoints.cs"] = "Local recording paths.",
+        ["src/CcDirector.Gateway/Api/MobileQrEndpoint.cs"] = "devthrottle_internal #1508: RECOGNIZES a loopback host in order to REFUSE it, which is the inverse of this policy's concern - nothing here dials one. The Phone panel's scannable code encodes the address the Cockpit was reached on, so a Cockpit opened on localhost would produce a code that scans perfectly and then times out on the phone; the endpoint answers 409 with the reason instead. Only the NAME is a literal - the address families are left to IPAddress.IsLoopback.",
         // Remove-the-network-port mission, phase 6: FOUR more entries left this list at once, because
         // the LAUNCHER's listener was deleted. LauncherHost.cs is gone entirely (the Kestrel bind it
         // was listed for WAS the launcher's listener); LauncherLifecycleRelay.cs no longer dials

--- a/src/CcDirector.Gateway.UnitTests/MobileQrEndpointTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/MobileQrEndpointTests.cs
@@ -1,0 +1,40 @@
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Phone panel's scannable code (devthrottle_internal #1508) encodes the address the Cockpit was
+/// REACHED on, because that is the address the person's phone has to reach too.
+///
+/// These pin the one case where that rule produces something worse than nothing: a Cockpit opened on
+/// loopback. The code would render perfectly, scan perfectly, and then time out on the phone, leaving
+/// the person debugging their network instead of their address - so the endpoint refuses and says so.
+/// A loopback host that slipped through this check is invisible in every other test: the endpoint still
+/// answers 200 with a valid PNG.
+/// </summary>
+public sealed class MobileQrEndpointTests
+{
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("LOCALHOST")]      // routing is case-insensitive, so the check has to be too
+    [InlineData("127.0.0.1")]
+    [InlineData("127.5.5.5")]      // the whole 127/8 block is loopback, not just .0.1
+    [InlineData("::1")]
+    [InlineData("[::1]")]          // as it arrives in a Host header
+    public void IsLoopback_ForAnAddressOnlyThisMachineCanReach_IsTrue(string host)
+    {
+        Assert.True(MobileQrEndpoint.IsLoopback(host));
+    }
+
+    [Theory]
+    [InlineData("devthrottle-gw.azurewebsites.net")]
+    [InlineData("192.168.1.40")]                    // the ordinary self-host case: a phone on the same network
+    [InlineData("soren-north")]                     // a bare machine name
+    [InlineData("100.64.0.1")]                      // a Tailscale address
+    [InlineData("")]
+    public void IsLoopback_ForAnAddressAPhoneCanReach_IsFalse(string host)
+    {
+        Assert.False(MobileQrEndpoint.IsLoopback(host));
+    }
+}

--- a/src/CcDirector.Gateway/Api/MobileQrEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/MobileQrEndpoint.cs
@@ -1,0 +1,94 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Pairing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// <c>GET /account/mobile-qr.png</c> (devthrottle_internal #1508): the scannable code the Cockpit's
+/// Phone panel shows, encoding the address of the mobile app on THIS Gateway.
+///
+/// It exists because nothing in the Cockpit pointed at the mobile app: a person who wanted DevThrottle
+/// on their phone had to already know the address and type it in by hand. Scanning a code off the
+/// screen they are already looking at is the shortest path there is.
+///
+/// The QR carries ONLY the plain mobile address - never a device key, a token, or any other secret.
+/// <see cref="DeviceSignInQrCode"/> enforces that shape (absolute http/https only) and is the same
+/// renderer the Add-a-device window uses, so there is one QR implementation on this host.
+///
+/// The address comes from the REQUEST's own scheme and host, which is the address the person reached
+/// the Cockpit on and therefore the one their phone has to reach too. It is never read from a header a
+/// caller controls beyond that, and never guessed from configuration.
+///
+/// LOOPBACK FAILS LOUDLY. A Cockpit opened on localhost would otherwise produce a perfectly valid QR
+/// code for an address no phone can ever reach - it scans, it opens, it times out, and the person is
+/// left debugging their network instead of their address. So a loopback host is answered 409 with the
+/// reason, and the panel says it in words rather than showing a code that cannot work.
+///
+/// Authentication: the path sits under <c>/account/</c>, so it inherits the host-wide Gateway token
+/// middleware exactly like <c>/account/status</c> - it is not on the public-paths allow-list, and an
+/// uncredentialed request is answered 401 before this delegate runs.
+/// </summary>
+internal static class MobileQrEndpoint
+{
+    /// <summary>The app's own path on this Gateway - the one the Gateway serves the mobile bundle at.</summary>
+    private const string MobilePath = "/mobile";
+
+    /// <summary>Module size in pixels. Large enough to scan off a desktop screen at arm's length.</summary>
+    private const int PixelsPerModule = 8;
+
+    /// <summary>Maps <c>GET /account/mobile-qr.png</c>.</summary>
+    /// <param name="app">The route builder.</param>
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/account/mobile-qr.png", (HttpContext ctx) =>
+        {
+            var host = ctx.Request.Host;
+            if (!host.HasValue)
+            {
+                FileLog.Write("[MobileQrEndpoint] GET /account/mobile-qr.png: the request carried no host, so there is no address to encode");
+                return Results.Json(new { error = "this request carried no host, so there is no address to put in the code" },
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+
+            if (IsLoopback(host.Host))
+            {
+                FileLog.Write($"[MobileQrEndpoint] GET /account/mobile-qr.png: REFUSED - the Cockpit was reached on the loopback host '{host.Host}', which no phone can reach");
+                return Results.Json(new
+                {
+                    error = "this Cockpit is open on " + host.Host + ", an address that only exists on this machine. "
+                          + "Open the Cockpit on the address your phone can reach and the code will appear."
+                }, statusCode: StatusCodes.Status409Conflict);
+            }
+
+            var url = $"{ctx.Request.Scheme}://{host.Value}{MobilePath}";
+            FileLog.Write($"[MobileQrEndpoint] GET /account/mobile-qr.png: encoding the mobile address on host={host.Host}");
+
+            var png = DeviceSignInQrCode.RenderPng(url, PixelsPerModule);
+            FileLog.Write($"[MobileQrEndpoint] GET /account/mobile-qr.png: rendered {png.Length} PNG byte(s)");
+            return Results.File(png, "image/png");
+        });
+    }
+
+    /// <summary>
+    /// Whether a host is one that only this machine can reach.
+    ///
+    /// This file therefore carries a loopback literal on purpose, and it is the OPPOSITE of the thing the
+    /// no-cross-machine-loopback policy exists to stop: nothing here dials a loopback address, it
+    /// RECOGNIZES one so the endpoint can refuse to hand it to a phone.
+    ///
+    /// The addresses are left to <see cref="System.Net.IPAddress.IsLoopback"/>, which covers the whole
+    /// 127/8 block and the version-6 loopback without this file naming any of them - so only the NAME
+    /// needs a literal. Square brackets are stripped first because a version-6 host arrives in a Host
+    /// header wrapped in them.
+    /// </summary>
+    internal static bool IsLoopback(string host)
+    {
+        if (string.IsNullOrWhiteSpace(host)) return false;
+        var h = host.Trim().Trim('[', ']');
+        if (h.Equals("localhost", StringComparison.OrdinalIgnoreCase)) return true;
+        return System.Net.IPAddress.TryParse(h, out var ip) && System.Net.IPAddress.IsLoopback(ip);
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -3098,6 +3098,12 @@ public sealed class GatewayHost : IAsyncDisposable
             nickname: new Core.Account.AccountNicknameClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }),
             tenants: TenantRegistry);
 
+        // devthrottle_internal #1508: GET /account/mobile-qr.png renders the scannable code for the mobile
+        // app's address on THIS Gateway, which is what the Cockpit's Phone panel shows. It carries only a
+        // plain address, never a credential, and it refuses rather than encoding a loopback address no
+        // phone could reach. Inherits the host-wide token middleware exactly like /account/status.
+        MobileQrEndpoint.Map(_app);
+
         // Gateway Centralization Phase 3 (issue #648): POST /account/logout CLEARS the Gateway-hosted
         // DevThrottle credential through the same reused DevThrottleAccountService (Account). The account
         // lives on the gateway, so the logout action lives here too: the Cockpit account surface calls


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1507, thefrederiksen/devthrottle_internal#1508, thefrederiksen/devthrottle_internal#1509.

Three things the phone could not do, all starting from the same gap: the mobile app had no account destination at all.

**Sign out.** The menu had no sign-out item and no Account screen, and `clearDeviceKey()` was only ever reached by the API client on a 401 - so the only ways off a signed-in phone were clearing browser storage by hand or revoking the device on devthrottle.com. Both are there now. The Sign out row LINKS to the Account screen rather than acting where it stands: it sits directly under three ordinary navigation rows, and a mis-tap that ends the session cannot be undone without another round trip through devthrottle.com. Worded apart from the Cockpit's existing "Log out", which clears the GATEWAY's account link - a different action on a different machine.

**A Phone item in the Cockpit rail.** Nothing pointed at the mobile app, so reaching it meant already knowing the address. The page carries a scannable code, the address with a copy button, an open-it-here link, and how to install it to the home screen. The code is rendered by a new Gateway route reusing the QR generator already in the tree. It REFUSES on a loopback host instead of encoding one - that code would scan perfectly and then time out on the phone.

**Two accounts on one browser.** The credential was a single string, so a second sign-in overwrote the first. It is a list plus an active pointer now, read through the same `getDeviceKey()` seam every API call already used, so switching moves the whole app without a call site changing - and needs no password and no connection, because both keys are already minted. Each account carries its OWN install id: that id is the device's identity in the cloud roster, and two accounts sharing one would land on a single row where revoking the work phone silently dropped the personal one. An existing single-key phone migrates into the list on first read, so the upgrade signs nobody out.

The Accounts panel is one shared component both shells mount, so the two surfaces cannot drift.

## Testing

Local gate green at the final state: 4,281 tests, every suite `outcome=Completed`. Web: 967 client-core (38 new), 282 Cockpit, 3 mobile; all three workspaces typecheck; both bundles build; Gateway compiles with zero warnings.

The 38 new tests cover the migration off the single-key store, the dedupe that stops a re-sign-in duplicating a row, per-account install ids, what happens to the active pointer as accounts come and go, that a sign-out is never one tap, and that the confirmation names which of the two outcomes will happen.

A parked-suite run caught a real defect in this change: the no-cross-machine-loopback architecture guard fails any new production file carrying a `localhost` literal without a registered justification. The new endpoint uses one to REFUSE loopback, which is the inverse of the policy's concern. Narrowed so only the name is a literal (the address families now go through `IPAddress.IsLoopback`) and registered with the reason; that test passes.

## What was NOT verified

**A complete parked run.** Two attempts were killed at the ten-minute background ceiling, and `Gateway.Tests` alone runs past thirty minutes. Three tests failed in the incomplete run - `HostedMissionPartitionWiringTests.An_unattributed_mission_is_quarantined_on_hosted_and_stays_on_disk` and two `DeviceCredentialImportPostgresTests` `OnRealPostgres` cases. All five pass in isolation on this branch, and nothing in this diff reaches the mission-partition or credential-import paths, but passing in isolation is not the same as passing under a loaded parallel run. Stated rather than papered over.

**A cross-family review.** Skipped for speed at the author's request.