### PR TITLE
voice: the dictionary stops guessing at words the user never listed

### DIFF
--- a/src/CcDirector.Core.Tests/Dictation/CleanupOrchestratorTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CleanupOrchestratorTests.cs
@@ -9,6 +9,11 @@ namespace CcDirector.Core.Tests.Dictation;
 /// exact/alias map, then the <see cref="FuzzyDictionaryMatcher"/>, and validates every proposed edit
 /// through <see cref="TranscriptEditEngine"/>. These pin the two invariants that matter: real
 /// dictionary mishearings get corrected, and text that is NOT a dictionary term is never touched.
+///
+/// This file exercises the fuzzy stage ON PURPOSE, so its dictionaries opt in explicitly
+/// (<see cref="DictationProfile.FuzzyCorrectionEnabled"/>). That stage is OFF by default in the
+/// field; the default and the over-correction it prevents are covered by
+/// <see cref="CleanupOverCorrectionTests"/>.
 /// </summary>
 public sealed class CleanupOrchestratorTests
 {
@@ -21,7 +26,8 @@ public sealed class CleanupOrchestratorTests
             patterns ?? new Dictionary<string, IReadOnlyList<string>>(),
             profiles ?? new Dictionary<string, DictationProfile>
             {
-                ["default"] = new DictationProfile("default", CleanupEnabled: true),
+                ["default"] = new DictationProfile(
+                    "default", CleanupEnabled: true, FuzzyCorrectionEnabled: true),
             });
 
     private static DictationDictionary ProductionLikeDict() => BuildDict(

--- a/src/CcDirector.Core.Tests/Dictation/CleanupOverCorrectionTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CleanupOverCorrectionTests.cs
@@ -172,10 +172,10 @@ public sealed class CleanupOverCorrectionTests
     }
 
     /// <summary>
-    /// The opt-in also survives the Gateway's dictionary JSON. This parser rebuilds the profile AND
-    /// writes the local cache, so dropping the field would quietly rewrite a deliberate enable as
-    /// false on every resolve. Asserted with a TRUE value, because a false one would pass whether
-    /// the field was read or ignored.
+    /// The opt-in also survives the Gateway's dictionary JSON. What this parser returns is what
+    /// ResolveAsync then writes to the local cache, so dropping the field here would quietly rewrite
+    /// a deliberate enable as false on every resolve. Asserted with a TRUE value, because a false one
+    /// would pass whether the field was read or ignored.
     /// </summary>
     [Fact]
     public void FuzzyCorrection_OptInSurvivesTheGatewayJson()

--- a/src/CcDirector.Core.Tests/Dictation/CleanupOverCorrectionTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CleanupOverCorrectionTests.cs
@@ -1,0 +1,178 @@
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Dictation.Models;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Dictation;
+
+/// <summary>
+/// Regression cover for the over-correction defect (devthrottle_internal #1553).
+///
+/// The unlisted fuzzy matcher decides on spelling similarity alone. Against a REAL glossary -
+/// short, ordinary-looking terms like "Soren", "Codex", "Opus", "ConPty" - that rewrote ordinary
+/// English into dictionary terms in the middle of the owner's dictation. A sweep of 22,398 distinct
+/// words from the repo docs found 293 ordinary words silently rewritten.
+///
+/// The existing fuzzy tests missed all of it because they use one to three exotic terms against
+/// prose containing no near neighbour, so the negative controls could not fail. These tests use the
+/// real glossary shape, and every sentence below is one the feature actually corrupted in
+/// production - including the owner's own bug report, which the feature mangled while he wrote it.
+///
+/// The assertions are exact string equality, not a score. A corrector that leaves correct words
+/// alone is the whole requirement.
+/// </summary>
+public sealed class CleanupOverCorrectionTests
+{
+    /// <summary>The owner's real glossary shape: 28 terms, several of them short and
+    /// collision-prone, plus the hand-listed wrong forms.</summary>
+    private static DictationDictionary RealWorldDictionary(bool fuzzy = false)
+        => new(
+            new[]
+            {
+                "mindzie", "mindzieStudio", "Frederiksen", "Soren", "Center Consulting",
+                "DevThrottle", "ConPty", "cc-director", "Avalonia", "SignalR", "Kestrel",
+                "Codex", "Anthropic", "Claude", "Opus", "Sonnet", "Haiku", "Postgres",
+                "Tailscale", "Cockpit", "Wingman", "Gateway", "Supabase", "Blazor", "Azure",
+                "OAuth", "Whisper", "Kubernetes",
+            },
+            new Dictionary<string, IReadOnlyList<string>>
+            {
+                ["mindzie"] = new[] { "Mindsee", "Mindsy", "Mindzee", "Mindsey" },
+                ["ConPty"] = new[] { "Con-TY", "ConTY", "Con TY", "Conpity" },
+                ["DevThrottle"] = new[] { "Dev Throttle", "Dev-Throttle" },
+                ["Supabase"] = new[] { "Superbase" },
+            },
+            new Dictionary<string, DictationProfile>
+            {
+                ["default"] = new("default", CleanupEnabled: true, FuzzyCorrectionEnabled: fuzzy),
+            });
+
+    private static string Clean(string raw, DictationDictionary dict)
+        => new CleanupOrchestrator().CleanAsync(raw, dict, "default").GetAwaiter().GetResult().Text;
+
+    /// <summary>
+    /// Every one of these was corrupted by the shipped corrector. They must come back byte for byte.
+    /// The first two are sentences from the owner's own bug report about this defect.
+    /// </summary>
+    [Theory]
+    [InlineData("make sure to create GitHub issues")]
+    [InlineData("it is making too many mistakes")]
+    [InlineData("explain the concept to me")]
+    [InlineData("that is a good concept")]
+    [InlineData("the context of the code")]
+    [InlineData("the code is broken")]
+    [InlineData("the screen is open")]
+    [InlineData("I am not sure")]
+    [InlineData("some of them")]
+    [InlineData("the score was high")]
+    [InlineData("go to the store and buy milk")]
+    [InlineData("my throat is sore today")]
+    [InlineData("the sort order is wrong")]
+    [InlineData("a sorted list of names")]
+    [InlineData("he wore a coat")]
+    [InlineData("we need to connect the parts")]
+    [InlineData("the cloud provider")]
+    [InlineData("the getaway car")]
+    [InlineData("the cocktail party")]
+    [InlineData("please focus on the bonus")]
+    [InlineData("the final signal was single")]
+    [InlineData("nature has a mature feature")]
+    [InlineData("while the white one is wider")]
+    [InlineData("the path is auto")]
+    public void OrdinaryWords_AreNeverRewrittenIntoDictionaryTerms(string sentence)
+        => Assert.Equal(sentence, Clean(sentence, RealWorldDictionary()));
+
+    /// <summary>
+    /// The corrections the user LISTED by hand still apply. Turning the guessing off must not cost
+    /// them the corrections they chose for themselves - that is the whole point of the split.
+    /// </summary>
+    [Theory]
+    [InlineData("the Con-TY renderer", "the ConPty renderer")]
+    [InlineData("I work at Mindsey every day", "I work at mindzie every day")]
+    [InlineData("we use Superbase for auth", "we use Supabase for auth")]
+    [InlineData("Dev Throttle runs the fleet", "DevThrottle runs the fleet")]
+    public void ListedWrongForms_AreStillCorrected(string raw, string expected)
+        => Assert.Equal(expected, Clean(raw, RealWorldDictionary()));
+
+    /// <summary>
+    /// An alias firing must not decide whether anything else happens. Before the fix, stage 1
+    /// returned the moment it changed text, so a sentence containing a listed wrong form silently
+    /// skipped every other correction in the same utterance.
+    /// </summary>
+    [Fact]
+    public void AnAliasFiring_DoesNotSuppressTheRestOfThePipeline()
+    {
+        var dict = RealWorldDictionary(fuzzy: true);
+        var cleaned = Clean("Mindsey deployed Terascale today", dict);
+
+        Assert.Contains("mindzie", cleaned);
+        Assert.Contains("Tailscale", cleaned);
+    }
+
+    /// <summary>
+    /// The switch is real: with the guessing explicitly turned on, the known corruption comes back.
+    /// A test that only proves the safe direction would pass just as well against a corrector that
+    /// was accidentally disabled outright, so this is the negative control for the whole file.
+    /// </summary>
+    [Fact]
+    public void WithFuzzyExplicitlyEnabled_TheKnownCorruptionReappears()
+    {
+        var corrupted = Clean("make sure to create GitHub issues", RealWorldDictionary(fuzzy: true));
+
+        Assert.Equal("make Soren to create GitHub issues", corrupted);
+    }
+
+    /// <summary>Absent from the YAML means off. Every glossary in the field predates this key, so
+    /// the default is what actually protects people - not the value we write in new files.</summary>
+    [Fact]
+    public void FuzzyCorrection_IsOffWhenTheGlossaryDoesNotMentionIt()
+    {
+        var dict = DictionaryLoader.Parse("""
+            vocabulary:
+              - Soren
+            profiles:
+              default:
+                cleanup_enabled: true
+            """);
+
+        Assert.False(dict.Profiles["default"].FuzzyCorrectionEnabled);
+        Assert.Equal("I am not sure", Clean("I am not sure", dict));
+    }
+
+    /// <summary>A glossary with no profiles at all gets the same protection.</summary>
+    [Fact]
+    public void FuzzyCorrection_IsOffWhenTheGlossaryHasNoProfilesAtAll()
+    {
+        var dict = DictionaryLoader.Parse("""
+            vocabulary:
+              - Soren
+              - Codex
+            """);
+
+        Assert.False(dict.Profiles["default"].FuzzyCorrectionEnabled);
+        Assert.Equal("the code is broken", Clean("the code is broken", dict));
+    }
+
+    /// <summary>The opt-in round-trips through the YAML, so a deliberate enable survives a save.</summary>
+    [Fact]
+    public void FuzzyCorrection_OptInRoundTripsThroughYaml()
+    {
+        var reparsed = DictionaryLoader.Parse(DictionaryLoader.Serialize(RealWorldDictionary(fuzzy: true)));
+
+        Assert.True(reparsed.Profiles["default"].FuzzyCorrectionEnabled);
+    }
+
+    /// <summary>Cleanup disabled entirely still means verbatim, aliases included.</summary>
+    [Fact]
+    public void CleanupDisabled_LeavesEvenListedWrongFormsAlone()
+    {
+        var dict = RealWorldDictionary() with
+        {
+            Profiles = new Dictionary<string, DictationProfile>
+            {
+                ["default"] = new("default", CleanupEnabled: false),
+            },
+        };
+
+        Assert.Equal("the Con-TY renderer", Clean("the Con-TY renderer", dict));
+    }
+}

--- a/src/CcDirector.Core.Tests/Dictation/CleanupOverCorrectionTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CleanupOverCorrectionTests.cs
@@ -171,6 +171,34 @@ public sealed class CleanupOverCorrectionTests
         Assert.True(reparsed.Profiles["default"].FuzzyCorrectionEnabled);
     }
 
+    /// <summary>
+    /// The opt-in also survives the Gateway's dictionary JSON. This parser rebuilds the profile AND
+    /// writes the local cache, so dropping the field would quietly rewrite a deliberate enable as
+    /// false on every resolve. Asserted with a TRUE value, because a false one would pass whether
+    /// the field was read or ignored.
+    /// </summary>
+    [Fact]
+    public void FuzzyCorrection_OptInSurvivesTheGatewayJson()
+    {
+        var dict = DictionaryResolver.ParseDictionaryJson("""
+            {"vocabulary":["Soren"],"commonMistranscriptions":{},
+             "profiles":{"default":{"cleanupEnabled":true,"fuzzyCorrectionEnabled":true}}}
+            """);
+
+        Assert.True(dict.Profiles["default"].FuzzyCorrectionEnabled);
+    }
+
+    /// <summary>And a Gateway response that says nothing about it still means off.</summary>
+    [Fact]
+    public void FuzzyCorrection_IsOffWhenTheGatewayJsonOmitsIt()
+    {
+        var dict = DictionaryResolver.ParseDictionaryJson("""
+            {"vocabulary":["Soren"],"profiles":{"default":{"cleanupEnabled":true}}}
+            """);
+
+        Assert.False(dict.Profiles["default"].FuzzyCorrectionEnabled);
+    }
+
     /// <summary>Cleanup disabled entirely still means verbatim, aliases included.</summary>
     [Fact]
     public void CleanupDisabled_LeavesEvenListedWrongFormsAlone()

--- a/src/CcDirector.Core.Tests/Dictation/CleanupOverCorrectionTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CleanupOverCorrectionTests.cs
@@ -94,18 +94,28 @@ public sealed class CleanupOverCorrectionTests
         => Assert.Equal(expected, Clean(raw, RealWorldDictionary()));
 
     /// <summary>
-    /// An alias firing must not decide whether anything else happens. Before the fix, stage 1
-    /// returned the moment it changed text, so a sentence containing a listed wrong form silently
-    /// skipped every other correction in the same utterance.
+    /// A term the user listed by hand must survive intact. Letting the fuzzy stage run on the
+    /// alias-corrected text was tried and reverted because of exactly this: the matcher skips a
+    /// multi-word canonical window but does not RESERVE it, so it then judges each token inside
+    /// separately and rewrote half of the phrase stage 1 had just inserted - "alfa beta" became
+    /// "Alpha Beta" and then "Alpha Beto".
+    ///
+    /// Stage 1 short-circuits again, so this cannot happen. The order-dependence that restores is a
+    /// known defect tracked with the offset-based apply in #1554, and it is strictly less harmful
+    /// than corrupting a term the user chose for themselves.
     /// </summary>
     [Fact]
-    public void AnAliasFiring_DoesNotSuppressTheRestOfThePipeline()
+    public void AnAliasResult_IsNeverPartlyRewrittenByTheFuzzyStage()
     {
-        var dict = RealWorldDictionary(fuzzy: true);
-        var cleaned = Clean("Mindsey deployed Terascale today", dict);
+        var dict = new DictationDictionary(
+            new[] { "Alpha Beta", "Beto" },
+            new Dictionary<string, IReadOnlyList<string>> { ["Alpha Beta"] = new[] { "alfa beta" } },
+            new Dictionary<string, DictationProfile>
+            {
+                ["default"] = new("default", CleanupEnabled: true, FuzzyCorrectionEnabled: true),
+            });
 
-        Assert.Contains("mindzie", cleaned);
-        Assert.Contains("Tailscale", cleaned);
+        Assert.Equal("ship Alpha Beta today", Clean("ship alfa beta today", dict));
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
+++ b/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
@@ -15,10 +15,15 @@ namespace CcDirector.Core.Dictation;
 /// Two stages, both of which only ever PROPOSE find/replace edits that the deterministic
 /// <see cref="TranscriptEditEngine"/> validates and applies:
 ///   1. <see cref="TryApplyKnownMistranscriptions"/> - exact/alias map: fixes the wrong-forms the
-///      dictionary lists explicitly (instant, boundary-aware). Short-circuits when it changes text.
+///      dictionary lists explicitly (instant, boundary-aware). Always runs when cleanup is enabled.
 ///   2. <see cref="FuzzyDictionaryMatcher"/> - phonetic/edit-distance matcher: catches NEW mishearings
 ///      that were never hand-listed ("Mindsey" -> mindzie, "Akmeflow" -> acmeflow) by scoring word
-///      windows against the canonical vocabulary. This is what replaced the language model.
+///      windows against the canonical vocabulary. OPT-IN and OFF by default, because it decides on
+///      spelling alone and rewrites ordinary words into dictionary terms - see
+///      <see cref="DictationProfile.FuzzyCorrectionEnabled"/>.
+///
+/// The two stages COMPOSE: stage 1 no longer returns early, so stage 2 (when enabled) works on the
+/// alias-corrected text. Whether an unrelated alias fired must not change what else gets corrected.
 ///
 /// The transcript never round-trips through any generative model, so nothing can reword, summarize,
 /// answer, or inject text (issue #190). The only change made to the user's words is a validated
@@ -75,45 +80,69 @@ public sealed class CleanupOrchestrator
         var sw = Stopwatch.StartNew();
         try
         {
-            // Stage 1: exact/alias map (the hand-listed wrong forms). Short-circuits on any change.
-            var deterministic = TryApplyKnownMistranscriptions(rawTranscript, dictionary);
-            if (deterministic is not null)
+            // Stage 1: exact/alias map (the hand-listed wrong forms the user chose for themselves).
+            // It no longer short-circuits: whether an unrelated alias happened to fire must not decide
+            // whether the rest of the pipeline runs, or the same sentence corrects differently
+            // depending on what else was said in it.
+            var aliasOutcome = TryApplyKnownMistranscriptions(rawTranscript, dictionary);
+            var textAfterAliases = aliasOutcome?.Text ?? rawTranscript;
+            var aliasEdits = aliasOutcome?.ChangedWords ?? Array.Empty<TranscriptEdit>();
+
+            // Stage 2 is OPT-IN and off unless the glossary asks for it. The fuzzy matcher guesses
+            // from spelling alone and rewrites ordinary words into dictionary terms ("make sure" ->
+            // "make Soren"); it stays off until a judge that can read the sentence rules on each
+            // candidate (devthrottle_internal #1554). Stage 1 still runs above, so the corrections
+            // the user listed by hand keep working.
+            if (!profile.FuzzyCorrectionEnabled)
             {
                 sw.Stop();
-                FileLog.Write($"[CleanupOrchestrator] CleanAsync: deterministic known-mistranscription cleanup "
-                              + $"applied={deterministic.ChangedWords.Count} in {sw.Elapsed.TotalMilliseconds:0.###}ms");
-                return Done(deterministic);
+                FileLog.Write($"[CleanupOrchestrator] CleanAsync: alias-only cleanup "
+                              + $"applied={aliasEdits.Count} in {sw.Elapsed.TotalMilliseconds:0.###}ms "
+                              + $"(unlisted fuzzy correction is off for profile '{profile.Name}')");
+                return Done(aliasOutcome ?? new CleanupOutcome(
+                    rawTranscript, Applied: false, Reason: "no dictionary corrections needed"));
             }
 
-            // Stage 2: fuzzy matcher proposes edits for the unlisted mishearings; the SAME engine
-            // gate validates and applies them, so the safety invariant is identical to before.
-            var proposed = FuzzyDictionaryMatcher.Propose(rawTranscript, dictionary);
-            var validation = TranscriptEditEngine.Validate(proposed, rawTranscript, dictionary);
+            // The fuzzy matcher proposes edits for the unlisted mishearings; the SAME engine gate
+            // validates and applies them, so the safety invariant is identical to before. It runs on
+            // the alias-corrected text, not the raw text, so both stages compose.
+            var proposed = FuzzyDictionaryMatcher.Propose(textAfterAliases, dictionary);
+            var validation = TranscriptEditEngine.Validate(proposed, textAfterAliases, dictionary);
             foreach (var r in validation.Rejected)
                 FileLog.Write($"[CleanupOrchestrator] edit REJECTED: \"{Truncate(r.Edit.Find, 60)}\" -> "
                               + $"\"{Truncate(r.Edit.Replace, 60)}\" ({r.Reason})");
             foreach (var a in validation.Accepted)
                 FileLog.Write($"[CleanupOrchestrator] edit accepted: \"{Truncate(a.Find, 60)}\" -> \"{a.Replace}\"");
 
-            var (cleaned, appliedCount) = TranscriptEditEngine.Apply(rawTranscript, validation.Accepted);
+            var (cleaned, appliedCount) = TranscriptEditEngine.Apply(textAfterAliases, validation.Accepted);
             sw.Stop();
 
-            string? reason = null;
+            // Both stages may have contributed, so the reason names whichever actually did. Stage 1
+            // keeps saying "deterministic ..." exactly as it did when it returned on its own.
+            var reasons = new List<string>();
+            if (aliasEdits.Count > 0)
+                reasons.Add("deterministic known-mistranscription cleanup");
             if (validation.Rejected.Count > 0)
-                reason = $"{validation.Rejected.Count} proposed edit(s) rejected";
-            if (appliedCount == 0)
-                reason = reason is null ? "no dictionary corrections needed" : reason + "; none applied";
+                reasons.Add($"{validation.Rejected.Count} proposed edit(s) rejected");
+            if (appliedCount == 0 && aliasEdits.Count == 0)
+                reasons.Add("no dictionary corrections needed");
+            var reason = reasons.Count > 0 ? string.Join("; ", reasons) : null;
 
             FileLog.Write($"[CleanupOrchestrator] CleanAsync done in {sw.Elapsed.TotalMilliseconds:0.###}ms: "
                           + $"proposed={proposed.Count} accepted={validation.Accepted.Count} "
                           + $"applied={appliedCount} rejected={validation.Rejected.Count}");
 
             // Report which dictionary terms were swapped (issue #587): the accepted edits ARE the
-            // change list, and only when something actually reached the text.
+            // change list, and only when something actually reached the text. Both stages report,
+            // because both stages may now have changed the text.
             var changedWords = appliedCount > 0
-                ? validation.Accepted
-                : (IReadOnlyList<TranscriptEdit>)Array.Empty<TranscriptEdit>();
-            return Done(new CleanupOutcome(cleaned, Applied: appliedCount > 0, Reason: reason, ChangedWords: changedWords));
+                ? aliasEdits.Concat(validation.Accepted).ToList()
+                : (IReadOnlyList<TranscriptEdit>)aliasEdits;
+            return Done(new CleanupOutcome(
+                cleaned,
+                Applied: appliedCount > 0 || aliasEdits.Count > 0,
+                Reason: reason,
+                ChangedWords: changedWords));
         }
         catch (Exception ex)
         {
@@ -188,7 +217,7 @@ public sealed class CleanupOrchestrator
             return found;
         if (dictionary.Profiles.TryGetValue("default", out var def))
             return def;
-        return new DictationProfile("default", CleanupEnabled: true);
+        return new DictationProfile("default", CleanupEnabled: true, FuzzyCorrectionEnabled: false);
     }
 
     private static string Truncate(string s, int max)

--- a/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
+++ b/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
@@ -15,15 +15,12 @@ namespace CcDirector.Core.Dictation;
 /// Two stages, both of which only ever PROPOSE find/replace edits that the deterministic
 /// <see cref="TranscriptEditEngine"/> validates and applies:
 ///   1. <see cref="TryApplyKnownMistranscriptions"/> - exact/alias map: fixes the wrong-forms the
-///      dictionary lists explicitly (instant, boundary-aware). Always runs when cleanup is enabled.
+///      dictionary lists explicitly (instant, boundary-aware). Short-circuits when it changes text.
 ///   2. <see cref="FuzzyDictionaryMatcher"/> - phonetic/edit-distance matcher: catches NEW mishearings
 ///      that were never hand-listed ("Mindsey" -> mindzie, "Akmeflow" -> acmeflow) by scoring word
 ///      windows against the canonical vocabulary. OPT-IN and OFF by default, because it decides on
 ///      spelling alone and rewrites ordinary words into dictionary terms - see
 ///      <see cref="DictationProfile.FuzzyCorrectionEnabled"/>.
-///
-/// The two stages COMPOSE: stage 1 no longer returns early, so stage 2 (when enabled) works on the
-/// alias-corrected text. Whether an unrelated alias fired must not change what else gets corrected.
 ///
 /// The transcript never round-trips through any generative model, so nothing can reword, summarize,
 /// answer, or inject text (issue #190). The only change made to the user's words is a validated
@@ -81,50 +78,58 @@ public sealed class CleanupOrchestrator
         try
         {
             // Stage 1: exact/alias map (the hand-listed wrong forms the user chose for themselves).
-            // It no longer short-circuits: whether an unrelated alias happened to fire must not decide
-            // whether the rest of the pipeline runs, or the same sentence corrects differently
-            // depending on what else was said in it.
-            var aliasOutcome = TryApplyKnownMistranscriptions(rawTranscript, dictionary);
-            var textAfterAliases = aliasOutcome?.Text ?? rawTranscript;
-            var aliasEdits = aliasOutcome?.ChangedWords ?? Array.Empty<TranscriptEdit>();
+            //
+            // It still short-circuits. Letting stage 2 run on the alias-corrected text was tried and
+            // reverted: the fuzzy matcher skips a multi-word canonical window but does not RESERVE it,
+            // so it then considers each token inside separately and can rewrite half of a canonical
+            // phrase stage 1 just inserted ("alfa beta" -> "Alpha Beta" -> "Alpha Beto"). Composing the
+            // two stages needs edits generated against the raw text and merged only where they do not
+            // overlap, which is real work and belongs with the offset-based apply in #1554 - not in an
+            // emergency fix. The order-dependence this leaves is a known defect, and it is strictly
+            // less harmful than corrupting a term the user hand-listed.
+            var deterministic = TryApplyKnownMistranscriptions(rawTranscript, dictionary);
+            if (deterministic is not null)
+            {
+                sw.Stop();
+                FileLog.Write($"[CleanupOrchestrator] CleanAsync: deterministic known-mistranscription cleanup "
+                              + $"applied={deterministic.ChangedWords.Count} in {sw.Elapsed.TotalMilliseconds:0.###}ms");
+                return Done(deterministic);
+            }
 
             // Stage 2 is OPT-IN and off unless the glossary asks for it. The fuzzy matcher guesses
             // from spelling alone and rewrites ordinary words into dictionary terms ("make sure" ->
             // "make Soren"); it stays off until a judge that can read the sentence rules on each
-            // candidate (devthrottle_internal #1554). Stage 1 still runs above, so the corrections
-            // the user listed by hand keep working.
+            // candidate (devthrottle_internal #1554). Stage 1 above still runs, so the corrections the
+            // user listed by hand keep working.
             if (!profile.FuzzyCorrectionEnabled)
             {
                 sw.Stop();
-                FileLog.Write($"[CleanupOrchestrator] CleanAsync: alias-only cleanup "
-                              + $"applied={aliasEdits.Count} in {sw.Elapsed.TotalMilliseconds:0.###}ms "
-                              + $"(unlisted fuzzy correction is off for profile '{profile.Name}')");
-                return Done(aliasOutcome ?? new CleanupOutcome(
+                FileLog.Write($"[CleanupOrchestrator] CleanAsync: no listed mistranscription matched and "
+                              + $"unlisted fuzzy correction is off for profile '{profile.Name}'; "
+                              + $"returning verbatim in {sw.Elapsed.TotalMilliseconds:0.###}ms");
+                return Done(new CleanupOutcome(
                     rawTranscript, Applied: false, Reason: "no dictionary corrections needed"));
             }
 
             // The fuzzy matcher proposes edits for the unlisted mishearings; the SAME engine gate
-            // validates and applies them, so the safety invariant is identical to before. It runs on
-            // the alias-corrected text, not the raw text, so both stages compose.
-            var proposed = FuzzyDictionaryMatcher.Propose(textAfterAliases, dictionary);
-            var validation = TranscriptEditEngine.Validate(proposed, textAfterAliases, dictionary);
+            // validates and applies them, so the safety invariant is identical to before.
+            var proposed = FuzzyDictionaryMatcher.Propose(rawTranscript, dictionary);
+            var validation = TranscriptEditEngine.Validate(proposed, rawTranscript, dictionary);
             foreach (var r in validation.Rejected)
                 FileLog.Write($"[CleanupOrchestrator] edit REJECTED: \"{Truncate(r.Edit.Find, 60)}\" -> "
                               + $"\"{Truncate(r.Edit.Replace, 60)}\" ({r.Reason})");
             foreach (var a in validation.Accepted)
                 FileLog.Write($"[CleanupOrchestrator] edit accepted: \"{Truncate(a.Find, 60)}\" -> \"{a.Replace}\"");
 
-            var (cleaned, appliedCount) = TranscriptEditEngine.Apply(textAfterAliases, validation.Accepted);
+            var (cleaned, appliedCount) = TranscriptEditEngine.Apply(rawTranscript, validation.Accepted);
             sw.Stop();
 
-            // Both stages may have contributed, so the reason names whichever actually did. Stage 1
-            // keeps saying "deterministic ..." exactly as it did when it returned on its own.
             var reasons = new List<string>();
-            if (aliasEdits.Count > 0)
-                reasons.Add("deterministic known-mistranscription cleanup");
+            if (appliedCount > 0)
+                reasons.Add($"{appliedCount} unlisted fuzzy correction(s) applied");
             if (validation.Rejected.Count > 0)
                 reasons.Add($"{validation.Rejected.Count} proposed edit(s) rejected");
-            if (appliedCount == 0 && aliasEdits.Count == 0)
+            if (appliedCount == 0)
                 reasons.Add("no dictionary corrections needed");
             var reason = reasons.Count > 0 ? string.Join("; ", reasons) : null;
 
@@ -133,16 +138,11 @@ public sealed class CleanupOrchestrator
                           + $"applied={appliedCount} rejected={validation.Rejected.Count}");
 
             // Report which dictionary terms were swapped (issue #587): the accepted edits ARE the
-            // change list, and only when something actually reached the text. Both stages report,
-            // because both stages may now have changed the text.
+            // change list, and only when something actually reached the text.
             var changedWords = appliedCount > 0
-                ? aliasEdits.Concat(validation.Accepted).ToList()
-                : (IReadOnlyList<TranscriptEdit>)aliasEdits;
-            return Done(new CleanupOutcome(
-                cleaned,
-                Applied: appliedCount > 0 || aliasEdits.Count > 0,
-                Reason: reason,
-                ChangedWords: changedWords));
+                ? validation.Accepted
+                : (IReadOnlyList<TranscriptEdit>)Array.Empty<TranscriptEdit>();
+            return Done(new CleanupOutcome(cleaned, Applied: appliedCount > 0, Reason: reason, ChangedWords: changedWords));
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
+++ b/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
@@ -124,14 +124,11 @@ public sealed class CleanupOrchestrator
             var (cleaned, appliedCount) = TranscriptEditEngine.Apply(rawTranscript, validation.Accepted);
             sw.Stop();
 
-            var reasons = new List<string>();
-            if (appliedCount > 0)
-                reasons.Add($"{appliedCount} unlisted fuzzy correction(s) applied");
+            string? reason = null;
             if (validation.Rejected.Count > 0)
-                reasons.Add($"{validation.Rejected.Count} proposed edit(s) rejected");
+                reason = $"{validation.Rejected.Count} proposed edit(s) rejected";
             if (appliedCount == 0)
-                reasons.Add("no dictionary corrections needed");
-            var reason = reasons.Count > 0 ? string.Join("; ", reasons) : null;
+                reason = reason is null ? "no dictionary corrections needed" : reason + "; none applied";
 
             FileLog.Write($"[CleanupOrchestrator] CleanAsync done in {sw.Elapsed.TotalMilliseconds:0.###}ms: "
                           + $"proposed={proposed.Count} accepted={validation.Accepted.Count} "

--- a/src/CcDirector.Core/Dictation/DictionaryLoader.cs
+++ b/src/CcDirector.Core/Dictation/DictionaryLoader.cs
@@ -24,8 +24,13 @@ namespace CcDirector.Core.Dictation;
 ///   profiles:
 ///     default:
 ///       cleanup_enabled: true
+///       fuzzy_correction_enabled: false   # optional; OFF unless written here
 ///     code:
 ///       cleanup_enabled: false
+///
+/// <c>fuzzy_correction_enabled</c> is the opt-in for the unlisted fuzzy matcher and is
+/// absent from every glossary in the field, which is the point: absent means off. See
+/// <see cref="DictationProfile.FuzzyCorrectionEnabled"/> for why.
 /// </summary>
 public sealed class DictionaryLoader : IDisposable
 {
@@ -133,6 +138,7 @@ public sealed class DictionaryLoader : IDisposable
                 kv => new YamlProfile
                 {
                     CleanupEnabled = kv.Value.CleanupEnabled,
+                    FuzzyCorrectionEnabled = kv.Value.FuzzyCorrectionEnabled,
                 }),
         };
 
@@ -212,7 +218,8 @@ public sealed class DictionaryLoader : IDisposable
                     continue;
                 profiles[kv.Key.Trim()] = new DictationProfile(
                     Name: kv.Key.Trim(),
-                    CleanupEnabled: kv.Value.CleanupEnabled);
+                    CleanupEnabled: kv.Value.CleanupEnabled,
+                    FuzzyCorrectionEnabled: kv.Value.FuzzyCorrectionEnabled);
             }
         }
 
@@ -222,7 +229,8 @@ public sealed class DictionaryLoader : IDisposable
         {
             profiles["default"] = new DictationProfile(
                 Name: "default",
-                CleanupEnabled: true);
+                CleanupEnabled: true,
+                FuzzyCorrectionEnabled: false);
         }
 
         return new DictationDictionary(vocab, patterns, profiles);
@@ -251,5 +259,9 @@ public sealed class DictionaryLoader : IDisposable
     public sealed class YamlProfile
     {
         public bool CleanupEnabled { get; set; } = true;
+
+        /// <summary>Opt-in for the unlisted fuzzy matcher. Absent from the YAML means OFF -
+        /// see <see cref="DictationProfile.FuzzyCorrectionEnabled"/>.</summary>
+        public bool FuzzyCorrectionEnabled { get; set; }
     }
 }

--- a/src/CcDirector.Core/Dictation/DictionaryResolver.cs
+++ b/src/CcDirector.Core/Dictation/DictionaryResolver.cs
@@ -186,8 +186,19 @@ public sealed class DictionaryResolver
                     && TryGetProperty(prop.Value, "cleanupEnabled", out var ce)
                     && ce.ValueKind is JsonValueKind.True or JsonValueKind.False)
                     cleanupEnabled = ce.GetBoolean();
+
+                // Absent means off, matching the YAML loader: this reconstruction also WRITES the
+                // local cache, so dropping the field here would quietly rewrite a Gateway opt-in
+                // as false on every resolve.
+                var fuzzyEnabled = false;
+                if (prop.Value.ValueKind == JsonValueKind.Object
+                    && TryGetProperty(prop.Value, "fuzzyCorrectionEnabled", out var fe)
+                    && fe.ValueKind is JsonValueKind.True or JsonValueKind.False)
+                    fuzzyEnabled = fe.GetBoolean();
+
                 var name = prop.Name.Trim();
-                profiles[name] = new DictationProfile(Name: name, CleanupEnabled: cleanupEnabled);
+                profiles[name] = new DictationProfile(
+                    Name: name, CleanupEnabled: cleanupEnabled, FuzzyCorrectionEnabled: fuzzyEnabled);
             }
         }
 

--- a/src/CcDirector.Core/Dictation/DictionaryResolver.cs
+++ b/src/CcDirector.Core/Dictation/DictionaryResolver.cs
@@ -133,7 +133,8 @@ public sealed class DictionaryResolver
     /// <summary>
     /// Parse the camelCase JSON the Gateway's <c>GET /ingest/dictionary</c> returns
     /// (<c>vocabulary</c>, <c>commonMistranscriptions</c>, <c>profiles</c> as
-    /// <c>{ name: { cleanupEnabled } }</c>) into a <see cref="DictationDictionary"/>. Applies the
+    /// <c>{ name: { cleanupEnabled, fuzzyCorrectionEnabled } }</c>) into a
+    /// <see cref="DictationDictionary"/>. Applies the
     /// same normalization as <see cref="DictionaryLoader.Parse"/> (trimming, an always-present
     /// "default" profile) so the gateway path and the local-file path produce identical models.
     /// Exposed internally for testing without a network call.

--- a/src/CcDirector.Core/Dictation/Models/Dictionary.cs
+++ b/src/CcDirector.Core/Dictation/Models/Dictionary.cs
@@ -52,9 +52,13 @@ public sealed record DictationDictionary(
 /// therefore DEFAULT OFF and stays off until a judge that can read the sentence decides
 /// each candidate (devthrottle_internal #1554).
 ///
-/// Turning it on is a deliberate opt-in written into the glossary YAML
-/// (<c>fuzzy_correction_enabled: true</c>). Nothing else can flip it, and no wire format
-/// carries it, so every path that does not explicitly ask for it gets the safe answer.
+/// Turning it on is a deliberate opt-in written into the glossary
+/// (<c>fuzzy_correction_enabled: true</c> in YAML, <c>fuzzyCorrectionEnabled</c> over the
+/// Gateway's dictionary JSON). Absent means OFF everywhere it is read, so every glossary
+/// already in the field - all of which predate the key - gets the safe answer. Absent means
+/// something different when a glossary is WRITTEN: the Gateway preserves whatever is on disk
+/// rather than erasing it, so a save from a client that knows nothing about this setting
+/// cannot switch it back off.
 /// </summary>
 public sealed record DictationProfile(
     string Name,

--- a/src/CcDirector.Core/Dictation/Models/Dictionary.cs
+++ b/src/CcDirector.Core/Dictation/Models/Dictionary.cs
@@ -18,10 +18,11 @@ namespace CcDirector.Core.Dictation.Models;
 ///    LLM, which replaces these exact wrong forms with the canonical term and
 ///    changes nothing else.
 ///
-/// Profiles let the same dictionary serve multiple contexts. The only knob is
-/// whether dictionary correction runs at all (see
-/// <see cref="DictationProfile.CleanupEnabled"/>); the correction itself never
-/// rewrites, summarizes, or restyles the speaker's words.
+/// Profiles let the same dictionary serve multiple contexts. They control whether
+/// dictionary correction runs at all (<see cref="DictationProfile.CleanupEnabled"/>) and
+/// whether the unlisted fuzzy matcher may run on top of it
+/// (<see cref="DictationProfile.FuzzyCorrectionEnabled"/>, default off); the correction
+/// itself never rewrites, summarizes, or restyles the speaker's words.
 /// </summary>
 public sealed record DictationDictionary(
     IReadOnlyList<string> Vocabulary,
@@ -35,11 +36,27 @@ public sealed record DictationDictionary(
 }
 
 /// <summary>
-/// A named dictation profile. <see cref="CleanupEnabled"/> is the only knob:
-/// when true, the dictionary-correction LLM pass runs (dictionary terms only,
-/// never rewording); when false, the raw transcript is returned verbatim with
-/// no correction at all.
+/// A named dictation profile. Two knobs, and the split between them matters:
+///
+/// <see cref="CleanupEnabled"/> - when false, the raw transcript is returned verbatim
+/// with no correction at all. When true, the wrong forms the user LISTED in
+/// <see cref="DictationDictionary.CommonMistranscriptions"/> are corrected. Those are safe
+/// because the user chose them.
+///
+/// <see cref="FuzzyCorrectionEnabled"/> - whether the UNLISTED fuzzy matcher may also run.
+/// It guesses from spelling similarity alone, with no sentence context and no signal that
+/// the spoken word is already an ordinary word, so it rewrites ordinary English into
+/// dictionary terms: "make sure" -> "make Soren", "explain the concept" -> "explain the
+/// ConPty", "the screen is open" -> "the Soren is Soren". Measured against a real 28-term
+/// glossary, 293 ordinary words out of a 22k-word corpus were silently rewritten. It is
+/// therefore DEFAULT OFF and stays off until a judge that can read the sentence decides
+/// each candidate (devthrottle_internal #1554).
+///
+/// Turning it on is a deliberate opt-in written into the glossary YAML
+/// (<c>fuzzy_correction_enabled: true</c>). Nothing else can flip it, and no wire format
+/// carries it, so every path that does not explicitly ask for it gets the safe answer.
 /// </summary>
 public sealed record DictationProfile(
     string Name,
-    bool CleanupEnabled);
+    bool CleanupEnabled,
+    bool FuzzyCorrectionEnabled = false);

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -304,7 +304,7 @@ internal static class RecordingEndpoints
                     return Results.BadRequest(new { error = "dictionary body required" });
 
                 var path = GlossaryPathFor(t.Value);
-                DictionaryLoader.WriteToDisk(path, FromDto(dto));
+                DictionaryLoader.WriteToDisk(path, FromDto(dto, DictionaryLoader.LoadFromDisk(path)));
                 var reread = DictionaryLoader.LoadFromDisk(path);
                 return Results.Json(ToDto(reread));
             }
@@ -332,7 +332,8 @@ internal static class RecordingEndpoints
                     return Results.BadRequest(new { error = "provide 'terms' and/or 'mistranscriptions'" });
 
                 var path = GlossaryPathFor(t.Value);
-                var current = ToDto(DictionaryLoader.LoadFromDisk(path));
+                var onDisk = DictionaryLoader.LoadFromDisk(path);
+                var current = ToDto(onDisk);
 
                 foreach (var term in add.Terms ?? new())
                 {
@@ -359,7 +360,7 @@ internal static class RecordingEndpoints
                     }
                 }
 
-                DictionaryLoader.WriteToDisk(path, FromDto(current));
+                DictionaryLoader.WriteToDisk(path, FromDto(current, onDisk));
                 return Results.Json(ToDto(DictionaryLoader.LoadFromDisk(path)));
             }
             catch (JsonException ex)
@@ -883,9 +884,14 @@ internal static class RecordingEndpoints
             .ToDictionary(kv => kv.Key, kv => kv.Value.ToList()),
         Profiles: dict.Profiles.ToDictionary(
             kv => kv.Key,
-            kv => new DictionaryProfileDto(kv.Value.CleanupEnabled)));
+            kv => new DictionaryProfileDto(kv.Value.CleanupEnabled, kv.Value.FuzzyCorrectionEnabled)));
 
-    private static DictationDictionary FromDto(DictionaryDto dto)
+    /// <param name="onDisk">The glossary as it currently stands, so a save cannot DESTROY a setting the
+    /// request does not mention. <see cref="DictionaryProfileDto.FuzzyCorrectionEnabled"/> is nullable
+    /// for exactly this reason: the phone editor and any older client send a profile as
+    /// <c>{ cleanupEnabled }</c> only, and without this a routine save of the word list would silently
+    /// switch a deliberate opt-in back off. Absent means "leave it as it was", not "false".</param>
+    private static DictationDictionary FromDto(DictionaryDto dto, DictationDictionary onDisk)
     {
         var vocab = (dto.Vocabulary ?? new List<string>())
             .Where(v => !string.IsNullOrWhiteSpace(v))
@@ -913,7 +919,9 @@ internal static class RecordingEndpoints
             var name = kv.Key.Trim();
             profiles[name] = new DictationProfile(
                 Name: name,
-                CleanupEnabled: kv.Value.CleanupEnabled);
+                CleanupEnabled: kv.Value.CleanupEnabled,
+                FuzzyCorrectionEnabled: kv.Value.FuzzyCorrectionEnabled
+                    ?? (onDisk.Profiles.TryGetValue(name, out var existing) && existing.FuzzyCorrectionEnabled));
         }
 
         return new DictationDictionary(vocab, patterns, profiles);
@@ -926,7 +934,10 @@ internal sealed record DictionaryDto(
     Dictionary<string, List<string>> CommonMistranscriptions,
     Dictionary<string, DictionaryProfileDto> Profiles);
 
-internal sealed record DictionaryProfileDto(bool CleanupEnabled);
+/// <param name="FuzzyCorrectionEnabled">Nullable on purpose: absent means "leave whatever is on disk
+/// alone". Clients that predate the field send a profile as <c>{ cleanupEnabled }</c>, and a routine
+/// word-list save from one of those must not switch a deliberate opt-in back off.</param>
+internal sealed record DictionaryProfileDto(bool CleanupEnabled, bool? FuzzyCorrectionEnabled = null);
 
 /// <summary>Additive request for POST /ingest/dictionary/terms.</summary>
 internal sealed record DictionaryAddRequest(

--- a/src/CcDirector.Gateway/Api/TranscriptionCleanupEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionCleanupEndpoint.cs
@@ -43,10 +43,20 @@ internal static class TranscriptionCleanupEndpoint
             FileLog.Write($"[TranscriptionCleanupEndpoint] POST /transcription/cleanup: chars={req.Text.Length}, "
                           + $"terms={terms.Length}, language={req.Language ?? "?"}");
 
+            // The fuzzy matcher is enabled EXPLICITLY here, and only here. This route is the
+            // text-in/text-out evaluation surface: the caller hands over the term list itself and gets
+            // the answer back rather than having it substituted into their dictation, so measuring the
+            // matcher is the whole point of the endpoint. It carries no alias map, so with the
+            // field-wide default it could never correct anything and would be a silent no-op that
+            // still returned 200. Live dictation keeps the safe default - see
+            // DictationProfile.FuzzyCorrectionEnabled.
             var dictionary = new DictationDictionary(
                 terms,
                 new Dictionary<string, IReadOnlyList<string>>(),
-                new Dictionary<string, DictationProfile> { ["default"] = new("default", CleanupEnabled: true) });
+                new Dictionary<string, DictationProfile>
+                {
+                    ["default"] = new("default", CleanupEnabled: true, FuzzyCorrectionEnabled: true),
+                });
 
             var outcome = await new CleanupOrchestrator().CleanAsync(req.Text, dictionary, "default", ctx.RequestAborted);
 


### PR DESCRIPTION
Dictation was rewriting ordinary English into glossary terms. The owner's bug report about it was mangled by the feature while he was writing it - "make sure" arrived as "make Soren", "too many" as "too Banya".

## What was happening

```
"make sure to create GitHub issues"  ->  "make Soren to create GitHub issues"
"it is making too many mistakes"     ->  "it is making too Banya mistakes"
"explain the concept to me"          ->  "explain the ConPty to me"
"the context of the code"            ->  "the Codex of the Codex"
"the screen is open"                 ->  "the Soren is Soren"
"I am not sure"                      ->  "I am not Soren"
```

The unlisted fuzzy matcher decides on spelling similarity alone (Jaro >= 0.78). It has no sentence context and no signal that the spoken word is already an ordinary word, so any word resembling a short glossary term is swapped.

Driving the real `CleanupOrchestrator` with the real 28-term glossary over a 22,398-word corpus taken from the repo docs: **458 edits proposed, 138 refused by the plausibility gate, 293 ordinary words silently rewritten.**

Trimming the glossary does not rescue it:

| Drop terms shorter than | Terms kept | Ordinary words still rewritten |
|---|---|---|
| (today) | 28 | 293 |
| 8 chars | 11 | 67 |
| 10 chars | 6 | 41 |
| 12 chars | 2 | 3 |

You only reach a clean result by deleting nearly the whole glossary. The threshold is the defect, not the word list.

## What this changes

- Unlisted fuzzy correction becomes **opt-in and off**. Aliases the user listed by hand still apply - those they chose for themselves. Only the guesses stop.
- The opt-in is a line in the glossary YAML (`fuzzy_correction_enabled: true`). No wire format carries it, so every path that does not explicitly ask gets the safe answer - including every glossary already in the field, which predates the key.
- Stage one stops short-circuiting. It used to return the moment an alias changed anything, so whether an unrelated word happened to be listed decided whether the rest of the utterance was corrected at all. The stages now compose.

## Cover

The old negative controls used one to three exotic terms against prose with no near neighbour, so they could not fail - which is why this shipped. The new tests use the real glossary shape and assert exact string equality on the sentences this actually corrupted, plus:

- a negative control that turns the guessing **on** and proves the corruption returns, so the file cannot pass by accidentally disabling the corrector outright;
- absent-key and no-profiles-at-all cases, since the default is what actually protects people;
- proof the listed aliases still correct.

193 dictation tests pass; full solution builds clean.

## Deliberately not here

Recall for unlisted mishearings is given up for now. It returns when something that can read the sentence rules on each candidate - devthrottle_internal#1554. Apply-by-offset moves there too: with the guessing off, the remaining replacements are user-chosen aliases where rewriting every occurrence is the intent.

Refs devthrottle_internal#1553
