### PR TITLE
point the account-work comments at the issue they actually belong to

### DIFF
--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -173,7 +173,7 @@ export function ensureGatewayCookie(): void {
   document.cookie = `cc-gateway-token=${encodeURIComponent(token)}; path=/; SameSite=Lax; Max-Age=${oneYearSeconds}`;
 }
 
-// THE COOKIE IS HttpOnly, SO ONLY THE SERVER CAN MOVE IT (devthrottle_internal #1513).
+// THE COOKIE IS HttpOnly, SO ONLY THE SERVER CAN MOVE IT (devthrottle_internal #1509).
 //
 // GatewayTokenCookie writes cc-gateway-token with HttpOnly set, which means a document.cookie write or
 // delete from this side is silently IGNORED - no error, no effect, and nothing in a test would notice.
@@ -280,7 +280,7 @@ export function resolveSignInTarget(current: SignInLocation): string {
 //   401 after the person has switched to B, and deleting the active account would then remove B - a
 //   perfectly good login - while leaving the actually-revoked A in place. The next poll would then take
 //   out A too, so one revoked key could sign the browser out of two valid accounts
-//   (devthrottle_internal #1513).
+//   (devthrottle_internal #1509).
 function onUnauthorized(rejectedKey: string): void {
   const account = listAccounts().find((a) => a.deviceKey === rejectedKey);
   // The rejected credential is no longer stored - it was already removed, or the person has moved on.

--- a/packages/client-core/src/auth/accountActions.ts
+++ b/packages/client-core/src/auth/accountActions.ts
@@ -1,4 +1,4 @@
-// Switching and signing out (devthrottle_internal #1507, #1509, #1513). accountStore owns the STORAGE;
+// Switching and signing out (devthrottle_internal #1507, #1509). accountStore owns the STORAGE;
 // this owns what the running app and the SERVER have to do about a change of identity, which is more
 // than moving a pointer.
 //

--- a/packages/client-core/src/auth/accountIsolation.test.ts
+++ b/packages/client-core/src/auth/accountIsolation.test.ts
@@ -1,4 +1,4 @@
-// Account ISOLATION (devthrottle_internal #1512, #1513) - the review findings that a text assertion
+// Account ISOLATION (devthrottle_internal #1509) - the review findings that a text assertion
 // could never have caught, because in every one of them the screen looks right.
 //
 // The shape they share: local storage, the IndexedDB queues and the cc-gateway-token cookie are all

--- a/packages/client-core/src/auth/accountStore.ts
+++ b/packages/client-core/src/auth/accountStore.ts
@@ -57,7 +57,7 @@ function announce(): void {
   for (const listener of listeners) listener();
 }
 
-// ANOTHER TAB CAN CHANGE WHO YOU ARE (devthrottle_internal #1513). localStorage is shared across every
+// ANOTHER TAB CAN CHANGE WHO YOU ARE (devthrottle_internal #1509). localStorage is shared across every
 // tab on this origin, but only the tab that ran the switch reloads - so a second tab went on showing
 // account A's name and A's roster while its very next call read the shared pointer and authenticated as
 // B. That is the work-versus-personal mis-send the hard reload was supposed to make impossible,
@@ -314,7 +314,7 @@ export function addAccount(entry: { deviceKey: string; installId: string; email:
 }
 
 /**
- * Attach an identity that arrived AFTER the account was stored (devthrottle_internal #1513).
+ * Attach an identity that arrived AFTER the account was stored (devthrottle_internal #1509).
  *
  * Enrollment writes the key immediately and looks up who it belongs to afterwards, so the account
  * exists for a moment with no email. This fills that in. The label is only overwritten while it is

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -218,7 +218,7 @@ export async function backgroundTranscribeAndSend(
     sourceBytes,
     captureWarning,
     surface: sendSurface,
-    // WHICH ACCOUNT RECORDED THIS (devthrottle_internal #1512). Stamped at record time, because the
+    // WHICH ACCOUNT RECORDED THIS (devthrottle_internal #1509). Stamped at record time, because the
     // upload happens later and authenticates as whoever is active THEN - see resumePendingDictations.
     accountId: activeAccount()?.id,
     before: hooks.composeParts?.before ?? "",
@@ -314,7 +314,7 @@ export async function resumePendingDictations(): Promise<void> {
   // re-publish their status so the strip and roster still show them after a reopen, but never re-drive them. A
   // dropped clip especially - its upload id carries a permanent moved-on tombstone, so re-driving it could only
   // be dropped again, and re-publishing is what keeps a lost dictation visible instead of vanishing on reload.
-  // A CLIP BELONGS TO THE ACCOUNT THAT RECORDED IT (devthrottle_internal #1512). This store is one
+  // A CLIP BELONGS TO THE ACCOUNT THAT RECORDED IT (devthrottle_internal #1509). This store is one
   // IndexedDB database per origin, shared by every account on the browser, and this resume runs on load
   // authenticating as whichever account is active NOW. Driving another account's clip would send the
   // person's own voice - and the text it becomes - into the wrong tenant.

--- a/packages/client-core/src/dictation/pendingStore.ts
+++ b/packages/client-core/src/dictation/pendingStore.ts
@@ -37,7 +37,7 @@ export interface PendingDictation {
    *  the shell that actually recorded it. Absent on records written before this field existed - the
    *  Gateway then falls back to the tag that path has always used. */
   surface?: string;
-  /** The id of the account that RECORDED this clip (devthrottle_internal #1512). This database is one
+  /** The id of the account that RECORDED this clip (devthrottle_internal #1509). This database is one
    *  per ORIGIN, so two accounts on one browser share it, while the upload authenticates as whichever
    *  account is active when it finally runs - so a clip recorded with no connection on one account would
    *  otherwise be driven with the other account's credential after a switch. Absent on records written

--- a/packages/client-core/src/push/register.ts
+++ b/packages/client-core/src/push/register.ts
@@ -257,7 +257,7 @@ export async function disablePush(): Promise<void> {
 
 /**
  * Hand the browser's push subscription BACK from the account that is active right now
- * (devthrottle_internal #1513), without unsubscribing the browser itself.
+ * (devthrottle_internal #1509), without unsubscribing the browser itself.
  *
  * A browser has exactly ONE push subscription for the origin, but the Gateway stores it per account.
  * Startup registers whatever subscription exists under whichever account is active, so with two

--- a/packages/client-core/src/recorder/ingestUpload.ts
+++ b/packages/client-core/src/recorder/ingestUpload.ts
@@ -287,7 +287,7 @@ async function drivePass(recordingId: string, onProgress?: () => void): Promise<
  */
 export async function resumePendingRecordingUploads(onProgress?: () => void): Promise<void> {
   const all = await listRecordings();
-  // A RECORDING BELONGS TO THE ACCOUNT THAT MADE IT (devthrottle_internal #1512). This store is one
+  // A RECORDING BELONGS TO THE ACCOUNT THAT MADE IT (devthrottle_internal #1509). This store is one
   // IndexedDB database per ORIGIN, so two accounts on one browser share it, while the upload
   // authenticates as whichever account is ACTIVE. Without this filter, recording something with no
   // connection on one account and then switching would upload that audio into the OTHER account's

--- a/src/CcDirector.Gateway/Api/DeviceCookieEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/DeviceCookieEndpoint.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Routing;
 namespace CcDirector.Gateway.Api;
 
 /// <summary>
-/// <c>POST</c> and <c>DELETE /account/device-cookie</c> (devthrottle_internal #1513): move the
+/// <c>POST</c> and <c>DELETE /account/device-cookie</c> (devthrottle_internal #1509): move the
 /// <c>cc-gateway-token</c> cookie onto the calling account, or take it away.
 ///
 /// WHY THIS HAS TO BE A SERVER ROUTE. The cookie is written <c>HttpOnly</c>

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -3127,7 +3127,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // phone could reach. Inherits the host-wide token middleware exactly like /account/status.
         MobileQrEndpoint.Map(_app);
 
-        // devthrottle_internal #1513: POST/DELETE /account/device-cookie move the HttpOnly cc-gateway-token
+        // devthrottle_internal #1509: POST/DELETE /account/device-cookie move the HttpOnly cc-gateway-token
         // cookie onto the calling account, or clear it. A browser can do NEITHER from JavaScript, which is
         // why the multi-account switch and the new sign-out both needed a server route: without it the
         // cookie channel silently stayed on the previous account, so the WebSockets and bare image/iframe


### PR DESCRIPTION
Comment-only. No behaviour changes.

Twelve code comments across nine files cited `devthrottle_internal #1512` and `#1513`. I picked those numbers while writing the code and assumed they were free. They were not:

- **#1512** is "BY 25 AUGUST: three video-competition creators' trials must be extended by hand"
- **#1513** is "Deploy skill documents 'no user-visible gap at all' while the real post-swap outage is 2.3-6.8s"

So anyone reading `accountStore.ts`, `DeviceCookieEndpoint.cs` or the dictation and recorder queues and following the citation landed on unrelated work.

They now cite **#1509**, the multi-account issue this work belongs to. No new issues were filed - the work already had a home.

The pre-existing `pull request #1512`/`#1513` references under `src/CcDirector.Core` are this repository's own pull request numbers, are correct, and are untouched. A blanket substitution would have corrupted them; the replacement was anchored on the `devthrottle_internal ` prefix and then the two remaining bare references were fixed by hand.

## Verified

What continuous integration runs, in its order, reading every exit code:

- `npm run typecheck --workspaces --if-present` - exit 0
- client-core, Cockpit, mobile suites - exit 0 each, no errors line
- `dotnet build src/CcDirector.Gateway` (which wraps the workspace typecheck) - exit 0