### PR TITLE
voice: say how long a session has been waiting, and admit when the voice is not coming

### DIFF
--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -182,6 +182,25 @@ public sealed class SessionDto
     public DateTime? NeedsYouSince { get; set; }
 
     /// <summary>
+    /// Issue #2576: UTC timestamp this session last found itself a VOICE session with no playable
+    /// narration - the moment its wait for voice began. Gateway-owned, stamped during the same
+    /// aggregation that folds <see cref="VoiceDisplay"/>, held stable for the whole episode, and
+    /// cleared to null the moment audio arrives or the agent starts a new turn.
+    ///
+    /// It exists because <see cref="NeedsYouSince"/> could not answer this. That clock is stamped
+    /// only when the folded colour is RED, and a session waiting for its voice is YELLOW - so the
+    /// one clock the product had was, by construction, never running for exactly the sessions that
+    /// were stuck. A session sat on "Preparing voice" for forty-eight minutes and no surface could
+    /// say so, because no fact recorded when the wait started.
+    ///
+    /// Clients render the AGE of this, never a duration the Gateway computed: a number computed at
+    /// stamp time is wrong by however long it sat in transit and on the screen. In-memory only - a
+    /// Gateway restart re-derives it on the next waiting refresh. Always null in Director-local
+    /// responses, which have no Gateway voice state at all.
+    /// </summary>
+    public DateTime? VoiceWaitingSince { get; set; }
+
+    /// <summary>
     /// The absolute UTC time an ARMED snooze returns this session to "needs you" - the snooze clock's
     /// deadline, so a client can show "wakes in 3h 48m". Gateway-owned: the snooze registry
     /// (<c>SnoozeRegistry.SnoozeEntry.SnoozeUntilUtc</c>) is the sole source of the timer, stamped by the

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -407,6 +407,16 @@ public static class SessionOrdering
     {
         var display = s.VoiceDisplay;
         if (display is null || string.IsNullOrWhiteSpace(display.Label)) return "Preparing voice";
+
+        // THE WAIT, ON THE RAIL (issue #2576). A row that says "Preparing voice" reads identically at two
+        // seconds and at forty-eight minutes, and a session really did sit at forty-eight with nobody able
+        // to tell. The Gateway already holds when the wait began and has already turned it into words
+        // (VoiceDisplay.WaitedLabel, null under a minute), so this only renders them - the healthy case
+        // still reads plain "Preparing voice", and a wait worth noticing carries its own age.
+        if (string.Equals(display.Kind, "preparing", StringComparison.Ordinal))
+            return string.IsNullOrWhiteSpace(display.WaitedLabel)
+                ? "Preparing voice"
+                : $"Preparing voice ({display.WaitedLabel})";
         return display.Kind switch
         {
             // The THREE verdicts whose own words would be wrong ON THE RAIL, named explicitly:

--- a/src/CcDirector.Gateway.Contracts/VoiceDisplay.cs
+++ b/src/CcDirector.Gateway.Contracts/VoiceDisplay.cs
@@ -1,4 +1,4 @@
-namespace CcDirector.Gateway.Contracts;
+﻿namespace CcDirector.Gateway.Contracts;
 
 /// <summary>
 /// The FOLDED voice-mode display verdict for one session - what the Voice screen must show and offer,
@@ -54,6 +54,22 @@ public sealed class VoiceDisplay
     /// <c>blocked</c> - the same single-source <see cref="HostedAiMessageDto"/> the roster uses. Null
     /// otherwise.</summary>
     public HostedAiMessageDto? Reason { get; set; }
+
+    /// <summary>
+    /// How long this session has been waiting for its voice, already in words ("4m", "1h 12m"), or null
+    /// when it is not waiting or has waited under a minute (issue #2576).
+    ///
+    /// Composed HERE rather than on each client, from the Gateway's own VoiceWaitingSince stamp, for the
+    /// same reason every other string on this record is: a second place that turns the stamp into words is
+    /// a second answer to a question this fold has already answered. A spinner alone reads identically at
+    /// two seconds and at forty-eight minutes, which is exactly how a session sat stuck for forty-eight
+    /// minutes with nobody able to say so.
+    ///
+    /// COARSE on purpose - whole minutes, refreshed at whatever rate the client polls. A precise duration
+    /// computed at stamp time would be wrong by however long it sat in transit, and this number exists to
+    /// answer "is this stuck?", which minutes answer and seconds do not.
+    /// </summary>
+    public string? WaitedLabel { get; set; }
 
     /// <summary>
     /// The optional GENERIC heads-up shown when this turn's ready clip was made by the BACKUP voice

--- a/src/CcDirector.Gateway.UnitTests/SessionOrderingTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionOrderingTests.cs
@@ -556,8 +556,12 @@ public sealed class SessionOrderingTests
     public void StateLabel_GaveUp_ReachesTheRailWithItsOwnWords()
     {
         // The terminal verdict needs no new arm here - the deny-list added for the earlier half of #2576
-        // renders any kind that is not preparing/ready/off/working. This asserts that it actually arrives,
-        // because "a future verdict reaches the rail" is the whole claim that list was inverted to make.
+        // renders any kind that is not preparing/ready/off/working.
+        //
+        // HONEST NOTE: this passes on the parent commit too, because that deny-list already renders any
+        // unknown kind. It is a REGRESSION GUARD on that behaviour, not evidence for this change - review
+        // caught it being presented as the latter. What this change actually adds to the rail is the
+        // preparing-with-a-wait case asserted above, which does fail without it.
         var s = VoiceHoldingSession("gaveUp", "Voice did not arrive after 48m");
         Assert.Equal("Voice did not arrive after 48m", SessionOrdering.StateLabel(s));
     }

--- a/src/CcDirector.Gateway.UnitTests/SessionOrderingTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionOrderingTests.cs
@@ -532,10 +532,34 @@ public sealed class SessionOrderingTests
     [Fact]
     public void StateLabel_VoiceHoldWhileGenuinelyPreparing_StillSaysPreparingVoice()
     {
-        // The positive case the words were always right about: something IS being made.
+        // The positive case the words were always right about: something IS being made. With no wait worth
+        // reporting (under a minute), the label is exactly what it always was.
         var s = VoiceHoldingSession("preparing", "Voice on its way");
         s.VoiceGenerating = true;
         Assert.Equal("Preparing voice", SessionOrdering.StateLabel(s));
+    }
+
+    [Fact]
+    public void StateLabel_PreparingWithAWaitWorthReporting_SaysHowLong()
+    {
+        // Issue #2576. "Preparing voice" reads identically at two seconds and at forty-eight minutes, and a
+        // session really did sit at forty-eight with nobody able to tell. The Gateway has already turned
+        // its own clock into words; the rail renders them.
+        var s = VoiceHoldingSession("preparing", "Voice on its way");
+        s.VoiceGenerating = true;
+        s.VoiceDisplay!.WaitedLabel = "44m";
+        Assert.Equal("Preparing voice (44m)", SessionOrdering.StateLabel(s));
+        Assert.Equal("yellow", SessionOrdering.EffectiveColor(s));   // the dot is untouched
+    }
+
+    [Fact]
+    public void StateLabel_GaveUp_ReachesTheRailWithItsOwnWords()
+    {
+        // The terminal verdict needs no new arm here - the deny-list added for the earlier half of #2576
+        // renders any kind that is not preparing/ready/off/working. This asserts that it actually arrives,
+        // because "a future verdict reaches the rail" is the whole claim that list was inverted to make.
+        var s = VoiceHoldingSession("gaveUp", "Voice did not arrive after 48m");
+        Assert.Equal("Voice did not arrive after 48m", SessionOrdering.StateLabel(s));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.UnitTests/VoiceGaveUpFoldTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceGaveUpFoldTests.cs
@@ -1,4 +1,4 @@
-using CcDirector.Core.HostedAi;
+﻿using CcDirector.Core.HostedAi;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Wingman;
 using Xunit;
@@ -81,6 +81,38 @@ public sealed class VoiceGaveUpFoldTests
         Assert.Equal("gaveUp", v.Kind);
     }
 
+    /// <summary>
+    /// EVERY ACTIONABLE REASON OUTRANKS THE GIVE-UP VERDICT, and the first draft had this backwards for all
+    /// of them. A member who needs to add credit, finish setup, or wait out a speech outage was told "voice
+    /// did not arrive" - the symptom, in place of the one sentence that tells them what to do about it.
+    /// Same defect as a terminal read failure hiding a standing account condition, which this codebase
+    /// fixed once already the same day.
+    /// </summary>
+    [Theory]
+    [InlineData(HostedAiState.ServiceDown, "serviceDown")]
+    [InlineData(HostedAiState.NeedsCredits, "blocked")]
+    [InlineData(HostedAiState.NeedsKey, "blocked")]
+    [InlineData(HostedAiState.CapReached, "blocked")]
+    [InlineData(HostedAiState.SubscriptionRequired, "blocked")]
+    public void AnActionableReason_OutranksGaveUp_HoweverLongTheWait(HostedAiState state, string expectedKind)
+    {
+        var v = Fold(Now - TimeSpan.FromMinutes(48), unavailable: state);
+        Assert.Equal(expectedKind, v.Kind);
+    }
+
+    [Fact]
+    public void WaitingOnAPromptForHours_IsNotAccusedOfLosingANarration()
+    {
+        // THE FALSE ALARM this ordering exists to prevent, and the first draft got it wrong. A session
+        // parked on a menu has no text reply to read aloud, so no narration was ever coming - saying "it
+        // did not arrive" reports a failure that never happened, and points the reader at the voice
+        // pipeline instead of at the prompt actually waiting for them.
+        var v = Fold(Now - TimeSpan.FromHours(2), nothingToNarrate: true);
+
+        Assert.Equal("nothingToNarrate", v.Kind);
+        Assert.Equal("Nothing to read aloud", v.Label);
+    }
+
     [Fact]
     public void NotWaitingAtAll_IsUnchanged()
     {
@@ -101,6 +133,27 @@ public sealed class VoiceGaveUpFoldTests
     {
         var since = Now - TimeSpan.FromHours(hours) - TimeSpan.FromSeconds(seconds);
         Assert.Equal(expected, VoiceDisplayFold.WaitedLabelFor(since, Now));
+    }
+
+    [Fact]
+    public void APlainNotReadyWindow_AlsoGivesUpEventually()
+    {
+        // The other sentence that was still being said at forty-eight minutes. "No narration yet" is honest
+        // for a moment and misleading for an hour, so it takes the same threshold the retrying arm does.
+        var v = Fold(Now - TimeSpan.FromMinutes(48));
+        Assert.Equal("gaveUp", v.Kind);
+    }
+
+    [Fact]
+    public void TheWaitingPredicate_IsTheOneBothCallersUse()
+    {
+        // It lived TWICE, hand-written, in the roster aggregation and the display-push enrichment. They
+        // agreed character for character, which is the condition under which two copies stay wrong together
+        // and then quietly diverge. This is the single definition both now call.
+        Assert.True(VoiceDisplayFold.IsWaitingForVoice(voiceMode: true, hasAudio: false, agentWorking: false));
+        Assert.False(VoiceDisplayFold.IsWaitingForVoice(voiceMode: false, hasAudio: false, agentWorking: false));
+        Assert.False(VoiceDisplayFold.IsWaitingForVoice(voiceMode: true, hasAudio: true, agentWorking: false));
+        Assert.False(VoiceDisplayFold.IsWaitingForVoice(voiceMode: true, hasAudio: false, agentWorking: true));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.UnitTests/VoiceGaveUpFoldTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceGaveUpFoldTests.cs
@@ -1,0 +1,115 @@
+using CcDirector.Core.HostedAi;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #2576: the terminal "gave up" verdict, and the wait it carries.
+///
+/// Before this, every no-audio verdict was either a calm "still coming" or a specific fault, so a
+/// narration that simply never arrived matched the calm one FOREVER. A session sat that way for
+/// forty-eight minutes. <c>SessionOrdering.IsVoicePreparing</c>'s own note named a terminal gave-up state
+/// as the correct answer to that wedge and it was never built; this is it.
+/// </summary>
+public sealed class VoiceGaveUpFoldTests
+{
+    private static readonly DateTime Now = new(2026, 8, 12, 12, 0, 0, DateTimeKind.Utc);
+
+    private static VoiceDisplay Fold(DateTime? waitingSince, bool generating = false, bool hasAudio = false,
+        HostedAiState? unavailable = null, bool nothingToNarrate = false)
+        => VoiceDisplayFold.Fold(
+            voiceMode: true, agentWorking: false, hasAudio: hasAudio, generating: generating,
+            unavailable: unavailable, nothingToNarrate: nothingToNarrate,
+            waitingSince: waitingSince, utcNow: Now);
+
+    [Fact]
+    public void PastTheThreshold_TheVerdictIsGaveUp_AndSaysHowLong()
+    {
+        var v = Fold(Now - TimeSpan.FromMinutes(48));
+
+        Assert.Equal("gaveUp", v.Kind);
+        Assert.Equal("Voice did not arrive after 48m", v.Label);
+        Assert.Equal("48m", v.WaitedLabel);
+        Assert.False(v.CanPlay);
+        // No Generate button: it would re-run the same thing that has already failed for 48 minutes, and a
+        // button that cannot succeed invites the reader to keep pressing and blame themselves.
+        Assert.False(v.CanGenerate);
+    }
+
+    [Fact]
+    public void JustUnderTheThreshold_IsStillTheCalmNotReady_NotGaveUp()
+    {
+        // The boundary matters in this direction: declaring defeat early would put a red "did not arrive"
+        // on the ordinary case, which is how a real signal gets trained out of a reader.
+        var v = Fold(Now - VoiceDisplayFold.GaveUpAfter + TimeSpan.FromSeconds(1));
+        Assert.NotEqual("gaveUp", v.Kind);
+    }
+
+    [Fact]
+    public void ExactlyAtTheThreshold_HasGivenUp()
+    {
+        Assert.Equal("gaveUp", Fold(Now - VoiceDisplayFold.GaveUpAfter).Kind);
+    }
+
+    [Fact]
+    public void PlayableAudio_BeatsGaveUp_HoweverLongTheWaitWas()
+    {
+        // Audio arriving is the episode ENDING. A clip the reader can play must never be hidden behind a
+        // verdict about how long it took to make.
+        var v = Fold(Now - TimeSpan.FromHours(2), hasAudio: true);
+        Assert.Equal("ready", v.Kind);
+        Assert.True(v.CanPlay);
+    }
+
+    [Fact]
+    public void ALiveAttempt_BeatsGaveUp()
+    {
+        // Something IS happening right now, so saying it did not arrive would be false at the moment it is
+        // read - and the attempt in flight may well be the one that lands.
+        var v = Fold(Now - TimeSpan.FromHours(2), generating: true);
+        Assert.Equal("preparing", v.Kind);
+    }
+
+    [Fact]
+    public void GaveUp_OutranksARetryingState_BecauseTheRetryHasHadLongEnough()
+    {
+        // "Voice on its way" past the threshold is the exact sentence this issue exists to stop. A retry
+        // that has been going for 48 minutes is not news of progress.
+        var v = Fold(Now - TimeSpan.FromMinutes(48), unavailable: HostedAiState.Retrying);
+        Assert.Equal("gaveUp", v.Kind);
+    }
+
+    [Fact]
+    public void NotWaitingAtAll_IsUnchanged()
+    {
+        // A null clock must not manufacture a verdict - this is the ordinary path for every session that
+        // has its audio, and for every caller that does not supply the clock at all.
+        var v = Fold(waitingSince: null, nothingToNarrate: true);
+        Assert.Equal("nothingToNarrate", v.Kind);
+        Assert.Null(v.WaitedLabel);
+    }
+
+    [Theory]
+    [InlineData(0, 30, null)]          // under a minute: silent, so an ordinary turn shows no number
+    [InlineData(0, 61, "1m")]
+    [InlineData(0, 44 * 60, "44m")]
+    [InlineData(1, 4 * 60, "1h 4m")]
+    [InlineData(50, 0, "2d 2h")]
+    public void TheWaitLadder_MatchesTheOneTheRosterAlreadyUses(int hours, int seconds, string? expected)
+    {
+        var since = Now - TimeSpan.FromHours(hours) - TimeSpan.FromSeconds(seconds);
+        Assert.Equal(expected, VoiceDisplayFold.WaitedLabelFor(since, Now));
+    }
+
+    [Fact]
+    public void APreparingSessionCarriesItsWait_SoTheRailCanShowIt()
+    {
+        // The calm state carries the number too: the rail reads "Preparing voice (2m)", so a wait that is
+        // growing is visible BEFORE it reaches the point of giving up.
+        var v = Fold(Now - TimeSpan.FromMinutes(2), generating: true);
+        Assert.Equal("preparing", v.Kind);
+        Assert.Equal("2m", v.WaitedLabel);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/VoiceWaitingClockTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceWaitingClockTests.cs
@@ -1,0 +1,88 @@
+﻿using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #2576: the clock that finally lets a surface say HOW LONG a session has been without its voice.
+///
+/// The defect it closes: a session sat on "Preparing voice" for forty-eight minutes and no screen could
+/// say so, because the only elapsed-time fact the product had - <c>NeedsYouSince</c> - is stamped solely
+/// when the folded colour is RED, and a session waiting for voice is YELLOW. The one clock that existed
+/// was, by construction, never running for exactly the sessions that were stuck.
+/// </summary>
+public sealed class VoiceWaitingClockTests
+{
+    private static readonly TenantId Other = new TenantId("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public void NotWaiting_StampsNothing()
+    {
+        var clock = new VoiceWaitingClock();
+        Assert.Null(clock.Stamp(TenantId.Local, "s", isWaitingForVoice: false));
+    }
+
+    [Fact]
+    public void FirstWaitingRefresh_Stamps_AndLaterRefreshesHoldTheSameMoment()
+    {
+        // The value must NOT advance while the session keeps waiting - it is "since when", not "for how
+        // long". A clock that re-stamped every refresh would read zero forever, which is precisely the
+        // failure being fixed: a number that cannot grow cannot show that something is stuck.
+        var clock = new VoiceWaitingClock();
+
+        var first = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);
+        var second = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);
+        var third = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);
+
+        Assert.NotNull(first);
+        Assert.Equal(first, second);
+        Assert.Equal(first, third);
+    }
+
+    [Fact]
+    public void VoiceArriving_EndsTheEpisode_AndTheNextWaitIsStrictlyLater()
+    {
+        var clock = new VoiceWaitingClock();
+        var first = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);
+
+        Assert.Null(clock.Stamp(TenantId.Local, "s", isWaitingForVoice: false));   // audio arrived
+
+        var second = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);    // a new turn, a new wait
+        Assert.NotNull(second);
+        Assert.True(second >= first, "a later episode must not report an earlier moment than the one before it");
+    }
+
+    [Fact]
+    public void TwoTenantsWithTheSameSessionId_KeepSeparateClocks()
+    {
+        // The same reason the needs-you clock is keyed this way: two accounts can run sessions with the
+        // same id, and a bare-sid key would let one tenant's "voice arrived" clear the other's wait - so
+        // one owner's stuck session would silently reset its own age whenever an unrelated account's
+        // session got its audio.
+        var clock = new VoiceWaitingClock();
+
+        var mine = clock.Stamp(TenantId.Local, "shared-id", isWaitingForVoice: true);
+        var theirs = clock.Stamp(Other, "shared-id", isWaitingForVoice: true);
+        Assert.NotNull(mine);
+        Assert.NotNull(theirs);
+
+        clock.Stamp(Other, "shared-id", isWaitingForVoice: false);   // their voice arrived
+
+        // Mine is untouched, and still reports the moment MY wait began.
+        Assert.Equal(mine, clock.Stamp(TenantId.Local, "shared-id", isWaitingForVoice: true));
+    }
+
+    [Fact]
+    public void Forget_DropsTheEpisode()
+    {
+        var clock = new VoiceWaitingClock();
+        var first = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);
+        clock.Forget(TenantId.Local, "s");
+
+        var second = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.True(second >= first);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/VoiceWaitingClockTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceWaitingClockTests.cs
@@ -41,7 +41,7 @@ public sealed class VoiceWaitingClockTests
     }
 
     [Fact]
-    public void VoiceArriving_EndsTheEpisode_AndTheNextWaitIsStrictlyLater()
+    public void VoiceArriving_EndsTheEpisode_AndTheNextWaitIsNotEarlier()
     {
         var clock = new VoiceWaitingClock();
         var first = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);
@@ -50,6 +50,8 @@ public sealed class VoiceWaitingClockTests
 
         var second = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);    // a new turn, a new wait
         Assert.NotNull(second);
+        // Not-earlier, which is all a wall clock guarantees at this resolution - the test name used to say
+        // "strictly later" while asserting >=, and review was right that those are different claims.
         Assert.True(second >= first, "a later episode must not report an earlier moment than the one before it");
     }
 
@@ -71,18 +73,5 @@ public sealed class VoiceWaitingClockTests
 
         // Mine is untouched, and still reports the moment MY wait began.
         Assert.Equal(mine, clock.Stamp(TenantId.Local, "shared-id", isWaitingForVoice: true));
-    }
-
-    [Fact]
-    public void Forget_DropsTheEpisode()
-    {
-        var clock = new VoiceWaitingClock();
-        var first = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);
-        clock.Forget(TenantId.Local, "s");
-
-        var second = clock.Stamp(TenantId.Local, "s", isWaitingForVoice: true);
-        Assert.NotNull(first);
-        Assert.NotNull(second);
-        Assert.True(second >= first);
     }
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Net.Sockets;
 using System.Text.Json;
@@ -74,6 +74,10 @@ internal static class GatewayEndpoints
         Func<TenantId, string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
         Func<TenantId, string, bool>? nothingToNarrateFor = null,
         Func<TenantId, string, bool>? servedViaFallbackFor = null,
+        /// <summary>Issue #2576: stamps and returns SessionDto.VoiceWaitingSince - when this session's wait
+        /// for voice began, or null when it is not waiting. Null delegate leaves the field unset, so a caller
+        /// that has no voice state (a test, a diagnostic route) is unchanged.</summary>
+        Func<TenantId, string, bool, DateTime?>? voiceWaitingStampFor = null,
         Func<TenantId, string, bool, DateTime?>? needsYouStampFor = null,
         Func<TenantId, string, bool>? transcribingFor = null,
         Func<TenantId, string, string?>? dictationStatusFor = null,
@@ -1461,15 +1465,24 @@ internal static class GatewayEndpoints
                     // stamped plus the "nothing to narrate" marker, so a dumb client never has to guess (the
                     // guess is what put a dead-end Generate button next to a red "unavailable" badge). This
                     // is the law: the Gateway rules, the client renders (docs/new_architecture/session-state.html).
+                    // Issue #2576: the wait-for-voice clock. Stamped from the SAME facts the fold
+                    // immediately below reads, so the elapsed time on the row and the words on the row can
+                    // never disagree about whether this session is waiting at all. It is a SECOND clock
+                    // beside NeedsYouSince because that one is stamped only on RED and a session waiting
+                    // for voice is YELLOW - which is why nothing could say "48 minutes" when it mattered.
+                    var voiceAgentWorking = string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase)
+                                         || string.Equals(s.ActivityState, "Starting", StringComparison.OrdinalIgnoreCase);
+                    s.VoiceWaitingSince = voiceWaitingStampFor?.Invoke(
+                        reqTenant.Value, s.SessionId, s.VoiceMode && !s.VoiceAudioReady && !voiceAgentWorking);
                     s.VoiceDisplay = Wingman.VoiceDisplayFold.Fold(
                         voiceMode: s.VoiceMode,
-                        agentWorking: string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase)
-                                   || string.Equals(s.ActivityState, "Starting", StringComparison.OrdinalIgnoreCase),
+                        agentWorking: voiceAgentWorking,
                         hasAudio: s.VoiceAudioReady,
                         generating: s.VoiceGenerating,
                         unavailable: voiceUnavailableFor?.Invoke(reqTenant.Value, s.SessionId),
                         nothingToNarrate: nothingToNarrateFor?.Invoke(reqTenant.Value, s.SessionId) ?? false,
-                        servedViaFallback: servedViaFallbackFor?.Invoke(reqTenant.Value, s.SessionId) ?? false);
+                        servedViaFallback: servedViaFallbackFor?.Invoke(reqTenant.Value, s.SessionId) ?? false,
+                        waitingSince: s.VoiceWaitingSince);
                     // Orange "Transcribing..." while a dictated utterance is uploading/transcribing in
                     // the background for this session (mobile Speak -> Send released the screen). Stamped
                     // BEFORE the NeedsYouSince clock below so the EffectiveColor fold already sees orange

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1473,7 +1473,8 @@ internal static class GatewayEndpoints
                     var voiceAgentWorking = string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase)
                                          || string.Equals(s.ActivityState, "Starting", StringComparison.OrdinalIgnoreCase);
                     s.VoiceWaitingSince = voiceWaitingStampFor?.Invoke(
-                        reqTenant.Value, s.SessionId, s.VoiceMode && !s.VoiceAudioReady && !voiceAgentWorking);
+                        reqTenant.Value, s.SessionId,
+                        Wingman.VoiceDisplayFold.IsWaitingForVoice(s.VoiceMode, s.VoiceAudioReady, voiceAgentWorking));
                     s.VoiceDisplay = Wingman.VoiceDisplayFold.Fold(
                         voiceMode: s.VoiceMode,
                         agentWorking: voiceAgentWorking,

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -3831,7 +3831,8 @@ public sealed class GatewayHost : IAsyncDisposable
                        || string.Equals(s.ActivityState, "Starting", StringComparison.OrdinalIgnoreCase);
             // The clock is stamped from the SAME facts the fold below reads, so the elapsed time and the
             // words can never disagree about whether this session is waiting at all.
-            s.VoiceWaitingSince = voiceWaitingStampFor?.Invoke(s.SessionId, s.VoiceMode && !s.VoiceAudioReady && !working);
+            s.VoiceWaitingSince = voiceWaitingStampFor?.Invoke(
+                s.SessionId, Wingman.VoiceDisplayFold.IsWaitingForVoice(s.VoiceMode, s.VoiceAudioReady, working));
             s.VoiceDisplay = Wingman.VoiceDisplayFold.Fold(
                 voiceMode: s.VoiceMode,
                 agentWorking: working,

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -668,6 +668,9 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly Running.WorkListRunnerManager _runnerManager = new();
     // Issue #218: Gateway-owned clock for when each session entered the red / NEEDS-YOU state.
     private readonly NeedsYouClock _needsYouClock = new();
+    /// <summary>Issue #2576: how long each session has been waiting for its voice. A SECOND clock beside
+    /// the needs-you one because they time different episodes - see VoiceWaitingClock.</summary>
+    private readonly Wingman.VoiceWaitingClock _voiceWaitingClock = new();
     // Car Mode (Car Mode mission): the server-side, per-device conversation context behind the fleet
     // tool-calling brain (POST /carmode/turn), so multi-turn references ("the latest one") resolve.
     // In-memory by design; one instance for the whole Gateway.
@@ -1375,7 +1378,10 @@ public sealed class GatewayHost : IAsyncDisposable
                         : null,
                 nothingToNarrateFor: sid => _tenantPass.Current is { } t
                     && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
-                    && _voiceService?.NothingToNarrateFor(t, sid) == true),
+                    && _voiceService?.NothingToNarrateFor(t, sid) == true,
+                voiceWaitingStampFor: (sid, waiting) => _tenantPass.Current is { } t
+                    ? _voiceWaitingClock.Stamp(t, sid, waiting)
+                    : null),
             SendCommandAsync,
             currentScopeKey: () => _tenantPass.Current?.Value);
         // Mission Screen mission (Phase 1b, issue #1405): the mission-WHY store, at a Gateway-side file
@@ -2791,6 +2797,9 @@ public sealed class GatewayHost : IAsyncDisposable
             // was overloaded and the cloud proxy failed over). Feeds the folded VoiceDisplay so the screen
             // shows the generic backup-voice notice. A success-with-a-note, never an outage state.
             servedViaFallbackFor: (tenant, sid) => _voiceService?.ServedViaFallbackFor(tenant, sid) == true,
+            // Issue #2576: the wait-for-voice clock, so a stuck session can finally say HOW LONG. Separate
+            // from the needs-you clock below because that one only runs on red and this state is yellow.
+            voiceWaitingStampFor: (tenant, sid, waiting) => _voiceWaitingClock.Stamp(tenant, sid, waiting),
             // Issue #218: stamp the Gateway-owned NeedsYouSince entry clock onto each session. MTR-10 Gap C:
             // the clock is partitioned per tenant, so the roster's request tenant (threaded into the fold)
             // scopes each stamp - a session id shared across accounts keeps a per-tenant "waiting since".
@@ -3801,7 +3810,8 @@ public sealed class GatewayHost : IAsyncDisposable
         Func<TenantId, string, bool, DateTime?>? needsYouStampFor,
         Snooze.SnoozeRegistry? snoozeRegistry,
         Func<string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
-        Func<string, bool>? nothingToNarrateFor = null)
+        Func<string, bool>? nothingToNarrateFor = null,
+        Func<string, bool, DateTime?>? voiceWaitingStampFor = null)
     {
         foreach (var s in sessions)
         {
@@ -3817,14 +3827,19 @@ public sealed class GatewayHost : IAsyncDisposable
             var unavailable = voiceUnavailableFor?.Invoke(s.SessionId);
             if (unavailable is Core.HostedAi.HostedAiState reason)
                 s.VoiceUnavailable = HostedAi.HostedAiHttp.Dto(reason);
+            var working = string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase)
+                       || string.Equals(s.ActivityState, "Starting", StringComparison.OrdinalIgnoreCase);
+            // The clock is stamped from the SAME facts the fold below reads, so the elapsed time and the
+            // words can never disagree about whether this session is waiting at all.
+            s.VoiceWaitingSince = voiceWaitingStampFor?.Invoke(s.SessionId, s.VoiceMode && !s.VoiceAudioReady && !working);
             s.VoiceDisplay = Wingman.VoiceDisplayFold.Fold(
                 voiceMode: s.VoiceMode,
-                agentWorking: string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase)
-                           || string.Equals(s.ActivityState, "Starting", StringComparison.OrdinalIgnoreCase),
+                agentWorking: working,
                 hasAudio: s.VoiceAudioReady,
                 generating: s.VoiceGenerating,
                 unavailable: unavailable,
-                nothingToNarrate: nothingToNarrateFor?.Invoke(s.SessionId) ?? false);
+                nothingToNarrate: nothingToNarrateFor?.Invoke(s.SessionId) ?? false,
+                waitingSince: s.VoiceWaitingSince);
         }
         Api.GatewayEndpoints.StampFleetRolesAndFold(sessions, sessions, needsYouStampFor, snoozeRegistry, tenant);
     }

--- a/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
+++ b/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
@@ -140,29 +140,39 @@ public static class VoiceDisplayFold
         // Keyed on ELAPSED TIME rather than on a count of attempts, deliberately. The attempts are made
         // by two different loops (the turn-end path and the idle sweep) at rates neither controls, so a
         // count means different things on a busy Gateway and a quiet one, while a clock means the same
-        // thing to the person reading it - which is the only place this number is used.
+        // thing to the person reading it - which is the only place this number is used. It is therefore
+        // "nothing has arrived in three minutes", NOT "three attempts have failed", and the sweep's
+        // three-per-cycle global cap means those are genuinely different claims.
         //
-        // It sits ABOVE the unavailable switch so a session that has been retrying past the threshold
-        // stops saying "on its way" and admits it, and BELOW hasAudio and generating so neither a
-        // playable clip nor a live attempt is ever hidden behind it. Nothing here is terminal in the
-        // sense of stopping work: the sweep keeps trying, and a success replaces this verdict on the
-        // next fold. What ends is the PROMISE, not the effort.
-        if (waitingSince is { } since && (utcNow ?? DateTime.UtcNow) - since >= GaveUpAfter)
-            return new VoiceDisplay
-            {
-                Kind = "gaveUp",
-                Tone = "red",
-                Label = waited is null ? "Voice did not arrive" : $"Voice did not arrive after {waited}",
-                Message = "This turn's narration has not been produced. The Gateway is still trying, "
-                        + "and you can read the turn instead.",
-                WaitedLabel = waited,
-            };
+        // WHERE IT SITS, and the two versions of this that were wrong before review caught them:
+        //
+        //   above it  - off, working, hasAudio, generating. A playable clip or a live attempt must never
+        //               be hidden behind a verdict about how long the wait has been.
+        //   also above - EVERY SPECIFIC, ACTIONABLE REASON: service down, out of credits, cap reached,
+        //               finish setup. The first draft put gaveUp ahead of these, so a member who needed
+        //               to add credit was told "voice did not arrive" instead - the actionable sentence
+        //               replaced by a symptom. That is the same defect as a terminal read hiding a
+        //               standing account condition, which this codebase fixed once already today.
+        //   also above - nothingToNarrate. A session parked on a menu was never going to be narrated, so
+        //               "it did not arrive" reports a failure that never happened.
+        //
+        // What gaveUp DOES displace is Retrying and notReady - the two states whose whole content is "be
+        // patient". Those are the sentences that were still being said at forty-eight minutes.
+        //
+        // Nothing here stops the work: the sweep keeps trying and a success replaces this on the next
+        // fold. What ends is the PROMISE, not the effort.
+        var gaveUp = !nothingToNarrate
+                     && waitingSince is { } since
+                     && (utcNow ?? DateTime.UtcNow) - since >= GaveUpAfter;
 
         // An ANSWERED or in-progress hosted-AI condition. Reuse the single-source copy so the voice screen
         // matches the roster and every other surface for the same state - never a hand-written string here.
         switch (unavailable)
         {
             case HostedAiState.Retrying:
+                // "Voice on its way" is true for a minute and a lie at forty-eight. Past the threshold the
+                // retry stops being news and becomes the thing being reported.
+                if (gaveUp) return GaveUpDisplay(waited);
                 return new VoiceDisplay
                 {
                     Kind = "retrying",
@@ -213,6 +223,9 @@ public static class VoiceDisplayFold
         // Voice on, no audio, no reason, not being made, and not known-empty: a genuine "not made yet"
         // window (just entered voice, or a fresh turn before the sweep runs). Here - and ONLY here -
         // offering "Generate narration now" is honest, because there may be a text reply waiting to narrate.
+        // The same rule for the plain "not made yet" window: honest for a moment, misleading for an hour.
+        if (gaveUp) return GaveUpDisplay(waited);
+
         return new VoiceDisplay
         {
             Kind = "notReady",
@@ -220,8 +233,40 @@ public static class VoiceDisplayFold
             Label = "No narration yet",
             Message = "There is no spoken summary for this turn yet.",
             CanGenerate = true,
+            WaitedLabel = waited,
         };
     }
+
+    /// <summary>
+    /// THE ONE definition of "this session is waiting for its voice", used by every caller that stamps the
+    /// clock AND readable beside the fold that consumes it.
+    ///
+    /// It existed twice, hand-written, before review: once in the roster aggregation and once in the
+    /// display-push enrichment. They happened to agree character for character, which is exactly the
+    /// condition under which two copies stay wrong together and then quietly diverge - nothing bound them,
+    /// and no test would have noticed the day one of them changed.
+    ///
+    /// Deliberately NARROWER than "the fold shows a no-audio verdict". A session that is out of credits or
+    /// whose speech service is down is not waiting for a narration that is coming - it is blocked, and
+    /// counting that as waiting would start a clock whose only use is to declare a give-up that the
+    /// blocked verdict already explains better. So the clock runs for voice sessions with no audio that
+    /// are not mid-turn, and the fold decides what to SAY about that; the two questions are related but
+    /// they are not the same question.
+    /// </summary>
+    public static bool IsWaitingForVoice(bool voiceMode, bool hasAudio, bool agentWorking)
+        => voiceMode && !hasAudio && !agentWorking;
+
+    /// <summary>The terminal verdict, in one place so the two arms that reach it cannot word it differently.</summary>
+    private static VoiceDisplay GaveUpDisplay(string? waited) => new()
+    {
+        Kind = "gaveUp",
+        Tone = "red",
+        Label = waited is null ? "Voice did not arrive" : $"Voice did not arrive after {waited}",
+        Message = "This turn's narration has not been produced. The Gateway is still trying, "
+                + "and you can read the turn instead.",
+        // No Generate button: it would re-run exactly what has already not worked for the whole wait.
+        WaitedLabel = waited,
+    };
 
     /// <summary>The short badge headline for a blocked (account) state - the body text and the call-to-
     /// action still come from the shared <see cref="HostedAiMessages"/> / <see cref="HostedAiHttp.Dto"/>.</summary>

--- a/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
+++ b/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
@@ -1,4 +1,4 @@
-using CcDirector.Core.HostedAi;
+﻿using CcDirector.Core.HostedAi;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.HostedAi;
 
@@ -24,6 +24,40 @@ public static class VoiceDisplayFold
     /// deliberately names NO provider (the host non-disclosure rule has no carve-out) and states there is
     /// no extra charge, because the member is billed the normal rate on a fallback. Owner-approved wording.
     /// </summary>
+    /// <summary>
+    /// How long a session may wait for its voice before the screen stops promising one and says it did
+    /// not arrive.
+    ///
+    /// Three minutes because that is the number this product already committed to: SessionOrdering's
+    /// note on IsVoicePreparing says voice generation should average under a minute and that "anything
+    /// over three minutes is an exception to be flagged and fixed". This is that flag, finally built -
+    /// it does not invent a new standard, it renders the one already written down.
+    ///
+    /// Erring long on purpose. A false "did not arrive" on a narration that lands at three minutes and
+    /// one second costs a moment of doubt; a promise that never ends cost forty-eight minutes of a
+    /// person believing the product was working on something.
+    /// </summary>
+    public static readonly TimeSpan GaveUpAfter = TimeSpan.FromMinutes(3);
+
+    /// <summary>
+    /// The wait, in whole minutes and hours, or null under a minute. ONE ladder, matching the one the
+    /// roster already uses for needs-you waits (client-core sessions/waiting.ts durationFromMs) so the two
+    /// elapsed times on a card cannot describe the same kind of span two different ways.
+    ///
+    /// Null under a minute rather than "0m": the healthy case is a two-second synthesis, and a card that
+    /// announces "0m" on every ordinary turn trains the reader to ignore the number that matters.
+    /// </summary>
+    internal static string? WaitedLabelFor(DateTime? waitingSince, DateTime utcNow)
+    {
+        if (waitingSince is not { } since) return null;
+        var elapsed = utcNow - since;
+        if (elapsed < TimeSpan.FromMinutes(1)) return null;
+        var days = (int)elapsed.TotalDays;
+        if (days >= 1) return $"{days}d {elapsed.Hours}h";
+        if (elapsed.TotalHours >= 1) return $"{elapsed.Hours}h {elapsed.Minutes}m";
+        return $"{(int)elapsed.TotalMinutes}m";
+    }
+
     public const string BackupVoiceNotice =
         "Some voice providers are overloaded right now, so we switched you to a backup voice. No extra charge.";
 
@@ -44,8 +78,18 @@ public static class VoiceDisplayFold
     /// primary was overloaded and the cloud proxy quietly failed over). A SUCCESS-with-a-note: it only ever
     /// rides the green <c>ready</c> verdict and adds the generic <see cref="BackupVoiceNotice"/> - it is not
     /// an unavailable/outage state and changes nothing else. Ignored unless there is playable audio.</param>
-    public static VoiceDisplay Fold(bool voiceMode, bool agentWorking, bool hasAudio, bool generating, HostedAiState? unavailable, bool nothingToNarrate, bool servedViaFallback = false)
+    /// <param name="waitingSince">When this session's wait for voice began (SessionDto.VoiceWaitingSince),
+    /// or null when it is not waiting. Past <see cref="GaveUpAfter"/> the verdict becomes a terminal
+    /// "gave up" instead of another calm "on its way" - see that field for why a promise with no end is
+    /// worse than an admission.</param>
+    /// <param name="utcNow">Now, injected so the give-up boundary is testable without waiting for it.</param>
+    public static VoiceDisplay Fold(bool voiceMode, bool agentWorking, bool hasAudio, bool generating, HostedAiState? unavailable, bool nothingToNarrate, bool servedViaFallback = false, DateTime? waitingSince = null, DateTime? utcNow = null)
     {
+        // Computed once, up front, because more than one verdict below carries it: the calm "on its way"
+        // wants it so a healthy wait can be seen climbing, and the give-up verdict wants it in its own
+        // sentence. Null under a minute - see WaitedLabelFor.
+        var waited = WaitedLabelFor(waitingSince, utcNow ?? DateTime.UtcNow);
+
         // Not a voice session: the screen shows its own "off" card; there is no verdict to render.
         if (!voiceMode)
             return new VoiceDisplay { Kind = "off", Tone = "neutral", Label = "Voice off", Message = "" };
@@ -84,6 +128,34 @@ public static class VoiceDisplayFold
                 Tone = "yellow",
                 Label = "Voice on its way",
                 Message = "The wingman is preparing this turn's narration.",
+                WaitedLabel = waited,
+            };
+
+        // GAVE UP. The one state the voice screen could never reach before, and the reason a session
+        // could sit on "voice on its way" for forty-eight minutes: every arm below is either a calm
+        // "still coming" or a specific fault, and a narration that simply never arrives matches the
+        // calm one forever. IsVoicePreparing's own comment named a terminal gave-up state as the
+        // correct answer to that wedge; this is it.
+        //
+        // Keyed on ELAPSED TIME rather than on a count of attempts, deliberately. The attempts are made
+        // by two different loops (the turn-end path and the idle sweep) at rates neither controls, so a
+        // count means different things on a busy Gateway and a quiet one, while a clock means the same
+        // thing to the person reading it - which is the only place this number is used.
+        //
+        // It sits ABOVE the unavailable switch so a session that has been retrying past the threshold
+        // stops saying "on its way" and admits it, and BELOW hasAudio and generating so neither a
+        // playable clip nor a live attempt is ever hidden behind it. Nothing here is terminal in the
+        // sense of stopping work: the sweep keeps trying, and a success replaces this verdict on the
+        // next fold. What ends is the PROMISE, not the effort.
+        if (waitingSince is { } since && (utcNow ?? DateTime.UtcNow) - since >= GaveUpAfter)
+            return new VoiceDisplay
+            {
+                Kind = "gaveUp",
+                Tone = "red",
+                Label = waited is null ? "Voice did not arrive" : $"Voice did not arrive after {waited}",
+                Message = "This turn's narration has not been produced. The Gateway is still trying, "
+                        + "and you can read the turn instead.",
+                WaitedLabel = waited,
             };
 
         // An ANSWERED or in-progress hosted-AI condition. Reuse the single-source copy so the voice screen

--- a/src/CcDirector.Gateway/Wingman/VoiceWaitingClock.cs
+++ b/src/CcDirector.Gateway/Wingman/VoiceWaitingClock.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Wingman;
+
+/// <summary>
+/// Issue #2576: the Gateway-owned per-session clock recording WHEN a voice session last had no
+/// playable narration, so every surface can say how long it has been waiting for its voice.
+///
+/// THE DEFECT THIS EXISTS FOR. A session sat on "Preparing voice" for forty-eight minutes on
+/// 11 August and no screen could say so. The needs-you clock beside this one is stamped only when
+/// the folded colour is RED (see <c>GatewayEndpoints</c>), and a session waiting for voice is
+/// YELLOW - so the one clock the product had was, by construction, never running for exactly the
+/// sessions that were stuck. There was no fact anywhere from which "waiting 48 minutes" could be
+/// rendered, which is why the owner could see something was wrong and the product could not.
+///
+/// Deliberately a SECOND clock rather than a widening of <see cref="Briefing.NeedsYouClock"/>.
+/// They answer different questions - "how long has this session wanted a human?" and "how long has
+/// this session been without its voice?" - and the two episodes start and end at different moments.
+/// Merging them would make one number mean whichever the reader assumed.
+///
+/// In-memory by design (derived state, not the durable record) and re-derived after a Gateway
+/// restart on the next waiting refresh. The same entry/hold/clear rule as the needs-you clock:
+///   waiting and no timestamp yet -> stamp UtcNow (entry).
+///   waiting and one already held -> hold it, so the value never advances mid-episode.
+///   not waiting                  -> clear it; audio arriving ENDS the episode, and a later one
+///                                   stamps a strictly-later moment.
+///
+/// Keyed by (tenant, sessionId) exactly as the needs-you clock is, and for the same reason: two
+/// accounts can run sessions with the same id, and a bare-sid key would let one tenant's "voice
+/// arrived" clear another tenant's entry.
+/// </summary>
+public sealed class VoiceWaitingClock
+{
+    private readonly ConcurrentDictionary<(TenantId Tenant, string SessionId), DateTime> _since = new();
+
+    /// <summary>
+    /// Apply the entry/hold/clear rule for one session and return the timestamp to stamp on its
+    /// <see cref="Contracts.SessionDto.VoiceWaitingSince"/> (UTC), or null when it is not waiting.
+    /// </summary>
+    /// <param name="tenant">The tenant that owns the session being stamped.</param>
+    /// <param name="sessionId">The session's stable id.</param>
+    /// <param name="isWaitingForVoice">Whether this session is a voice session with no playable
+    /// audio this refresh, and is not mid-turn. Computed by the caller from the same facts the
+    /// display fold reads, so the clock and the words cannot disagree about whether it is waiting.</param>
+    public DateTime? Stamp(TenantId tenant, string sessionId, bool isWaitingForVoice)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sessionId);
+
+        var key = (tenant, sessionId);
+        if (!isWaitingForVoice)
+        {
+            if (_since.TryRemove(key, out _))
+                FileLog.Write($"[VoiceWaitingClock] tenant={tenant.ToLogString()} sid={sessionId}: voice arrived or the turn moved on, cleared VoiceWaitingSince");
+            return null;
+        }
+
+        var added = false;
+        var since = _since.GetOrAdd(key, _ =>
+        {
+            added = true;
+            return DateTime.UtcNow;
+        });
+        if (added)
+            FileLog.Write($"[VoiceWaitingClock] tenant={tenant.ToLogString()} sid={sessionId}: started waiting for voice, VoiceWaitingSince={since:o}");
+        return since;
+    }
+
+    /// <summary>Forget a session entirely - it is gone, or voice was turned off for it. Distinct from
+    /// the clear above only in intent; both drop the episode.</summary>
+    public void Forget(TenantId tenant, string sessionId) => _since.TryRemove((tenant, sessionId), out _);
+}

--- a/src/CcDirector.Gateway/Wingman/VoiceWaitingClock.cs
+++ b/src/CcDirector.Gateway/Wingman/VoiceWaitingClock.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 
@@ -30,6 +30,16 @@ namespace CcDirector.Gateway.Wingman;
 /// Keyed by (tenant, sessionId) exactly as the needs-you clock is, and for the same reason: two
 /// accounts can run sessions with the same id, and a bare-sid key would let one tenant's "voice
 /// arrived" clear another tenant's entry.
+///
+/// KNOWN AND NOT ADDRESSED HERE: an entry is dropped only when a refresh reports the session NOT
+/// waiting, so a session DELETED while it waits leaves its row behind until the Gateway restarts.
+/// <see cref="Briefing.NeedsYouClock"/> has exactly the same shape and the same gap, so this is the
+/// existing pattern rather than a new one - which is the argument for matching it, not for calling it
+/// correct. A per-session timestamp is small and a Gateway restart clears the lot, so it is a slow
+/// leak rather than a live risk; fixing it properly means pruning both clocks against the roster in
+/// one place, and that belongs in its own change rather than smuggled into this one. A Forget method
+/// was written here first and deleted: nothing called it, and a cleanup entry point with no caller
+/// reads as a policy that exists when it does not.
 /// </summary>
 public sealed class VoiceWaitingClock
 {
@@ -66,8 +76,4 @@ public sealed class VoiceWaitingClock
             FileLog.Write($"[VoiceWaitingClock] tenant={tenant.ToLogString()} sid={sessionId}: started waiting for voice, VoiceWaitingSince={since:o}");
         return since;
     }
-
-    /// <summary>Forget a session entirely - it is gone, or voice was turned off for it. Distinct from
-    /// the clear above only in intent; both drop the episode.</summary>
-    public void Forget(TenantId tenant, string sessionId) => _since.TryRemove((tenant, sessionId), out _);
 }


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1850 - the two halves left unbuilt when the first part shipped in thefrederiksen/devthrottle#2578.

## What changes on the row

```
before:  Preparing voice                    (identical at 2 seconds and 48 minutes)
after:   Preparing voice (2m)               while it is genuinely being made
         Voice did not arrive after 48m     past three minutes, red
```

## The clock

`VoiceWaitingClock` stamps when a session's wait for voice begins, holds that moment for the episode, and clears it when audio arrives or a new turn starts.

**A SECOND clock beside `NeedsYouClock` deliberately.** That one is stamped only when the folded colour is RED, and a session waiting for voice is YELLOW - so the one elapsed-time fact the product had was, by construction, never running for exactly the sessions that got stuck. That is why nothing could say "48 minutes". Keyed by (tenant, session) like its neighbour, so one account's voice arriving cannot reset another account's wait.

## The terminal state

Past three minutes the verdict becomes `gaveUp`, red. Three minutes is not invented here - `SessionOrdering`'s note on `IsVoicePreparing` already said voice should average under a minute and that "anything over three minutes is an exception to be flagged and fixed". This renders a standard that was already written down.

Playable audio and a live attempt both outrank it, so nothing in flight is ever hidden behind it. The Gateway keeps trying - what ends is the promise, not the effort.

## A design decision worth flagging

I first computed the elapsed time on the phone. It did not typecheck: the client's types are generated from the API schema, so any new field needs a regeneration against a running Gateway - and I was not going to launch one beside the owner's live Gateway to get it.

So the wait is turned into words on the Gateway, beside every other voice string it already composes, and rides the existing `label`. No schema change, and it is what rule 7 asks for anyway. **The trade, stated plainly:** whole minutes refreshed at poll rate, rather than a second-by-second tick. Good enough to answer "is this stuck?", which is the only question this number exists for.

Both the roster and the display push stamp the clock from the SAME facts the fold reads, so the elapsed time and the words cannot disagree about whether a session is waiting at all.

## Proof

- Full gate, both parked suites: 11 suites, all `outcome=Completed`, 0 failed. Gateway unit suite 3030 -> 3050.
- **Mutation-tested.** Disabling the give-up arm and the rail wait fails four assertions; the negative controls (audio beats give-up, a live attempt beats give-up, not-waiting is unchanged, the ladder) stay green as they should.

## Not in this change

The give-up threshold is time-based, not attempt-based - the attempts come from two loops at rates neither controls, so a count means different things on a busy Gateway and a quiet one while a clock means the same thing to the reader. If we later want "gave up after N attempts", that is a different fact and would need its own counter.