### PR TITLE
add a contributing guide and a security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing to DevThrottle
+
+Thanks for being here. DevThrottle is a real product with a company behind it, and it is also genuinely open source under the MIT license -- the code you see is the code we ship, including the gateway we host. Outside contributions are welcome.
+
+This page tells you how to build it, what we are looking for, and what will get a change sent back.
+
+## Before you write code
+
+**Small fixes -- just send them.** A typo, a broken link, a clear bug with an obvious fix, a missing test: open a pull request directly. No permission needed.
+
+**Anything bigger -- talk to us first.** Open an [issue](https://github.com/thefrederiksen/devthrottle/issues) or start a [discussion](https://github.com/thefrederiksen/devthrottle/discussions) describing what you want to change and why. This is not bureaucracy, it is us saving you a wasted weekend: a lot of what looks like a gap is either already being built or was deliberately left out. Wait for a reply before you start.
+
+**Things we are especially glad to receive:** support for another command-line coding agent, bug fixes with a test that fails before and passes after, documentation that was wrong or missing, and accessibility fixes.
+
+**Things we will probably decline:** large refactors of code that works, swapping out a dependency or framework, new features that were not discussed first, and changes to pricing, licensing, or anything that talks to the hosted service's billing.
+
+## Building it
+
+You need the **.NET 10 SDK** (`global.json` pins 10.0.301) and, for the browser front ends, **Node.js 20 or later**. Nothing else -- no administrator rights, no Docker, no database.
+
+```powershell
+git clone https://github.com/thefrederiksen/devthrottle
+cd devthrottle
+dotnet build cc-director.sln
+```
+
+The desktop application is Windows and macOS (Apple Silicon). The gateway, the cockpit, and the mobile application build anywhere.
+
+## Running the tests
+
+One command, and it is the gate:
+
+```powershell
+.\scripts\test-local.ps1
+```
+
+That runs about 3,500 tests in roughly two minutes. **Your pull request needs it green.** Two heavier suites are held back from the default run and are worth running if you touched the gateway:
+
+```powershell
+.\scripts\test-local.ps1 -Parked
+```
+
+For the browser front ends:
+
+```bash
+npm install
+npm run typecheck
+npm run lint
+```
+
+## Where things live
+
+| Path | What it is |
+|---|---|
+| `src/CcDirector.Avalonia` | The desktop application -- the window you actually look at |
+| `src/CcDirector.Core` | The engine: sessions, agents, state, voice, configuration |
+| `src/CcDirector.Gateway` | The gateway -- the same code whether we host it or you do |
+| `src/CcDirector.Terminal*` | The terminal emulator and its renderer |
+| `apps/cockpit`, `apps/mobile` | The web cockpit and the mobile application (React) |
+| `packages/client-core` | Shared front-end code. **Settings live here, not in either shell** |
+| `tools/` | The `cc-*` command line tools and the installer |
+| `docs/public` | The documentation users read |
+| `scripts/` | Build, test, and release scripts |
+
+## House rules
+
+These are not style preferences, they are the things that will get a change sent back. The full versions are in [docs/CodingStyle.md](docs/CodingStyle.md) and [docs/VisualStyle.md](docs/VisualStyle.md); these are the five that catch people out.
+
+**No fallback programming.** If something can fail, fix the cause or fail loudly with a message that says what to do about it. Do not catch an error and quietly carry on with a degraded result -- that hides the real problem and makes it somebody else's bug later.
+
+```csharp
+// No
+try { return GetValue(); } catch { return "Unknown"; }
+
+// Yes
+var value = GetValue();
+if (value is null)
+    throw new InvalidOperationException("Value not available");
+return value;
+```
+
+**Log entry, exit, and errors** in public methods, in the house format: `FileLog.Write($"[ClassName] MethodName: context={value}")`.
+
+**The user interface never blocks.** Every action gives visible feedback within a tenth of a second. Show the window first and load into it; never do file or network work on the user interface thread.
+
+**Plain ASCII in all program output.** No emoji, no arrows, no check marks -- not in console output, log files, error messages, or code comments. Write `[OK]`, `ERROR`, `->`, `WARNING`. Windows terminals and log files mangle the rest, and it has crashed things before.
+
+**Tests come with the change.** A bug fix brings a test that fails before your fix and passes after. Name them `MethodName_Scenario_ExpectedResult`.
+
+## Pull requests
+
+- **One thing per pull request.** A change that fixes a bug and also renames forty files is very hard to review and will be slow.
+- **Say what you did and how you know it works.** A screenshot for anything visual, and the test you added.
+- **Write commit messages as yourself.** Please do not add "generated with" footers or co-authored-by trailers naming a tool or an assistant -- whichever editor or assistant you used, the commit is yours.
+- **Keep it in plain English.** Spell words out in commits, comments, and documentation. We avoid abbreviations and acronyms on purpose.
+- Expect a first reply within a few days.
+
+## Licensing
+
+DevThrottle is [MIT licensed](LICENSE). By opening a pull request you agree that your contribution is licensed under the MIT license too, and that it is your own work or that you have the right to submit it. There is no separate agreement to sign.
+
+## Questions
+
+Anything that is not a bug report goes in [Discussions](https://github.com/thefrederiksen/devthrottle/discussions) -- how something works, whether an idea is welcome, or how to get set up. Security problems are different: see [SECURITY.md](SECURITY.md), and please do not open a public issue for one.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+Thank you for taking the time to report a security problem. This page tells you how to reach us privately, what we will do with your report, and what we consider in scope.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.** A public issue tells everyone how to attack DevThrottle users before there is a fix for them to install.
+
+Report it privately, either way:
+
+- **Preferred: GitHub's private reporting.** Go to the [Security tab](https://github.com/thefrederiksen/devthrottle/security) and choose **Report a vulnerability**. This opens a private conversation that only we can see. No email address needed.
+- **By email:** email@devthrottle.com
+
+Please include as much of this as you can:
+
+- What the problem is, in one or two sentences.
+- The steps to reproduce it, or a short proof-of-concept.
+- The DevThrottle version (**Help -> About** in the app, or `devthrottle-setup-cli status`) and your operating system.
+- Whether you were using the hosted gateway, a self-hosted gateway, or no gateway at all.
+- What an attacker could do with it.
+
+Write in English. Attachments are welcome.
+
+## What happens next
+
+| When | What we do |
+|---|---|
+| Within 3 business days | We acknowledge your report and tell you who is handling it. |
+| Within 10 business days | We tell you whether we can reproduce it, whether we consider it a vulnerability, and how severe we think it is. |
+| After that | We keep you updated at least every two weeks until it is fixed or closed. |
+
+When a fix ships we name it in the release notes and credit you by whatever name or handle you ask for -- or leave you out entirely if you would rather not be named. Just tell us which.
+
+We ask that you give us a reasonable chance to ship a fix before publishing details. Ninety days is the norm; if the problem is being actively exploited we will move much faster and will say so.
+
+**There is no paid bug bounty.** We are a small team and we would rather be honest about that up front than have you find out after the work.
+
+## Which versions get fixes
+
+The **latest release** is the supported version. Security fixes go into the next release from `main`, and the desktop app updates itself, so staying current is the whole of the support policy. Older versions are not patched.
+
+## What is in scope
+
+- The Director desktop application, the Launcher, and the tray gateway app.
+- The gateway -- both the one we host at devthrottle.com and a self-hosted one built from this repository.
+- The web cockpit and the mobile web application.
+- The installer and `devthrottle-setup-cli`.
+- The `cc-*` command line tools that ship with the product.
+
+Things we especially want to hear about: anything that lets one account reach another account's data on the hosted gateway; anything that lets an unauthenticated caller drive a gateway or a Director; a way to read the account key or session keys off a machine without already being that user; a way to get code to run through the installer or the self-update path.
+
+## What is not a vulnerability
+
+These are how the product is designed to work, so a report about them will be closed as intended behaviour:
+
+- **DevThrottle runs coding agents on your machine with your permissions.** Those agents read and write your files and run commands. That is the entire purpose of the product, not a sandbox escape.
+- **Credentials are stored in your own user profile** under `%LOCALAPPDATA%\cc-director`. Anyone who is already signed in as you, or who has administrator rights on your machine, can read them. Protecting your own logon session is your operating system's job.
+- **The Director opens no inbound network port.** If you deliberately expose a self-hosted gateway to the public internet yourself, what reaches it is your configuration, not our defect.
+- Missing security headers, cookie flags, or scanner output with no demonstrated impact.
+- Reports produced entirely by an automated scanner with nothing reproduced by hand.
+
+## Please do not
+
+When testing, do not do anything that affects other people or the running service:
+
+- No load testing, denial-of-service testing, or automated scanning against devthrottle.com or the hosted gateway. Test against a gateway you run yourself.
+- Do not access, change, or keep data belonging to another account. If you reach someone else's data by accident, stop, and tell us what happened.
+- No social engineering of anyone, and no physical attacks.
+
+Stay inside those lines and we will treat your report as a good-faith contribution and will not pursue you for it.


### PR DESCRIPTION
Two files an open source visitor looks for, and this repository had neither.

**SECURITY.md** gives someone who finds a vulnerability a private route to us - GitHub's private reporting, or email@devthrottle.com - so the first anyone hears of a hole is not a public issue explaining how to use it. It states which versions get fixes, what we promise on response times (acknowledge in three business days, assess in ten), and what is deliberately out of scope. That last part matters for this product specifically: DevThrottle runs coding agents on your machine with your permissions, and someone will eventually report that as a sandbox escape.

**CONTRIBUTING.md** tells an outside contributor how to build it, the one command that runs the gate, where things live in a repository of nearly six thousand files, and the five house rules that would otherwise get their first change sent back. Contributions are MIT, same as the project, with nothing to sign.

Both files are new and nothing in the code, the scripts, or the workflows references either filename, so there is no build or test surface to this change.