### PR TITLE
release: v2.0.4 - the voice wait has a clock, and the Gateway waits for its database

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>2.0.3</Version>
+    <Version>2.0.4</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v2.0.4.md
+++ b/docs/public/release-notes/v2.0.4.md
@@ -1,0 +1,91 @@
+# DevThrottle v2.0.4
+
+A small release with two fixes. Both were named in the v2.0.3 notes as things that
+were still wrong.
+
+## A session waiting for voice now has a clock, and can admit defeat
+
+v2.0.3 stopped a session going quiet without saying why, but left two gaps and said
+so: there was no clock on a session waiting for voice, and there was no point at
+which the product stopped promising a narration that was never going to arrive. A
+row reading "Preparing voice" read exactly the same at two seconds and at
+forty-eight minutes.
+
+- **The wait is now on the screen.** A session waiting for voice says how long it
+  has been waiting, in whole minutes, and the wait is timed from the moment it
+  began rather than from the last time anything happened.
+- **After three minutes the product stops promising.** The row turns red and says
+  the voice did not arrive, with the elapsed time, instead of another calm "on its
+  way". Three minutes is the standard the product already held itself to and had
+  written down; it is now rendered rather than merely intended. The Gateway keeps
+  trying in the background - what ends is the promise, not the effort.
+- **The reason you can act on still wins.** If the speech service is down, or the
+  account is out of credit, or setup is unfinished, the row says that. Those
+  sentences tell you what to do, and none of them is replaced by the give-up
+  message. A session that has audio, or has an attempt in flight, or has nothing to
+  read aloud, is unaffected.
+
+## The Gateway waits longer for its database before the platform gives up
+
+A deploy on 12 August took the hosted service off the air for 46.7 seconds. The
+container gave up on its database after ninety seconds and exited, and stopping a
+failed container during startup also takes down the healthy one serving traffic
+next to it. The same database, on the same image, opened cleanly minutes later.
+
+The ninety seconds bought nothing: exiting early and being timed out end the same
+way, so giving up early only threw away the roughly two minutes of budget in which
+the database might have recovered. The Gateway now waits inside the budget it
+actually has, with room left to finish starting up.
+
+**This is a mitigation, not a cure.** It widens the window in which a slow database
+can recover; it does not remove the dependency that causes the outage. The real fix
+is for the Gateway to start answering before it touches the database at all, and
+that is not built yet.
+
+It has one cost, and it is deliberate: a Gateway that cannot reach its database at
+all - a wrong password, a bad host, a failed migration - now takes about eighty
+seconds longer to report the error. That is eighty seconds for one operator who is
+already debugging a broken configuration, against a live outage for every user on
+an ordinary deploy.
+
+## Upgrading
+
+Nothing to do beyond the usual update. There is no migration and no new setting.
+
+**Both fixes live on the Gateway side.** If you use the hosted service, they are
+already running and updating the app is all you need. If you run your own Gateway,
+update it too - the words describing a voice wait are composed by the Gateway, and
+the database change is Gateway-only.
+
+## Known and not fixed here
+
+Five faults are known, filed, and deliberately not in this release. They were not
+introduced by the two fixes above, and they are the work queued for the next one.
+
+- **The 14-day Pro trial is invisible in the app.** Every new account gets one, and
+  no screen ever says a trial is running or how many days are left.
+- **A snooze does not survive the agent's own update-check.** Any output from the
+  terminal counts as work and clears the hold, so a hold on an idle session can die
+  within about half an hour.
+- **A Gateway serving an evicted Director shows an empty fleet as though it were a
+  fact**, while the sessions are running normally. A connection that has failed is
+  now reported honestly; this case is a connection that succeeds and answers with
+  nothing.
+- **Spawning a session with a prompt can lose the prompt**, deciding the agent is
+  ready when it is not, giving up after several attempts, and telling the caller
+  nothing went wrong.
+- **The hosted morning report can say no sessions ran** on days when sessions
+  demonstrably ran.
+
+Carried forward, unchanged from earlier releases:
+
+- Deploying the hosted Gateway can still take the service off the air for longer
+  than intended. Mitigated above, not closed.
+- The Director still opens a local listener during interactive sign-in. Unchanged
+  from v1.9.11.
+- The first-run wizard has not been verified on a genuinely clean Windows machine.
+  Unchanged from v1.9.9.
+- The v1.9.9 launcher work has not been run on macOS or Linux.
+- Two places still fall back to a local answer when the Gateway fails - session
+  numbering and the dictation dictionary. Both are filed.
+- The Director's large-object heap still grows on a long-running instance.


### PR DESCRIPTION
Bumps `Directory.Build.props` to 2.0.4 and adds `docs/public/release-notes/v2.0.4.md`.
The release workflow publishes that file verbatim and fails without it, so it lands here
with the bump.

## What is in v2.0.4

Two changes already merged to main since the v2.0.3 tag. Both were listed in the v2.0.3
notes as known and not fixed.

- **#2588 - the voice wait has a clock, and a give-up state.** Closes the two halves of
  thefrederiksen/devthrottle_internal#1850 left unbuilt. A session waiting for voice says how long it has been waiting, and
  past three minutes the row turns red and says the voice did not arrive rather than
  promising again. Service-down, out-of-credit and finish-setup still outrank it.
- **#2587 - the Gateway waits for its database inside the platform's budget.** Ninety
  seconds to a hundred and seventy. The 12 August deploy was dark for 46.7 seconds
  because the container gave up early and the platform then stopped the site, taking the
  healthy container with it. Stated in the notes as a mitigation, not a cure - thefrederiksen/devthrottle_internal#1856
  stays open and the real fix (bind the port before the database work, thefrederiksen/devthrottle_internal#1766) is unbuilt.

## Not in this release, deliberately

The five issues labelled `release-blocker` (#2532, thefrederiksen/devthrottle_internal#1833, thefrederiksen/devthrottle_internal#1836, thefrederiksen/devthrottle_internal#1837, thefrederiksen/devthrottle_internal#1847) are
deferred to the next release by the owner's decision. None is a regression from the two
fixes above, and all five are named in the notes under "Known and not fixed here" so the
release page states them rather than hiding them.

## After this merges

The release gate runs on merged main at this exact commit, per `docs/releasing.md`:
`scripts\test-local.ps1 -Parked -Configuration Release`, plus the two installer test
projects that are not in the solution. Then the tag.

The hosted Gateway is already running this main (deploy 13 August, green), so no
redeploy follows this release - only the desktop download changes.
