### PR TITLE
fix the web job on main: test stubs that resolved to nothing

### DIFF
--- a/packages/client-core/src/auth/AccountsPanel.test.tsx
+++ b/packages/client-core/src/auth/AccountsPanel.test.tsx
@@ -12,9 +12,15 @@ import { addAccount, removeAllAccounts } from "./accountStore";
 // accountActions ends every path in a hard navigation, which jsdom cannot perform. Stubbing the module
 // keeps these tests about the PANEL - what it offers and what it says - and leaves where it navigates to
 // accountActions itself.
+//
+// THE STUBS MUST RESOLVE TO A RESULT, exactly like the real actions do. A bare vi.fn() resolves to
+// undefined, and the panel then reads .ok off it - which throws ASYNCHRONOUSLY, after the assertion has
+// already passed. Vitest reports that as an unhandled error rather than a failing test, so the suite
+// prints "961 passed" beside "Errors 2" and a summary skimmed for failures alone reads as green. It
+// reached main that way, and the web job on main is what caught it.
 const switchAccount = vi.fn();
-const signOutAccount = vi.fn();
-const signOutAllAccounts = vi.fn();
+const signOutAccount = vi.fn(async () => ({ ok: true as const }));
+const signOutAllAccounts = vi.fn(async () => ({ ok: true as const }));
 vi.mock("./accountActions", () => ({
   switchAccount: (id: string) => switchAccount(id),
   signOutAccount: (id: string) => signOutAccount(id),

--- a/packages/client-core/src/auth/accountsLayout.test.tsx
+++ b/packages/client-core/src/auth/accountsLayout.test.tsx
@@ -28,10 +28,13 @@ import { dirname, join } from "node:path";
 import { AccountsPanel } from "./AccountsPanel";
 import { addAccount, removeAllAccounts } from "./accountStore";
 
+// Resolving to a real result, for the reason spelled out in AccountsPanel.test.tsx: a stub resolving to
+// undefined makes the panel read .ok off nothing, and it throws after the assertion has passed - an
+// unhandled error the summary reports separately from the test count.
 vi.mock("./accountActions", () => ({
-  switchAccount: () => {},
-  signOutAccount: () => {},
-  signOutAllAccounts: () => {},
+  switchAccount: async () => {},
+  signOutAccount: async () => ({ ok: true as const }),
+  signOutAllAccounts: async () => ({ ok: true as const }),
 }));
 
 const HERE = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Fixes the red web check on `c31dbe2a1`.

The panel awaits the sign-out action and reads `.ok` off the result. The stubs in `AccountsPanel.test.tsx` and `accountsLayout.test.tsx` were bare `vi.fn()`, which resolve to `undefined`, so it read a property off nothing.

It throws ASYNCHRONOUSLY - after the assertion has already passed - so vitest counts it as an unhandled error rather than a failed test. The run printed `961 passed` and `Errors 2` on adjacent lines and exited non-zero. I checked the summary for failures and for the test count, both of which said green, and missed the line that did not. The local gate does not run web tests at all, so the web job on main was the only thing that would catch it.

The stubs now resolve to a result, like the real actions do.

Verified on the EXIT CODE this time rather than on a grep of the summary: client-core, Cockpit and mobile all exit zero, and the errors line is absent rather than merely unread.