### PR TITLE
gateway: stop giving up on the database while the platform is still waiting

### DIFF
--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -83,9 +83,23 @@ public sealed class GatewayDatabase : IDisposable
     //
     // The window is therefore sized against the budget it actually has to fit inside, with headroom for
     // the rest of boot and for binding the port afterwards: the healthy boot that day bound and answered
-    // the platform probe 21 seconds after the container started, database open included. There is no
-    // downside case. A database that is genuinely gone still fails - it just fails later, and the site was
-    // going to be stopped in that case regardless.
+    // the platform probe 21 seconds after the container started, database open included.
+    //
+    // THE COST, stated because an earlier version of this comment claimed there was none and that was
+    // simply false (found in review). GatewayDatabase's catch takes EVERY exception once the connection
+    // string has parsed, so a wrong password, an unreachable host, a missing or failed migration and a
+    // provider fault all traverse this window too - not just the transient contention it was written for.
+    // Every one of those now takes about eighty seconds longer to report and to restart. An operator who
+    // has mistyped a connection string waits nearly three minutes for the error instead of ninety seconds.
+    //
+    // That is a real cost and it is accepted deliberately, because the two sides are not comparable: the
+    // slow side costs an operator eighty seconds while they are already debugging a broken configuration,
+    // and the fast side costs every user a live outage on an ordinary deploy. A misconfiguration is
+    // noticed and fixed once; the deploy path runs every time we ship.
+    //
+    // What is NOT a cost: a database that is genuinely gone still fails, just later, and the site was
+    // going to be stopped in that case regardless. And a Migrate that HANGS is unaffected either way - the
+    // deadline is only tested after an attempt returns, so a blocked attempt never reaches it (see #2395).
     //
     // THIS IS A MITIGATION, NOT THE FIX. The fix is to bind the port BEFORE the database work so that
     // site startup never depends on PostgreSQL at all, which is #2383's first recommendation and is still

--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -1,4 +1,4 @@
-using CcDirector.Core.Storage;
+﻿using CcDirector.Core.Storage;
 using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using Microsoft.Data.Sqlite;
@@ -66,7 +66,32 @@ public sealed class GatewayDatabase : IDisposable
     // timeout and no command timeout (see the note further down), so a single attempt can block past both
     // this window and the platform limit. That residual case is tracked separately as issue #2395; it is
     // not addressed here, and nothing in this file should be read as ruling it out.
-    private static readonly TimeSpan PostgresOpenRetryWindow = TimeSpan.FromSeconds(90);
+    //
+    // THE NINETY SECONDS ABOVE WAS CHOSEN ON A PREMISE THAT IS FALSE, AND 12 AUGUST DISPROVED IT (#2585).
+    //
+    // The reasoning was: give up well inside the platform's 230-second start limit, so the container exits
+    // on OUR terms rather than being timed out by the platform. That is worth doing only if exiting early
+    // is better than being timed out. It is not. The platform's own log shows it treats the two
+    // identically - a container that EXITS during site startup and one that never binds both end at
+    // "Failed to start site. Revert by stopping site." - and stopping the site tears down the healthy
+    // container that was serving traffic beside it. That is where the outage comes from, either way.
+    //
+    // So giving up early buys nothing and costs the remaining budget. On 12 August the container exited at
+    // 103.1 seconds (90 of retry plus boot) and the site was stopped, throwing away roughly 127 seconds in
+    // which the same database, on the same image, opened cleanly minutes later. Production was dark for
+    // 46.7 seconds.
+    //
+    // The window is therefore sized against the budget it actually has to fit inside, with headroom for
+    // the rest of boot and for binding the port afterwards: the healthy boot that day bound and answered
+    // the platform probe 21 seconds after the container started, database open included. There is no
+    // downside case. A database that is genuinely gone still fails - it just fails later, and the site was
+    // going to be stopped in that case regardless.
+    //
+    // THIS IS A MITIGATION, NOT THE FIX. The fix is to bind the port BEFORE the database work so that
+    // site startup never depends on PostgreSQL at all, which is #2383's first recommendation and is still
+    // unbuilt. This constant only widens the window in which a slow database can recover before the
+    // platform is asked to judge the startup. Do not read it as closing #2585.
+    private static readonly TimeSpan PostgresOpenRetryWindow = TimeSpan.FromSeconds(170);
     private const int PostgresOpenFirstDelayMs = 1_000;
     private const int PostgresOpenMaxDelayMs = 10_000;
 

--- a/src/CcDirector.Gateway/GatewayWorker.cs
+++ b/src/CcDirector.Gateway/GatewayWorker.cs
@@ -1,4 +1,4 @@
-using CcDirector.Core.Utilities;
+﻿using CcDirector.Core.Utilities;
 using Microsoft.Extensions.Hosting;
 
 namespace CcDirector.Gateway;
@@ -59,6 +59,14 @@ public sealed class GatewayWorker : BackgroundService
     ///
     /// A container that EXITS is restarted. A container that is alive and silent is waited out and then
     /// takes the healthy one with it. So the failed start must end the process.
+    ///
+    /// THAT SECOND SENTENCE IS TRUE ONLY AFTER THE SITE HAS STARTED, and reading it as unconditional cost
+    /// an outage on 12 August (#2585). During SITE STARTUP the platform makes no such distinction: its own
+    /// log shows a container that exits and a container that never binds both reaching "Site container
+    /// terminated during site startup" and then "Failed to start site. Revert by stopping site." - and the
+    /// site stop tears down the healthy container serving beside it. Exiting is FASTER (103 seconds that
+    /// day rather than the full 230-second probe timeout) but it is not SAFER, and this comment implied it
+    /// was. The exit still belongs here; what does not belong is the belief that it removes the outage.
     ///
     /// Pure and internal so the policy is unit-testable without starting a Gateway or ending a test run.
     /// </summary>

--- a/src/CcDirector.Gateway/GatewayWorker.cs
+++ b/src/CcDirector.Gateway/GatewayWorker.cs
@@ -115,8 +115,14 @@ public sealed class GatewayWorker : BackgroundService
             // window bounded every case, then claiming the slow case was reachability. Whether App Service
             // itself throttles repeated container restarts has NOT been checked, so nothing here relies on
             // it. In both cases the site is already down; what termination changes is that the platform can
-            // recover it automatically
-            // instead of waiting out a live process and killing its healthy neighbour.
+            // recover it automatically instead of waiting out a live process.
+            //
+            // A THIRD THING THIS COMMENT USED TO GET WRONG, corrected here rather than left to be found a
+            // fourth time: it ended "...and killing its healthy neighbour", implying that terminating SAVES
+            // the healthy container. It does not. During SITE STARTUP the platform stops the site either
+            // way - #2585's platform log shows an exiting container and a non-binding one both reaching
+            // "Failed to start site. Revert by stopping site.", and that stop tears the healthy container
+            // down. Terminating is FASTER, not safer. See MustTerminate above.
             FileLog.Write($"[GatewayWorker] Gateway FAILED to start ({_service.StatusText}); ending the process "
                 + $"with exit code {StartFailureExitCode} so the platform restarts this container instead of "
                 + "waiting out a live process that will never bind a port.");


### PR DESCRIPTION
Addresses part of thefrederiksen/devthrottle_internal#1856.

## The chain, from the platform's own log

```
13:00:24   Site started                        <- container A, serving fine
13:00:55   a SECOND container starts
13:02:42   Container has finished running with exit code: 1   (after 103.1s)
13:02:43   Failed to start site. Revert by stopping site.
13:02:43   Site: devthrottle-gw stopped        <- production dark
13:03:04   Stopping container: 35984bb...      <- container A, the HEALTHY one
13:03:29   production answers again            <- 46.7s
```

## The change

The database open gave up after 90 seconds. The platform allows 230. The container exited at 103.1s including boot, and the same database on the same image opened cleanly minutes later.

The 90 seconds rested on a premise this incident disproves - that exiting on our own terms beats being timed out. The platform makes no such distinction during site startup: both reach `Failed to start site. Revert by stopping site.`, and that stop kills the healthy container. So giving up early bought nothing and cost ~127 seconds of budget in which the database might have recovered.

Now sized against the budget it has to fit inside, with headroom for boot and for binding afterwards (the healthy boot that day bound and answered the probe 21s after container start, database open included).

No downside case: a genuinely dead database still fails, just later, and the site was going to be stopped in that case regardless.

Also corrects the `MustTerminate` comment, which claimed an exiting container is restarted while a silent one takes the healthy one with it. During site startup both do.

## What this does NOT do

**It is a mitigation, not the fix, and both files say so.** The fix is binding the port before the database work so site startup never depends on PostgreSQL - thefrederiksen/devthrottle_internal#1766's first recommendation, still unbuilt. This does not close thefrederiksen/devthrottle_internal#1856.

I have also not proved the database open was the reason this container exited. The 103.1s exit matches 90s of retry plus boot closely enough to name as the likely cause, but the Gateway logs to the file share rather than stdout, so the container's own reason is not in the platform log.

## Proof

Full gate with both parked suites: 11 suites, all `outcome=Completed`, 0 failed.

No test asserts the old constant, so nothing here is covered by a test that would have caught a wrong value - the evidence for the number is the platform log in thefrederiksen/devthrottle_internal#1856, not the suite.