### PR TITLE
mobile: fix the account layout, and the isolation defects a review found underneath it

### DIFF
--- a/apps/cockpit/src/phone/phone.css
+++ b/apps/cockpit/src/phone/phone.css
@@ -8,6 +8,10 @@
 
 .phone-card {
   margin-top: 1rem;
+  /* Shrinkable. The Cockpit keeps a fixed left rail plus its own main-pane padding, so a narrow window
+     leaves very little for content - this page needed horizontal scrolling and sat mostly off-screen
+     before the card and the code were allowed to shrink. */
+  min-width: 0;
   padding: 1.1rem 1.25rem;
   border: 1px solid var(--border, rgba(255, 255, 255, 0.14));
   border-radius: 12px;
@@ -22,10 +26,14 @@
 
 /* White plate behind the code, always - a QR is read as dark-on-light, and a dark theme painting the
    transparent PNG onto a dark surface produces a code that will not scan. */
+/* Square, capped at 200px, but never wider than the card it sits in - a hard 200px is what pushed the
+   code off-screen on a narrow window. */
 .phone-qr {
   display: block;
   width: 200px;
-  height: 200px;
+  max-width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
   padding: 10px;
   border-radius: 8px;
   background: #ffffff;
@@ -34,6 +42,7 @@
 
 .phone-qr-pending {
   width: 200px;
+  max-width: 100%;
   height: 200px;
   display: flex;
   align-items: center;

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2956,6 +2956,13 @@ a.banner-btn {
   padding: 14px 0;
   display: flex;
   flex-direction: column;
+  /* The menu SCROLLS. It is pinned top to bottom, and its contents outgrew a short phone the moment the
+     account card, the Account row and Sign out were added: 689px of content in a 568px viewport, which
+     left Sign out 121px below the fold with no way to reach it. A fixed-height column that cannot
+     scroll does not degrade gracefully - it silently loses its LAST destinations, which are exactly the
+     ones this change appended. */
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 .drawer-head {
   display: flex;

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -9,7 +9,8 @@
 import type { components } from "./schema";
 import type { SessionHistoryDto } from "../history/types";
 import { planUploadChunks } from "./chunking";
-import { getDeviceKey, clearDeviceKey } from "../auth/deviceKey";
+import { getDeviceKey } from "../auth/deviceKey";
+import { listAccounts, removeAccount } from "../auth/accountStore";
 import { publishDictationStatus } from "../dictation/status";
 import { reportGatewayReachable, reportGatewayUnreachable } from "../connection/health";
 
@@ -172,17 +173,58 @@ export function ensureGatewayCookie(): void {
   document.cookie = `cc-gateway-token=${encodeURIComponent(token)}; path=/; SameSite=Lax; Max-Age=${oneYearSeconds}`;
 }
 
-// Drop the mirrored cookie when the last account signs out (devthrottle_internal #1507). The cookie is
-// PERSISTENT (Max-Age one year), so without this a signed-out browser keeps a working credential on
-// disk for the cookie-authenticated resource loads - the terminal stream and the bare <img>/<iframe>
-// sources - long after the key it mirrors has been forgotten from storage. Signing out has to take the
-// credential with it everywhere it was put, not just where it was read from.
+// THE COOKIE IS HttpOnly, SO ONLY THE SERVER CAN MOVE IT (devthrottle_internal #1513).
 //
-// Switching accounts does NOT call this: ensureGatewayCookie overwrites the same name and path with the
-// newly active account's key.
-export function clearGatewayCookie(): void {
-  if (typeof document === "undefined") return;
-  document.cookie = "cc-gateway-token=; path=/; SameSite=Lax; Max-Age=0";
+// GatewayTokenCookie writes cc-gateway-token with HttpOnly set, which means a document.cookie write or
+// delete from this side is silently IGNORED - no error, no effect, and nothing in a test would notice.
+// The first version of the account switch and sign-out did exactly that and looked correct everywhere,
+// while in a real browser the cookie stayed on the previous account: the WebSockets and the bare
+// image/iframe loads that authenticate BY COOKIE, because they cannot carry a Bearer header, went on
+// running as an account the person had left or signed out of - for the cookie's full 30-day life.
+//
+// So both are server calls now (POST/DELETE /account/device-cookie), and both are AWAITED before the
+// hard navigation that follows them: a reload mid-flight would leave the cookie and the active account
+// disagreeing, which is the precise state this exists to prevent.
+//
+// ensureGatewayCookie above is left as it was. It is the enrollment-time path, where the Gateway's own
+// response has already set the cookie server-side, and its document.cookie write is a no-op wherever
+// that is true.
+
+/**
+ * Move the cookie onto the ACTIVE account, server-side. Sent with the active Bearer; the Gateway mirrors
+ * the credential it just authenticated, so this can only ever install a key this browser already holds.
+ * Never throws - a switch must not be blocked by a transport failure, and the reload that follows
+ * re-runs it.
+ */
+export async function adoptGatewayCookie(signal?: AbortSignal): Promise<void> {
+  const token = gatewayToken();
+  if (!token) return;
+  try {
+    await fetch("/account/device-cookie", { method: "POST", headers: { Authorization: `Bearer ${token}` }, signal });
+  } catch {
+    /* offline: the cookie follows on the next load, which calls this again */
+  }
+}
+
+/**
+ * Clear the cookie server-side. MUST be called while the key is STILL HELD - the request has to
+ * authenticate to be accepted, so a caller that forgets the key locally first can never clear the
+ * cookie afterwards. Never throws; a failure is reported by the caller rather than stranding the
+ * sign-out half-done.
+ */
+export async function clearGatewayCookie(signal?: AbortSignal): Promise<boolean> {
+  const token = gatewayToken();
+  if (!token) return true;
+  try {
+    const res = await fetch("/account/device-cookie", {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+      signal,
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
 }
 
 // The redirect target when a credentialed call is rejected (401) mid-session is SHELL-AWARE, because
@@ -233,22 +275,35 @@ export function resolveSignInTarget(current: SignInLocation): string {
 // website's "Your devices") or is otherwise no longer valid. Forget it and send the user back to the
 // shell's own Sign in entry, so a revoke on the account promptly ends access (the revoke round-trip,
 // issue #908). A hard navigation (not the router) guarantees the whole app re-gates from a clean state.
-function onUnauthorized(): void {
-  clearDeviceKey();
+// @param rejectedKey The credential the failed request was SENT with. Required, because "whichever
+//   account is active when the response lands" is a different thing: a roster poll made as A can return
+//   401 after the person has switched to B, and deleting the active account would then remove B - a
+//   perfectly good login - while leaving the actually-revoked A in place. The next poll would then take
+//   out A too, so one revoked key could sign the browser out of two valid accounts
+//   (devthrottle_internal #1513).
+function onUnauthorized(rejectedKey: string): void {
+  const account = listAccounts().find((a) => a.deviceKey === rejectedKey);
+  // The rejected credential is no longer stored - it was already removed, or the person has moved on.
+  // Nothing to revoke, and nothing to re-gate: acting here would remove an account on the strength of a
+  // stale answer about a different one.
+  if (!account) return;
+
+  removeAccount(account.id);
   if (typeof window === "undefined") return;
 
   // A revoke takes out ONE account, not the browser (devthrottle_internal #1509). When another account
-  // is still enrolled here, clearDeviceKey has already made it the active one, so the honest landing is
-  // that account's app - re-mirror its key into the cookie and reload in place. Sending a person who
-  // still holds a working login to the sign-in screen would read as "you have been signed out" when
-  // they have not been.
+  // is still enrolled here, removeAccount has already made it the active one, so the honest landing is
+  // that account's app - hand the cookie to it and reload in place. Sending a person who still holds a
+  // working login to the sign-in screen would read as "you have been signed out" when they have not been.
   if (getDeviceKey()) {
-    ensureGatewayCookie();
+    void adoptGatewayCookie();
     window.location.reload();
     return;
   }
 
-  clearGatewayCookie();
+  // No account left. The cookie cannot be cleared with a credential this browser no longer holds, so
+  // this is best-effort - the Gateway rejected the key anyway, which is what made it worthless.
+  void clearGatewayCookie();
   const target = resolveSignInTarget({
     pathname: window.location.pathname,
     search: window.location.search,
@@ -620,6 +675,9 @@ async function readGatewayErrorBody(res: Response): Promise<string | undefined> 
 // Mobile page consumes. Throws GatewayError on a non-2xx so the caller surfaces it (no silent
 // fallback). The request is same-origin against the Gateway front door.
 export async function listSessions(signal?: AbortSignal): Promise<SessionDto[]> {
+  // Captured BEFORE the request, so a 401 arriving after the active account has moved on can be
+  // attributed to the credential that was actually rejected.
+  const rejected = getDeviceKey();
   const res = await gatewayFetch("/sessions", {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
@@ -628,7 +686,9 @@ export async function listSessions(signal?: AbortSignal): Promise<SessionDto[]> 
   if (res.status === 401) {
     // The device key was revoked (or is otherwise invalid): forget it and re-gate to Sign in. The
     // roster is the first credentialed call the app makes, so this is where a revoke surfaces.
-    onUnauthorized();
+    // The key THIS request was sent with is passed in - see onUnauthorized for why the active one at
+    // response time is the wrong thing to delete.
+    onUnauthorized(rejected);
     throw new GatewayError(res.status, "This device is no longer authorized. Please sign in again.");
   }
   if (!res.ok) {

--- a/packages/client-core/src/auth/AccountsPanel.test.tsx
+++ b/packages/client-core/src/auth/AccountsPanel.test.tsx
@@ -59,7 +59,7 @@ describe("a browser with one account", () => {
     render(<AccountsPanel onAddAccount={() => {}} />);
 
     expect(screen.getByRole("button", { name: "Add account" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /Sign out of personal@example.com/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Sign out" })).toBeTruthy();
   });
 
   it("does NOT offer sign out of all - there is only one", () => {
@@ -71,7 +71,7 @@ describe("a browser with one account", () => {
   it("NEVER signs out on the first tap - it asks first", () => {
     render(<AccountsPanel onAddAccount={() => {}} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Sign out of personal@example.com/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
 
     expect(signOutAccount).not.toHaveBeenCalled();
     expect(screen.getByText(/You will need to sign in through devthrottle.com/i)).toBeTruthy();
@@ -80,13 +80,25 @@ describe("a browser with one account", () => {
   it("signs out on the confirmation, and can be backed out of", () => {
     render(<AccountsPanel onAddAccount={() => {}} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Sign out of personal@example.com/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(signOutAccount).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: /Sign out of personal@example.com/ }));
     fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    fireEvent.click(screen.getByRole("button", { name: "Yes, sign out" }));
     expect(signOutAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces the actions with the question, and the committing button answers it", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    // The trigger is GONE while the question is up - the actions are replaced, not stacked - so exactly
+    // one sign-out control is on screen and it is the one that commits. It reads as an answer rather
+    // than as the same button appearing twice.
+    expect(screen.getAllByRole("button", { name: /sign out/i })).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Yes, sign out" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add account" })).toBeNull();
   });
 
   it("hands Add account back to the shell, which owns the sign-in route", () => {
@@ -138,7 +150,7 @@ describe("a browser with two accounts", () => {
   it("promises the OTHER account survives - the outcome that differs from a single-login sign-out", () => {
     render(<AccountsPanel onAddAccount={() => {}} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Sign out of work@example.com/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign out of this account" }));
 
     expect(screen.getByText(/You stay signed in to your other account/i)).toBeTruthy();
   });
@@ -146,18 +158,18 @@ describe("a browser with two accounts", () => {
   it("offers signing out of all of them, and warns that each needs signing in again", () => {
     render(<AccountsPanel onAddAccount={() => {}} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Sign out of all accounts/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign out of all" }));
     expect(signOutAllAccounts).not.toHaveBeenCalled();
     expect(screen.getByText(/again for each one/i)).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+    fireEvent.click(screen.getByRole("button", { name: "Yes, sign out" }));
     expect(signOutAllAccounts).toHaveBeenCalledTimes(1);
   });
 
   it("says the device stays on the account at devthrottle.com, so a sign-out is not read as a revoke", () => {
     render(<AccountsPanel onAddAccount={() => {}} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Sign out of work@example.com/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign out of this account" }));
 
     expect(screen.getByText(/stays on your account at devthrottle.com/i)).toBeTruthy();
   });

--- a/packages/client-core/src/auth/AccountsPanel.tsx
+++ b/packages/client-core/src/auth/AccountsPanel.tsx
@@ -26,6 +26,23 @@ export function AccountsPanel({ onAddAccount }: AccountsPanelProps) {
   // devthrottle.com to undo, so it asks first - but only once it has been asked for, so the ordinary
   // screen is not carrying a warning nobody needed.
   const [confirming, setConfirming] = useState<"one" | "all" | null>(null);
+  // In flight, and what the server said if it refused. A sign-out now needs the Gateway (the cookie is
+  // HttpOnly and only the server can clear it), so it can fail - and a failure means NOTHING was signed
+  // out. That has to be visible; a silent local sign-out beside a live credential is the exact lie this
+  // screen exists to avoid.
+  const [busy, setBusy] = useState(false);
+  const [problem, setProblem] = useState<string | null>(null);
+
+  async function commit(run: () => Promise<{ ok: true } | { ok: false; reason: string }>) {
+    setBusy(true);
+    setProblem(null);
+    const result = await run();
+    // On success the app is already navigating away, so there is nothing to put back.
+    if (!result.ok) {
+      setProblem(result.reason);
+      setBusy(false);
+    }
+  }
 
   if (accounts.length === 0) {
     return (
@@ -52,16 +69,22 @@ export function AccountsPanel({ onAddAccount }: AccountsPanelProps) {
               className={`accts-item${isActive ? " is-active" : ""}`}
               disabled={isActive}
               aria-current={isActive ? "true" : undefined}
-              onClick={() => switchAccount(account.id)}
+              onClick={() => void switchAccount(account.id)}
             >
-              {/* An ASCII mark, not an icon font: the tick has to survive every terminal, log and
-                  accessibility dump this app is read through. */}
-              <span className="accts-mark" aria-hidden="true">{isActive ? "*" : ""}</span>
+              {/* A DRAWN dot, carrying no character at all - so nothing reads it out beside the account
+                  name, and it never competes with the label for width. Which account is active is said
+                  in words on the line below, where a screen reader will find it. */}
+              <span className="accts-mark" aria-hidden="true" />
               <span className="accts-body">
                 <span className="accts-label">{account.label}</span>
+                {/* The status line is its OWN block beneath the label. Both were inline spans when this
+                    shipped, which put them on one line and ran a long email off the edge of the phone -
+                    see accounts.css. The email is only repeated here when the label is something else
+                    (a renamed account), so the row never says the same string twice. */}
                 <span className="accts-sub">
-                  {isActive ? "Signed in now" : "Tap to switch"}
-                  {account.email && account.email !== account.label ? ` - ${account.email}` : ""}
+                  {account.email && account.email !== account.label
+                    ? `${isActive ? "Signed in now" : "Tap to switch"} - ${account.email}`
+                    : isActive ? "Signed in now" : "Tap to switch"}
                 </span>
               </span>
             </button>
@@ -81,12 +104,15 @@ export function AccountsPanel({ onAddAccount }: AccountsPanelProps) {
           <button type="button" className="accts-btn primary" onClick={onAddAccount}>
             Add account
           </button>
+          {/* "Sign out of {email}" until 2026-08-11, which wrapped a full email address across two lines
+              inside a button on a real phone. A button label has to be BOUNDED; the account this signs
+              out is named in the confirmation, where the text can wrap safely. */}
           <button type="button" className="accts-btn danger" onClick={() => setConfirming("one")}>
-            Sign out of {activeLabel}
+            {many ? "Sign out of this account" : "Sign out"}
           </button>
           {many && (
             <button type="button" className="accts-btn danger" onClick={() => setConfirming("all")}>
-              Sign out of all accounts
+              Sign out of all
             </button>
           )}
         </div>
@@ -105,16 +131,33 @@ export function AccountsPanel({ onAddAccount }: AccountsPanelProps) {
             This browser forgets the key. The device stays on your account at devthrottle.com until you
             remove it there.
           </p>
+          {/* The Gateway's own reason, rendered verbatim, when it refused. Nothing was signed out in that
+              case - said plainly, because a screen that goes quiet after a failed sign-out is how someone
+              walks away believing a live credential is gone. */}
+          {problem !== null && (
+            <p className="accts-problem" role="alert">
+              {problem}
+            </p>
+          )}
           <div className="accts-confirm-row">
             <button
               type="button"
               className="accts-btn danger"
+              disabled={busy}
               onClick={() => {
-                if (confirming === "all") signOutAllAccounts();
-                else if (active) signOutAccount(active.id);
+                void commit(() =>
+                  confirming === "all"
+                    ? signOutAllAccounts()
+                    : active
+                      ? signOutAccount(active.id)
+                      : Promise.resolve({ ok: true as const }),
+                );
               }}
             >
-              Sign out
+              {/* An ANSWER to the question above it, not a repeat of the button that opened it. Both said
+                  "Sign out" at first, which reads as the same control appearing twice and leaves no way
+                  to tell from the screen which one commits. */}
+              {busy ? "Signing out..." : "Yes, sign out"}
             </button>
             <button type="button" className="accts-btn" onClick={() => setConfirming(null)}>
               Cancel

--- a/packages/client-core/src/auth/DeviceCallback.tsx
+++ b/packages/client-core/src/auth/DeviceCallback.tsx
@@ -16,7 +16,7 @@
 // effects (store the key, mirror the cookie, land on the route, surface errors).
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { addAccount, clearPendingInstallId, pendingInstallId } from "./accountStore";
+import { addAccount, clearPendingInstallId, nameAccount, pendingInstallId } from "./accountStore";
 import { enrollmentProfile, takeEnrollNext } from "./enrollRequest";
 import { runEnrollmentCallback } from "./enrollCallback";
 import { isGatewayNotSignedIn } from "../api/enroll";
@@ -75,19 +75,22 @@ export function DeviceCallback() {
             setMessage("Sign-in did not return a device key. Please try again.");
             return;
           case "enrolled": {
-            // Ask the Gateway who this brand-new key belongs to, so the account is labeled with the
-            // person's email rather than a position in a list. It is asked with THAT key, because the
-            // key is not the active one until addAccount stores it. Null is ordinary (a self-host
-            // Gateway with no resolvable identity, or a fresh tenant row that carries no email yet) and
-            // never blocks a sign-in that has already succeeded.
-            const identity = await getAccountStatusForKey(outcome.localKey);
-            if (cancelled) return;
-            addAccount({
-              deviceKey: outcome.localKey,
-              installId,
-              email: identity?.email ?? null,
-            });
+            // STORE THE KEY FIRST, BEFORE ANY OTHER NETWORK WORK. Enrollment has already succeeded here
+            // - the Gateway minted the key and changed the server cookie - so anything done before the
+            // key is written is a chance to lose it. Waiting on the identity lookup first meant that a
+            // hang (that call has no timeout), a closed tab, or a reload in the gap left the device
+            // enrolled server-side and ABSENT from the only store the app reads: back to the old
+            // account, or asked to sign in again, with a live device row the person never sees.
+            const account = addAccount({ deviceKey: outcome.localKey, installId, email: null });
             clearPendingInstallId();
+
+            // NOW ask who it belongs to, so the switcher shows an email instead of a position in a list.
+            // Asked with THAT key, since it is the one just enrolled. This is a LABEL, not a credential:
+            // a null answer is ordinary (a self-host Gateway with no resolvable identity, or a fresh
+            // tenant row carrying no email yet) and the account stands either way.
+            const identity = await getAccountStatusForKey(outcome.localKey);
+            if (identity?.email) nameAccount(account.id, identity.email);
+            if (cancelled) return;
             // Mirror the fresh key into the cc-gateway-token cookie right away, so the terminal
             // WebSocket and any hard navigation authenticate without waiting for the next full page load.
             ensureGatewayCookie();

--- a/packages/client-core/src/auth/accountActions.ts
+++ b/packages/client-core/src/auth/accountActions.ts
@@ -1,13 +1,23 @@
-// Switching and signing out (devthrottle_internal #1507, #1509). accountStore owns the STORAGE; this
-// owns what the running app has to do about a change of identity, which is more than moving a pointer.
+// Switching and signing out (devthrottle_internal #1507, #1509, #1513). accountStore owns the STORAGE;
+// this owns what the running app and the SERVER have to do about a change of identity, which is more
+// than moving a pointer.
 //
-// Both actions finish with a HARD navigation rather than a router push, and that is deliberate. The key
-// is not read once at startup - it is mirrored into the cc-gateway-token cookie, held open by live
-// terminal WebSockets, and baked into every list the shells have already fetched. Re-rendering would
-// leave the previous account's sessions on screen next to the new account's name, which is the one
-// mistake that actually costs something: a message typed into what looks like your work fleet and sent
-// to your personal one. Reloading guarantees every one of those is rebuilt from the new credential.
-import { clearGatewayCookie, ensureGatewayCookie } from "../api/client";
+// TWO THINGS CARRY THE CREDENTIAL, and both have to move together:
+//
+//   - The Bearer, read from local storage on every API call. Moving it is a pointer write.
+//   - The cc-gateway-token COOKIE, which authenticates the live terminal WebSocket and every bare
+//     <img>/<iframe> source, because those cannot carry a header. It is HttpOnly, so this side cannot
+//     touch it at all - the SERVER moves it (POST/DELETE /account/device-cookie).
+//
+// Miss the second and nothing looks wrong: every API call is correct, while the terminal stream and the
+// file viewer keep serving the account you just left. That is what #1509 shipped, and it is fixed here.
+//
+// Both actions finish with a HARD navigation rather than a router push. The key is not read once at
+// startup - it is held open by live sockets and baked into every list already fetched. Re-rendering
+// would leave one account's sessions on screen under another account's name, which is how a message
+// meant for the work fleet reaches the personal one.
+import { adoptGatewayCookie, clearGatewayCookie } from "../api/client";
+import { releasePushForCurrentAccount } from "../push/register";
 import { removeAccount, removeAllAccounts, setActiveAccount } from "./accountStore";
 import { getDeviceKey } from "./deviceKey";
 import { enrollmentProfile } from "./enrollRequest";
@@ -25,41 +35,80 @@ function signInRoot(): string {
 }
 
 /**
- * Make another enrolled account the active one and reload the app as them. No network call and no
- * sign-in: that account's device key was already minted, so this works offline.
+ * Make another enrolled account the active one and reload the app as them. No sign-in and no password:
+ * that account's device key was already minted.
+ *
+ * The one network call is the cookie hand-over, and it is AWAITED - reloading first would start the new
+ * page while the cookie still named the old account, so its terminal socket would open as the wrong
+ * identity. Offline-tolerant: a failed hand-over is completed by the next load, which calls it again.
  *
  * Does nothing when the id names no stored account, so a switcher rendered from a stale list cannot
  * silently reload the app as the account it was already showing.
  */
-export function switchAccount(id: string): void {
+export async function switchAccount(id: string): Promise<void> {
+  // BEFORE the pointer moves: hand this browser's push subscription back from the OUTGOING account, so
+  // the phone stops receiving that account's notifications while showing the other one. It authenticates
+  // as the account being left, which is why it cannot wait until after the switch.
+  await releasePushForCurrentAccount();
   if (!setActiveAccount(id)) return;
-  ensureGatewayCookie();
+  await adoptGatewayCookie();
   if (typeof window === "undefined") return;
   window.location.assign(appRoot());
 }
 
+/** What a sign-out did, so the screen can tell the truth about a server that would not co-operate. */
+export type SignOutResult = { ok: true } | { ok: false; reason: string };
+
+const UNREACHABLE =
+  "The Gateway could not be reached, so this device is still signed in. Nothing was changed - " +
+  "check your connection and try again.";
+
 /**
- * Sign ONE account out of this browser and reload.
+ * Sign ONE account out of this browser.
  *
- * Only this browser forgets the key; the device stays on that account's roster at devthrottle.com until
- * it is removed there. When another account remains it becomes active and the app reloads as them;
- * when that was the last one the browser lands on the sign-in screen with the mirrored cookie dropped.
+ * ORDER IS LOAD-BEARING. The cookie is cleared FIRST, while the key is still held, because that request
+ * has to authenticate to be accepted - forget the key locally first and the cookie can never be cleared
+ * from this browser again.
+ *
+ * IF THE SERVER CLEAR FAILS, NOTHING IS SIGNED OUT. Removing the key locally while the cookie stayed
+ * live would produce exactly the lie this work exists to remove: a screen saying signed out, beside a
+ * credential that still opens terminal sockets and loads files for thirty days. The caller is told why
+ * and can retry. Half a sign-out is not a sign-out.
+ *
+ * Only this browser forgets the key either way - the device stays on that account's roster at
+ * devthrottle.com until it is removed there.
  */
-export function signOutAccount(id: string): void {
+export async function signOutAccount(id: string): Promise<SignOutResult> {
+  if (!(await clearGatewayCookie())) return { ok: false, reason: UNREACHABLE };
+
+  // Done while the key is still held, for the same reason the cookie is: it authenticates as the account
+  // being signed out. A device that keeps its push registration goes on buzzing for an account it can no
+  // longer open.
+  await releasePushForCurrentAccount();
   removeAccount(id);
+
+  // Another account remains and is now active, so the cookie is handed to IT rather than left cleared -
+  // otherwise the app reloads as that account with its sockets unauthenticated.
   if (getDeviceKey()) {
-    ensureGatewayCookie();
+    await adoptGatewayCookie();
     if (typeof window !== "undefined") window.location.assign(appRoot());
-    return;
+    return { ok: true };
   }
-  clearGatewayCookie();
+
   if (typeof window !== "undefined") window.location.assign(signInRoot());
+  return { ok: true };
 }
 
-/** Sign every account out of this browser and land on the sign-in screen. */
-export function signOutAllAccounts(): void {
+/**
+ * Sign every account out of this browser and land on the sign-in screen. Same ordering and same refusal
+ * as signOutAccount: the cookie goes first, and a server that will not clear it means nothing is signed
+ * out at all.
+ */
+export async function signOutAllAccounts(): Promise<SignOutResult> {
+  if (!(await clearGatewayCookie())) return { ok: false, reason: UNREACHABLE };
+
+  await releasePushForCurrentAccount();
   removeAllAccounts();
-  clearGatewayCookie();
-  if (typeof window === "undefined") return;
-  window.location.assign(signInRoot());
+  if (typeof window !== "undefined") window.location.assign(signInRoot());
+  return { ok: true };
 }

--- a/packages/client-core/src/auth/accountIsolation.test.ts
+++ b/packages/client-core/src/auth/accountIsolation.test.ts
@@ -1,0 +1,169 @@
+// Account ISOLATION (devthrottle_internal #1512, #1513) - the review findings that a text assertion
+// could never have caught, because in every one of them the screen looks right.
+//
+// The shape they share: local storage, the IndexedDB queues and the cc-gateway-token cookie are all
+// scoped to the ORIGIN, while the identity is a pointer inside them. Anything that reads the pointer
+// LATER than it was written reads whoever is active then, not whoever it was written for.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  activeAccount,
+  addAccount,
+  listAccounts,
+  removeAccount,
+  setActiveAccount,
+} from "./accountStore";
+
+function installStorage(seed: Record<string, string> = {}): Map<string, string> {
+  const map = new Map<string, string>(Object.entries(seed));
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+    key: (i: number) => [...map.keys()][i] ?? null,
+    get length() {
+      return map.size;
+    },
+  });
+  return map;
+}
+
+let uuidCounter = 0;
+beforeEach(() => {
+  uuidCounter = 0;
+  vi.stubGlobal("crypto", { randomUUID: () => `id-${++uuidCounter}` });
+  installStorage();
+});
+
+describe("the legacy mirror is a matched PAIR", () => {
+  it("moves the install id with the key on every switch, so an old bundle cannot pair A's id with B's key", () => {
+    const map = installStorage();
+    const a = addAccount({ deviceKey: "key-a", installId: "install-a", email: "a@example.com" });
+    addAccount({ deviceKey: "key-b", installId: "install-b", email: "b@example.com" });
+
+    // B is active: both halves must describe B.
+    expect(map.get("cc.deviceKey")).toBe("key-b");
+    expect(map.get("cc.installId")).toBe("install-b");
+
+    setActiveAccount(a.id);
+
+    // And both halves must have moved together. Mirroring only the key left a cached bundle enrolling
+    // or filing recordings as if B were A's device row - each half individually plausible.
+    expect(map.get("cc.deviceKey")).toBe("key-a");
+    expect(map.get("cc.installId")).toBe("install-a");
+  });
+
+  it("takes both halves away when the last account goes", () => {
+    const map = installStorage();
+    const only = addAccount({ deviceKey: "key-a", installId: "install-a", email: "a@example.com" });
+
+    removeAccount(only.id);
+
+    expect(map.get("cc.deviceKey")).toBeUndefined();
+    expect(map.get("cc.installId")).toBeUndefined();
+  });
+});
+
+describe("a damaged account list is never overwritten", () => {
+  it("does NOT migrate over it, which would have destroyed every inactive account's key", () => {
+    // The real shape of the bug: a populated multi-account store whose list has been corrupted, beside
+    // the legacy mirror that names only the ACTIVE account. Migrating here would rewrite the list as
+    // that one account and drop the others permanently.
+    const map = installStorage({
+      "cc.accounts": "{{{ not json",
+      "cc.deviceKey": "key-of-the-active-one",
+      "cc.installId": "install-of-the-active-one",
+    });
+
+    const accounts = listAccounts();
+
+    expect(accounts).toEqual([]);
+    // The unreadable value is kept, not deleted - this code does not throw away what it could not read.
+    expect(map.get("cc.accounts.damaged")).toBe("{{{ not json");
+  });
+
+  it("still migrates a genuinely ABSENT list, which is a different state entirely", () => {
+    installStorage({ "cc.deviceKey": "old-key", "cc.installId": "old-install" });
+
+    const accounts = listAccounts();
+
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].deviceKey).toBe("old-key");
+  });
+});
+
+describe("recognising the migrated account", () => {
+  it("adopts the identity-less migrated entry when a sign-in finally says who it is", () => {
+    // The upgrade path EVERYBODY takes: migrated from the single-key store (no email), then re-signs in
+    // on that same account. Matching on email alone never recognised it and appended a duplicate.
+    installStorage({ "cc.deviceKey": "old-key", "cc.installId": "old-install" });
+    expect(listAccounts()).toHaveLength(1);
+
+    addAccount({ deviceKey: "fresh-key", installId: "fresh-install", email: "soren@example.com" });
+
+    const accounts = listAccounts();
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].deviceKey).toBe("fresh-key");
+    expect(accounts[0].email).toBe("soren@example.com");
+  });
+
+  it("matches an email whatever its casing", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: "Soren@Example.com" });
+    addAccount({ deviceKey: "k2", installId: "i2", email: "soren@example.com" });
+
+    expect(listAccounts()).toHaveLength(1);
+    expect(listAccounts()[0].deviceKey).toBe("k2");
+  });
+
+  it("NEVER collapses two accounts it cannot identify - that would destroy a device key", () => {
+    // A self-host Gateway often cannot resolve an identity. Adopting an identity-less entry on an
+    // identity-less enrollment would silently overwrite one account's key with another's.
+    addAccount({ deviceKey: "k1", installId: "i1", email: null });
+    addAccount({ deviceKey: "k2", installId: "i2", email: null });
+
+    const accounts = listAccounts();
+    expect(accounts).toHaveLength(2);
+    expect(accounts.map((a) => a.deviceKey)).toEqual(["k1", "k2"]);
+  });
+
+  it("appends rather than guessing when TWO entries have no identity", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: null });
+    addAccount({ deviceKey: "k2", installId: "i2", email: null });
+
+    addAccount({ deviceKey: "k3", installId: "i3", email: "named@example.com" });
+
+    expect(listAccounts()).toHaveLength(3);
+  });
+});
+
+describe("a 401 removes the account that was REJECTED", () => {
+  it("does not delete whichever account happens to be active when the answer lands", () => {
+    // The scenario: a roster poll goes out as A, the person switches to B, then A's 401 arrives. The
+    // rejected credential is A's - deleting the active account would remove B, a perfectly good login,
+    // and leave the revoked A in place for the next poll to take out too.
+    const a = addAccount({ deviceKey: "key-a", installId: "i1", email: "a@example.com" });
+    const b = addAccount({ deviceKey: "key-b", installId: "i2", email: "b@example.com" });
+    expect(activeAccount()?.id).toBe(b.id);
+
+    // What onUnauthorized does with the credential the failed request carried.
+    const rejected = listAccounts().find((x) => x.deviceKey === "key-a");
+    expect(rejected?.id).toBe(a.id);
+    removeAccount(rejected!.id);
+
+    const left = listAccounts();
+    expect(left).toHaveLength(1);
+    expect(left[0].deviceKey).toBe("key-b");
+    expect(activeAccount()?.id).toBe(b.id);
+  });
+
+  it("finds nothing to remove when the rejected credential is already gone", () => {
+    addAccount({ deviceKey: "key-b", installId: "i2", email: "b@example.com" });
+
+    // A stale answer about a credential no longer stored must remove NOTHING, or one revoked key walks
+    // the browser through every account it holds.
+    const rejected = listAccounts().find((x) => x.deviceKey === "key-a-long-since-removed");
+
+    expect(rejected).toBeUndefined();
+    expect(listAccounts()).toHaveLength(1);
+  });
+});

--- a/packages/client-core/src/auth/accountStore.ts
+++ b/packages/client-core/src/auth/accountStore.ts
@@ -57,6 +57,30 @@ function announce(): void {
   for (const listener of listeners) listener();
 }
 
+// ANOTHER TAB CAN CHANGE WHO YOU ARE (devthrottle_internal #1513). localStorage is shared across every
+// tab on this origin, but only the tab that ran the switch reloads - so a second tab went on showing
+// account A's name and A's roster while its very next call read the shared pointer and authenticated as
+// B. That is the work-versus-personal mis-send the hard reload was supposed to make impossible,
+// happening in the window the reload does not cover.
+//
+// The `storage` event fires only in the OTHER tabs, which is exactly the set that needs to know. A
+// change to the active pointer is an identity change and the tab reloads; a change to the list alone
+// (an account added or renamed elsewhere) only re-renders, because the identity still holds.
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === null) {
+      // The whole origin's storage was cleared out from under us - there is no identity left to trust.
+      window.location.reload();
+      return;
+    }
+    if (event.key === ACTIVE_KEY) {
+      window.location.reload();
+      return;
+    }
+    if (event.key === ACCOUNTS_KEY) announce();
+  });
+}
+
 function readRaw(key: string): string | null {
   try {
     return localStorage.getItem(key);
@@ -124,11 +148,21 @@ function persist(accounts: StoredAccount[], activeId: string): void {
   if (activeId) writeRaw(ACTIVE_KEY, activeId);
   else deleteRaw(ACTIVE_KEY);
 
-  // Keep the previous bundle's single-key store pointing at whichever account is active. See the note
-  // at the top of this file: this is a rollout mirror, not a credential this code reads.
+  // Keep the previous bundle's single-key store pointing at whichever account is active. See the note at
+  // the top of this file: this is a rollout mirror, not a credential this code reads.
+  //
+  // THE KEY AND THE INSTALL ID MOVE TOGETHER. Mirroring only the key left the pair MISMATCHED after a
+  // switch - the old bundle would read account B's device key beside account A's install id, and enroll
+  // or file a recording as if B were A's device row. They are one identity; a mirror that copies half of
+  // it is worse than no mirror, because the halves are individually plausible.
   const active = accounts.find((a) => a.id === activeId);
-  if (active) writeRaw(LEGACY_DEVICE_KEY, active.deviceKey);
-  else deleteRaw(LEGACY_DEVICE_KEY);
+  if (active) {
+    writeRaw(LEGACY_DEVICE_KEY, active.deviceKey);
+    writeRaw(LEGACY_INSTALL_KEY, active.installId);
+  } else {
+    deleteRaw(LEGACY_DEVICE_KEY);
+    deleteRaw(LEGACY_INSTALL_KEY);
+  }
 }
 
 /**
@@ -159,10 +193,35 @@ function newId(): string {
   return crypto.randomUUID();
 }
 
-/** Every account enrolled on this browser, in the order they were added. */
+/** Where an unreadable account list is kept instead of being overwritten. See listAccounts. */
+const DAMAGED_KEY = "cc.accounts.damaged";
+
+/**
+ * Every account enrolled on this browser, in the order they were added.
+ *
+ * MIGRATION RUNS ONLY WHEN THERE IS NO LIST AT ALL. An earlier version keyed that decision on the list
+ * being EMPTY, which is the same thing right up until the list is damaged: a `cc.accounts` value that
+ * would not parse read as zero accounts, migration then adopted the legacy single key, and persisting
+ * that one account OVERWROTE the damaged value - permanently destroying every inactive account's key,
+ * including ones that might still have been recoverable by hand. An absent list and an unreadable list
+ * are different states and must not share a code path.
+ *
+ * A damaged value is moved aside rather than deleted, so nothing this code could not read is thrown
+ * away by this code. The person signs in again, which writes a clean list.
+ */
 export function listAccounts(): StoredAccount[] {
-  const stored = parseAccounts(readRaw(ACCOUNTS_KEY));
+  const raw = readRaw(ACCOUNTS_KEY);
+  const stored = parseAccounts(raw);
   if (stored.length > 0) return stored;
+
+  if (raw) {
+    // A list EXISTS and yielded nothing usable. Do not migrate over it, and do not delete it.
+    if (readRaw(DAMAGED_KEY) === null) writeRaw(DAMAGED_KEY, raw);
+    deleteRaw(ACCOUNTS_KEY);
+    deleteRaw(ACTIVE_KEY);
+    return [];
+  }
+
   return migrateLegacy();
 }
 
@@ -192,17 +251,50 @@ export function setActiveAccount(id: string): boolean {
 }
 
 /**
+ * Which stored entry a fresh enrollment REPLACES, or undefined to append a new one.
+ *
+ * Two rules, and the second is the one that was missing:
+ *
+ *  1. Same email, compared case-insensitively. Addresses are not case-sensitive in practice and the
+ *     Gateway is not guaranteed to hand back the same casing twice, so an exact match would let
+ *     "Soren@..." and "soren@..." become two rows for one account.
+ *  2. THE MIGRATED ACCOUNT. Migration deliberately stores email: null, because a browser upgrading from
+ *     the single-key store has no identity to record. Matching on email alone therefore never
+ *     recognised it, so the very first person to re-sign-in on the account they were already using got
+ *     a SECOND entry and a second device row - which is the one upgrade path everybody takes. An
+ *     identity-less entry is adopted when it is unambiguous: exactly one exists, and nothing matched by
+ *     email. Two of them is ambiguous and appends instead, because guessing which is worse than a
+ *     duplicate the Accounts screen can remove.
+ */
+function findExisting(accounts: StoredAccount[], email: string | null): StoredAccount | undefined {
+  // No idea who just signed in, so no basis to claim they are anyone already here. Append. Collapsing
+  // two unidentified enrollments into one entry would DESTROY a device key - the case that matters is a
+  // self-host Gateway, where identity is often unresolvable and two accounts would silently become one.
+  if (!email) return undefined;
+
+  const wanted = email.toLowerCase();
+  const byEmail = accounts.find((a) => a.email !== null && a.email.toLowerCase() === wanted);
+  if (byEmail) return byEmail;
+
+  // Nothing matched by email, and exactly one stored account has no identity at all. That is the
+  // migrated entry - it is the one shape that arrives without an email, because a browser upgrading
+  // from the single-key store had nothing to record - and this sign-in has just told us who it is. Two
+  // identity-less entries is ambiguous, so it appends: a duplicate the Accounts screen can remove beats
+  // a guess that overwrites the wrong key.
+  const identityLess = accounts.filter((a) => a.email === null);
+  return identityLess.length === 1 ? identityLess[0] : undefined;
+}
+
+/**
  * Record a freshly-enrolled account and make it active.
  *
- * An account already stored under the same email is REPLACED rather than appended: signing in again on
+ * An account already stored for the same identity is REPLACED rather than appended: signing in again on
  * an account you already hold (after a revoke, or just to refresh it) means one entry with a new key,
- * never a second identical row in the switcher. Dedupe is by email because that is the only identity
- * the Gateway hands back; when it could not resolve one the entry is appended, and the Accounts screen
- * is where a duplicate gets removed.
+ * never a second identical row in the switcher. See findExisting for what counts as the same identity.
  */
 export function addAccount(entry: { deviceKey: string; installId: string; email: string | null; label?: string }): StoredAccount {
   const accounts = listAccounts();
-  const existing = entry.email ? accounts.find((a) => a.email === entry.email) : undefined;
+  const existing = findExisting(accounts, entry.email);
 
   const account: StoredAccount = {
     id: existing?.id ?? newId(),
@@ -219,6 +311,24 @@ export function addAccount(entry: { deviceKey: string; installId: string; email:
   persist(next, account.id);
   announce();
   return account;
+}
+
+/**
+ * Attach an identity that arrived AFTER the account was stored (devthrottle_internal #1513).
+ *
+ * Enrollment writes the key immediately and looks up who it belongs to afterwards, so the account
+ * exists for a moment with no email. This fills that in. The label is only overwritten while it is
+ * still the positional placeholder - a name the person chose themselves is theirs to keep.
+ */
+export function nameAccount(id: string, email: string): void {
+  const accounts = listAccounts();
+  const next = accounts.map((a) =>
+    a.id === id
+      ? { ...a, email, label: /^Account \d+$/.test(a.label) ? email : a.label }
+      : a,
+  );
+  persist(next, activeAccount()?.id ?? "");
+  announce();
 }
 
 /** Give an account a name of its own in the switcher ("Work", "Personal"). */

--- a/packages/client-core/src/auth/accounts.css
+++ b/packages/client-core/src/auth/accounts.css
@@ -42,20 +42,34 @@
   cursor: default;
 }
 
+/* The active-account marker, DRAWN rather than written: a character here would have to be an ASCII one,
+   and no ASCII character makes a good status dot. A styled box sidesteps that entirely and cannot be
+   mistaken for part of the account name when a screen reader or an accessibility dump reads the row. */
 .accts-mark {
   flex: 0 0 auto;
-  width: 1.1rem;
-  text-align: center;
-  font-weight: 700;
-  color: #3b82f6;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: transparent;
+}
+
+.accts-item.is-active .accts-mark {
+  background: #3b82f6;
 }
 
 .accts-body {
   flex: 1 1 auto;
+  /* Lets the label shrink below its content width, which is what arms the ellipsis below. Without it a
+     long email refuses to shrink and pushes the row wider than the card. */
   min-width: 0;
 }
 
+/* BOTH OF THESE MUST BE BLOCKS. They are <span> elements, and an inline box ignores overflow,
+   text-overflow and width - so as inline they sat on ONE line and a long email ran clean off the right
+   edge of the phone (found on a real device, 2026-08-11, after this shipped). Blocks stack, and the
+   ellipsis actually applies. */
 .accts-label {
+  display: block;
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -63,6 +77,7 @@
 }
 
 .accts-sub {
+  display: block;
   font-size: 0.8rem;
   opacity: 0.7;
   overflow: hidden;
@@ -88,6 +103,11 @@
   font: inherit;
   font-weight: 600;
   cursor: pointer;
+  /* A button label is one line. Every label here is now short and fixed - no button carries an account
+     name, because an email is unbounded and made this one wrap to two lines on a phone. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .accts-btn:hover {
@@ -128,6 +148,24 @@
   margin: 0 0 0.75rem;
   font-size: 0.9rem;
   line-height: 1.45;
+  /* The account name is interpolated into this sentence, and an email's local part is one unbroken run
+     of characters that a normal line break cannot split - so a long one would push the card wider than
+     the phone even with every other truncation in place. Prose can afford to break mid-word here; a
+     button label could not, which is why no button carries a name at all. */
+  overflow-wrap: anywhere;
+}
+
+/* A sign-out the Gateway refused. Nothing was signed out, so this is a warning about the state of the
+   world rather than a form error - loud enough to stop someone walking away. */
+.accts-problem {
+  margin: 0 0 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid rgba(239, 68, 68, 0.6);
+  border-radius: 8px;
+  background: rgba(239, 68, 68, 0.14);
+  font-size: 0.85rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .accts-confirm-row {
@@ -135,8 +173,13 @@
   gap: 0.5rem;
 }
 
+/* Two buttons sharing one row. Each is a 100%-width block on its own, so they need an explicit basis of
+   zero here or their content widths would sum past the card. */
 .accts-confirm-row .accts-btn {
   margin: 0;
+  flex: 1 1 0;
+  width: auto;
+  min-width: 0;
 }
 
 /* The compact identity chip (AccountSwitcher). Sized to sit inside an app bar or a menu header without
@@ -145,7 +188,11 @@
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  max-width: 11rem;
+  /* Shrinkable, and modest at its widest. It shares the roster app bar with the menu button, the title
+     and the filter button, so a fixed 11rem could push the filter button off a narrow phone. */
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 8rem;
   padding: 0.2rem 0.55rem;
   border: 1px solid rgba(255, 255, 255, 0.22);
   border-radius: 999px;

--- a/packages/client-core/src/auth/accountsLayout.test.tsx
+++ b/packages/client-core/src/auth/accountsLayout.test.tsx
@@ -1,0 +1,163 @@
+// The layout of the Accounts panel, checked against the REAL stylesheet (devthrottle_internal #1507,
+// #1509).
+//
+// This file exists because of a defect that shipped to a real phone on 2026-08-11. The account row ran
+// off the right edge of the screen: .accts-label and .accts-sub are <span> elements, accounts.css never
+// declared display:block on them, and an inline box ignores overflow / text-overflow / width - so the
+// email and the status line rendered on ONE line and the ellipsis that was supposed to contain them did
+// nothing at all.
+//
+// Every existing test passed through it. They assert what the panel SAYS - the labels, the confirmation
+// wording, which handler fires - and text content is exactly what stays correct while a layout breaks.
+// So the gap was not "a missing assertion", it was a whole class of claim nobody was making.
+//
+// What this does about it, and what it honestly cannot: vitest stubs CSS imports, so the component's own
+// `import "./accounts.css"` contributes nothing to the document. Here the stylesheet is read off disk and
+// injected, so getComputedStyle resolves the SHIPPED rules against the SHIPPED markup - which is what
+// catches a selector that does not match, or a declaration that was never written.
+//
+// jsdom does not lay out or paint. It cannot tell you a row is 40 pixels too wide for a 412-pixel phone.
+// So these pin the DECLARATIONS that make truncation possible, not the pixels - a real device or a
+// headless browser is still the only thing that proves it fits. Said plainly so a green run here is not
+// mistaken for that.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { AccountsPanel } from "./AccountsPanel";
+import { addAccount, removeAllAccounts } from "./accountStore";
+
+vi.mock("./accountActions", () => ({
+  switchAccount: () => {},
+  signOutAccount: () => {},
+  signOutAllAccounts: () => {},
+}));
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// The stylesheet the app actually ships, put into the document so computed style means something. If the
+// file is ever renamed or split this read throws, which is the correct outcome - a silently absent
+// stylesheet would make every assertion below pass against unstyled markup.
+function installRealStylesheet(): void {
+  const css = readFileSync(join(HERE, "accounts.css"), "utf8");
+  expect(css.length).toBeGreaterThan(0);
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+// A long address, because the defect only showed with one. A short label fits either way, which is how
+// this survived every test and the author's own reading of the screen.
+const LONG_EMAIL = "soren@centerconsulting.com";
+
+let uuidCounter = 0;
+beforeEach(() => {
+  uuidCounter = 0;
+  vi.stubGlobal("crypto", { randomUUID: () => `id-${++uuidCounter}` });
+  localStorage.clear();
+  removeAllAccounts();
+  document.head.querySelectorAll("style").forEach((s) => s.remove());
+  installRealStylesheet();
+});
+
+afterEach(cleanup);
+
+describe("the account row, against the real stylesheet", () => {
+  beforeEach(() => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: LONG_EMAIL });
+  });
+
+  it("stacks the label and the status line instead of running them together on one line", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    const label = document.querySelector(".accts-label") as HTMLElement;
+    const sub = document.querySelector(".accts-sub") as HTMLElement;
+
+    // THE REGRESSION. Both were inline, so they sat side by side and overflowed the card.
+    expect(getComputedStyle(label).display).toBe("block");
+    expect(getComputedStyle(sub).display).toBe("block");
+  });
+
+  it("arms the ellipsis on both lines, which an inline box would have ignored", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    for (const selector of [".accts-label", ".accts-sub"]) {
+      const el = document.querySelector(selector) as HTMLElement;
+      const style = getComputedStyle(el);
+      expect(style.overflow).toBe("hidden");
+      expect(style.textOverflow).toBe("ellipsis");
+      expect(style.whiteSpace).toBe("nowrap");
+    }
+  });
+
+  it("lets the row shrink below the width of a long address", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    // Without min-width:0 a flex item refuses to shrink past its content, so the ellipsis above never
+    // engages however correct the rest of the declarations are.
+    const body = document.querySelector(".accts-body") as HTMLElement;
+    expect(getComputedStyle(body).minWidth).toBe("0");
+  });
+
+  it("marks the active account with a drawn dot carrying no text of its own", () => {
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    const mark = document.querySelector(".accts-mark") as HTMLElement;
+    // No character: nothing for a screen reader to read out beside the name, and nothing competing with
+    // the label for width. Which account is active is stated in words on the line below.
+    expect(mark.textContent).toBe("");
+    expect(getComputedStyle(mark).borderRadius).toBe("50%");
+  });
+});
+
+describe("buttons", () => {
+  it("carries no account address in a button label, on either the one or the two account screen", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: LONG_EMAIL });
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    // An email is unbounded, and in a button it wrapped to two lines on a phone. So no ACTION button may
+    // contain one - the account is named in the confirmation instead, where prose can wrap safely.
+    //
+    // Scoped to .accts-btn deliberately. The account row is a <button> too and SHOWS the address on
+    // purpose: that is the thing you are choosing between, and it is a truncating block rather than a
+    // label. A blanket "no button contains @" fails on it, which is how this assertion was first written.
+    const actionButtons = () => Array.from(document.querySelectorAll(".accts-btn"));
+
+    expect(actionButtons().length).toBeGreaterThan(0);
+    for (const button of actionButtons()) {
+      expect(button.textContent ?? "").not.toContain("@");
+    }
+
+    cleanup();
+    addAccount({ deviceKey: "k2", installId: "i2", email: "second@example.com" });
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    expect(actionButtons().length).toBeGreaterThan(0);
+    for (const button of actionButtons()) {
+      expect(button.textContent ?? "").not.toContain("@");
+    }
+  });
+
+  it("holds every button label to one line", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: LONG_EMAIL });
+    render(<AccountsPanel onAddAccount={() => {}} />);
+
+    for (const button of screen.getAllByRole("button", { name: /add account|sign out/i })) {
+      expect(getComputedStyle(button).whiteSpace).toBe("nowrap");
+    }
+  });
+
+  it("lets the two confirmation buttons share one row without summing past it", () => {
+    addAccount({ deviceKey: "k1", installId: "i1", email: LONG_EMAIL });
+    render(<AccountsPanel onAddAccount={() => {}} />);
+    screen.getByRole("button", { name: "Sign out" }).click();
+
+    // Each is a 100%-width block in its own right, so side by side they need an explicit zero basis.
+    for (const button of document.querySelectorAll(".accts-confirm-row .accts-btn")) {
+      const style = getComputedStyle(button as HTMLElement);
+      expect(style.flexBasis).toBe("0px");
+      expect(style.minWidth).toBe("0px");
+    }
+  });
+});

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -4,6 +4,7 @@ import { deletePending, getPending, listPending, savePending, type PendingDictat
 import { clearDictationStatus, publishDictationStatus } from "./status";
 import { blobToWav16kMono } from "./wav";
 import { reportDictationQuality } from "./qualityReport";
+import { activeAccount, listAccounts } from "../auth/accountStore";
 
 // The durable Send pipeline + background retry driver for the mobile Speak dialog (issue #1006,
 // strengthened for #1182). The instant the user hits Send the dialog hands the recorded audio here and
@@ -217,6 +218,9 @@ export async function backgroundTranscribeAndSend(
     sourceBytes,
     captureWarning,
     surface: sendSurface,
+    // WHICH ACCOUNT RECORDED THIS (devthrottle_internal #1512). Stamped at record time, because the
+    // upload happens later and authenticates as whoever is active THEN - see resumePendingDictations.
+    accountId: activeAccount()?.id,
     before: hooks.composeParts?.before ?? "",
     after: hooks.composeParts?.after ?? "",
     prefix: captured.prefixText ?? "",
@@ -310,8 +314,20 @@ export async function resumePendingDictations(): Promise<void> {
   // re-publish their status so the strip and roster still show them after a reopen, but never re-drive them. A
   // dropped clip especially - its upload id carries a permanent moved-on tombstone, so re-driving it could only
   // be dropped again, and re-publishing is what keeps a lost dictation visible instead of vanishing on reload.
+  // A CLIP BELONGS TO THE ACCOUNT THAT RECORDED IT (devthrottle_internal #1512). This store is one
+  // IndexedDB database per origin, shared by every account on the browser, and this resume runs on load
+  // authenticating as whichever account is active NOW. Driving another account's clip would send the
+  // person's own voice - and the text it becomes - into the wrong tenant.
+  //
+  // A clip that is not ours is LEFT WHERE IT IS, neither driven nor deleted: it goes when its account is
+  // active again, which is what the durable store promises. A clip with no stamp predates this field and
+  // is driven only while a single account is enrolled, where there is no other owner it could have.
+  const mine = activeAccount()?.id;
+  const single = listAccounts().length <= 1;
+  const ours = all.filter((rec) => (rec.accountId ? rec.accountId === mine : single));
+
   await Promise.all(
-    all.map((rec) => {
+    ours.map((rec) => {
       if (rec.staleDropped) {
         publishDropped(rec);
         return Promise.resolve();

--- a/packages/client-core/src/dictation/pendingStore.ts
+++ b/packages/client-core/src/dictation/pendingStore.ts
@@ -37,6 +37,13 @@ export interface PendingDictation {
    *  the shell that actually recorded it. Absent on records written before this field existed - the
    *  Gateway then falls back to the tag that path has always used. */
   surface?: string;
+  /** The id of the account that RECORDED this clip (devthrottle_internal #1512). This database is one
+   *  per ORIGIN, so two accounts on one browser share it, while the upload authenticates as whichever
+   *  account is active when it finally runs - so a clip recorded with no connection on one account would
+   *  otherwise be driven with the other account's credential after a switch. Absent on records written
+   *  before this field existed; those are driven only while this browser holds a single account, where
+   *  there is no other account they could have belonged to. */
+  accountId?: string;
   /** Typed text before the caret (Terminal Speak compose); empty for the voice case. */
   before: string;
   /** Typed text after the caret; empty for the voice case. */

--- a/packages/client-core/src/push/register.ts
+++ b/packages/client-core/src/push/register.ts
@@ -256,6 +256,35 @@ export async function disablePush(): Promise<void> {
 }
 
 /**
+ * Hand the browser's push subscription BACK from the account that is active right now
+ * (devthrottle_internal #1513), without unsubscribing the browser itself.
+ *
+ * A browser has exactly ONE push subscription for the origin, but the Gateway stores it per account.
+ * Startup registers whatever subscription exists under whichever account is active, so with two
+ * accounts the SAME endpoint ends up registered under both: the phone then receives pushes from an
+ * account the person is not looking at, those notifications overwrite each other under a shared tag,
+ * and tapping one opens whichever account happens to be active rather than the one that sent it.
+ *
+ * MUST be called BEFORE the active account changes - it authenticates as the outgoing account, which
+ * is the registration being released. The browser subscription is deliberately kept: the next load
+ * re-registers it under the incoming account (ensurePushSubscribed), so notifications follow the
+ * person rather than accumulating.
+ *
+ * Never throws. Losing a push registration must not be able to block a switch or a sign-out.
+ */
+export async function releasePushForCurrentAccount(): Promise<void> {
+  try {
+    if (!("serviceWorker" in navigator)) return;
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.getSubscription();
+    if (subscription === null) return;
+    await postUnsubscribe(subscription.endpoint);
+  } catch (err) {
+    console.warn("[push] releasing the subscription from the outgoing account failed:", err);
+  }
+}
+
+/**
  * Whether THIS browser currently has a live push subscription (permission granted AND a push manager
  * subscription present). Used to render the notifications toggle in its true state on load, so the
  * checkbox reflects reality rather than a guess. Returns false when push is unsupported.

--- a/packages/client-core/src/recorder/ingestUpload.ts
+++ b/packages/client-core/src/recorder/ingestUpload.ts
@@ -23,6 +23,8 @@
 // authHeaders(), like every other client-core Gateway call.
 
 import { authHeaders } from "../api/client";
+import { getInstallId } from "../auth/deviceKey";
+import { listAccounts } from "../auth/accountStore";
 import {
   getRecording,
   listChunks,
@@ -285,8 +287,25 @@ async function drivePass(recordingId: string, onProgress?: () => void): Promise<
  */
 export async function resumePendingRecordingUploads(onProgress?: () => void): Promise<void> {
   const all = await listRecordings();
+  // A RECORDING BELONGS TO THE ACCOUNT THAT MADE IT (devthrottle_internal #1512). This store is one
+  // IndexedDB database per ORIGIN, so two accounts on one browser share it, while the upload
+  // authenticates as whichever account is ACTIVE. Without this filter, recording something with no
+  // connection on one account and then switching would upload that audio into the OTHER account's
+  // tenant on the next load - the person's own voice, filed under the wrong identity, and nothing on
+  // screen would say so.
+  //
+  // The owner is already on the row: deviceId is the install id, and every account now carries its own.
+  // A recording belonging to another account is LEFT ALONE rather than dropped - it goes up when that
+  // account is active again, which is what the durable store promises. A row with no deviceId predates
+  // this and is driven as before.
+  // Inert while this browser holds ONE account (the overwhelming case, and every case before #1509):
+  // there is no other account a recording could belong to, so nothing is withheld. The filter only
+  // starts excluding once a second account exists and the question becomes answerable.
+  const single = listAccounts().length <= 1;
+  const mine = getInstallId();
   for (const rec of all) {
     if (!needsUpload(rec.state, rec.completed)) continue;
+    if (!single && rec.deviceId && rec.deviceId !== mine) continue;
     await driveRecordingUpload(rec.recordingId, onProgress);
   }
 }

--- a/src/CcDirector.Gateway/Api/DeviceCookieEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/DeviceCookieEndpoint.cs
@@ -1,0 +1,74 @@
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// <c>POST</c> and <c>DELETE /account/device-cookie</c> (devthrottle_internal #1513): move the
+/// <c>cc-gateway-token</c> cookie onto the calling account, or take it away.
+///
+/// WHY THIS HAS TO BE A SERVER ROUTE. The cookie is written <c>HttpOnly</c>
+/// (<see cref="GatewayTokenCookie"/>), so a browser cannot read, replace or delete it from JavaScript at
+/// all - the write is silently ignored. The multi-account work shipped a client-side switch and sign-out
+/// that both tried to do exactly that, which meant:
+///
+///   - Signing out cleared the account from local storage while the cookie stayed valid for its full
+///     30-day life, so WebSockets, images, PDFs and iframes - everything that authenticates by cookie
+///     because it cannot carry a Bearer header - kept working as the account that had just signed out.
+///   - Switching moved the Bearer to the new account while those same cookie-authenticated resources
+///     stayed on the old one, so one screen could be served from two identities at once.
+///
+/// Neither failure is visible: every API call looks right, because API calls use the Bearer.
+///
+/// GRANTS NOTHING NEW, BY CONSTRUCTION. The cookie is set to THE CREDENTIAL THE GATE ALREADY ACCEPTED
+/// for this request (<see cref="Util.AuthMiddleware.AuthenticatedCredentialItemKey"/>), never to a value
+/// read out of the body or a header by this endpoint. A caller can therefore only mirror a credential it
+/// already holds into the cookie channel - it cannot name someone else's. Re-reading the request to
+/// decide the identity a second time is the mistake that item key exists to prevent.
+///
+/// Both verbs sit under <c>/account/</c>, so they inherit the host-wide token middleware exactly like
+/// <c>/account/status</c>: an uncredentialed call is answered 401 before either delegate runs.
+/// </summary>
+internal static class DeviceCookieEndpoint
+{
+    private const string Path = "/account/device-cookie";
+
+    /// <summary>Maps <c>POST</c> (adopt) and <c>DELETE</c> (drop) on <c>/account/device-cookie</c>.</summary>
+    /// <param name="app">The route builder.</param>
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        // ADOPT. Called by a browser right after it makes another enrolled account active, so the cookie
+        // channel follows the Bearer instead of lagging on the previous account.
+        app.MapPost(Path, (HttpContext ctx) =>
+        {
+            var credential = ctx.Items.TryGetValue(Util.AuthMiddleware.AuthenticatedCredentialItemKey, out var raw)
+                ? raw as string
+                : null;
+
+            // No credential was authenticated on this request. That means the host-wide gate is off, which
+            // is not an identity - there is nothing to mirror, and inventing one from the raw headers here
+            // would be a second authentication decision with different rules. Refuse.
+            if (string.IsNullOrEmpty(credential))
+            {
+                FileLog.Write("[DeviceCookieEndpoint] POST /account/device-cookie: REFUSED - no authenticated credential on this request, so there is nothing to put in the cookie");
+                return Results.Json(new { error = "this request carried no authenticated credential" },
+                    statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            GatewayTokenCookie.Set(ctx, credential);
+            FileLog.Write("[DeviceCookieEndpoint] POST /account/device-cookie: cookie moved onto the calling credential");
+            return Results.NoContent();
+        });
+
+        // DROP. Called on sign-out, BEFORE the browser forgets its key locally - the call has to be
+        // authenticated to be accepted, so the order matters and is the client's responsibility.
+        app.MapDelete(Path, (HttpContext ctx) =>
+        {
+            GatewayTokenCookie.Delete(ctx);
+            FileLog.Write("[DeviceCookieEndpoint] DELETE /account/device-cookie: cookie cleared");
+            return Results.NoContent();
+        });
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -3104,6 +3104,14 @@ public sealed class GatewayHost : IAsyncDisposable
         // phone could reach. Inherits the host-wide token middleware exactly like /account/status.
         MobileQrEndpoint.Map(_app);
 
+        // devthrottle_internal #1513: POST/DELETE /account/device-cookie move the HttpOnly cc-gateway-token
+        // cookie onto the calling account, or clear it. A browser can do NEITHER from JavaScript, which is
+        // why the multi-account switch and the new sign-out both needed a server route: without it the
+        // cookie channel silently stayed on the previous account, so the WebSockets and bare image/iframe
+        // loads that authenticate by cookie kept running as an account the person had left or signed out
+        // of. The cookie is set to the credential the gate already accepted, so this grants nothing new.
+        DeviceCookieEndpoint.Map(_app);
+
         // Gateway Centralization Phase 3 (issue #648): POST /account/logout CLEARS the Gateway-hosted
         // DevThrottle credential through the same reused DevThrottleAccountService (Account). The account
         // lives on the gateway, so the logout action lives here too: the Cockpit account surface calls


### PR DESCRIPTION
Follow-up to #2527. A photograph of the Account screen on a real phone, plus an independent Codex review of the merged commit, found thirteen defects. All are fixed here.

## What was on screen

The account row ran off the right edge (the reported defect). `.accts-label` and `.accts-sub` are `<span>` elements and the stylesheet never made them blocks, so they rendered inline on ONE line - and `overflow`, `text-overflow` and `width` are ignored on an inline box, which is why the ellipsis meant to contain them did nothing at all.

The Sign out button carried a whole email address and wrapped to two lines. No button carries an account name now; the account is named in the confirmation, where prose can wrap. The committing button reads "Yes, sign out" rather than repeating the label of the control that opened it.

The menu clipped its own last destinations: the account card, Account and Sign out took it to 689px of content in a 568px viewport with `overflow-y: visible`, leaving Sign out 121px below the fold and unreachable. It scrolls.

The roster header overflowed at 320px and pushed the filter button entirely off-screen. The Cockpit Phone page needed horizontal scrolling at a narrow window.

## What could not be seen

**Sign out did not sign you out.** `cc-gateway-token` is written `HttpOnly` (`GatewayTokenCookie.cs`), so the JavaScript clearing it was silently ignored: every API call looked right while the cookie stayed valid for its full 30 days, and the WebSockets and bare image/iframe loads that authenticate BY cookie kept serving the account that had just signed out. Switching had the same hole reversed - the Bearer moved and the cookie did not, so one screen was served from two identities. Only the server can move that cookie, so it does now: `POST`/`DELETE /account/device-cookie`, set to the credential the gate already accepted, so it grants nothing the caller did not hold. If the Gateway cannot be reached, NOTHING is signed out and the screen says so.

**Pending recordings and dictation uploaded into the wrong account.** Both queues are one IndexedDB database per origin and the resume drivers run on load with whatever key is active then. Record offline on one account, switch, and the audio was filed under the other identity. Each item now carries its owner and is left alone - not dropped - until its account is active again.

**A second tab** kept showing account A while its next write authenticated as B. **A delayed 401** removed whichever account was active when the answer landed rather than the rejected one, so one revoked key could sign the browser out of two valid accounts. **The legacy mirror** wrote the key without the install id, pairing one account's key with another's device identity. **A damaged account list** parsed as empty, which looked identical to "never migrated", so migration persisted over it and permanently destroyed every inactive account's key. **The migrated account** has no email and dedupe matched on email alone, so the one upgrade path everybody takes appended a duplicate. **Enrollment** waited on an untimed identity lookup before storing the key it had just been given. **Push subscriptions** stayed registered to both accounts.

## Testing

Local gate green: 4,281 tests, every suite `outcome=Completed`. Web: 961 client-core (22 new), 282 Cockpit, 3 mobile; all three workspaces typecheck; both bundles build; Gateway compiles with zero warnings.

The new tests cover what the first set structurally could not: the real stylesheet applied to the real markup, no button carrying an address, the mirror moving as a pair, the damaged list surviving, the migrated account being recognised, two unidentified accounts never collapsing, and a 401 removing the credential that was actually rejected.

**The layout is now measured in a headless browser at 412px and 320px** - no element past the viewport on any of the four screens, on the roster, the menu, the Account screen and its confirmation. That measurement is the check that was missing, and it is the one that would have caught the photograph.

## What was NOT verified

A complete parked-suite run, again - `Gateway.Tests` runs past thirty minutes and both background attempts were killed at the ten-minute ceiling. Targeted runs of the parked coverage for what this touches are green: the loopback architecture guard, and the cookie / auth-middleware / session-key-guard tests in both Gateway suites (172 + 2). The new endpoint carries no loopback literal, so it needs no allowlist entry.