### PR TITLE
release: v2.0.3 - sessions no longer go quiet without saying why

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <!--
     THE single source of truth for the CC Director product version.
 
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v2.0.3.md
+++ b/docs/public/release-notes/v2.0.3.md
@@ -1,0 +1,80 @@
+# DevThrottle v2.0.3
+
+## Sessions no longer go quiet without saying why
+
+A session in voice mode could stop speaking and never start again. Its row sat on
+"Preparing voice" indefinitely, no narration was ever produced, and nothing
+anywhere reported a fault. One session was found sitting like that for
+forty-eight minutes.
+
+The cause was that reading a session's conversation could FAIL and be reported as
+a success with nothing in it. Voice narration then concluded there was nothing to
+say, recorded that as a normal state rather than a problem, and never tried
+again. A transcript that had not been written yet, one that could not be read, and
+an agent that keeps no conversation at all all looked identical to a session that
+was simply waiting on a question.
+
+- **It now keeps trying, and says so.** A failed read is treated as a failure: the
+  narration is attempted again on its own, and the row says voice is on its way
+  instead of claiming it is being prepared when nothing is happening.
+- **The row tells you the actual reason.** Where it used to say "Preparing voice"
+  for every possible cause, it now says "Nothing to read aloud" when the session
+  is waiting on a question rather than a written answer, "Voice service down" when
+  the speech service cannot be reached, and "Voice needs credit" when that is what
+  is wrong. The colour is unchanged.
+- **An agent that keeps no conversation is now said so once**, rather than
+  promising a narration that could never arrive.
+- **Asking for a narration by hand no longer misreports a failure.** Pressing to
+  generate one used to answer "this session has not produced anything to
+  summarize yet" even when the read had simply failed.
+
+## Signing out, and two accounts on one browser
+
+- **You can sign out.** The mobile app previously had no way to do it at all.
+- **You can keep two accounts and switch between them** on both the phone and the
+  desktop Cockpit, without a password and without a connection.
+- Signing out always asks first, and the confirmation says which of the two
+  outcomes will happen, because signing out of one account and signing out of all
+  of them are different things.
+
+## Also in this release
+
+- An administrator can extend a member's Pro trial, so a promise made to somebody
+  about their trial can actually be honoured. This is an administrator action on
+  the hosted service, not something a member does.
+- The project now carries a contributing guide and a security policy, so anyone
+  reporting a vulnerability has a stated route.
+- Repairs to the build and the test suites, including a broken check that had the
+  mainline failing.
+
+## Upgrading
+
+Nothing to do beyond the usual update. There is no migration and no new setting.
+
+**The voice fixes need BOTH halves to be current.** The part that reads a
+session's conversation runs in the app on your own machine; the part that decides
+what to say about it runs on the Gateway. Until the app is updated, a transcript
+that cannot be found is still reported as an empty conversation, and the session
+it belongs to can still go quiet. Update the app, and update your Gateway too if
+you run your own.
+
+## Known and not fixed here
+
+- **There is still no clock on a session waiting for voice.** Nothing records when
+  the wait began, so no screen can yet tell you how long a session has been
+  without narration. This was asked for and is not in this release.
+- **There is still no general "gave up" state.** A session whose narration keeps
+  failing goes on saying voice is on its way rather than eventually admitting
+  defeat.
+- Deploying the hosted Gateway can still take the service off the air for longer
+  than intended after the changeover. Measured at forty-seven seconds on the
+  deploy that shipped this release, against a five-second budget. Under
+  investigation; it does not affect the app.
+- The Director still opens a local listener during interactive sign-in. Unchanged
+  from v1.9.11.
+- The first-run wizard has not been verified on a genuinely clean Windows machine.
+  Unchanged from v1.9.9.
+- The v1.9.9 launcher work has not been run on macOS or Linux.
+- Two places still fall back to a local answer when the Gateway fails - session
+  numbering and the dictation dictionary. Both are filed.
+- The Director's large-object heap still grows on a long-running instance.


### PR DESCRIPTION
The release notes for v2.0.3 and the version bump in `Directory.Build.props`.

Headline: the voice fix from thefrederiksen/devthrottle#2578. A failed read of a session's conversation was reported as a success with nothing in it, so narration recorded "nothing to say" and never tried again. Also carries the mobile accounts work (sign out, two logins) and the administrator trial extension.

Both headline claims were verified against running code, not documentation: `AccountsPanel` is mounted in both the Cockpit and the mobile shell, and `AdminTrialEndpoint` is a real route backed by its own table.

The notes list the deploy outage under "Known and not fixed here", naming the 47 seconds against a 5-second budget. That is deliberate and public - it is tracked in thefrederiksen/devthrottle_internal#1856.

The release gate (`test-local.ps1 -Parked -Configuration Release` plus the two installer projects) runs on MERGED main at the exact commit to be tagged, immediately before the tag - not on this pull request head.