### PR TITLE
fix the build: mock implementations that took no arguments

### DIFF
--- a/packages/client-core/src/auth/AccountsPanel.test.tsx
+++ b/packages/client-core/src/auth/AccountsPanel.test.tsx
@@ -18,8 +18,12 @@ import { addAccount, removeAllAccounts } from "./accountStore";
 // already passed. Vitest reports that as an unhandled error rather than a failing test, so the suite
 // prints "961 passed" beside "Errors 2" and a summary skimmed for failures alone reads as green. It
 // reached main that way, and the web job on main is what caught it.
-const switchAccount = vi.fn();
-const signOutAccount = vi.fn(async () => ({ ok: true as const }));
+// The implementations take the SAME arguments the call sites pass. vi.fn(async () => ...) infers a
+// ZERO-argument mock, so calling it with an id is a type error (TS2554) - which vitest never sees,
+// because it does not typecheck. It broke the .NET build too: the Gateway project runs the workspace
+// typecheck as part of its own build, so one TypeScript error reddens both jobs.
+const switchAccount = vi.fn((_id: string) => {});
+const signOutAccount = vi.fn(async (_id: string) => ({ ok: true as const }));
 const signOutAllAccounts = vi.fn(async () => ({ ok: true as const }));
 vi.mock("./accountActions", () => ({
   switchAccount: (id: string) => switchAccount(id),


### PR DESCRIPTION
Fixes both red checks on `b65eea636`, which share one cause.

`AccountsPanel.test.tsx(26,50): error TS2554: Expected 0 arguments, but got 1.`

The stubs I added to stop the unhandled-rejection failure were written `vi.fn(async () => ...)`, which infers a ZERO-argument mock - so the call sites passing an id are a type error.

Two things this exposes, both worth writing down:

- **Vitest does not typecheck.** The tests passed and exited zero while the code did not compile. A green test run is not evidence the workspace builds.
- **A test-only change can break the .NET build.** `CcDirector.Gateway.csproj` runs `npm run typecheck --workspaces` as part of its own build, so one TypeScript error anywhere in the workspaces reddens the solution build as well as the web job. That is why `Build & Test (.NET)` failed on a change that touched no C# at all.

The implementations now take the arguments their call sites pass.

## Verified

By running what continuous integration runs, in its order, and reading every exit code rather than a summary:

- `npm run typecheck --workspaces --if-present` - exit 0
- client-core, Cockpit, mobile test suites - exit 0 each, no errors line
- `dotnet build src/CcDirector.Gateway` (the project that wraps the typecheck) - exit 0, zero warnings