### PR TITLE
voice: a failed transcript read is no longer reported as "nothing to say"

### DIFF
--- a/src/CcDirector.ControlApi/SessionReadExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionReadExecutor.cs
@@ -107,8 +107,34 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
                 return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
             }
 
+            // AN UNRESOLVED TRANSCRIPT IS A FAILED READ, NOT AN EMPTY CONVERSATION.
+            //
+            // This branch used to stamp "ok" unconditionally. But SessionHistoryReader.ReadAll returns
+            // ConversationHistory.Empty whenever ResolveTranscriptPath returns null - which is exactly what
+            // the per-agent locators (PiSessionLocator, CodexRolloutLocator, GrokSessionLocator) do when they
+            // cannot find the session's transcript. So a Codex / Pi / Grok session whose transcript had not
+            // been located reported a SUCCESSFUL read of an EMPTY conversation, and the one field that could
+            // have told the caller otherwise said "ok".
+            //
+            // What that cost: voice narration reads this verb, sees no text widget, and records "there is
+            // nothing to read aloud" - a NON-failure that is never retried. A Pi session on worktrees/oc-8403
+            // sat silent for 48 minutes on 12 August with no error raised anywhere, and the roster showed it
+            // "Preparing voice" the whole time. See issue #2561.
+            //
+            // Gemini is the deliberate exception and must NOT be caught by this: it persists no transcript at
+            // all, so a null path is its normal state and its conversation is read from the session's own
+            // terminal buffer (see SessionHistoryReader.ReadAll). A null path for Gemini is honest; for every
+            // other agent here it means the transcript has not been found yet.
+            var transcriptPath = SessionHistoryReader.ResolveTranscriptPath(session);
+            if (transcriptPath is null && session.AgentKind != AgentKind.Gemini)
+            {
+                resp.Status = "no_transcript";
+                resp.Error = $"No transcript has been located yet for this {session.AgentKind} session.";
+                return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
+            }
+
             var history = SessionHistoryReader.Read(session);
-            resp.JsonlPath = SessionHistoryReader.ResolveTranscriptPath(session);
+            resp.JsonlPath = transcriptPath;
             resp.LineCount = history.Messages.Count;
             resp.Widgets = ControlEndpoints.BuildTurnWidgetsFromHistory(history);
             resp.Status = "ok";

--- a/src/CcDirector.ControlApi/SessionReadExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionReadExecutor.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Text;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Claude;
@@ -187,6 +187,19 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
             var messages = StreamMessageParser.ParseFile(jsonl);
             resp.LineCount = messages.Count;
             resp.Widgets = WidgetBuilder.BuildFromMessages(messages);
+
+            // The SAME rule as the branch above, and it belongs here for the same reason (found in review:
+            // the first version applied it only to the non-Claude branch, leaving Claude Code - the agent
+            // this runs for most often - with exactly the false-success shape the change exists to remove).
+            // A transcript that exists but parses to nothing is not a conversation that was read; it is a
+            // read that produced none. Retryable, not terminal: the next turn writes into this same file.
+            if (messages.Count == 0)
+            {
+                resp.Status = "empty_history";
+                resp.Error = $"No conversation was read for this session from {jsonl}.";
+                return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
+            }
+
             resp.Status = "ok";
             return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
         }

--- a/src/CcDirector.ControlApi/SessionReadExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionReadExecutor.cs
@@ -137,6 +137,30 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
             resp.JsonlPath = transcriptPath;
             resp.LineCount = history.Messages.Count;
             resp.Widgets = ControlEndpoints.BuildTurnWidgetsFromHistory(history);
+
+            // A RESOLVED PATH IS NOT A PROVEN READ EITHER, and this is the other half of the same defect
+            // (found in review). Having a path only says where to look.
+            //
+            // It is at its sharpest for Copilot and OpenCode, whose "path" is a GLOBAL SQLite store rather
+            // than a per-session file: ResolveTranscriptPath hands back the store as soon as it exists,
+            // which says nothing about whether it holds a row for THIS session - and both readers answer an
+            // empty history for a store with no repository match AND for a database error they caught. A Pi,
+            // Codex or Grok transcript that resolves but holds no readable message lands in the same place.
+            //
+            // Stamping "ok" on any of those recreates exactly the false success this change exists to
+            // remove: the voice service would see no text, record the never-retried "nothing to read aloud",
+            // and the session would go silent with nothing raised. So an empty conversation gets its OWN
+            // status. It is deliberately NOT an error - a session that has genuinely not spoken yet is the
+            // ordinary case, and this status is retryable rather than terminal, because the very next turn
+            // makes it non-empty.
+            if (history.Messages.Count == 0)
+            {
+                resp.Status = "empty_history";
+                resp.Error = $"No conversation was read for this {session.AgentKind} session"
+                             + (transcriptPath is null ? "." : $" from {transcriptPath}.");
+                return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
+            }
+
             resp.Status = "ok";
             return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
         }

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -1,4 +1,4 @@
-namespace CcDirector.Gateway.Contracts;
+﻿namespace CcDirector.Gateway.Contracts;
 
 /// <summary>
 /// Shared client-side policy for how a roster of <see cref="SessionDto"/> is ordered and
@@ -409,12 +409,18 @@ public static class SessionOrdering
         if (display is null || string.IsNullOrWhiteSpace(display.Label)) return "Preparing voice";
         return display.Kind switch
         {
-            // Nothing is being prepared, and for the first three nothing ever will be without a change of
-            // state - which is exactly what the reader needs to know and could not previously be told.
-            "nothingToNarrate" or "serviceDown" or "blocked" or "retrying" or "notReady" => display.Label,
-            // "preparing" (genuinely in flight), "ready", "off", or anything added later: the existing
-            // words stand. A new voice state does NOT silently change this label until it is listed here.
-            _ => "Preparing voice",
+            // The THREE verdicts whose own words would be wrong ON THE RAIL, named explicitly:
+            //  - "preparing" is the case the existing words are already right about.
+            //  - "ready" and "off" cannot honestly reach here at all (this arm runs only for a session the
+            //    voice hold is keeping yellow), so if one ever does, the safe answer is the old behaviour
+            //    rather than a rail reading "Voice ready" beside a yellow dot.
+            "preparing" or "ready" or "off" => "Preparing voice",
+            // EVERYTHING ELSE renders the fold's own words - including a verdict added later. The list runs
+            // this way round deliberately: an allow-list of known-good kinds would mean adding a state to
+            // VoiceDisplayFold and having the rail quietly keep saying "Preparing voice" about it, which is
+            // a second rule wearing the shape of a default (found in review). A new state now reaches the
+            // rail by being added ONCE, in the fold.
+            _ => display.Label,
         };
     }
 

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -411,10 +411,14 @@ public static class SessionOrdering
         {
             // The THREE verdicts whose own words would be wrong ON THE RAIL, named explicitly:
             //  - "preparing" is the case the existing words are already right about.
-            //  - "ready" and "off" cannot honestly reach here at all (this arm runs only for a session the
-            //    voice hold is keeping yellow), so if one ever does, the safe answer is the old behaviour
-            //    rather than a rail reading "Voice ready" beside a yellow dot.
-            "preparing" or "ready" or "off" => "Preparing voice",
+            //  - "ready", "off" and "working" cannot honestly reach here at all: this arm runs only for a
+            //    session the voice hold is keeping yellow, which requires voice mode, no audio, and a
+            //    WAITING activity - and StateLabel has already returned "Working" above for anything
+            //    actually working. So if one of them ever does arrive on a row, the safe answer is the old
+            //    behaviour rather than a rail reading "Voice ready" or "Agent is working" beside a yellow
+            //    dot on a session that is doing neither. ("working" was missed by the first version of this
+            //    list and found in review - it is a kind VoiceDisplayFold really does emit.)
+            "preparing" or "ready" or "off" or "working" => "Preparing voice",
             // EVERYTHING ELSE renders the fold's own words - including a verdict added later. The list runs
             // this way round deliberately: an allow-list of known-good kinds would mean adding a state to
             // VoiceDisplayFold and having the rail quietly keep saying "Preparing voice" about it, which is

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -364,7 +364,7 @@ public static class SessionOrdering
         // generation. The Gateway's old BriefingState overwrite made a voice-generating session take the
         // first arm and read "Wingman reading" - the wrong words, on top of a destroyed fact (gap 5).
         if (IsBriefing(s)) return "Wingman reading";
-        if (IsVoicePreparing(s)) return "Preparing voice";
+        if (IsVoicePreparing(s)) return VoiceHoldLabel(s);
         return BaseColor(s) switch
         {
             // "supporting" now means ONLY a Worker whose red was suppressed (see BaseColor). A working
@@ -378,6 +378,43 @@ public static class SessionOrdering
             "grey" => "Exited",              // Phase 2.3: an exited session's grey base (see RawActivityColor)
             "error" => "Crashed",            // issue #959: died, not finished - never reads as a clean "Exited"
             _ => "Idle",
+        };
+    }
+
+    /// <summary>
+    /// The WORDS for a session the voice hold is keeping yellow - "Preparing voice" only when something is
+    /// genuinely being prepared, and the honest reason otherwise.
+    ///
+    /// WHY THIS IS NOT A SECOND RULE. <see cref="IsVoicePreparing"/> - the COLOR - reads two booleans, and
+    /// deliberately so: yellow is held across the gaps between attempts and must never flash red (owner's
+    /// ruling, 2026-07-19, see that method). But those two booleans are also the ONLY thing the label had,
+    /// so every reason a session has no audio came out as one sentence claiming work was in flight. On
+    /// 11 August a session sat on "Preparing voice" for 48 minutes while the Gateway's OWN verdict for it,
+    /// on the same row, was "Nothing to read aloud" - a state that would never become audio. Another row
+    /// carried the label "Preparing voice" beside a "No voice" chip, because the chip reads a fact the label
+    /// could not see. See issue #2576.
+    ///
+    /// The verdict already exists and is already on the row: <see cref="SessionDto.VoiceDisplay"/>, folded
+    /// by the Gateway's VoiceDisplayFold from all six voice facts. So this does not compute anything - it
+    /// RENDERS the words that fold already chose, which is what keeps this from becoming a second answer to
+    /// the same question. The dot is unchanged; only the words are.
+    ///
+    /// Deliberately narrow: it defers ONLY for the verdicts that mean "no audio, and here is why", and
+    /// falls back to "Preparing voice" for everything else - including a row carrying no verdict at all
+    /// (the display-push seam does not stamp one, and an older client may not send one either).
+    /// </summary>
+    private static string VoiceHoldLabel(SessionDto s)
+    {
+        var display = s.VoiceDisplay;
+        if (display is null || string.IsNullOrWhiteSpace(display.Label)) return "Preparing voice";
+        return display.Kind switch
+        {
+            // Nothing is being prepared, and for the first three nothing ever will be without a change of
+            // state - which is exactly what the reader needs to know and could not previously be told.
+            "nothingToNarrate" or "serviceDown" or "blocked" or "retrying" or "notReady" => display.Label,
+            // "preparing" (genuinely in flight), "ready", "off", or anything added later: the existing
+            // words stand. A new voice state does NOT silently change this label until it is listed here.
+            _ => "Preparing voice",
         };
     }
 

--- a/src/CcDirector.Gateway.Contracts/TurnWidgetDto.cs
+++ b/src/CcDirector.Gateway.Contracts/TurnWidgetDto.cs
@@ -1,4 +1,4 @@
-namespace CcDirector.Gateway.Contracts;
+﻿namespace CcDirector.Gateway.Contracts;
 
 /// <summary>
 /// One card / "widget" in the structured Agent view, transport-friendly DTO.
@@ -58,7 +58,8 @@ public sealed class TurnsResponse
     public int LineCount { get; set; }
 
     /// <summary>
-    /// Status string: "ok" | "unsupported" | "no_session_id" | "no_jsonl" | "no_transcript" | "parse_error".
+    /// Status string: "ok" | "unsupported" | "no_session_id" | "no_jsonl" | "no_transcript" |
+    /// "empty_history" | "parse_error".
     ///
     /// ONLY "ok" means the conversation was actually read. Every other value is a FAILED read that still
     /// arrives as a SUCCESSFUL command result (the transport worked; the read did not), carrying an empty

--- a/src/CcDirector.Gateway.Contracts/TurnWidgetDto.cs
+++ b/src/CcDirector.Gateway.Contracts/TurnWidgetDto.cs
@@ -57,7 +57,16 @@ public sealed class TurnsResponse
     /// <summary>How many JSONL lines were parsed.</summary>
     public int LineCount { get; set; }
 
-    /// <summary>Status string: "ok" | "no_session_id" | "no_jsonl" | "parse_error".</summary>
+    /// <summary>
+    /// Status string: "ok" | "unsupported" | "no_session_id" | "no_jsonl" | "no_transcript" | "parse_error".
+    ///
+    /// ONLY "ok" means the conversation was actually read. Every other value is a FAILED read that still
+    /// arrives as a SUCCESSFUL command result (the transport worked; the read did not), carrying an empty
+    /// <see cref="Widgets"/> list. So a caller that looks only at the widgets cannot tell a failed read from
+    /// a session that genuinely has nothing to say - which is how voice narration went permanently silent on
+    /// unreadable sessions, recording "nothing to narrate" and never retrying (issue #2561). Check this
+    /// before drawing ANY conclusion from an empty widget list.
+    /// </summary>
     public string Status { get; set; } = "ok";
 
     /// <summary>Free-text error message if Status != "ok".</summary>

--- a/src/CcDirector.Gateway.UnitTests/DisplayPushVoiceEnrichmentTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/DisplayPushVoiceEnrichmentTests.cs
@@ -86,4 +86,77 @@ public sealed class DisplayPushVoiceEnrichmentTests
 
         Assert.Equal("yellow", s.EffectiveColor);
     }
+
+    // ---------- The push seam carries the REASON, not just the readiness (issue #2576) ----------
+
+    /// <summary>
+    /// The two booleans say there is no audio; they cannot say WHY. Without the reason on the row,
+    /// <c>SessionOrdering.StateLabel</c> has nothing to render and falls back to "Preparing voice" - so the
+    /// desktop would claim a narration was in flight for a session that will never produce one, which is the
+    /// defect on the phone wearing a different surface. The push seam must therefore stamp the same
+    /// <c>VoiceUnavailable</c> and <c>VoiceDisplay</c> facts the roster stamps.
+    ///
+    /// Asserted on the LABEL, not on the stamped field: the point is that the reason reaches the words the
+    /// desktop renders. Asserting the field alone would pass even if the label never read it.
+    /// </summary>
+    [Fact]
+    public void PushSeam_WhenNothingToNarrate_LabelSaysSo_NotPreparingVoice()
+    {
+        var s = PushedVoiceSession(snapshotAudioReady: false);
+
+        GatewayHost.EnrichVoiceThenFoldForPush(
+            new List<SessionDto> { s },
+            voiceGeneratingFor: _ => false,
+            voiceAudioReadyFor: _ => false,
+            tenant: TenantId.Local,
+            needsYouStampFor: null,
+            snoozeRegistry: null,
+            voiceUnavailableFor: _ => null,
+            nothingToNarrateFor: _ => true);
+
+        Assert.Equal("yellow", s.EffectiveColor);                    // the hold is unchanged
+        Assert.Equal("nothingToNarrate", s.VoiceDisplay?.Kind);      // the reason rode the push
+        Assert.Equal("Nothing to read aloud", s.StateLabel);         // and reached the words
+    }
+
+    [Fact]
+    public void PushSeam_WhenVoiceServiceDown_LabelSaysSo_NotPreparingVoice()
+    {
+        var s = PushedVoiceSession(snapshotAudioReady: false);
+
+        GatewayHost.EnrichVoiceThenFoldForPush(
+            new List<SessionDto> { s },
+            voiceGeneratingFor: _ => false,
+            voiceAudioReadyFor: _ => false,
+            tenant: TenantId.Local,
+            needsYouStampFor: null,
+            snoozeRegistry: null,
+            voiceUnavailableFor: _ => Core.HostedAi.HostedAiState.ServiceDown,
+            nothingToNarrateFor: _ => false);
+
+        Assert.NotNull(s.VoiceUnavailable);                          // the roster's own fact, on the push row
+        Assert.Equal("yellow", s.EffectiveColor);
+        Assert.Equal("Voice service down", s.StateLabel);
+    }
+
+    /// <summary>The negative control: with no reason to give, the push seam still folds the genuine
+    /// "being made right now" case to the existing words. The new stamps add a reason; they do not
+    /// change what a session with nothing wrong says.</summary>
+    [Fact]
+    public void PushSeam_WhileGenerating_WithNoReason_StillSaysPreparingVoice()
+    {
+        var s = PushedVoiceSession(snapshotAudioReady: false);
+
+        GatewayHost.EnrichVoiceThenFoldForPush(
+            new List<SessionDto> { s },
+            voiceGeneratingFor: _ => true,
+            voiceAudioReadyFor: _ => false,
+            tenant: TenantId.Local,
+            needsYouStampFor: null,
+            snoozeRegistry: null,
+            voiceUnavailableFor: _ => null,
+            nothingToNarrateFor: _ => false);
+
+        Assert.Equal("Preparing voice", s.StateLabel);
+    }
 }

--- a/src/CcDirector.Gateway.UnitTests/SessionOrderingTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionOrderingTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using CcDirector.Gateway.Contracts;
 using Xunit;
@@ -550,10 +550,25 @@ public sealed class SessionOrderingTests
     }
 
     [Fact]
-    public void StateLabel_VoiceHoldWithAnUnknownVerdictKind_FallsBackToPreparingVoice()
+    public void StateLabel_VoiceHoldWithAVerdictKindAddedLater_RendersItsWords()
     {
-        // A voice state added later does not silently change this label until it is listed in VoiceHoldLabel.
+        // A verdict added to VoiceDisplayFold later reaches the rail WITHOUT a second edit here. An earlier
+        // version of this rule kept an allow-list of known-good kinds and defaulted everything else back to
+        // "Preparing voice", which meant adding a voice state to the fold and having the rail quietly go on
+        // claiming a narration was in flight about it - a second rule wearing the shape of a default.
         var s = VoiceHoldingSession("somethingAddedLater", "Some new words");
+        Assert.Equal("Some new words", SessionOrdering.StateLabel(s));
+    }
+
+    [Theory]
+    [InlineData("ready", "Voice ready")]
+    [InlineData("off", "Voice off")]
+    public void StateLabel_VoiceHoldWithAVerdictThatCannotHonestlyReachHere_KeepsTheOldWords(string kind, string label)
+    {
+        // These two cannot honestly co-occur with the yellow hold (it runs only for a session with no audio
+        // that is in voice mode). If one ever does, the safe answer is the old behaviour - never a rail
+        // reading "Voice ready" beside a yellow dot, which is a row contradicting itself.
+        var s = VoiceHoldingSession(kind, label);
         Assert.Equal("Preparing voice", SessionOrdering.StateLabel(s));
     }
 

--- a/src/CcDirector.Gateway.UnitTests/SessionOrderingTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionOrderingTests.cs
@@ -563,11 +563,19 @@ public sealed class SessionOrderingTests
     [Theory]
     [InlineData("ready", "Voice ready")]
     [InlineData("off", "Voice off")]
+    [InlineData("working", "Agent is working")]
     public void StateLabel_VoiceHoldWithAVerdictThatCannotHonestlyReachHere_KeepsTheOldWords(string kind, string label)
     {
-        // These two cannot honestly co-occur with the yellow hold (it runs only for a session with no audio
-        // that is in voice mode). If one ever does, the safe answer is the old behaviour - never a rail
-        // reading "Voice ready" beside a yellow dot, which is a row contradicting itself.
+        // These three cannot honestly co-occur with the yellow hold (it runs only for a voice-mode session
+        // with no audio that is WAITING, and StateLabel returns "Working" above this arm for anything
+        // actually working). If one ever does arrive, the safe answer is the old behaviour - never a rail
+        // reading "Voice ready" or "Agent is working" beside a yellow dot on a session doing neither, which
+        // is a row contradicting itself.
+        //
+        // HONEST NOTE ON WHAT THESE PROVE: the "ready" and "off" rows also pass on the parent commit, so
+        // they are REGRESSION GUARDS on retained behaviour rather than evidence for the inversion - the
+        // inversion itself is proved by the future-kind test above. The "working" row is the discriminating
+        // one: the first version of the inverted list omitted it, so it renders "Agent is working" there.
         var s = VoiceHoldingSession(kind, label);
         Assert.Equal("Preparing voice", SessionOrdering.StateLabel(s));
     }

--- a/src/CcDirector.Gateway.UnitTests/SessionOrderingTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionOrderingTests.cs
@@ -496,6 +496,67 @@ public sealed class SessionOrderingTests
         Assert.Equal("Preparing voice", SessionOrdering.StateLabel(s));
     }
 
+    // ---------- The voice hold's WORDS tell the truth (issue #2576) ----------
+
+    /// <summary>A waiting voice session with no audio, carrying the Gateway's folded voice verdict.</summary>
+    private static SessionDto VoiceHoldingSession(string kind, string label)
+    {
+        var s = BrandNewVoiceSession();
+        s.IsBrandNew = false;
+        s.VoiceDisplay = new VoiceDisplay { Kind = kind, Label = label };
+        return s;
+    }
+
+    /// <summary>
+    /// THE DEFECT: "Preparing voice" was the only thing the label could say about a session with no audio,
+    /// so a state that would NEVER become audio wore it indefinitely. On 11 August a session sat on it for
+    /// 48 minutes while the Gateway's own verdict on the same row read "Nothing to read aloud".
+    ///
+    /// The dot is unchanged - the hold is still yellow, by the 2026-07-19 ruling. Only the words move, and
+    /// they are the words VoiceDisplayFold already chose, so there is one answer and not two.
+    /// </summary>
+    [Theory]
+    [InlineData("nothingToNarrate", "Nothing to read aloud")]
+    [InlineData("serviceDown", "Voice service down")]
+    [InlineData("blocked", "Voice needs credit")]
+    [InlineData("retrying", "Voice on its way")]
+    [InlineData("notReady", "No narration yet")]
+    public void StateLabel_VoiceHoldWithAReason_SaysTheReason_NotPreparingVoice(string kind, string label)
+    {
+        var s = VoiceHoldingSession(kind, label);
+        Assert.True(SessionOrdering.IsVoicePreparing(s));           // the hold itself is untouched...
+        Assert.Equal("yellow", SessionOrdering.EffectiveColor(s));  // ...and so is the dot
+        Assert.Equal(label, SessionOrdering.StateLabel(s));         // only the words changed
+    }
+
+    [Fact]
+    public void StateLabel_VoiceHoldWhileGenuinelyPreparing_StillSaysPreparingVoice()
+    {
+        // The positive case the words were always right about: something IS being made.
+        var s = VoiceHoldingSession("preparing", "Voice on its way");
+        s.VoiceGenerating = true;
+        Assert.Equal("Preparing voice", SessionOrdering.StateLabel(s));
+    }
+
+    [Fact]
+    public void StateLabel_VoiceHoldWithNoVerdictOnTheRow_FallsBackToPreparingVoice()
+    {
+        // A row carrying no folded verdict (an older client, or a surface that does not stamp one) keeps the
+        // existing words. The label renders a verdict; it never invents one.
+        var s = BrandNewVoiceSession();
+        s.IsBrandNew = false;
+        s.VoiceDisplay = null;
+        Assert.Equal("Preparing voice", SessionOrdering.StateLabel(s));
+    }
+
+    [Fact]
+    public void StateLabel_VoiceHoldWithAnUnknownVerdictKind_FallsBackToPreparingVoice()
+    {
+        // A voice state added later does not silently change this label until it is listed in VoiceHoldLabel.
+        var s = VoiceHoldingSession("somethingAddedLater", "Some new words");
+        Assert.Equal("Preparing voice", SessionOrdering.StateLabel(s));
+    }
+
     [Fact]
     public void EffectiveColor_BackgroundRunningAtTurnEnd_IsPurple_FromRawFacts()
     {

--- a/src/CcDirector.Gateway.UnitTests/TurnsVerbUnresolvedTranscriptTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TurnsVerbUnresolvedTranscriptTests.cs
@@ -119,9 +119,42 @@ public sealed class TurnsVerbUnresolvedTranscriptTests
 
             var resp = Read(sm, session);
 
-            Assert.NotEqual("ok", resp.Status);                    // the false success is gone...
-            Assert.Contains(resp.Status, new[] { "empty_history", "no_transcript" });
+            // Pinned to the EXACT status, not "anything but ok". Accepting either value would have passed
+            // just as happily on the no_transcript branch and proved nothing about the one under test.
+            Assert.Equal("empty_history", resp.Status);
+            Assert.False(string.IsNullOrWhiteSpace(resp.Error));
             Assert.Empty(resp.Widgets);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    /// <summary>
+    /// CLAUDE CODE TOO - the agent this verb runs for most often, and the one the first version of this rule
+    /// left out (found in review). A transcript file that EXISTS but parses to nothing is a read that
+    /// produced no conversation, not a conversation that was read, and stamping "ok" on it is the exact
+    /// false success this change exists to remove.
+    /// </summary>
+    [Fact]
+    public void Turns_ClaudeTranscriptThatExistsButIsEmpty_ReportsEmptyHistory_NotOk()
+    {
+        var (sm, session) = NewSession();
+        var claudeId = Guid.NewGuid();
+        try
+        {
+            // Put a REAL, empty transcript exactly where the reader will look for it, so the branch under
+            // test is the one that parses a present file - not the no_jsonl branch above it.
+            session.ClaudeSessionId = claudeId.ToString();
+            var jsonl = Core.Claude.ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(jsonl)!);
+            File.WriteAllText(jsonl, "");
+            try
+            {
+                var resp = Read(sm, session);
+
+                Assert.Equal("empty_history", resp.Status);
+                Assert.Empty(resp.Widgets);
+            }
+            finally { try { File.Delete(jsonl); } catch { /* best-effort */ } }
         }
         finally { sm.Dispose(); }
     }

--- a/src/CcDirector.Gateway.UnitTests/TurnsVerbUnresolvedTranscriptTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TurnsVerbUnresolvedTranscriptTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using CcDirector.ControlApi;
 using CcDirector.Core.Sessions;
 using CcDirector.Gateway.Contracts;
@@ -68,8 +68,9 @@ public sealed class TurnsVerbUnresolvedTranscriptTests
 
     /// <summary>
     /// The negative control: an agent that exposes no conversation history at all keeps its own distinct
-    /// status. "Unsupported" and "the transcript has not appeared yet" are different facts and a caller may
-    /// reasonably treat them differently - collapsing them would trade one lie for another.
+    /// status. "Unsupported" and "the transcript has not appeared yet" are different facts and the voice
+    /// service now treats them differently - one is terminal, the other is retried - so collapsing them
+    /// would trade one lie for another.
     /// </summary>
     [Fact]
     public void Turns_AgentWithNoHistoryProvider_StillReportsUnsupported()
@@ -82,6 +83,45 @@ public sealed class TurnsVerbUnresolvedTranscriptTests
             var resp = Read(sm, session);
 
             Assert.Equal("unsupported", resp.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    /// <summary>
+    /// THE OTHER HALF (found in review): a RESOLVED path is not a proven read either.
+    ///
+    /// Copilot and OpenCode resolve to a GLOBAL SQLite store, which exists or does not exist for reasons
+    /// that have nothing to do with this session - and both readers answer an empty history both for a store
+    /// with no repository match AND for a database error they caught. Stamping "ok" on that recreates the
+    /// exact false success this whole change removes, so an empty conversation gets its own status.
+    ///
+    /// Gemini is the case asserted here: it goes down the same branch with a deliberately null transcript
+    /// path (it reads the terminal buffer), and an embedded test session's buffer is empty - so it produces
+    /// a resolved-but-empty read deterministically, on any machine.
+    ///
+    /// COPILOT AND OPENCODE ARE DELIBERATELY NOT ASSERTED HERE, and the reason is worth writing down: their
+    /// readers open the DEVELOPER'S OWN store at CopilotHistoryReader.DefaultDatabasePath and match by
+    /// repository path, so what this test would assert depends on what happens to be in that database on the
+    /// machine running it. A first version of this test did include them and failed on exactly that - the
+    /// local Copilot store answered a non-empty history for a temporary directory. A test whose verdict
+    /// moves with the developer's machine is not evidence, so the store-backed agents are covered by the
+    /// status-handling tests in WingmanVoiceServiceTests (which drive "empty_history" directly) rather than
+    /// by reading a real database here.
+    /// </summary>
+    [Theory]
+    [InlineData(Core.Agents.AgentKind.Gemini)]
+    public void Turns_ResolvedSourceWithNoConversation_ReportsEmptyHistory_NotOk(Core.Agents.AgentKind agent)
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            session.AgentKind = agent;
+
+            var resp = Read(sm, session);
+
+            Assert.NotEqual("ok", resp.Status);                    // the false success is gone...
+            Assert.Contains(resp.Status, new[] { "empty_history", "no_transcript" });
+            Assert.Empty(resp.Widgets);
         }
         finally { sm.Dispose(); }
     }

--- a/src/CcDirector.Gateway.UnitTests/TurnsVerbUnresolvedTranscriptTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TurnsVerbUnresolvedTranscriptTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #2561: the <c>turns</c> verb must not report an UNRESOLVED TRANSCRIPT as a successful read of an
+/// empty conversation.
+///
+/// The non-Claude-Code branch used to stamp <c>Status = "ok"</c> unconditionally, but
+/// <c>SessionHistoryReader.ReadAll</c> answers <c>ConversationHistory.Empty</c> whenever
+/// <c>ResolveTranscriptPath</c> returns null - which is exactly what the per-agent locators
+/// (<c>PiSessionLocator</c>, <c>CodexRolloutLocator</c>, <c>GrokSessionLocator</c>) do before an agent has
+/// written its first transcript. So a Pi / Codex / Grok session whose transcript had not been located
+/// returned "ok" with no widgets, and the ONE field that could have told the caller otherwise agreed.
+///
+/// The cost was voice narration going permanently silent: it read this verb, saw no text widget, and
+/// recorded the non-failure "nothing to narrate", which is never retried and raises nothing anywhere. A Pi
+/// session observed on 12 August sat silent for 48 minutes while the roster showed it "Preparing voice".
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class TurnsVerbUnresolvedTranscriptTests
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private static (SessionManager sm, Session session) NewSession()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
+        return (sm, session);
+    }
+
+    private static TurnsResponse Read(SessionManager sm, Session session)
+    {
+        var command = new DirectorCommand { CommandId = "t1", Verb = "turns", SessionId = session.Id.ToString() };
+        var result = SessionReadExecutor.Turns(sm, command);
+        Assert.True(result.Ok);   // a failed READ still rides a successful command result - that is the trap
+        return JsonSerializer.Deserialize<TurnsResponse>(result.BodyJson!, Json)!;
+    }
+
+    /// <summary>
+    /// A supported non-Claude agent whose transcript has not been located yet. The session is embedded on a
+    /// throwaway repo path with a fresh id, so no locator can resolve a transcript for it - the exact state a
+    /// freshly-spawned Pi session is in before it writes its first turn.
+    /// </summary>
+    [Theory]
+    [InlineData(Core.Agents.AgentKind.Pi)]
+    [InlineData(Core.Agents.AgentKind.Codex)]
+    [InlineData(Core.Agents.AgentKind.Grok)]
+    public void Turns_SupportedAgentWithNoTranscriptYet_ReportsNoTranscript_NotOk(Core.Agents.AgentKind agent)
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            session.AgentKind = agent;
+
+            var resp = Read(sm, session);
+
+            Assert.Equal("no_transcript", resp.Status);
+            Assert.False(string.IsNullOrWhiteSpace(resp.Error));   // and it says WHY, so a caller can log it
+            Assert.Empty(resp.Widgets);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    /// <summary>
+    /// The negative control: an agent that exposes no conversation history at all keeps its own distinct
+    /// status. "Unsupported" and "the transcript has not appeared yet" are different facts and a caller may
+    /// reasonably treat them differently - collapsing them would trade one lie for another.
+    /// </summary>
+    [Fact]
+    public void Turns_AgentWithNoHistoryProvider_StillReportsUnsupported()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            session.AgentKind = Core.Agents.AgentKind.Cursor;
+
+            var resp = Read(sm, session);
+
+            Assert.Equal("unsupported", resp.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using CcDirector.AgentBrain;
@@ -437,7 +437,7 @@ public sealed class WingmanVoiceServiceTests : IDisposable
     [InlineData("no_transcript")]
     [InlineData("no_jsonl")]
     [InlineData("parse_error")]
-    [InlineData("unsupported")]
+    [InlineData("empty_history")]
     [InlineData("no_session_id")]
     public async Task GenerateAsync_WhenTurnsReadFailed_RecordsRetrying_NotNothingToNarrate(string status)
     {
@@ -513,9 +513,11 @@ public sealed class WingmanVoiceServiceTests : IDisposable
     }
 
     /// <summary>
-    /// A read that answers ends the read-failure Retrying it caused, so the session does not carry a stale
+    /// A read that answers ends the read-failure state it caused, so the session does not carry a stale
     /// "voice on its way" forever once the transcript appears. Cleared BEFORE the reply check, because the
     /// display fold consults the unavailable state ahead of nothing-to-narrate and would otherwise mask it.
+    /// Seeded through NoteReadFailed so the test proves the READ's own state clears - seeding the generic
+    /// NoteRetrying instead would have proved nothing about provenance, which is the point of the split.
     /// </summary>
     [Fact]
     public async Task GenerateAsync_WhenReadRecovers_ClearsTheReadFailureRetrying()
@@ -526,14 +528,104 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         try
         {
             var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath);
-            svc.NoteRetrying(TenantId.Local, "sid-1");   // left behind by an earlier failed read
+            svc.NoteReadFailed(TenantId.Local, "sid-1", HostedAiState.Retrying);   // left behind by an earlier failed read
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
-            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
-            Assert.True(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));   // and the honest verdict is not masked
+            Assert.Null(svc.ReadFailedFor(TenantId.Local, "sid-1"));
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));    // nothing else was standing, so the row is clean
+            Assert.True(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));    // and the honest verdict is not masked
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+
+    /// <summary>
+    /// "unsupported" is the one read failure that CANNOT recover: the agent exposes no conversation history
+    /// at all, so retrying can never produce one. It takes the terminal state instead, so the screen says
+    /// "Voice unavailable" rather than promising a narration that is not coming - and so the voice sweep can
+    /// leave it out of its three-per-cycle budget instead of letting it starve sessions that would produce
+    /// audio. Found in review: the first version of this fix retried it forever.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_WhenAgentHasNoConversationHistory_IsTerminal_NotRetriedForever()
+    {
+        var director = new TunnelReadStub("{\"status\":\"unsupported\",\"error\":\"no history provider\",\"widgets\":[]}");
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-unsup-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath);
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(HostedAiState.Unavailable, svc.ReadFailedFor(TenantId.Local, "sid-1"));
+            Assert.Equal(HostedAiState.Unavailable, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// A failed read must NEVER replace a standing account condition. "Add credit" is actionable and certain;
+    /// a failed transcript read is neither, and says nothing whatever about the account. The first version of
+    /// this fix wrote the read state into the SAME dictionary, so one unreachable tunnel downgraded
+    /// "Voice needs credit" to "voice on its way" - found in review.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_WhenReadFails_DoesNotOverwriteAStandingAccountCondition()
+    {
+        var director = new TunnelReadStub("{\"status\":\"no_transcript\",\"error\":\"not located\",\"widgets\":[]}");
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-acct-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath);
+            svc.NoteUnavailableForTest(TenantId.Local, "sid-1", HostedAiState.NeedsCredits);
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            // The account condition still wins: it is the more actionable and the more certain of the two.
+            Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            // ...and the read failure is still recorded, in its own store, so nothing is lost either.
+            Assert.Equal(HostedAiState.Retrying, svc.ReadFailedFor(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// The mirror: a successful read clears only the READ's own state. A Retrying set by the MODEL leg or the
+    /// speech leg is not evidence a transcript read can speak to, and erasing it flipped the row to "no
+    /// narration yet" for the length of another slow attempt and back again - found in review.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_WhenReadRecovers_DoesNotEraseAModelLegRetrying()
+    {
+        var director = new TunnelReadStub("{\"status\":\"ok\",\"widgets\":[{\"kind\":\"ToolUse\",\"content\":\"running a tool\"}]}");
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelretry-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath);
+            svc.NoteRetrying(TenantId.Local, "sid-1");   // the MODEL leg's own state, on the shared map
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            Assert.Null(svc.ReadFailedFor(TenantId.Local, "sid-1"));   // the read's own store is empty - it answered
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    [Fact]
+    public void ANewTurnReopensTheRead()
+    {
+        // A terminal read state must not outlive the turn that produced it: a new turn is a new transcript to
+        // try, and it is what lets a session the sweep had skipped back in.
+        var svc = NewService();
+        svc.NoteReadFailed(TenantId.Local, "s", HostedAiState.Unavailable);
+        svc.OnSessionWorking(TenantId.Local, "s");
+        Assert.Null(svc.ReadFailedFor(TenantId.Local, "s"));
     }
 
     /// <summary>A voice service wired to a recording brain and a text-to-speech stub that returns

--- a/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
@@ -617,6 +617,61 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
 
+    /// <summary>
+    /// The terminal skip is BOUNDED. Found in review: its first version was an unbounded skip whose only
+    /// escape was a Working transition, which the hosted push path observes on a 15-second sampler and can
+    /// miss entirely - so a stale terminal verdict would have survived forever and no later sweep could have
+    /// found the recovery. The sweep's question must therefore be time-limited, not "is it terminal".
+    /// </summary>
+    [Fact]
+    public void SweepSkip_IsBounded_AndAppliesOnlyToATerminalVerdict()
+    {
+        var svc = NewService();
+
+        // Nothing recorded: never skipped.
+        Assert.False(svc.ShouldSkipSweep(TenantId.Local, "s"));
+
+        // A RETRYABLE failure must not stand the sweep down at all - it is the thing the sweep exists to
+        // retry, and skipping it would recreate the permanent silence this whole change removes.
+        svc.NoteReadFailed(TenantId.Local, "s", HostedAiState.Retrying);
+        Assert.False(svc.ShouldSkipSweep(TenantId.Local, "s"));
+
+        // A TERMINAL one stands it down - for now.
+        svc.NoteReadFailed(TenantId.Local, "s", HostedAiState.Unavailable);
+        Assert.True(svc.ShouldSkipSweep(TenantId.Local, "s"));
+
+        // ...and the verdict itself is still reported while the skip holds, so the screen keeps saying why.
+        Assert.Equal(HostedAiState.Unavailable, svc.VoiceUnavailableFor(TenantId.Local, "s"));
+    }
+
+    /// <summary>
+    /// A terminal read verdict outranks a stale shared condition. Found in review: ranking the shared map
+    /// first let a stale "add credit" sit in front of "this agent has no conversation to read" - and for such
+    /// a session nothing clears the shared value, because it can never reach a successful synthesis. The
+    /// reader would be told to fix it with credit, which cannot fix it.
+    /// </summary>
+    [Fact]
+    public void ATerminalReadVerdict_OutranksAStaleAccountCondition()
+    {
+        var svc = NewService();
+        svc.NoteUnavailableForTest(TenantId.Local, "s", HostedAiState.NeedsCredits);
+        svc.NoteReadFailed(TenantId.Local, "s", HostedAiState.Unavailable);
+
+        Assert.Equal(HostedAiState.Unavailable, svc.VoiceUnavailableFor(TenantId.Local, "s"));
+    }
+
+    [Fact]
+    public void ARetryableReadVerdict_StillYieldsToAStandingAccountCondition()
+    {
+        // The other direction, unchanged: "add credit" is the more actionable and the more certain of the
+        // two, and a read that merely has not answered yet says nothing that should displace it.
+        var svc = NewService();
+        svc.NoteUnavailableForTest(TenantId.Local, "s", HostedAiState.NeedsCredits);
+        svc.NoteReadFailed(TenantId.Local, "s", HostedAiState.Retrying);
+
+        Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor(TenantId.Local, "s"));
+    }
+
     [Fact]
     public void ANewTurnReopensTheRead()
     {

--- a/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
@@ -421,6 +421,121 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         Assert.False(svc.NothingToNarrateFor(TenantId.Local, "s"));
     }
 
+    // ---------- A FAILED turns read is not "nothing to say" (issue #2561) ----------
+
+    /// <summary>
+    /// The turns verb reports a failed read as a SUCCESSFUL command result carrying an empty widget list and
+    /// a Status naming the real outcome. Before this fix nothing read that Status, so a missing transcript,
+    /// an unreadable transcript, a parse exception and an agent with no history provider were all recorded as
+    /// "nothing to narrate" - a NON-failure that is never retried and raises nothing anywhere. A Pi session
+    /// observed on 12 August sat silent for 48 minutes that way.
+    ///
+    /// Each of these statuses must record Retrying (so the voice sweep picks it up again and the screen says
+    /// something) and must NOT record nothing-to-narrate.
+    /// </summary>
+    [Theory]
+    [InlineData("no_transcript")]
+    [InlineData("no_jsonl")]
+    [InlineData("parse_error")]
+    [InlineData("unsupported")]
+    [InlineData("no_session_id")]
+    public async Task GenerateAsync_WhenTurnsReadFailed_RecordsRetrying_NotNothingToNarrate(string status)
+    {
+        // A failed read: the transport succeeded, so this is a success carrying no widgets - exactly the
+        // shape that used to be indistinguishable from a session waiting on a prompt.
+        var director = new TunnelReadStub($"{{\"status\":\"{status}\",\"error\":\"the read failed\",\"widgets\":[]}}");
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-readfail-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new RecordingBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath);
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));   // the lie this fix removes
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+            Assert.Equal(0, brain.AskCount);                                  // nothing was read, so nothing to translate
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>A tunnel read that does not answer at all (the owning Director is not connected) is the same
+    /// class of non-evidence and takes the same Retrying treatment - never "nothing to narrate".</summary>
+    [Fact]
+    public async Task GenerateAsync_WhenTurnsReadDoesNotAnswer_RecordsRetrying_NotNothingToNarrate()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-readnull-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new RecordingBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath);
+            // A null command result is what DirectorCommandRouter yields for an unreachable Director.
+            CcDirector.Gateway.Api.DirectorCommandRouter.SendDirectorCommandAsync unreachable =
+                (_, _, _) => Task.FromResult<CcDirector.Gateway.Contracts.DirectorCommandResult?>(null);
+            var route = new CcDirector.Gateway.Api.SessionVerbClient(
+                new CcDirector.Gateway.Contracts.DirectorDto { DirectorId = "d1", ControlEndpoint = "http://tunnel-only" },
+                unreachable);
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", route, CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));
+            Assert.Equal(0, brain.AskCount);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// The other direction, so the fix cannot be "record Retrying for everything": a read that SUCCEEDS and
+    /// genuinely contains no text reply is still the honest "nothing to narrate", and still raises no failure.
+    /// This is the state a session waiting on a prompt is actually in, and it must survive the change.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_WhenReadSucceedsWithNoText_StillRecordsNothingToNarrate()
+    {
+        var director = new TunnelReadStub("{\"status\":\"ok\",\"widgets\":[{\"kind\":\"ToolUse\",\"content\":\"running a tool\"}]}");
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-oknotext-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new RecordingBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath);
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.True(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));   // still NOT a failure
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// A read that answers ends the read-failure Retrying it caused, so the session does not carry a stale
+    /// "voice on its way" forever once the transcript appears. Cleared BEFORE the reply check, because the
+    /// display fold consults the unavailable state ahead of nothing-to-narrate and would otherwise mask it.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_WhenReadRecovers_ClearsTheReadFailureRetrying()
+    {
+        var director = new TunnelReadStub("{\"status\":\"ok\",\"widgets\":[{\"kind\":\"ToolUse\",\"content\":\"running a tool\"}]}");
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-recover-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath);
+            svc.NoteRetrying(TenantId.Local, "sid-1");   // left behind by an earlier failed read
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            Assert.True(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));   // and the honest verdict is not masked
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
     /// <summary>A voice service wired to a recording brain and a text-to-speech stub that returns
     /// <paramref name="audio"/>, so the full turn-end path (fetch -> translate -> synthesize -> store)
     /// runs without a live model or provider.</summary>

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -736,19 +736,34 @@ internal static class GatewayWingmanVoiceEndpoint
             // the screen says so, and let the voice sweep try again.
             if (turns is null || !string.Equals(turns.Status, "ok", StringComparison.OrdinalIgnoreCase))
             {
-                voice.NoteRetrying(reqTenant.Value, sid);
+                // "unsupported" is TERMINAL - this agent exposes no conversation history at all, so no amount
+                // of retrying will produce one and saying "it will keep trying" would be the same lie in a new
+                // costume. Everything else here can become readable on a later pass. Recorded through
+                // NoteReadFailed, into the read's own store, so it can never overwrite a standing account
+                // condition (see TenantVoiceState.ReadFailed).
+                var terminal = string.Equals(turns?.Status, "unsupported", StringComparison.OrdinalIgnoreCase);
+                voice.NoteReadFailed(reqTenant.Value, sid, terminal ? HostedAiState.Unavailable : HostedAiState.Retrying);
                 FileLog.Write(
                     $"[GatewayWingmanVoice] explain sid={sid}: turns read FAILED "
                     + $"(status={turns?.Status ?? "(no answer)"} error={turns?.Error ?? "(none)"}) "
-                    + "- Retrying; NOT reported as nothing-to-summarize (issue #2561).");
+                    + $"- {(terminal ? "TERMINAL" : "Retrying")}; NOT reported as nothing-to-summarize (issue #2561).");
                 return Results.Json(new
                 {
                     reply = "",
-                    spoken = "I could not read this session's conversation just now - it will keep trying.",
+                    spoken = terminal
+                        ? "This agent does not keep a conversation I can read back to you."
+                        : "I could not read this session's conversation just now - it will keep trying.",
                     replySeconds = 0.0,
-                    retrying = true,
+                    retrying = !terminal,
                 });
             }
+
+            // The read answered: clear whatever the LAST failed read recorded, so a stale retry verdict does
+            // not go on masking the honest result below. VoiceDisplayFold consults the unavailable state
+            // before nothingToNarrate, so without this an explain that failed once and then succeeded onto an
+            // empty turn kept reporting "voice on its way" forever (found in review). Only the read's own
+            // fact is cleared - the model and speech states clear where they were set.
+            voice.ClearReadFailed(reqTenant.Value, sid);
 
             var widgets = turns.Widgets ?? new List<TurnWidgetDto>();
             var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -721,12 +721,40 @@ internal static class GatewayWingmanVoiceEndpoint
                 return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
 
             var turns = await route.GetTurnsAsync(sid, ct);
-            var widgets = turns?.Widgets ?? new List<TurnWidgetDto>();
+
+            voice.Mark(reqTenant.Value, sid);   // opening voice on a session makes it a voice session (kept fresh on turn-end)
+
+            // A FAILED READ IS NOT "NOTHING TO SUMMARIZE" (issue #2561). GetTurnsAsync answers null when the
+            // tunnel call failed, and otherwise carries the real outcome in Status - a failed read arrives as
+            // a SUCCESS with an empty widget list, because the transport worked even though the read did not.
+            //
+            // Reading only the widgets makes this route tell the person "this session has not produced
+            // anything to summarize yet" - a confident, wrong sentence about their own session - and record
+            // the never-retried "nothing to narrate" fact behind it. It is the same mistake the automatic
+            // path made, and on THIS route it is the one the owner presses a button to see. The honest answer
+            // is the one the model-leg timeout below already gives: say it is still coming, record Retrying so
+            // the screen says so, and let the voice sweep try again.
+            if (turns is null || !string.Equals(turns.Status, "ok", StringComparison.OrdinalIgnoreCase))
+            {
+                voice.NoteRetrying(reqTenant.Value, sid);
+                FileLog.Write(
+                    $"[GatewayWingmanVoice] explain sid={sid}: turns read FAILED "
+                    + $"(status={turns?.Status ?? "(no answer)"} error={turns?.Error ?? "(none)"}) "
+                    + "- Retrying; NOT reported as nothing-to-summarize (issue #2561).");
+                return Results.Json(new
+                {
+                    reply = "",
+                    spoken = "I could not read this session's conversation just now - it will keep trying.",
+                    replySeconds = 0.0,
+                    retrying = true,
+                });
+            }
+
+            var widgets = turns.Widgets ?? new List<TurnWidgetDto>();
             var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;
             // Recent conversation so the wingman can give context to a short/terse reply.
             var recentContext = WingmanTranslator.BuildRecentContext(widgets);
 
-            voice.Mark(reqTenant.Value, sid);   // opening voice on a session makes it a voice session (kept fresh on turn-end)
             if (string.IsNullOrWhiteSpace(lastReply))
             {
                 // No text reply to read aloud (waiting on a prompt / menu). Record the honest "nothing to

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1366,7 +1366,16 @@ public sealed class GatewayHost : IAsyncDisposable
                 // owning tenant so a session id shared across accounts keeps a per-tenant "waiting since".
                 tenant: _tenantPass.Current ?? TenantId.Local,
                 needsYouStampFor: (tenant, sid, isRed) => _needsYouClock.Stamp(tenant, sid, isRed),
-                snoozeRegistry: _snoozeRegistry),
+                snoozeRegistry: _snoozeRegistry,
+                // Same tenant guard as the two booleans above: an ambient tenant that cannot name a voice
+                // partition answers "no voice state at all" rather than throwing out of PushSnapshot.
+                voiceUnavailableFor: sid => _tenantPass.Current is { } t
+                    && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
+                        ? _voiceService?.VoiceUnavailableFor(t, sid)
+                        : null,
+                nothingToNarrateFor: sid => _tenantPass.Current is { } t
+                    && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
+                    && _voiceService?.NothingToNarrateFor(t, sid) == true),
             SendCommandAsync,
             currentScopeKey: () => _tenantPass.Current?.Value);
         // Mission Screen mission (Phase 1b, issue #1405): the mission-WHY store, at a Gateway-side file
@@ -3776,12 +3785,32 @@ public sealed class GatewayHost : IAsyncDisposable
         Func<string, bool> voiceAudioReadyFor,
         TenantId tenant,
         Func<TenantId, string, bool, DateTime?>? needsYouStampFor,
-        Snooze.SnoozeRegistry? snoozeRegistry)
+        Snooze.SnoozeRegistry? snoozeRegistry,
+        Func<string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
+        Func<string, bool>? nothingToNarrateFor = null)
     {
         foreach (var s in sessions)
         {
             s.VoiceGenerating = voiceGeneratingFor(s.SessionId);
             s.VoiceAudioReady = voiceAudioReadyFor(s.SessionId);
+            // The REASON there is no voice, carried on the push exactly as the roster carries it. Without
+            // these two the pushed row holds only the two readiness booleans, so the desktop can be told
+            // "no audio" but never WHY - and SessionOrdering.VoiceHoldLabel, which renders the reason the
+            // Gateway already folded, has nothing to render and falls back to "Preparing voice" forever.
+            // The roster path stamps both (GatewayEndpoints); this is the same stamp so the two surfaces
+            // cannot say different things about one session. Null delegates leave the fields unset, which
+            // is the pre-existing behaviour and keeps every non-production caller compiling unchanged.
+            var unavailable = voiceUnavailableFor?.Invoke(s.SessionId);
+            if (unavailable is Core.HostedAi.HostedAiState reason)
+                s.VoiceUnavailable = HostedAi.HostedAiHttp.Dto(reason);
+            s.VoiceDisplay = Wingman.VoiceDisplayFold.Fold(
+                voiceMode: s.VoiceMode,
+                agentWorking: string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase)
+                           || string.Equals(s.ActivityState, "Starting", StringComparison.OrdinalIgnoreCase),
+                hasAudio: s.VoiceAudioReady,
+                generating: s.VoiceGenerating,
+                unavailable: unavailable,
+                nothingToNarrate: nothingToNarrateFor?.Invoke(s.SessionId) ?? false);
         }
         Api.GatewayEndpoints.StampFleetRolesAndFold(sessions, sessions, needsYouStampFor, snoozeRegistry, tenant);
     }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1989,6 +1989,14 @@ public sealed class GatewayHost : IAsyncDisposable
                 {
                     if (generated >= 3) break;                       // gentle on the serialized brain (global cap)
                     if (vs.HasVoice(tenant, sid)) continue;          // already cached, nothing to do
+                    // A session whose agent exposes NO conversation history will never become readable, so
+                    // re-reading it every cycle buys nothing and is not free: this pass generates at most
+                    // three per cycle across all tenants, and a handful of such sessions can hold those
+                    // slots and starve the sessions that would actually produce audio (found in review).
+                    // Its screen already says "Voice unavailable" from the terminal state the read recorded,
+                    // so nothing is hidden by skipping it. A new turn clears that state (OnSessionWorking),
+                    // which is what lets a session back in if it ever does start exposing a conversation.
+                    if (vs.ReadFailedFor(tenant, sid) == Core.HostedAi.HostedAiState.Unavailable) continue;
                     var located = PushedSessions.TryLocate(tenant, sid, stale);
                     if (located is not { } loc) continue;            // not owned by any of this tenant's directors
                     var director = Registry.Get(tenant, loc.DirectorId);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1989,14 +1989,20 @@ public sealed class GatewayHost : IAsyncDisposable
                 {
                     if (generated >= 3) break;                       // gentle on the serialized brain (global cap)
                     if (vs.HasVoice(tenant, sid)) continue;          // already cached, nothing to do
-                    // A session whose agent exposes NO conversation history will never become readable, so
-                    // re-reading it every cycle buys nothing and is not free: this pass generates at most
-                    // three per cycle across all tenants, and a handful of such sessions can hold those
-                    // slots and starve the sessions that would actually produce audio (found in review).
-                    // Its screen already says "Voice unavailable" from the terminal state the read recorded,
-                    // so nothing is hidden by skipping it. A new turn clears that state (OnSessionWorking),
-                    // which is what lets a session back in if it ever does start exposing a conversation.
-                    if (vs.ReadFailedFor(tenant, sid) == Core.HostedAi.HostedAiState.Unavailable) continue;
+                    // A session whose agent exposes NO conversation history will not become readable by being
+                    // asked again immediately, and asking is not free: this pass generates at most three per
+                    // cycle across ALL tenants, so a handful of such sessions can hold those slots and starve
+                    // the sessions that would actually produce audio (found in review). Its screen already
+                    // says "Voice unavailable" from the terminal verdict the read recorded, so nothing is
+                    // hidden by standing down for a while.
+                    //
+                    // BOUNDED, NEVER PERMANENT. The first version of this skip was an unbounded `continue`
+                    // whose only escape was the Working transition - which on the hosted push path is
+                    // observed by TurnEndWatcher's 15-second sampler and can be missed entirely by a quick
+                    // turn. A stale terminal verdict would then have survived forever, and unlike before the
+                    // skip existed, no later sweep could have found the recovery. ShouldSkipSweep carries its
+                    // own revalidation deadline, so the read happens again on its own (found in review).
+                    if (vs.ShouldSkipSweep(tenant, sid)) continue;
                     var located = PushedSessions.TryLocate(tenant, sid, stale);
                     if (located is not { } loc) continue;            // not owned by any of this tenant's directors
                     var director = Registry.Get(tenant, loc.DirectorId);

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -68,6 +68,24 @@ public sealed class WingmanVoiceService
         public readonly ConcurrentDictionary<string, byte> NothingToNarrate = new();       // sid -> the last turn has no text reply to read aloud (waiting on a prompt)
         public readonly ConcurrentDictionary<string, DateTime> PreferBackupUntil = new();  // sid -> UTC deadline while this session routes past a silent primary (issue devthrottle_internal#405)
         public readonly ConcurrentDictionary<string, byte> InFlight = new();               // sid -> a generation is running now
+
+        /// <summary>
+        /// Why the TRANSCRIPT READ for this session did not produce a conversation, or absent when the last
+        /// read answered (issue #2561). Its OWN dictionary, deliberately not a value written into
+        /// <see cref="Unavailable"/>, because a retry state has to carry its provenance.
+        ///
+        /// Writing it into Unavailable was wrong in both directions, and both were found in review. Setting
+        /// it OVERWROTE a standing NeedsCredits / CapReached / NeedsKey - an actionable account condition
+        /// replaced by a weaker "on its way", on the evidence of a failed read that says nothing about the
+        /// account. And clearing it on a successful read ERASED a Retrying that the MODEL or SPEECH leg had
+        /// set, which a transcript read has equally no evidence about; the row would flip to "no narration
+        /// yet" for the length of another slow attempt and back again.
+        ///
+        /// Separate storage makes both correct by construction: the read writes and clears only its own
+        /// fact, the account and provider states keep theirs, and <see cref="VoiceUnavailableFor"/> decides
+        /// precedence in ONE place.
+        /// </summary>
+        public readonly ConcurrentDictionary<string, HostedAiState> ReadFailed = new();
     }
 
     private readonly WingmanTranslator _translator;
@@ -629,8 +647,38 @@ public sealed class WingmanVoiceService
     /// <c>/sessions</c> aggregation stamps the shared message onto <c>SessionDto.VoiceUnavailable</c>
     /// from this so the owning UI shows the consistent state.
     /// </summary>
+    /// <remarks>
+    /// THE ONE PLACE the two sources are ranked (issue #2561). An account / provider condition
+    /// (<c>Unavailable</c>) OUTRANKS a transcript-read failure (<c>ReadFailed</c>), because it is the more
+    /// actionable of the two and the more certain: "add credit" tells the owner something to do, while a
+    /// failed read is a condition the sweep is already chasing on its own. Ranking here rather than by
+    /// overwriting one dictionary with the other is what lets each writer clear only what it established.
+    /// </remarks>
     public HostedAiState? VoiceUnavailableFor(TenantId tenant, string sid)
-        => StateFor(tenant).Unavailable.TryGetValue(sid, out var s) ? s : (HostedAiState?)null;
+    {
+        var state = StateFor(tenant);
+        if (state.Unavailable.TryGetValue(sid, out var s)) return s;
+        return state.ReadFailed.TryGetValue(sid, out var r) ? r : (HostedAiState?)null;
+    }
+
+    /// <summary>
+    /// Record why this session's TRANSCRIPT READ did not produce a conversation - <see cref="HostedAiState.Retrying"/>
+    /// for a condition that can become readable (the tunnel did not answer, the transcript has not appeared
+    /// yet, a parse failed), or <see cref="HostedAiState.Unavailable"/> for one that cannot without a change
+    /// of agent (this agent exposes no conversation history at all). Kept apart from the account / provider
+    /// state so neither overwrites the other - see <c>TenantVoiceState.ReadFailed</c>.
+    /// </summary>
+    public void NoteReadFailed(TenantId tenant, string sid, HostedAiState state) => StateFor(tenant).ReadFailed[sid] = state;
+
+    /// <summary>The transcript read answered, so whatever the last failed read recorded is over. Clears ONLY
+    /// the read's own fact: a model timeout, a rate limit, or a standing account condition are all things a
+    /// successful transcript read has no evidence about.</summary>
+    public void ClearReadFailed(TenantId tenant, string sid) => StateFor(tenant).ReadFailed.TryRemove(sid, out _);
+
+    /// <summary>What the last transcript read recorded, or null when it answered. Exposed so the voice sweep
+    /// can leave a session whose agent will NEVER have a conversation out of its per-cycle budget.</summary>
+    public HostedAiState? ReadFailedFor(TenantId tenant, string sid)
+        => StateFor(tenant).ReadFailed.TryGetValue(sid, out var s) ? s : (HostedAiState?)null;
 
     /// <summary>
     /// True when this session's latest turn has NO assistant text reply to read aloud - it is waiting for
@@ -661,6 +709,11 @@ public sealed class WingmanVoiceService
     /// speech-leg unavailable state.
     /// </summary>
     public void NoteRetrying(TenantId tenant, string sid) => StateFor(tenant).Unavailable[sid] = HostedAiState.Retrying;
+
+    /// <summary>Test seam: seed a standing ACCOUNT / provider condition (the state a failed synthesis
+    /// records) so a test can prove a later read failure does not overwrite it.</summary>
+    internal void NoteUnavailableForTest(TenantId tenant, string sid, HostedAiState state)
+        => StateFor(tenant).Unavailable[sid] = state;
 
     /// <summary>
     /// True when an exception from the model (translation) leg means it DID NOT ANSWER - a bounded
@@ -702,6 +755,7 @@ public sealed class WingmanVoiceService
         if (wasVoice) SaveVoiceSessions(tenant);
         state.Generating.TryRemove(sid, out _);
         state.Unavailable.TryRemove(sid, out _);        // voice is off, so its unavailable-state is moot (issue #939)
+        state.ReadFailed.TryRemove(sid, out _);         // ...and so is whatever the last transcript read recorded
         state.NothingToNarrate.TryRemove(sid, out _);   // voice is off, so "nothing to narrate" is moot too
         state.PreferBackupUntil.TryRemove(sid, out _);  // voice is off, so the backup-routing window is moot too (issue devthrottle_internal#405)
         if (state.Ready.TryRemove(sid, out _))
@@ -723,6 +777,7 @@ public sealed class WingmanVoiceService
         // yellow "wingman running" marker too - raw activity wins while the agent works.
         state.Generating.TryRemove(sid, out _);
         state.Unavailable.TryRemove(sid, out _);        // a fresh turn clears the old unavailable-state (dismissible, issue #939)
+        state.ReadFailed.TryRemove(sid, out _);         // ...and re-opens the read: a new turn is a new transcript to try
         state.NothingToNarrate.TryRemove(sid, out _);   // a fresh turn supersedes "nothing to narrate" - re-evaluated on its turn-end
         if (state.Ready.TryRemove(sid, out _))
         {
@@ -877,12 +932,22 @@ public sealed class WingmanVoiceService
         //
         // The correct treatment is the one the MODEL leg already applies a few dozen lines below (see
         // IsModelDidNotAnswer): a read that did not answer is evidence about the READ, not about the
-        // conversation, so it records Retrying and is picked up again by the voice sweep. Retrying is the
-        // right state rather than a hard failure because these conditions are genuinely transient - a
-        // transcript that has not been located yet appears once the agent writes its first turn.
+        // conversation, so it is recorded as a read failure and picked up again by the voice sweep.
+        //
+        // NOT EVERY FAILED READ IS RETRYABLE, and the difference is recorded rather than flattened (found in
+        // review). "unsupported" means this agent exposes no conversation history AT ALL - retrying cannot
+        // change that, and telling the owner "voice on its way" forever would be the same lie in a new
+        // costume. It takes the terminal HostedAiState.Unavailable, which folds to a plain "Voice
+        // unavailable". Everything else here CAN become readable on a later pass - the tunnel comes back, the
+        // transcript appears once the agent writes its first turn, a half-written line finishes - so those
+        // stay Retrying.
+        //
+        // The state is recorded through NoteReadFailed, into the read's OWN store, never over the account /
+        // provider state - see TenantVoiceState.ReadFailed for why writing it into Unavailable was wrong in
+        // both directions.
         if (turns is null)
         {
-            state.Unavailable[sid] = HostedAiState.Retrying;
+            NoteReadFailed(tenant, sid, HostedAiState.Retrying);
             FileLog.Write(
                 $"[WingmanVoiceService] turns read did not answer for sid={sid} (owning Director not connected) "
                 + "- Retrying; the voice sweep picks it up again. NOT recorded as nothing-to-narrate (issue #2561).");
@@ -890,22 +955,23 @@ public sealed class WingmanVoiceService
         }
         if (!string.Equals(turns.Status, "ok", StringComparison.OrdinalIgnoreCase))
         {
-            state.Unavailable[sid] = HostedAiState.Retrying;
+            var terminal = string.Equals(turns.Status, "unsupported", StringComparison.OrdinalIgnoreCase);
+            NoteReadFailed(tenant, sid, terminal ? HostedAiState.Unavailable : HostedAiState.Retrying);
             FileLog.Write(
                 $"[WingmanVoiceService] turns read FAILED for sid={sid}: status={turns.Status} "
-                + $"error={turns.Error ?? "(none)"} - Retrying; the voice sweep picks it up again. "
+                + $"error={turns.Error ?? "(none)"} - {(terminal ? "TERMINAL (this agent exposes no conversation history)" : "Retrying; the voice sweep picks it up again")}. "
                 + "NOT recorded as nothing-to-narrate (issue #2561).");
             return false;
         }
-        // The read answered, so a Retrying left behind by an EARLIER failed read is over. Cleared HERE,
-        // before the reply check, because VoiceDisplayFold consults `unavailable` BEFORE `nothingToNarrate`
-        // - a stale Retrying would mask the honest "nothing to read aloud" verdict on the very next pass.
-        // Only Retrying is cleared: a recorded NeedsCredits / CapReached / NeedsKey is a real, standing
-        // condition that a successful turns read says nothing about, and clearing it here would make the
-        // "add credit" message flap on and off with every sweep. Those still clear on a successful
-        // synthesis (StoreSpokenAsync) and on the Working transition, exactly as before.
-        if (state.Unavailable.TryGetValue(sid, out var prior) && prior == HostedAiState.Retrying)
-            state.Unavailable.TryRemove(sid, out _);
+        // The read answered, so whatever the last failed read recorded is over. Cleared HERE, before the
+        // reply check, because VoiceDisplayFold consults the unavailable state BEFORE nothingToNarrate - a
+        // stale read failure would mask the honest "nothing to read aloud" verdict on the very next pass.
+        // This clears ONLY the read's own fact: a model timeout, a rate limit, and a standing NeedsCredits /
+        // CapReached / NeedsKey are all things a successful transcript read has no evidence about, and each
+        // still clears where it was set (StoreSpokenAsync on a successful synthesis, OnSessionWorking on a
+        // new turn). An earlier version of this line cleared any Retrying in the shared Unavailable map and
+        // therefore erased model-leg and speech-leg states it had not established.
+        ClearReadFailed(tenant, sid);
         var widgets = turns.Widgets ?? new List<TurnWidgetDto>();
         var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;
         if (string.IsNullOrWhiteSpace(lastReply))

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -59,6 +59,30 @@ public sealed class WingmanVoiceService
     /// row. This is the in-memory twin of the per-tenant directory on disk: the isolation is the container,
     /// not a check performed at the point of read.
     /// </summary>
+    /// <summary>
+    /// What the last transcript read recorded, and WHEN IT STOPS BEING TAKEN ON TRUST.
+    ///
+    /// The deadline exists because a terminal read verdict is a claim about the world that can go stale, and
+    /// the sweep acts on it by SKIPPING the session. Found in review: the first version of that skip was an
+    /// unbounded `continue` whose only escape was <see cref="OnSessionWorking"/> - and on the hosted push
+    /// path that clear is driven by TurnEndWatcher's 15-second sampler, which the codebase already documents
+    /// as a racy sampled edge (see the note in GenerateOnceAsync about a Working transition falling between
+    /// two samples). A session whose turn was quick enough to be missed would have kept a stale terminal
+    /// marker forever, and - unlike before the skip existed - no later sweep could have discovered the
+    /// recovery. A Director update that ADDS a history provider is exactly when that would bite.
+    ///
+    /// So the skip is time-bounded rather than permanent: it saves the repeated work that starves the
+    /// sweep's small per-cycle budget, and it still re-reads on its own. Recovery no longer depends on
+    /// catching an edge.
+    /// </summary>
+    private readonly record struct ReadFailure(HostedAiState State, DateTime RevalidateAfterUtc);
+
+    /// <summary>How long a TERMINAL read verdict ("this agent exposes no conversation history") is taken on
+    /// trust before the sweep reads once more to check it is still true. Long enough that a handful of such
+    /// sessions cannot dominate the three generations a cycle allows; short enough that an agent which gains
+    /// a history provider is picked up without anyone intervening.</summary>
+    private static readonly TimeSpan TerminalReadRevalidateAfter = TimeSpan.FromMinutes(10);
+
     private sealed class TenantVoiceState
     {
         public readonly ConcurrentDictionary<string, byte> VoiceSessions = new();          // sid -> marker
@@ -85,7 +109,7 @@ public sealed class WingmanVoiceService
         /// fact, the account and provider states keep theirs, and <see cref="VoiceUnavailableFor"/> decides
         /// precedence in ONE place.
         /// </summary>
-        public readonly ConcurrentDictionary<string, HostedAiState> ReadFailed = new();
+        public readonly ConcurrentDictionary<string, ReadFailure> ReadFailed = new();
     }
 
     private readonly WingmanTranslator _translator;
@@ -657,8 +681,15 @@ public sealed class WingmanVoiceService
     public HostedAiState? VoiceUnavailableFor(TenantId tenant, string sid)
     {
         var state = StateFor(tenant);
+        var read = state.ReadFailed.TryGetValue(sid, out var r) ? r.State : (HostedAiState?)null;
+        // A TERMINAL read verdict outranks EVERYTHING. Found in review: ranking the shared map first meant a
+        // stale NeedsCredits - or a stale model-leg Retrying - could sit in front of "this agent has no
+        // conversation to read", and for such a session nothing clears the shared value, because it can never
+        // reach a successful synthesis. The reader would be told to add credit to fix a problem credit cannot
+        // fix. No account or provider action makes an unreadable transcript readable, so this fact wins.
+        if (read == HostedAiState.Unavailable) return HostedAiState.Unavailable;
         if (state.Unavailable.TryGetValue(sid, out var s)) return s;
-        return state.ReadFailed.TryGetValue(sid, out var r) ? r : (HostedAiState?)null;
+        return read;
     }
 
     /// <summary>
@@ -668,7 +699,12 @@ public sealed class WingmanVoiceService
     /// of agent (this agent exposes no conversation history at all). Kept apart from the account / provider
     /// state so neither overwrites the other - see <c>TenantVoiceState.ReadFailed</c>.
     /// </summary>
-    public void NoteReadFailed(TenantId tenant, string sid, HostedAiState state) => StateFor(tenant).ReadFailed[sid] = state;
+    public void NoteReadFailed(TenantId tenant, string sid, HostedAiState state)
+        => StateFor(tenant).ReadFailed[sid] = new ReadFailure(
+            state,
+            // Only a TERMINAL verdict is taken on trust for a while; a retryable one is re-read next cycle,
+            // so its deadline is already past.
+            state == HostedAiState.Unavailable ? DateTime.UtcNow + TerminalReadRevalidateAfter : DateTime.MinValue);
 
     /// <summary>The transcript read answered, so whatever the last failed read recorded is over. Clears ONLY
     /// the read's own fact: a model timeout, a rate limit, or a standing account condition are all things a
@@ -678,7 +714,17 @@ public sealed class WingmanVoiceService
     /// <summary>What the last transcript read recorded, or null when it answered. Exposed so the voice sweep
     /// can leave a session whose agent will NEVER have a conversation out of its per-cycle budget.</summary>
     public HostedAiState? ReadFailedFor(TenantId tenant, string sid)
-        => StateFor(tenant).ReadFailed.TryGetValue(sid, out var s) ? s : (HostedAiState?)null;
+        => StateFor(tenant).ReadFailed.TryGetValue(sid, out var s) ? s.State : (HostedAiState?)null;
+
+    /// <summary>
+    /// True when the voice sweep should leave this session alone THIS CYCLE: the last read said the agent
+    /// exposes no conversation history at all, and that verdict has not yet come up for revalidation. It is a
+    /// bounded skip, never a permanent one - see <see cref="ReadFailure"/> for why an unbounded one wedged.
+    /// </summary>
+    public bool ShouldSkipSweep(TenantId tenant, string sid)
+        => StateFor(tenant).ReadFailed.TryGetValue(sid, out var s)
+           && s.State == HostedAiState.Unavailable
+           && DateTime.UtcNow < s.RevalidateAfterUtc;
 
     /// <summary>
     /// True when this session's latest turn has NO assistant text reply to read aloud - it is waiting for

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -859,13 +859,61 @@ public sealed class WingmanVoiceService
     {
         var state = StateFor(tenant);
         var turns = await route.GetTurnsAsync(sid, ct);
-        var widgets = turns?.Widgets ?? new List<TurnWidgetDto>();
+        // A FAILED READ IS NOT "NOTHING TO SAY". This is the whole of issue #2561, and it is why sessions
+        // went permanently silent with no error raised anywhere.
+        //
+        // GetTurnsAsync answers null when the tunnel call failed (the owning Director is not connected), and
+        // otherwise hands back a TurnsResponse whose Status carries the REAL outcome - "ok", or one of
+        // "unsupported" / "no_session_id" / "no_jsonl" / "no_transcript" / "parse_error". Every one of those
+        // failures arrives as a SUCCESSFUL command result with an EMPTY widget list, because the transport
+        // worked even though the read did not.
+        //
+        // This method used to read the widgets and nothing else. So a missing transcript, an unreadable
+        // transcript, a parse exception and an agent with no history provider all looked identical to a
+        // session that was simply waiting on a prompt - and were recorded as NothingToNarrate, which is a
+        // NON-failure that is never retried and produces no log line, no Retrying state, and no error on any
+        // screen. Observed 12 August: a Pi session sat silent for 48 minutes while the roster showed it
+        // "Preparing voice".
+        //
+        // The correct treatment is the one the MODEL leg already applies a few dozen lines below (see
+        // IsModelDidNotAnswer): a read that did not answer is evidence about the READ, not about the
+        // conversation, so it records Retrying and is picked up again by the voice sweep. Retrying is the
+        // right state rather than a hard failure because these conditions are genuinely transient - a
+        // transcript that has not been located yet appears once the agent writes its first turn.
+        if (turns is null)
+        {
+            state.Unavailable[sid] = HostedAiState.Retrying;
+            FileLog.Write(
+                $"[WingmanVoiceService] turns read did not answer for sid={sid} (owning Director not connected) "
+                + "- Retrying; the voice sweep picks it up again. NOT recorded as nothing-to-narrate (issue #2561).");
+            return false;
+        }
+        if (!string.Equals(turns.Status, "ok", StringComparison.OrdinalIgnoreCase))
+        {
+            state.Unavailable[sid] = HostedAiState.Retrying;
+            FileLog.Write(
+                $"[WingmanVoiceService] turns read FAILED for sid={sid}: status={turns.Status} "
+                + $"error={turns.Error ?? "(none)"} - Retrying; the voice sweep picks it up again. "
+                + "NOT recorded as nothing-to-narrate (issue #2561).");
+            return false;
+        }
+        // The read answered, so a Retrying left behind by an EARLIER failed read is over. Cleared HERE,
+        // before the reply check, because VoiceDisplayFold consults `unavailable` BEFORE `nothingToNarrate`
+        // - a stale Retrying would mask the honest "nothing to read aloud" verdict on the very next pass.
+        // Only Retrying is cleared: a recorded NeedsCredits / CapReached / NeedsKey is a real, standing
+        // condition that a successful turns read says nothing about, and clearing it here would make the
+        // "add credit" message flap on and off with every sweep. Those still clear on a successful
+        // synthesis (StoreSpokenAsync) and on the Working transition, exactly as before.
+        if (state.Unavailable.TryGetValue(sid, out var prior) && prior == HostedAiState.Retrying)
+            state.Unavailable.TryRemove(sid, out _);
+        var widgets = turns.Widgets ?? new List<TurnWidgetDto>();
         var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;
         if (string.IsNullOrWhiteSpace(lastReply))
         {
-            // No text reply to read aloud - the session is waiting on a prompt / menu. Record the honest
-            // "nothing to narrate" fact so the Voice screen (via VoiceDisplayFold) says so, instead of
-            // offering a Generate button that would re-run this same empty read and never produce audio.
+            // The read SUCCEEDED and there is no text reply in it - the session is waiting on a prompt /
+            // menu. Only now are these words true. Record the honest "nothing to narrate" fact so the Voice
+            // screen (via VoiceDisplayFold) says so, instead of offering a Generate button that would re-run
+            // this same empty read and never produce audio.
             state.NothingToNarrate[sid] = 1;
             return false;  // nothing to say yet - the provider was not called
         }


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle_internal#1838. Addresses the reporting half of thefrederiksen/devthrottle_internal#1850.

## The defect

A session could stop speaking forever with no error raised anywhere, its rail stuck on "Preparing voice".

The `turns` verb reports every FAILED read as a SUCCESSFUL command result carrying an empty widget list, with the real outcome in a `Status` field - `ok`, `unsupported`, `no_session_id`, `no_jsonl`, `parse_error`. **Nothing read that field.** `WingmanVoiceService.GenerateOnceAsync` looked at the widgets alone, found no text, and recorded `NothingToNarrate` - a NON-failure that is never retried, logs nothing, sets no state, and surfaces on no screen.

There was a sixth case that was worse: the non-Claude-Code branch stamped `Status = "ok"` unconditionally, while `SessionHistoryReader.ReadAll` returns an empty conversation whenever the transcript path cannot be resolved. So a Codex, Pi or Grok session whose transcript had not been located reported a successful read of an empty conversation, and the one field that could have said otherwise agreed.

Observed live on 12 August: a Pi session on `worktrees/oc-8403` sat silent for 48 minutes. The Gateway's own verdict for it was `nothingToNarrate` while the roster label said "Preparing voice".

## The change

**It generates, or it says why.**

- `SessionReadExecutor.Turns` - an unresolved transcript is now `no_transcript`, not `ok`. Gemini is deliberately exempt: it persists no transcript by design and reads its conversation from the terminal buffer, so a null path there is honest.
- `WingmanVoiceService.GenerateOnceAsync` - reads `turns.Status`. A null answer or any non-`ok` status records `HostedAiState.Retrying` and logs the status and error, so the voice sweep tries again and the screen has something to say. `NothingToNarrate` is now set ONLY when the read genuinely succeeded and carries no text reply - the one case where those words are true.
- The same read-failure guard on `POST /sessions/{sid}/wingman/explain`, which is the path the owner presses a button to reach. It used to answer "this session has not produced anything to summarize yet" - a confident, wrong sentence - on a failed read.
- A read that answers clears the read-failure `Retrying` it caused. Only `Retrying`: a standing `NeedsCredits` / `CapReached` / `NeedsKey` is a real condition that a successful transcript read says nothing about, and clearing it here would make the "add credit" message flap with every sweep.

**And the rail stops claiming work is in flight when there is none.**

- `SessionOrdering.StateLabel` renders the voice verdict the Gateway ALREADY folded (`SessionDto.VoiceDisplay`, from `VoiceDisplayFold`) instead of saying "Preparing voice" for every no-audio state. A row now reads "Nothing to read aloud", "Voice service down", "Voice needs credit", "Voice on its way" or "No narration yet" when that is what is true.
  - **The colour rule is untouched.** `IsVoicePreparing` still holds yellow across the gaps, per the 2026-07-19 ruling. Only the words moved, and they are words the fold already chose - so this is one answer rendered in a second place, not a second answer.
  - Deliberately narrow: a row carrying no verdict, or a verdict kind not listed, keeps "Preparing voice". A voice state added later does not silently change this label.
- `EnrichVoiceThenFoldForPush` now stamps `VoiceUnavailable` and `VoiceDisplay` as well as the two booleans, so the desktop push carries the same facts as the roster poll and the two surfaces cannot say different things about one session.

## Also

`packages/client-core/src/auth/AccountsPanel.test.tsx` - a zero-argument mock implementation typed the mock as zero-argument, so the one-argument call below it was a typecheck error. This had main's web workspace red, which blocked the local gate entirely. Chased forward here.

## Proof

Every new test was run against the UNFIXED code first: 14 failed. With the fix, all pass.

- `dotnet test` local gate: 9 projects, all `Completed`, 4,299 passed, 0 failed.
- Parked suites (`-Parked`): the gate flagged `Core.Tests` and `Gateway.Tests` as covering touched code, so both were run.
- Web: `@devthrottle/client-core` 88 files, 961 tests passed, no unhandled errors.

New tests:
- `TurnsVerbUnresolvedTranscriptTests` - Pi, Codex and Grok with no transcript yet report `no_transcript`; an agent with no history provider still reports `unsupported` (the two are different facts and stay different).
- `WingmanVoiceServiceTests` - each of the five failure statuses, and a non-answering tunnel, record `Retrying` and NOT nothing-to-narrate; a successful read with no text still records nothing-to-narrate and still raises no failure; a recovered read clears the read-failure `Retrying`.
- `SessionOrderingTests` - each verdict kind renders its own words while the dot stays yellow; a genuinely preparing session still reads "Preparing voice"; a row with no verdict, and a row with an unknown verdict kind, both fall back.
