### PR TITLE
docs(deploy): the deploy skill stops promising no user-visible gap

### DIFF
--- a/.claude/skills/deploy-hosted-gateway/SKILL.md
+++ b/.claude/skills/deploy-hosted-gateway/SKILL.md
@@ -92,15 +92,41 @@ report it. That was wrong, and it trained people to accept the exact failure tha
 took the live service down for 38.5 seconds on 2 August 2026 (issue #2383).
 
 The deploy is a **warmed slot swap**: the old instance keeps serving until the new
-one is proven healthy, so a healthy deploy has **no user-visible gap at all**.
-Three consecutive deploys measured `Longest unavailable stretch: 0.0s` over a
-ten-minute watch. There is no cold start on the user path, because the user is
-never moved onto a cold instance.
+one is proven healthy, and the swap itself has measured `Longest unavailable
+stretch: 0.0s` across three consecutive deploys. There is no cold start on the
+user path, because the user is never moved onto a cold instance.
+
+**But the swap is not the whole cost of a deploy, and this section used to imply
+it was.** It said a healthy deploy has "no user-visible gap at all". Around the
+swap, a healthy deploy still costs roughly four seconds while the spare slot
+starts, five while the old slot stops, and about ten in which Directors show
+yellow and reconnect on their own - both slots share one worker, so starting and
+stopping the spare disturbs production.
+
+**And a deploy can be far worse than that, from a cause the swap number does not
+cover.** On 12 August 2026 one took the live service off the air for **46.7
+seconds** against a five-second budget (issue #2585) - worse than the 38.5-second
+failure above, and eight days after this section was written to prevent a repeat.
+Neither outage was the cutover. In both, a second container failed its own
+startup, the platform reverted by stopping the SITE, and stopping the site tore
+down the healthy container that was serving traffic beside it.
 
 So if `/healthz` does not answer `200` immediately after the run goes green,
-something went wrong with the hand-off. Say so; do not wait it out. The run itself
-now fails if the external outage exceeds five seconds, so a green run already
-means production stayed up.
+something went wrong with the hand-off. Say so; do not wait it out.
+
+**A failed run is a report, not a protection.** The watch job fails if the
+external outage exceeds five seconds, and it did fail on 12 August - users were
+dark for 46.7 seconds regardless. A green run means production stayed inside the
+budget; a red one tells you afterwards that it did not. Neither prevents an
+outage, so never present a green run as proof that deploying is free.
+
+v2.0.4 mitigates the 12 August cause: the Gateway now waits for its database
+inside the platform's start budget instead of giving up at ninety seconds and
+exiting. Its own code comments say it is a mitigation and NOT the fix. The fix is
+to bind the port before the database work, so site startup never depends on
+PostgreSQL (#2383's first recommendation), and that is unbuilt. Until it is,
+expect that a deploy CAN take the service down for tens of seconds, and say so
+when you report one.
 
 ### 5. Report plainly
 


### PR DESCRIPTION
The deploy skill's "a blip is NOT normal" section was written on 5 August (#2411) to stop people waving
through a gap, after one cost 38.5 seconds of live service on 2 August (#2383). Eight days later a
deploy took the service off the air for **46.7 seconds** (#2585) - worse, and against the same
five-second budget. The section still described a deploy as free.

## What changes

**The swap number stays.** The cutover itself really did measure `Longest unavailable stretch: 0.0s`
across three consecutive deploys, and that is worth keeping. What goes is the leap from that to "a
healthy deploy has **no user-visible gap at all**".

Around the swap, a healthy deploy still costs roughly four seconds while the spare slot starts, five
while the old one stops, and about ten in which Directors show yellow and reconnect - both slots share
one worker.

**Neither recorded outage was the cutover.** In both, a second container failed its own startup, the
platform reverted by stopping the SITE, and stopping the site tore down the healthy container serving
traffic beside it. A reader who trusts the swap number has no way to anticipate that, which is exactly
what happened on 12 August.

**"A green run already means production stayed up" was doing work it cannot do.** The watch job DID
fail on 12 August ([run 31598641454](https://github.com/thefrederiksen/devthrottle/actions/runs/31598641454))
and users were dark for 46.7 seconds regardless. A failed run is a report, not a protection. The text
now says that instead of offering the gate as reassurance.

It also names v2.0.4's mitigation, and that the code itself calls it a mitigation and not the fix -
binding the port before the database work (#2383's first recommendation) is still unbuilt.

## Why it went stale for eleven days

The internal repository carried a **second, independently written copy of this skill** - 118 lines
against this file's 130, same claim to be "the ONLY way", different wording throughout. Nobody
correcting one copy had reason to look at the other.

That copy is being replaced with a short pointer to this file, in a companion change, so this becomes
the single source. Found while auditing both repositories around the v2.0.4 release.

Documentation only - no code, no workflow change.
