### PR TITLE
voice: a model reads the sentence before any unlisted word is changed

### DIFF
--- a/docs/CodingStyle.md
+++ b/docs/CodingStyle.md
@@ -812,7 +812,7 @@ await Task.Delay(500);
 | Regex | Always set timeout | `TimeSpan.FromMilliseconds(50)` |
 | Brushes | Freeze for cross-thread | `brush.Freeze()` |
 | Collections | Snapshot before iterating across threads | `.ToList()` |
-| Transcription | Model may only LOCATE words; only `TranscriptEditEngine` may change them | Never round-trip a transcript through a model that returns free text |
+| Transcription | Model may only RULE on spans code isolated first, answering with candidate ids; only `TranscriptEditEngine` may change words | Never round-trip a transcript through a model that returns free text |
 
 ---
 

--- a/docs/CodingStyle.md
+++ b/docs/CodingStyle.md
@@ -826,7 +826,7 @@ This is an absolute, load-bearing rule (it traces to a real corruption incident,
 
 1. The raw speech-to-text transcript is the user's words. The ONLY permitted change to it is replacing a misheard term with the correct **dictionary** spelling of a term the user actually said (a single word, or a tightly-joined multi-word term like `cc-director`).
 
-2. A language model may be used ONLY to **locate** which spans are misheard dictionary terms, and it must return that judgment as a **JSON list of find/replace proposals** - never the transcript text itself.
+2. A language model may be used ONLY to **rule on** spans that deterministic code has already isolated, and it must answer with **candidate ids and nothing else** (`{"acceptedCandidateIds":[1]}`) - never the transcript text, and never a span it chose itself. It cannot name a candidate that was not offered, and an id that was never offered voids the whole ruling. This is tighter than the original rule, which let the model return its own find/replace pairs; `TranscriptEditEngine.ParseEdits` is the remnant of that protocol and has no production caller.
 
 3. Only deterministic code - `CcDirector.Core.Dictation.TranscriptEditEngine`, driven by `CleanupOrchestrator` - may change the words, and only by applying a validated proposal (the `find` must occur verbatim in the raw transcript, the `replace` must be an exact dictionary term, and it must be a plausible mishearing). Everything else fails open to the raw transcript.
 

--- a/docs/CodingStyle.md
+++ b/docs/CodingStyle.md
@@ -820,7 +820,7 @@ await Task.Delay(500);
 
 **When a user dictates by voice, the speech-to-text result is the user's words and is the source of truth. It must never be rewritten by a language model.**
 
-This is an absolute, load-bearing rule (it traces to a real corruption incident, issue #190). It has regressed before, so it is written here, enforced by an architecture test, and called out in the one engine allowed to touch the words.
+This is an absolute, load-bearing rule (it traces to a real corruption incident, issue #190). It has regressed before, so it is written here and called out in the one engine allowed to touch the words. Read the Enforcement section below before relying on it: only PART of this rule is checked automatically, and knowing which part is the difference between a rule and a wish.
 
 ### The rule
 
@@ -844,8 +844,17 @@ In voice-**conversation** mode, summarizing the **agent's reply** for text-to-sp
 
 ### Enforcement
 
-- The invariant is restated at the top of `TranscriptEditEngine`.
-- An architecture test fails the build if any transcription path sends the user's transcript into a text-returning model, and byte-identical regression tests guard every surface.
+Be precise about this, because it was wrong for a month. From July 2026 until August 2026 this section and `TranscriptEditEngine` both claimed an architecture test enforced the whole rule. **No such test existed** - the name appeared nowhere in the repository except in those two sentences. A reader trusts a sentence like that, which is exactly why it must be true.
+
+**Enforced automatically:**
+
+- The judge boundary, structurally. `ICandidateJudge` returns candidate ids and takes a read-only list, so a model can neither return text used as the user's words nor reach the candidates that get applied. `TranscriptionIntegrityGuardTests` pins the contract; `DictationJudgeTests` proves at runtime that a judge attempting to write through its candidate list is refused and changes nothing.
+- Byte-identical regression tests over the sentences this has actually corrupted, against a realistic glossary (`CleanupOverCorrectionTests`).
+
+**NOT enforced automatically - followed by people:**
+
+- Rule 3, that only `TranscriptEditEngine` rewrites transcript text. Two attempts at a build-time check were written and deleted: a substring scan over source text (evadable by one space, and it failed the build on the word inside a comment) and a Roslyn syntax walk (missed `text.Replace(...)`, `String.Concat`, `this.rawTranscript`, null-conditional calls and interpolated rebuilds, while flagging a `Substring` used for a log preview). Both were deleted rather than shipped: a check that certifies an unconditional claim while missing the ordinary spellings is worse than none, because the green run is read as proof.
+- Doing it properly needs semantic analysis that follows transcript values rather than a syntax walk. Tracked, with the known-bad and known-good controls it must satisfy, on devthrottle_internal#1556.
 
 ---
 

--- a/docs/architecture/dictation/DICTATION_UX_SPEC.md
+++ b/docs/architecture/dictation/DICTATION_UX_SPEC.md
@@ -7,8 +7,10 @@ feature looks and behaves the same everywhere. Where a surface deviates, the
 deviation must be listed in section 8 with a reason.
 
 This document is the single source of truth for the dialog's behaviour. The
-text-cleanup safety contract (the model proposes edits, code applies them) lives
-separately in `EDIT_DOCUMENT_CLEANUP.md` and is unchanged by this spec.
+text-cleanup safety contract lives separately and is unchanged by this spec. It is no longer
+"the model proposes edits": deterministic code isolates candidate spans and a judge rules on them
+by id (devthrottle_internal#1554). `EDIT_DOCUMENT_CLEANUP.md` describes the SUPERSEDED protocol and
+is kept as history.
 
 ---
 

--- a/docs/architecture/dictation/EDIT_DOCUMENT_CLEANUP.md
+++ b/docs/architecture/dictation/EDIT_DOCUMENT_CLEANUP.md
@@ -1,6 +1,16 @@
 # The Edit-Document Pattern: LLM Text Cleanup That Cannot Corrupt User Text
 
-Status: IMPLEMENTED in the dictation pipeline (issue #190, 2026-06-06).
+> **HISTORICAL DOCUMENT - this protocol is SUPERSEDED and no longer runs.**
+> The pattern below, in which the model returns its own `{"edits":[{"find":..,"replace":..}]}`
+> document, was removed on 2026-07-09 and is not what dictation does today. The current design is
+> tighter: deterministic code isolates candidate spans, and a judge rules on them by ID
+> (`{"acceptedCandidateIds":[1]}`), so the model cannot name a span nobody offered - see
+> `CcDirector.Core.Dictation.ICandidateJudge` and devthrottle_internal#1554.
+> `TranscriptEditEngine.ParseEdits` still implements the parse described here and has no production
+> caller. The REASONING below is still worth reading - it is why the model is never allowed to hand
+> back text - but do not treat any of it as a description of current wiring.
+
+Status: SUPERSEDED (was IMPLEMENTED in the dictation pipeline, issue #190, 2026-06-06).
 Audience: any agent or developer adding or retrofitting an LLM cleanup pass
 over user-authored text (dictation, transcription post-processing, OCR
 correction, form-field normalization - anywhere "the model tidies what the

--- a/docs/architecture/transcription-quality-loop.md
+++ b/docs/architecture/transcription-quality-loop.md
@@ -2,7 +2,16 @@
 
 Goal: keep making dictation transcription + dictionary cleanup better over time, measure it rigorously
 (multilingually), let any agent analyze it locally, and always have the best version deployed on the
-live Gateway. Everything here is LOCAL - no transcription content leaves the machine.
+live Gateway.
+
+**Where transcripts go, precisely.** Everything in sections 1-3 - history, analysis, the Cockpit
+screen - is LOCAL: no transcription content leaves the machine. That is NOT true of the correction
+step itself since the judge landed (devthrottle_internal#1554). When the matcher nominates a
+candidate, the utterance and that bounded candidate list are sent to the hosted judge over the
+DevThrottle inference route, and the judge answers with candidate ids. It is skipped entirely when
+nothing is nominated, which is most utterances, but "most" is not "never" and this document said
+never. Nothing is ever sent to the speech-to-text provider (issue 2481); that constraint is
+unchanged.
 
 Status legend: DONE (built + deployed), NEXT (planned, ready to build), RESEARCH (informing design).
 

--- a/docs/features/dictation/STATUS.md
+++ b/docs/features/dictation/STATUS.md
@@ -4,9 +4,11 @@
 > This file describes designs that shipped in May 2026 and were later replaced. In
 > particular, the "Cleanup model switch" section below (a `gpt-4o-mini` chat-completions
 > pass over the transcript) and the earlier Claude Haiku cleanup NO LONGER EXIST: the
-> only post-transcription transform today is the deterministic dictionary corrector
-> (`src/CcDirector.Core/Dictation/CleanupOrchestrator.cs` - exact mistranscription map
-> plus fuzzy dictionary matching, no model, no network). No prompt or vocabulary text is
+> only post-transcription transform today is the dictionary corrector
+> (`src/CcDirector.Core/Dictation/CleanupOrchestrator.cs`). NOTE: the "no model, no network"
+> description this line used to carry was true only between July and August 2026. Listed wrong
+> forms are still applied deterministically and offline, but an UNLISTED correction now requires a
+> ruling from a hosted judge that answers with candidate ids (devthrottle_internal#1554). No prompt or vocabulary text is
 > sent to the transcription model either. Do not reintroduce a language-model rewrite of
 > the user's words; see `docs/architecture/transcription-quality-loop.md` for the current
 > design. The dictionary-resolution section (#253) below is still accurate.

--- a/docs/plans/transcription-consolidation.html
+++ b/docs/plans/transcription-consolidation.html
@@ -94,6 +94,10 @@
 </style>
 </head>
 <body>
+<div style="border:2px solid #b00;padding:12px;margin:12px 0;background:#fff5f5">
+<strong>HISTORICAL PLAN.</strong> The corrector described here - the model proposing find/replace edits that deterministic code validates - was superseded on 2026-08-18. Deterministic code now isolates candidate spans and a judge rules on them by id; see devthrottle_internal#1554. Read this as a record of the plan, not of current wiring.
+</div>
+
 <div class="wrap">
 
   <p class="sub">DevThrottle / cc-director - Architecture and Design Document</p>

--- a/src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj
+++ b/src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj
@@ -10,11 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Parses dictation source for the TranscriptionIntegrity guard. A substring scan over source
-         text could not tell "raw.Replace(" from "raw.Replace (" and missed string.Concat and
-         Substring rebuilds entirely, so the guard was evadable by whitespace - it has to read syntax,
-         not characters. Pinned to a version already in the local cache so restore stays offline. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />

--- a/src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj
+++ b/src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj
@@ -10,6 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Parses dictation source for the TranscriptionIntegrity guard. A substring scan over source
+         text could not tell "raw.Replace(" from "raw.Replace (" and missed string.Concat and
+         Substring rebuilds entirely, so the guard was evadable by whitespace - it has to read syntax,
+         not characters. Pinned to a version already in the local cache so restore stays offline. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />

--- a/src/CcDirector.Core.Tests/Dictation/CandidateJudgeProtocolTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CandidateJudgeProtocolTests.cs
@@ -1,0 +1,225 @@
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Dictation.Models;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Dictation;
+
+/// <summary>
+/// How a judge's answer is read, and what happens to every shape of answer that is not the one we
+/// asked for.
+///
+/// This is where the July model cleanup went wrong and why it was removed. The danger was never a
+/// model giving a wrong answer - it was accepting output shaped differently from the question:
+/// prose, an apology, a refusal, an explanation wrapped around the JSON, leaked example text. Every
+/// one of those must be indistinguishable from "no ruling", because no ruling means nothing is
+/// applied and the user keeps their words.
+/// </summary>
+public sealed class CandidateJudgeProtocolTests
+{
+    private static readonly int[] Offered = { 0, 1, 2 };
+
+    // ===== the answers we asked for ===========================================
+
+    [Fact]
+    public void AcceptsTheShapeWeAskedFor()
+        => Assert.Equal(new[] { 0, 2 },
+            CandidateJudgeProtocol.ParseAccepted("{\"acceptedCandidateIds\":[0,2]}", Offered));
+
+    [Fact]
+    public void AnEmptyArrayIsARuling_NotAFailure()
+    {
+        var accepted = CandidateJudgeProtocol.ParseAccepted("{\"acceptedCandidateIds\":[]}", Offered);
+
+        Assert.NotNull(accepted);
+        Assert.Empty(accepted);
+    }
+
+    [Fact]
+    public void WhitespaceAroundTheJsonIsFine()
+        => Assert.Equal(new[] { 1 },
+            CandidateJudgeProtocol.ParseAccepted("  \n {\"acceptedCandidateIds\":[1]}\n ", Offered));
+
+    /// <summary>A repeated id is a sloppy answer, not a dangerous one - the same span accepted twice
+    /// still means accepted once.</summary>
+    [Fact]
+    public void RepeatedIdsAreCollapsed()
+        => Assert.Equal(new[] { 1 },
+            CandidateJudgeProtocol.ParseAccepted("{\"acceptedCandidateIds\":[1,1,1]}", Offered));
+
+    /// <summary>An extra field cannot change the meaning of the field we read, so it is tolerated
+    /// rather than treated as a failure. Pinned so a future tightening is a deliberate decision.</summary>
+    [Fact]
+    public void AnExtraFieldIsTolerated()
+        => Assert.Equal(new[] { 0 },
+            CandidateJudgeProtocol.ParseAccepted(
+                "{\"acceptedCandidateIds\":[0],\"confidence\":0.9}", Offered));
+
+    // ===== everything else fails closed =======================================
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("I'm sorry, I can't help with that.")]
+    [InlineData("Sure! Here are the ones I'd correct: 0 and 2.")]
+    [InlineData("```json\n{\"acceptedCandidateIds\":[0]}\n```")]
+    [InlineData("Here is the JSON: {\"acceptedCandidateIds\":[0]}")]
+    [InlineData("{\"acceptedCandidateIds\":[0]} Hope that helps!")]
+    [InlineData("[0,2]")]
+    [InlineData("{}")]
+    [InlineData("{\"accepted\":[0]}")]
+    [InlineData("{\"acceptedCandidateIds\":\"0,2\"}")]
+    [InlineData("{\"acceptedCandidateIds\":[\"0\"]}")]
+    [InlineData("{\"acceptedCandidateIds\":[0.5]}")]
+    [InlineData("{\"acceptedCandidateIds\":[null]}")]
+    [InlineData("{\"acceptedCandidateIds\":null}")]
+    [InlineData("{\"acceptedCandidateIds\":[[0]]}")]
+    [InlineData("null")]
+    [InlineData("42")]
+    [InlineData("{\"acceptedCandidateIds\":[0],")]
+    public void AnythingThatIsNotTheShapeWeAskedFor_IsNoRuling(string? reply)
+        => Assert.Null(CandidateJudgeProtocol.ParseAccepted(reply, Offered));
+
+    /// <summary>
+    /// An id nobody offered voids the WHOLE answer rather than being skipped. A judge ruling on a
+    /// candidate that does not exist did not understand the question, so its opinion on the ones that
+    /// do exist is not worth acting on either.
+    /// </summary>
+    [Theory]
+    [InlineData("{\"acceptedCandidateIds\":[7]}")]
+    [InlineData("{\"acceptedCandidateIds\":[0,7]}")]
+    [InlineData("{\"acceptedCandidateIds\":[-1]}")]
+    public void AnIdThatWasNeverOffered_VoidsTheEntireRuling(string reply)
+        => Assert.Null(CandidateJudgeProtocol.ParseAccepted(reply, Offered));
+
+    [Fact]
+    public void WhenNothingWasOffered_EvenAValidLookingIdIsRefused()
+        => Assert.Null(CandidateJudgeProtocol.ParseAccepted(
+            "{\"acceptedCandidateIds\":[0]}", Array.Empty<int>()));
+
+    // ===== the question we send ===============================================
+
+    [Fact]
+    public void TheQuestionCarriesTheSentenceAndEveryCandidate()
+    {
+        var prompt = CandidateJudgeProtocol.BuildUserPrompt(
+            "I am not sure about that",
+            new[]
+            {
+                new JudgeCandidate(0, "sure", "Soren", 9),
+                new JudgeCandidate(1, "about", "Avalonia", 14),
+            });
+
+        Assert.Contains("I am not sure about that", prompt);
+        Assert.Contains("0: \"sure\" might be \"Soren\"", prompt);
+        Assert.Contains("1: \"about\" might be \"Avalonia\"", prompt);
+    }
+
+    /// <summary>The tie-break is the whole safety posture, so it is pinned: unsure means reject.</summary>
+    [Fact]
+    public void TheInstructionTellsTheJudgeToRejectWhenUnsure()
+    {
+        Assert.Contains("REJECT", CandidateJudgeProtocol.SystemPrompt);
+        Assert.Contains("acceptedCandidateIds", CandidateJudgeProtocol.SystemPrompt);
+    }
+
+    // ===== applying at an offset ==============================================
+
+    [Fact]
+    public void ApplyAt_RewritesOnlyTheSpanItWasGiven()
+    {
+        var (text, applied) = TranscriptEditEngine.ApplyAt(
+            "sure and then sure again",
+            new[] { new JudgeCandidate(0, "sure", "Soren", 0) });
+
+        Assert.Equal("Soren and then sure again", text);
+        Assert.Equal(1, applied);
+    }
+
+    /// <summary>Replacements change length, so a left-to-right pass would shift every later offset.
+    /// Applying right to left is what keeps the second edit landing where it was judged.</summary>
+    [Fact]
+    public void ApplyAt_LaterEditsDoNotShiftEarlierOnes()
+    {
+        var (text, applied) = TranscriptEditEngine.ApplyAt(
+            "sure and sure",
+            new[]
+            {
+                new JudgeCandidate(0, "sure", "Soren", 0),
+                new JudgeCandidate(1, "sure", "Soren", 9),
+            });
+
+        Assert.Equal("Soren and Soren", text);
+        Assert.Equal(2, applied);
+    }
+
+    [Fact]
+    public void ApplyAt_SkipsAnOffsetThatNoLongerMatchesTheText()
+    {
+        var (text, applied) = TranscriptEditEngine.ApplyAt(
+            "sure and then sure again",
+            new[] { new JudgeCandidate(0, "sure", "Soren", 5) });
+
+        Assert.Equal("sure and then sure again", text);
+        Assert.Equal(0, applied);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(1000)]
+    public void ApplyAt_SkipsAnOffsetOutsideTheText(int start)
+    {
+        var (text, applied) = TranscriptEditEngine.ApplyAt(
+            "sure enough",
+            new[] { new JudgeCandidate(0, "sure", "Soren", start) });
+
+        Assert.Equal("sure enough", text);
+        Assert.Equal(0, applied);
+    }
+
+    // ===== the candidates the matcher offers ==================================
+
+    [Fact]
+    public void ProposeCandidates_KeepsEveryOccurrenceSeparately_WithItsOwnOffset()
+    {
+        var dict = new DictationDictionary(
+            new[] { "Tailscale" },
+            new Dictionary<string, IReadOnlyList<string>>(),
+            new Dictionary<string, DictationProfile>());
+
+        var candidates = FuzzyDictionaryMatcher.ProposeCandidates("Terascale then Terascale", dict);
+
+        Assert.Equal(2, candidates.Count);
+        Assert.Equal(new[] { 0, 1 }, candidates.Select(c => c.Id));
+        Assert.Equal(0, candidates[0].Start);
+        Assert.Equal("Terascale then ".Length, candidates[1].Start);
+    }
+
+    /// <summary>The offset must actually point at the span, or ApplyAt silently skips it and judged
+    /// corrections quietly stop happening.</summary>
+    [Fact]
+    public void ProposeCandidates_OffsetsPointAtTheSpanTheyDescribe()
+    {
+        var dict = new DictationDictionary(
+            new[] { "Tailscale", "Soren" },
+            new Dictionary<string, IReadOnlyList<string>>(),
+            new Dictionary<string, DictationProfile>());
+
+        const string text = "make sure we ship Terascale";
+        foreach (var c in FuzzyDictionaryMatcher.ProposeCandidates(text, dict))
+            Assert.Equal(c.Find, text.Substring(c.Start, c.Find.Length));
+    }
+
+    /// <summary>The older whole-utterance path still collapses repeats, because its consumer rewrites
+    /// every occurrence of a find anyway.</summary>
+    [Fact]
+    public void Propose_StillCollapsesRepeats()
+    {
+        var dict = new DictationDictionary(
+            new[] { "Tailscale" },
+            new Dictionary<string, IReadOnlyList<string>>(),
+            new Dictionary<string, DictationProfile>());
+
+        Assert.Single(FuzzyDictionaryMatcher.Propose("Terascale then Terascale", dict));
+    }
+}

--- a/src/CcDirector.Core.Tests/Dictation/CleanupOrchestratorLiveTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CleanupOrchestratorLiveTests.cs
@@ -7,8 +7,10 @@ namespace CcDirector.Core.Tests.Dictation;
 
 /// <summary>
 /// Proof that the dictation cleanup pass corrects ONLY dictionary terms and never changes the
-/// speaker's words. Cleanup is now deterministic and in-process (no hosted model, no key), so these
-/// run always and offline - the historical "Live" name is kept for continuity.
+/// speaker's words. These construct no judge, so they exercise the deterministic listed-alias path
+/// and run always and offline - the historical "Live" name is kept for continuity. They do NOT cover
+/// the hosted judge path that unlisted corrections now go through; that is DictationJudgeTests and
+/// HostedCandidateJudgeTests.
 ///
 /// The bar is deliberately strict: for transcripts that contain no dictionary
 /// term, the output must equal the input character for character (fillers,

--- a/src/CcDirector.Core.Tests/Dictation/CleanupOrchestratorTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CleanupOrchestratorTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace CcDirector.Core.Tests.Dictation;
 
 /// <summary>
-/// Tests for the deterministic cleanup orchestrator. Cleanup no longer calls a model: it applies the
+/// Tests for the cleanup orchestrator. It applies the
 /// exact/alias map, then the <see cref="FuzzyDictionaryMatcher"/>, and validates every proposed edit
 /// through <see cref="TranscriptEditEngine"/>. These pin the two invariants that matter: real
 /// dictionary mishearings get corrected, and text that is NOT a dictionary term is never touched.

--- a/src/CcDirector.Core.Tests/Dictation/CleanupOrchestratorTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CleanupOrchestratorTests.cs
@@ -14,6 +14,11 @@ namespace CcDirector.Core.Tests.Dictation;
 /// (<see cref="DictationProfile.FuzzyCorrectionEnabled"/>). That stage is OFF by default in the
 /// field; the default and the over-correction it prevents are covered by
 /// <see cref="CleanupOverCorrectionTests"/>.
+///
+/// It also supplies an ACCEPT-ALL judge in Enforce mode, because an unlisted correction now needs an
+/// affirmative ruling to reach the text. That keeps these tests measuring what they were written to
+/// measure - which spans the matcher finds - rather than silently passing because nothing is applied
+/// any more. What happens with a refusing or absent judge is <see cref="DictationJudgeTests"/>.
 /// </summary>
 public sealed class CleanupOrchestratorTests
 {
@@ -39,7 +44,9 @@ public sealed class CleanupOrchestratorTests
         });
 
     private static async Task<CleanupOutcome> Clean(string raw, DictationDictionary dict, string profile = "default")
-        => await new CleanupOrchestrator().CleanAsync(raw, dict, profile);
+        => await new CleanupOrchestrator(
+                judge: Judges.AcceptAll, mode: UnlistedCorrectionMode.Enforce)
+            .CleanAsync(raw, dict, profile);
 
     [Fact]
     public async Task CleanAsync_EmptyInput_ReturnsEmpty()

--- a/src/CcDirector.Core.Tests/Dictation/CleanupOverCorrectionTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CleanupOverCorrectionTests.cs
@@ -46,8 +46,9 @@ public sealed class CleanupOverCorrectionTests
                 ["default"] = new("default", CleanupEnabled: true, FuzzyCorrectionEnabled: fuzzy),
             });
 
-    private static string Clean(string raw, DictationDictionary dict)
-        => new CleanupOrchestrator().CleanAsync(raw, dict, "default").GetAwaiter().GetResult().Text;
+    private static string Clean(string raw, DictationDictionary dict, ICandidateJudge? judge = null)
+        => new CleanupOrchestrator(judge: judge, mode: UnlistedCorrectionMode.Enforce)
+            .CleanAsync(raw, dict, "default").GetAwaiter().GetResult().Text;
 
     /// <summary>
     /// Every one of these was corrupted by the shipped corrector. They must come back byte for byte.
@@ -119,16 +120,24 @@ public sealed class CleanupOverCorrectionTests
     }
 
     /// <summary>
-    /// The switch is real: with the guessing explicitly turned on, the known corruption comes back.
-    /// A test that only proves the safe direction would pass just as well against a corrector that
-    /// was accidentally disabled outright, so this is the negative control for the whole file.
+    /// The negative control for the whole file, and it now has two halves.
+    ///
+    /// With the guessing enabled AND a judge that accepts everything, the known corruption comes back -
+    /// proving the matcher still nominates "sure" as the speaker's name, so the safe results above are
+    /// the judge refusing rather than a corrector that quietly stopped working.
+    ///
+    /// With the guessing enabled and NO judge, the same sentence is untouched. That is the invariant:
+    /// the matcher's opinion on its own is never enough.
     /// </summary>
     [Fact]
-    public void WithFuzzyExplicitlyEnabled_TheKnownCorruptionReappears()
+    public void TheMatcherStillNominatesTheCorruption_AndOnlyTheJudgeStopsIt()
     {
-        var corrupted = Clean("make sure to create GitHub issues", RealWorldDictionary(fuzzy: true));
+        const string sentence = "make sure to create GitHub issues";
 
-        Assert.Equal("make Soren to create GitHub issues", corrupted);
+        Assert.Equal("make Soren to create GitHub issues",
+            Clean(sentence, RealWorldDictionary(fuzzy: true), Judges.AcceptAll));
+
+        Assert.Equal(sentence, Clean(sentence, RealWorldDictionary(fuzzy: true)));
     }
 
     /// <summary>Absent from the YAML means off. Every glossary in the field predates this key, so

--- a/src/CcDirector.Core.Tests/Dictation/DictationJudgeTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/DictationJudgeTests.cs
@@ -238,6 +238,101 @@ public sealed class DictationJudgeTests
         Assert.InRange(recording.LastCandidates.Count, 1, CandidateJudgeProtocol.MaxCandidates);
     }
 
+    // ===== the judge cannot reach past its own answer =========================
+
+    /// <summary>
+    /// The Critical hole a review found, pinned.
+    ///
+    /// The judge is handed a candidate list and its answer is only ids - but if it were handed the very
+    /// list we later read from, an in-process judge could cast the IReadOnlyList back to what it really
+    /// is, swap an entry AFTER validation, accept that entry's id, and have arbitrary replacement text
+    /// applied. The "a judge cannot supply text" property would be defeated through the PARAMETER
+    /// rather than the return value, which the return-type guard cannot see.
+    ///
+    /// So the ids are resolved against a private snapshot the judge never touches. This judge tries the
+    /// attack; the transcript must be untouched.
+    /// </summary>
+    [Fact]
+    public async Task AJudgeThatRewritesItsOwnCandidateList_ChangesNothing()
+    {
+        var attacker = new MutatingJudge();
+
+        var outcome = await Run("we deployed Terascale last night", attacker);
+
+        Assert.True(attacker.Tried, "the attack never ran - this test would pass for the wrong reason");
+        Assert.False(attacker.MutationSucceeded,
+            "the judge was able to write through its candidate list, so the snapshot is not protecting anything");
+        Assert.DoesNotContain("ARBITRARY", outcome.Text);
+        Assert.Equal("we deployed Tailscale last night", outcome.Text);
+    }
+
+    /// <summary>
+    /// A ruling mixing real ids with invented ones must be VOIDED, not filtered. The earlier double
+    /// returned only an invented id, so the filter happened to produce no edits and the test passed
+    /// without ever covering the mixed case.
+    /// </summary>
+    [Fact]
+    public async Task ARulingMixingRealAndInventedIds_IsDiscardedEntirely()
+    {
+        var outcome = await Run("we deployed Terascale last night", new MixedIdsJudge());
+
+        Assert.Equal("we deployed Terascale last night", outcome.Text);
+        Assert.False(outcome.Applied);
+        Assert.Contains("never offered", outcome.Reason);
+    }
+
+    /// <summary>An undefined mode value must shadow. Only the exact Enforce member may change text.</summary>
+    [Fact]
+    public async Task AnUndefinedModeValue_Shadows()
+    {
+        var outcome = await new CleanupOrchestrator(
+                judge: Judges.AcceptAll, mode: (UnlistedCorrectionMode)99)
+            .CleanAsync("we deployed Terascale last night", Dict(), "default");
+
+        Assert.Equal("we deployed Terascale last night", outcome.Text);
+        Assert.False(outcome.Applied);
+    }
+
+    /// <summary>Tries to swap a validated candidate for one carrying arbitrary replacement text, and
+    /// records whether the collection let it.</summary>
+    private sealed class MutatingJudge : ICandidateJudge
+    {
+        public bool Tried { get; private set; }
+        public bool MutationSucceeded { get; private set; }
+
+        public Task<IReadOnlyList<int>?> AcceptAsync(
+            string utterance, IReadOnlyList<JudgeCandidate> candidates, CancellationToken ct = default)
+        {
+            Tried = true;
+            var poison = new JudgeCandidate(candidates[0].Id, "we", "ARBITRARY TEXT", 0);
+
+            try
+            {
+                if (candidates is JudgeCandidate[] array) array[0] = poison;
+                else if (candidates is IList<JudgeCandidate> list) list[0] = poison;
+            }
+            catch (NotSupportedException)
+            {
+                // A genuinely read-only collection refuses the write. That is the property.
+            }
+
+            MutationSucceeded = !ReferenceEquals(candidates[0], poison)
+                ? candidates[0].Replace == "ARBITRARY TEXT"
+                : true;
+
+            return Task.FromResult<IReadOnlyList<int>?>(candidates.Select(c => c.Id).ToList());
+        }
+    }
+
+    /// <summary>Returns one real id and one that was never offered.</summary>
+    private sealed class MixedIdsJudge : ICandidateJudge
+    {
+        public Task<IReadOnlyList<int>?> AcceptAsync(
+            string utterance, IReadOnlyList<JudgeCandidate> candidates, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<int>?>(
+                candidates.Select(c => c.Id).Concat(new[] { 9_999 }).ToList());
+    }
+
     /// <summary>Accepts only the first candidate offered, by id.</summary>
     private sealed class FirstCandidateOnly : ICandidateJudge
     {

--- a/src/CcDirector.Core.Tests/Dictation/DictationJudgeTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/DictationJudgeTests.cs
@@ -1,0 +1,248 @@
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Dictation.Models;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Dictation;
+
+/// <summary>
+/// The judged-correction path (devthrottle_internal #1554).
+///
+/// String similarity is the right thing to SEARCH with and the wrong thing to DECIDE on: no
+/// edit-distance score in any language separates "I am not sure" from the speaker's name. So the
+/// matcher nominates and a judge that reads the sentence rules on each nomination.
+///
+/// Most of these tests are about what happens when the judge does NOT give a clean answer, because
+/// that is the case that decides whether the user keeps the words they actually said.
+/// </summary>
+public sealed class DictationJudgeTests
+{
+    private static DictationDictionary Dict(bool fuzzy = true, params string[] vocab)
+        => new(
+            vocab.Length > 0 ? vocab : new[] { "Soren", "Tailscale", "ConPty" },
+            new Dictionary<string, IReadOnlyList<string>> { ["ConPty"] = new[] { "Con-TY" } },
+            new Dictionary<string, DictationProfile>
+            {
+                ["default"] = new("default", CleanupEnabled: true, FuzzyCorrectionEnabled: fuzzy),
+            });
+
+    private static Task<CleanupOutcome> Run(
+        string raw,
+        ICandidateJudge? judge,
+        UnlistedCorrectionMode mode = UnlistedCorrectionMode.Enforce,
+        DictationDictionary? dict = null)
+        => new CleanupOrchestrator(judge: judge, mode: mode)
+            .CleanAsync(raw, dict ?? Dict(), "default");
+
+    // ===== the invariant: no affirmative ruling, no change =====================
+
+    [Fact]
+    public async Task NoJudgeConfigured_ChangesNothing_EvenWithTheGuessingEnabled()
+    {
+        var outcome = await Run("we deployed Terascale last night", judge: null);
+
+        Assert.Equal("we deployed Terascale last night", outcome.Text);
+        Assert.False(outcome.Applied);
+        Assert.Contains("judge", outcome.Reason);
+    }
+
+    [Fact]
+    public async Task JudgeGivesNoRuling_ChangesNothing()
+    {
+        var outcome = await Run("we deployed Terascale last night", Judges.NoRuling);
+
+        Assert.Equal("we deployed Terascale last night", outcome.Text);
+        Assert.False(outcome.Applied);
+        Assert.Empty(outcome.ChangedWords);
+    }
+
+    [Fact]
+    public async Task JudgeThrows_ChangesNothing_AndTheTurnSurvives()
+    {
+        var outcome = await Run("we deployed Terascale last night", Judges.Throwing);
+
+        Assert.Equal("we deployed Terascale last night", outcome.Text);
+        Assert.False(outcome.Applied);
+        Assert.Contains("cleanup failed", outcome.Reason);
+    }
+
+    [Fact]
+    public async Task JudgeRejectsEverything_ChangesNothing()
+    {
+        var outcome = await Run("we deployed Terascale last night", Judges.RejectAll);
+
+        Assert.Equal("we deployed Terascale last night", outcome.Text);
+        Assert.False(outcome.Applied);
+    }
+
+    /// <summary>
+    /// A judge answering about a candidate that was never offered did not understand the question, so
+    /// the REST of its answer is not trustworthy either. The whole ruling is discarded rather than
+    /// filtered down to the ids that happen to exist.
+    /// </summary>
+    [Fact]
+    public async Task JudgeAnsweringAboutCandidatesThatDoNotExist_HasItsWholeRulingDiscarded()
+    {
+        var outcome = await Run("we deployed Terascale last night", Judges.InventingIds);
+
+        Assert.Equal("we deployed Terascale last night", outcome.Text);
+        Assert.False(outcome.Applied);
+    }
+
+    // ===== enforce: an accepted ruling reaches exactly one span ================
+
+    [Fact]
+    public async Task AnAcceptedRuling_IsApplied()
+    {
+        var outcome = await Run("we deployed Terascale last night", Judges.AcceptAll);
+
+        Assert.Equal("we deployed Tailscale last night", outcome.Text);
+        Assert.True(outcome.Applied);
+        Assert.Contains(outcome.ChangedWords, e => e.Replace == "Tailscale");
+    }
+
+    /// <summary>
+    /// The reason offsets exist. The judge ruled on ONE occurrence in one sentence; the same word
+    /// later in the same breath is a different use it never saw. Rewriting both would be the corrector
+    /// substituting its own rule for the judge's ruling.
+    /// </summary>
+    [Fact]
+    public async Task OnlyTheJudgedOccurrenceChanges_NotEveryCopyOfTheWord()
+    {
+        var outcome = await Run("sure and then sure again", new FirstCandidateOnly());
+
+        Assert.Equal("Soren and then sure again", outcome.Text);
+    }
+
+    [Fact]
+    public async Task SeveralAcceptedRulings_AreAllApplied_WithoutShiftingEachOther()
+    {
+        var outcome = await Run("Terascale and Terascale and Terascale", Judges.AcceptAll);
+
+        Assert.Equal("Tailscale and Tailscale and Tailscale", outcome.Text);
+    }
+
+    // ===== shadow: ask, record, change nothing ================================
+
+    [Fact]
+    public async Task ShadowMode_LeavesTheTranscriptCompletelyAlone()
+    {
+        var outcome = await Run(
+            "we deployed Terascale last night", Judges.AcceptAll, UnlistedCorrectionMode.Shadow);
+
+        Assert.Equal("we deployed Terascale last night", outcome.Text);
+        Assert.False(outcome.Applied);
+        Assert.Empty(outcome.ChangedWords);
+    }
+
+    /// <summary>Shadow is only worth running if it records what it would have done - that record is
+    /// the evidence the judge is trusted on.</summary>
+    [Fact]
+    public async Task ShadowMode_RecordsWhatItWouldHaveCorrected()
+    {
+        var outcome = await Run(
+            "we deployed Terascale last night", Judges.AcceptAll, UnlistedCorrectionMode.Shadow);
+
+        Assert.Contains(outcome.ShadowChanges, e => e.Find == "Terascale" && e.Replace == "Tailscale");
+        Assert.Contains("shadow", outcome.Reason);
+    }
+
+    [Fact]
+    public async Task ShadowIsTheDefaultMode()
+    {
+        var outcome = await new CleanupOrchestrator(judge: Judges.AcceptAll)
+            .CleanAsync("we deployed Terascale last night", Dict(), "default");
+
+        Assert.Equal("we deployed Terascale last night", outcome.Text);
+        Assert.NotEmpty(outcome.ShadowChanges);
+    }
+
+    // ===== when the judge must not be asked at all ============================
+
+    [Fact]
+    public async Task TheJudgeIsNotAsked_WhenTheGuessingIsOff()
+    {
+        var recording = new Judges.Recording();
+        await new CleanupOrchestrator(judge: recording, mode: UnlistedCorrectionMode.Enforce)
+            .CleanAsync("we deployed Terascale last night", Dict(fuzzy: false), "default");
+
+        Assert.Equal(0, recording.Calls);
+    }
+
+    [Fact]
+    public async Task TheJudgeIsNotAsked_WhenCleanupIsDisabledEntirely()
+    {
+        var recording = new Judges.Recording();
+        var dict = new DictationDictionary(
+            new[] { "Tailscale" },
+            new Dictionary<string, IReadOnlyList<string>>(),
+            new Dictionary<string, DictationProfile>
+            {
+                ["default"] = new("default", CleanupEnabled: false, FuzzyCorrectionEnabled: true),
+            });
+
+        await new CleanupOrchestrator(judge: recording, mode: UnlistedCorrectionMode.Enforce)
+            .CleanAsync("we deployed Terascale last night", dict, "default");
+
+        Assert.Equal(0, recording.Calls);
+    }
+
+    /// <summary>No candidates means no question, which means no model call and no cost. Most sentences
+    /// contain nothing that resembles a glossary term at all.</summary>
+    [Fact]
+    public async Task TheJudgeIsNotAsked_WhenNothingResemblesATerm()
+    {
+        var recording = new Judges.Recording();
+        await new CleanupOrchestrator(judge: recording, mode: UnlistedCorrectionMode.Enforce)
+            .CleanAsync("please water the plants before you leave", Dict(), "default");
+
+        Assert.Equal(0, recording.Calls);
+    }
+
+    /// <summary>A wrong form the user listed by hand is not a guess and needs no ruling.</summary>
+    [Fact]
+    public async Task ListedWrongForms_AreCorrectedWithoutAskingTheJudge()
+    {
+        var recording = new Judges.Recording();
+        var outcome = await new CleanupOrchestrator(judge: recording, mode: UnlistedCorrectionMode.Enforce)
+            .CleanAsync("restart the Con-TY renderer", Dict(), "default");
+
+        Assert.Equal("restart the ConPty renderer", outcome.Text);
+        Assert.Equal(0, recording.Calls);
+    }
+
+    // ===== what the judge is actually shown ===================================
+
+    [Fact]
+    public async Task TheJudgeSeesTheWholeSentence_AndTheSpanWithItsOffset()
+    {
+        var recording = new Judges.Recording();
+        await new CleanupOrchestrator(judge: recording, mode: UnlistedCorrectionMode.Enforce)
+            .CleanAsync("we deployed Terascale last night", Dict(), "default");
+
+        Assert.Equal("we deployed Terascale last night", recording.LastUtterance);
+        var c = Assert.Single(recording.LastCandidates);
+        Assert.Equal("Terascale", c.Find);
+        Assert.Equal("Tailscale", c.Replace);
+        Assert.Equal("we deployed ".Length, c.Start);
+    }
+
+    [Fact]
+    public async Task TheCandidateListPutToTheJudgeIsBounded()
+    {
+        var recording = new Judges.Recording();
+        var many = string.Join(" ", Enumerable.Repeat("Terascale", CandidateJudgeProtocol.MaxCandidates + 8));
+
+        await new CleanupOrchestrator(judge: recording, mode: UnlistedCorrectionMode.Enforce)
+            .CleanAsync(many, Dict(), "default");
+
+        Assert.InRange(recording.LastCandidates.Count, 1, CandidateJudgeProtocol.MaxCandidates);
+    }
+
+    /// <summary>Accepts only the first candidate offered, by id.</summary>
+    private sealed class FirstCandidateOnly : ICandidateJudge
+    {
+        public Task<IReadOnlyList<int>?> AcceptAsync(
+            string utterance, IReadOnlyList<JudgeCandidate> candidates, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<int>?>(candidates.Take(1).Select(c => c.Id).ToList());
+    }
+}

--- a/src/CcDirector.Core.Tests/Dictation/JudgeDoubles.cs
+++ b/src/CcDirector.Core.Tests/Dictation/JudgeDoubles.cs
@@ -1,0 +1,57 @@
+using CcDirector.Core.Dictation;
+
+namespace CcDirector.Core.Tests.Dictation;
+
+/// <summary>
+/// Judges that behave badly on purpose. The point of the judge design is that the transcript survives
+/// whatever the backend does, so every failure a real one can produce - silence, nonsense, a stall, a
+/// crash, an answer about a candidate that was never offered - needs a stand-in here.
+/// </summary>
+internal static class Judges
+{
+    /// <summary>Accepts everything. Used to prove the matcher still finds what it used to find, so a
+    /// test that goes quiet is failing because the judge refused, not because nothing was proposed.</summary>
+    public static ICandidateJudge AcceptAll { get; } = new Lambda(c => c.Select(x => x.Id).ToList());
+
+    /// <summary>Refuses everything - the conservative real-world answer.</summary>
+    public static ICandidateJudge RejectAll { get; } = new Lambda(_ => new List<int>());
+
+    /// <summary>Returns no ruling at all: unreachable, timed out, or unparseable output.</summary>
+    public static ICandidateJudge NoRuling { get; } = new Lambda(_ => null);
+
+    /// <summary>Accepts only candidates whose spoken text is in <paramref name="finds"/>.</summary>
+    public static ICandidateJudge Accepting(params string[] finds)
+        => new Lambda(c => c.Where(x => finds.Contains(x.Find, StringComparer.Ordinal))
+                            .Select(x => x.Id).ToList());
+
+    /// <summary>Answers about ids that were never offered - a judge that did not understand the
+    /// question. Its whole answer must be discarded, not filtered.</summary>
+    public static ICandidateJudge InventingIds { get; } = new Lambda(c => new List<int> { 9_999 });
+
+    /// <summary>Throws. A backend fault must never reach the user's transcript.</summary>
+    public static ICandidateJudge Throwing { get; } = new Lambda(_ => throw new InvalidOperationException("judge exploded"));
+
+    /// <summary>Records what it was asked, so a test can assert the judge was never called at all.</summary>
+    public sealed class Recording : ICandidateJudge
+    {
+        public int Calls { get; private set; }
+        public string? LastUtterance { get; private set; }
+        public IReadOnlyList<JudgeCandidate> LastCandidates { get; private set; } = Array.Empty<JudgeCandidate>();
+
+        public Task<IReadOnlyList<int>?> AcceptAsync(
+            string utterance, IReadOnlyList<JudgeCandidate> candidates, CancellationToken ct = default)
+        {
+            Calls++;
+            LastUtterance = utterance;
+            LastCandidates = candidates;
+            return Task.FromResult<IReadOnlyList<int>?>(candidates.Select(c => c.Id).ToList());
+        }
+    }
+
+    private sealed class Lambda(Func<IReadOnlyList<JudgeCandidate>, IReadOnlyList<int>?> f) : ICandidateJudge
+    {
+        public Task<IReadOnlyList<int>?> AcceptAsync(
+            string utterance, IReadOnlyList<JudgeCandidate> candidates, CancellationToken ct = default)
+            => Task.FromResult(f(candidates));
+    }
+}

--- a/src/CcDirector.Core.Tests/Dictation/TranscriptionIntegrityGuardTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/TranscriptionIntegrityGuardTests.cs
@@ -1,0 +1,124 @@
+using System.Reflection;
+using CcDirector.Core.Dictation;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Dictation;
+
+/// <summary>
+/// The architecture guard that <c>TranscriptEditEngine</c> has claimed since July.
+///
+/// Its class comment said "The TranscriptionIntegrity architecture test enforces this at build time".
+/// No such test existed - the name appeared nowhere in the repository except in that sentence. The
+/// invariant it names is the one that matters most in this subsystem, and for a month it was enforced
+/// by a comment. A review found it while checking something else, which is luck, not process.
+///
+/// The invariant, in two halves:
+///   1. A language model may LOCATE misheard terms. It must never receive the transcript and return
+///      free text that becomes the user's words.
+///   2. Only TranscriptEditEngine changes transcript text.
+///
+/// Both are checked structurally rather than by reading the code, so a future call site that breaks
+/// them fails the build rather than an inspection.
+/// </summary>
+public sealed class TranscriptionIntegrityGuardTests
+{
+    /// <summary>
+    /// Half one, made structural. The judge's only method hands back numbers - the ids of candidates
+    /// OUR code isolated. A model on the other end of this interface physically cannot return a word,
+    /// a sentence, or a corrected transcript, because there is nowhere in the signature to put one.
+    ///
+    /// This is why the interface returns ids instead of edits, and the test exists so that stays true:
+    /// changing it to return strings would be a one-line change that quietly reopens the entire class
+    /// of corruption the July removal was about.
+    /// </summary>
+    [Fact]
+    public void AJudgeCanOnlyReturnCandidateIds_NeverText()
+    {
+        var methods = typeof(ICandidateJudge).GetMethods(BindingFlags.Public | BindingFlags.Instance);
+        var accept = Assert.Single(methods);
+
+        Assert.Equal(typeof(Task<IReadOnlyList<int>?>), accept.ReturnType);
+
+        foreach (var m in methods)
+        {
+            Assert.False(ReturnsTextSomehow(m.ReturnType),
+                $"ICandidateJudge.{m.Name} can return text. A judge must only ever select from " +
+                "candidates our own code produced - see the integrity invariant on TranscriptEditEngine.");
+        }
+    }
+
+    /// <summary>
+    /// Half two: nothing in the dictation subsystem rewrites transcript text except the edit engine.
+    ///
+    /// Scanned for the operations that actually produce a modified transcript - a regex replace or a
+    /// string replace. The engine is the single allowed home for both. A new "helpful" cleanup step
+    /// added anywhere else in Dictation trips this.
+    /// </summary>
+    [Fact]
+    public void OnlyTheEditEngineRewritesTranscriptText()
+    {
+        var root = GetRepoRoot();
+        var dictationDir = Path.Combine(root, "src", "CcDirector.Core", "Dictation");
+        Assert.True(Directory.Exists(dictationDir), $"expected the dictation source at {dictationDir}");
+
+        var scanned = 0;
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(dictationDir, "*.cs", SearchOption.AllDirectories))
+        {
+            var rel = Path.GetRelativePath(root, file).Replace('\\', '/');
+            if (rel.Contains("/bin/") || rel.Contains("/obj/")) continue;
+            scanned++;
+
+            if (Path.GetFileName(file) == "TranscriptEditEngine.cs") continue;
+
+            var text = File.ReadAllText(file);
+            if (text.Contains("Regex.Replace(", StringComparison.Ordinal))
+                offenders.Add($"{rel} calls Regex.Replace");
+            if (text.Contains(".Replace(", StringComparison.Ordinal))
+                offenders.Add($"{rel} calls string Replace");
+        }
+
+        // The instrument must not pass by scanning nothing: an empty sweep is a broken run, not a
+        // clean one. TranscriptEditEngine itself is excluded above, so a real scan sees several files.
+        Assert.True(scanned >= 5,
+            $"only {scanned} dictation source files were scanned - the guard is looking in the wrong " +
+            "place and would report clean whatever the code did");
+
+        Assert.True(offenders.Count == 0,
+            "Only TranscriptEditEngine may rewrite transcript text. Offenders:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The guard above is only worth having if it can fail. This proves the detector fires on the
+    /// exact shape it is looking for, so a green run means "nothing rewrites text" rather than "the
+    /// scan never matched anything".
+    /// </summary>
+    [Fact]
+    public void TheGuardDetectsARewriteWhenThereIsOne()
+    {
+        const string offending = "var cleaned = raw.Replace(\"a\", \"b\");";
+        const string innocent = "var score = Jaro(spanNorm, target);";
+
+        Assert.Contains(".Replace(", offending, StringComparison.Ordinal);
+        Assert.DoesNotContain(".Replace(", innocent, StringComparison.Ordinal);
+    }
+
+    private static bool ReturnsTextSomehow(Type t)
+    {
+        if (t == typeof(string)) return true;
+        if (t.IsGenericType)
+            return t.GetGenericArguments().Any(ReturnsTextSomehow);
+        return false;
+    }
+
+    private static string GetRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "cc-director.sln")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/src/CcDirector.Core.Tests/Dictation/TranscriptionIntegrityGuardTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/TranscriptionIntegrityGuardTests.cs
@@ -73,10 +73,9 @@ public sealed class TranscriptionIntegrityGuardTests
             if (Path.GetFileName(file) == "TranscriptEditEngine.cs") continue;
 
             var text = File.ReadAllText(file);
-            if (text.Contains("Regex.Replace(", StringComparison.Ordinal))
-                offenders.Add($"{rel} calls Regex.Replace");
-            if (text.Contains(".Replace(", StringComparison.Ordinal))
-                offenders.Add($"{rel} calls string Replace");
+            var hit = DetectRewrite(text);
+            if (hit is not null)
+                offenders.Add($"{rel}: {hit}");
         }
 
         // The instrument must not pass by scanning nothing: an empty sweep is a broken run, not a
@@ -91,18 +90,55 @@ public sealed class TranscriptionIntegrityGuardTests
     }
 
     /// <summary>
-    /// The guard above is only worth having if it can fail. This proves the detector fires on the
-    /// exact shape it is looking for, so a green run means "nothing rewrites text" rather than "the
-    /// scan never matched anything".
+    /// The guard above is only worth having if it can FAIL, and the previous version of this test could
+    /// not tell you that: it asserted a literal string contained a literal substring, which proves
+    /// nothing about the detector the scan actually uses. Now the same <see cref="DetectRewrite"/> the
+    /// scan calls is run over source fixtures, so a green sweep means "no rewrite mechanism present"
+    /// rather than "the pattern happened not to match".
     /// </summary>
-    [Fact]
-    public void TheGuardDetectsARewriteWhenThereIsOne()
-    {
-        const string offending = "var cleaned = raw.Replace(\"a\", \"b\");";
-        const string innocent = "var score = Jaro(spanNorm, target);";
+    [Theory]
+    [InlineData("var cleaned = raw.Replace(\"a\", \"b\");")]
+    [InlineData("return Regex.Replace(text, pattern, replacement);")]
+    [InlineData("var cleaned = raw[..start] + term + raw[(start + len)..];")]
+    [InlineData("text = text[..c.Start] + c.Replace + text[(c.Start + c.Find.Length)..];")]
+    [InlineData("var sb = new StringBuilder(raw); sb.Remove(0, 2); return sb.ToString();")]
+    public void TheDetectorFiresOnEveryRewriteMechanismWeKnowOf(string source)
+        => Assert.NotNull(DetectRewrite(source));
 
-        Assert.Contains(".Replace(", offending, StringComparison.Ordinal);
-        Assert.DoesNotContain(".Replace(", innocent, StringComparison.Ordinal);
+    /// <summary>And stays quiet on code that only READS or scores text, or the guard becomes a nuisance
+    /// that the next person deletes instead of honouring.</summary>
+    [Theory]
+    [InlineData("var score = Jaro(spanNorm, target.Norm);")]
+    [InlineData("var tokens = Regex.Matches(raw, TokenPattern);")]
+    [InlineData("if (raw.Contains(edit.Find, StringComparison.Ordinal)) { }")]
+    [InlineData("var norm = char.ToLowerInvariant(c);")]
+    [InlineData("// we never Replace anything here, we only measure it")]
+    public void TheDetectorStaysQuietOnCodeThatOnlyReadsText(string source)
+        => Assert.Null(DetectRewrite(source));
+
+    /// <summary>
+    /// The rewrite mechanisms we know how to spot. Heuristic by nature - it reads source text, not
+    /// semantics - so it is deliberately aimed at the shapes that actually produce a modified
+    /// transcript: a replace call, a slice-and-concatenate rebuild (what ApplyAt itself does), and
+    /// StringBuilder mutation. A new mechanism that evades all three is a gap to close here, and the
+    /// fixtures above are where it gets pinned.
+    /// </summary>
+    private static string? DetectRewrite(string source)
+    {
+        var code = string.Join(
+            Environment.NewLine,
+            source.Split('\n')
+                .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+        if (code.Contains("Regex.Replace(", StringComparison.Ordinal)) return "calls Regex.Replace";
+        if (code.Contains(".Replace(", StringComparison.Ordinal)) return "calls string Replace";
+        if (code.Contains("[..", StringComparison.Ordinal) && code.Contains("] +", StringComparison.Ordinal))
+            return "rebuilds a string by slicing and concatenating";
+        if (code.Contains("new StringBuilder(", StringComparison.Ordinal)
+            && (code.Contains(".Remove(", StringComparison.Ordinal)
+                || code.Contains(".Insert(", StringComparison.Ordinal)))
+            return "mutates text through a StringBuilder";
+        return null;
     }
 
     private static bool ReturnsTextSomehow(Type t)

--- a/src/CcDirector.Core.Tests/Dictation/TranscriptionIntegrityGuardTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/TranscriptionIntegrityGuardTests.cs
@@ -1,5 +1,8 @@
 using System.Reflection;
 using CcDirector.Core.Dictation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
 namespace CcDirector.Core.Tests.Dictation;
@@ -10,15 +13,22 @@ namespace CcDirector.Core.Tests.Dictation;
 /// Its class comment said "The TranscriptionIntegrity architecture test enforces this at build time".
 /// No such test existed - the name appeared nowhere in the repository except in that sentence. The
 /// invariant it names is the one that matters most in this subsystem, and for a month it was enforced
-/// by a comment. A review found it while checking something else, which is luck, not process.
+/// by a comment.
 ///
 /// The invariant, in two halves:
 ///   1. A language model may LOCATE misheard terms. It must never receive the transcript and return
 ///      free text that becomes the user's words.
 ///   2. Only TranscriptEditEngine changes transcript text.
 ///
-/// Both are checked structurally rather than by reading the code, so a future call site that breaks
-/// them fails the build rather than an inspection.
+/// The first version of this guard matched substrings in source text and was evadable by a space:
+/// <c>raw.Replace ("a","b")</c> passed, and so did <c>string.Concat</c> and <c>Substring</c> rebuilds -
+/// while an unrelated <c>.Replace(</c> anywhere in the folder failed the build. Known-bad code passing
+/// and unrelated code failing is the worst combination a fitness function can have, because it teaches
+/// the next person to delete it.
+///
+/// So it reads SYNTAX now, not characters. Roslyn parses each file and the check asks what operation
+/// is being invoked, which makes trivia - spaces, line breaks, comments, string literals containing
+/// the word - irrelevant by construction.
 /// </summary>
 public sealed class TranscriptionIntegrityGuardTests
 {
@@ -26,10 +36,6 @@ public sealed class TranscriptionIntegrityGuardTests
     /// Half one, made structural. The judge's only method hands back numbers - the ids of candidates
     /// OUR code isolated. A model on the other end of this interface physically cannot return a word,
     /// a sentence, or a corrected transcript, because there is nowhere in the signature to put one.
-    ///
-    /// This is why the interface returns ids instead of edits, and the test exists so that stays true:
-    /// changing it to return strings would be a one-line change that quietly reopens the entire class
-    /// of corruption the July removal was about.
     /// </summary>
     [Fact]
     public void AJudgeCanOnlyReturnCandidateIds_NeverText()
@@ -48,11 +54,23 @@ public sealed class TranscriptionIntegrityGuardTests
     }
 
     /// <summary>
+    /// The judge must not be able to reach the applied candidates through its PARAMETER either. It is
+    /// handed an <see cref="IReadOnlyList{T}"/>, and a review proved that a bare array or List handed
+    /// out under that type can be cast straight back and written through after validation. So the
+    /// contract is pinned as read-only AND the runtime type the orchestrator passes is checked by
+    /// <c>DictationJudgeTests.AJudgeThatRewritesItsOwnCandidateList_ChangesNothing</c>.
+    /// </summary>
+    [Fact]
+    public void AJudgeIsHandedCandidatesItCannotWriteThrough()
+    {
+        var accept = typeof(ICandidateJudge).GetMethods(BindingFlags.Public | BindingFlags.Instance).Single();
+        var candidates = accept.GetParameters().Single(p => p.Name == "candidates");
+
+        Assert.Equal(typeof(IReadOnlyList<JudgeCandidate>), candidates.ParameterType);
+    }
+
+    /// <summary>
     /// Half two: nothing in the dictation subsystem rewrites transcript text except the edit engine.
-    ///
-    /// Scanned for the operations that actually produce a modified transcript - a regex replace or a
-    /// string replace. The engine is the single allowed home for both. A new "helpful" cleanup step
-    /// added anywhere else in Dictation trips this.
     /// </summary>
     [Fact]
     public void OnlyTheEditEngineRewritesTranscriptText()
@@ -72,14 +90,12 @@ public sealed class TranscriptionIntegrityGuardTests
 
             if (Path.GetFileName(file) == "TranscriptEditEngine.cs") continue;
 
-            var text = File.ReadAllText(file);
-            var hit = DetectRewrite(text);
-            if (hit is not null)
+            foreach (var hit in FindRewrites(File.ReadAllText(file)))
                 offenders.Add($"{rel}: {hit}");
         }
 
         // The instrument must not pass by scanning nothing: an empty sweep is a broken run, not a
-        // clean one. TranscriptEditEngine itself is excluded above, so a real scan sees several files.
+        // clean one.
         Assert.True(scanned >= 5,
             $"only {scanned} dictation source files were scanned - the guard is looking in the wrong " +
             "place and would report clean whatever the code did");
@@ -90,55 +106,142 @@ public sealed class TranscriptionIntegrityGuardTests
     }
 
     /// <summary>
-    /// The guard above is only worth having if it can FAIL, and the previous version of this test could
-    /// not tell you that: it asserted a literal string contained a literal substring, which proves
-    /// nothing about the detector the scan actually uses. Now the same <see cref="DetectRewrite"/> the
-    /// scan calls is run over source fixtures, so a green sweep means "no rewrite mechanism present"
-    /// rather than "the pattern happened not to match".
+    /// The known-bad controls. Every one of these rebuilds a string from another one, which is what
+    /// rewriting a transcript actually looks like - and the substring version of this guard let four
+    /// of the five through. A guard that cannot fail on these is not evidence of anything.
     /// </summary>
     [Theory]
-    [InlineData("var cleaned = raw.Replace(\"a\", \"b\");")]
-    [InlineData("return Regex.Replace(text, pattern, replacement);")]
-    [InlineData("var cleaned = raw[..start] + term + raw[(start + len)..];")]
-    [InlineData("text = text[..c.Start] + c.Replace + text[(c.Start + c.Find.Length)..];")]
-    [InlineData("var sb = new StringBuilder(raw); sb.Remove(0, 2); return sb.ToString();")]
-    public void TheDetectorFiresOnEveryRewriteMechanismWeKnowOf(string source)
-        => Assert.NotNull(DetectRewrite(source));
-
-    /// <summary>And stays quiet on code that only READS or scores text, or the guard becomes a nuisance
-    /// that the next person deletes instead of honouring.</summary>
-    [Theory]
-    [InlineData("var score = Jaro(spanNorm, target.Norm);")]
-    [InlineData("var tokens = Regex.Matches(raw, TokenPattern);")]
-    [InlineData("if (raw.Contains(edit.Find, StringComparison.Ordinal)) { }")]
-    [InlineData("var norm = char.ToLowerInvariant(c);")]
-    [InlineData("// we never Replace anything here, we only measure it")]
-    public void TheDetectorStaysQuietOnCodeThatOnlyReadsText(string source)
-        => Assert.Null(DetectRewrite(source));
+    [InlineData("class C { string M(string raw) => raw.Replace(\"a\", \"b\"); }")]
+    [InlineData("class C { string M(string raw) => raw.Replace (\"a\", \"b\"); }")]
+    [InlineData("class C { string M(string raw) => raw\n    .Replace(\"a\", \"b\"); }")]
+    [InlineData("class C { string M(string raw) => Regex.Replace(raw, \"a\", \"b\"); }")]
+    [InlineData("class C { string M(string raw, int s, int e) => raw.Substring(0, s) + \"x\" + raw.Substring(e); }")]
+    [InlineData("class C { string M(string raw, int s, int e) => string.Concat(raw.AsSpan(0, s), \"x\", raw.AsSpan(e)); }")]
+    [InlineData("class C { string M(string raw, int s) => raw[..s] + \"x\" + raw[s..]; }")]
+    [InlineData("class C { string M(string raw) { var b = new StringBuilder(raw); b.Remove(0, 2); return b.ToString(); } }")]
+    [InlineData("class C { string M(string raw) { var b = new StringBuilder(raw); b[0] = 'x'; return b.ToString(); } }")]
+    [InlineData("class C { string M(string raw) { var b = new StringBuilder(raw); b.Insert(0, \"x\"); return b.ToString(); } }")]
+    public void TheGuardFailsOnEveryKnownRewrite(string source)
+        => Assert.NotEmpty(FindRewrites(source));
 
     /// <summary>
-    /// The rewrite mechanisms we know how to spot. Heuristic by nature - it reads source text, not
-    /// semantics - so it is deliberately aimed at the shapes that actually produce a modified
-    /// transcript: a replace call, a slice-and-concatenate rebuild (what ApplyAt itself does), and
-    /// StringBuilder mutation. A new mechanism that evades all three is a gap to close here, and the
-    /// fixtures above are where it gets pinned.
+    /// And stays quiet on code that only reads, measures or matches text - including the trivia that
+    /// broke the previous version: the forbidden words inside comments and string literals.
     /// </summary>
-    private static string? DetectRewrite(string source)
-    {
-        var code = string.Join(
-            Environment.NewLine,
-            source.Split('\n')
-                .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+    [Theory]
+    [InlineData("class C { double M(string a, string b) => Jaro(a, b); }")]
+    [InlineData("class C { void M(string raw) { var t = Regex.Matches(raw, P); } }")]
+    [InlineData("class C { bool M(string raw, string f) => raw.Contains(f, StringComparison.Ordinal); }")]
+    [InlineData("class C { int M(string raw) => raw.IndexOf('a'); }")]
+    [InlineData("class C { // we never Replace anything here, we only measure it\n void M() { } }")]
+    [InlineData("class C { string M() => \"call .Replace( to rewrite\"; }")]
+    [InlineData("class C { /* Regex.Replace( in a block comment */ void M() { } }")]
+    [InlineData("class C { string M(string s) { var sb = new System.Text.StringBuilder(s.Length); sb.Append('a'); return sb.ToString(); } }")]
+    public void TheGuardStaysQuietOnCodeThatOnlyReadsText(string source)
+        => Assert.Empty(FindRewrites(source));
 
-        if (code.Contains("Regex.Replace(", StringComparison.Ordinal)) return "calls Regex.Replace";
-        if (code.Contains(".Replace(", StringComparison.Ordinal)) return "calls string Replace";
-        if (code.Contains("[..", StringComparison.Ordinal) && code.Contains("] +", StringComparison.Ordinal))
-            return "rebuilds a string by slicing and concatenating";
-        if (code.Contains("new StringBuilder(", StringComparison.Ordinal)
-            && (code.Contains(".Remove(", StringComparison.Ordinal)
-                || code.Contains(".Insert(", StringComparison.Ordinal)))
-            return "mutates text through a StringBuilder";
-        return null;
+    /// <summary>
+    /// Every invocation or expression in <paramref name="source"/> that BUILDS a string out of another
+    /// one. Syntax-level, so spacing, line breaks, comments and string literals cannot hide or fake a
+    /// hit.
+    ///
+    /// It proves the operation, not the data flow: it cannot tell a transcript from any other string.
+    /// That is deliberate. In this folder every string of consequence is the user's words, so "no
+    /// rebuild happens here at all" is a stronger and far more checkable rule than "no rebuild of
+    /// specifically the transcript" - and it is the rule the engine already satisfies.
+    /// </summary>
+    /// <summary>Identifiers that hold the user's words. A rewrite that matters operates on one of
+    /// these; <c>sb.Append(...)</c> building a prompt or <c>patterns[key] = ...</c> writing a dictionary
+    /// does not, and an earlier version of this guard failed the build on both.</summary>
+    /// <remarks>"text" is deliberately NOT here. It matched the <c>Text</c> in
+    /// <c>System.Text.StringBuilder</c> and failed the build on a normalisation helper that only
+    /// lowercases characters for scoring. A name that collides with a namespace is not a name that can
+    /// identify the user's words. The cost is that a rewrite through a variable called exactly
+    /// <c>text</c> would evade this - which is why the engine, where that name is used, is the one file
+    /// exempt from the scan anyway.</remarks>
+    private static readonly string[] TranscriptNames =
+        { "raw", "rawtranscript", "transcript", "cleaned", "utterance" };
+
+    private static bool IsTranscript(string? expr)
+    {
+        if (string.IsNullOrWhiteSpace(expr)) return false;
+        var head = expr.Split('.', '[', '(')[0].Trim();
+        return TranscriptNames.Contains(head, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool MentionsTranscript(SyntaxNode node)
+        => node.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>()
+            .Any(i => TranscriptNames.Contains(i.Identifier.ValueText, StringComparer.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Every place <paramref name="source"/> builds a new string out of the user's words. Syntax-level,
+    /// so spacing, line breaks, comments and string literals cannot hide or fake a hit.
+    ///
+    /// It follows the transcript by NAME rather than by full data flow. That is a real limit and worth
+    /// stating: a rewrite of a transcript first copied into a deliberately unrelated variable name would
+    /// slip past. The alternative - a full semantic model - buys precision this guard does not need,
+    /// because the thing it is defending against is a well-meant second cleanup path, not a hostile one.
+    /// Following the name is what stops it failing the build on prompt building and dictionary writes,
+    /// which is what got the previous version into trouble in the other direction.
+    /// </summary>
+    /// <summary>Is <paramref name="name"/> a local initialised from the user's words - a StringBuilder
+    /// or span wrapped round the transcript? Mutating one of those rewrites the transcript just as
+    /// surely as calling Replace on it directly.</summary>
+    private static bool IsBufferFromTranscript(SyntaxNode root, string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return false;
+        return root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Any(v => v.Identifier.ValueText == name
+                      && v.Initializer is not null && MentionsTranscript(v.Initializer));
+    }
+
+    private static IReadOnlyList<string> FindRewrites(string source)
+    {
+        var root = CSharpSyntaxTree.ParseText(source).GetRoot();
+        var hits = new List<string>();
+
+        foreach (var call in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (call.Expression is not MemberAccessExpressionSyntax member) continue;
+            var name = member.Name.Identifier.ValueText;
+            var receiver = member.Expression.ToString();
+
+            var rewritesReceiver = name is "Replace" or "Substring" or "Insert" or "Remove"
+                                   && (IsTranscript(receiver) || IsBufferFromTranscript(root, receiver));
+            var mutatesBuffer = name is "Append" or "AppendLine"
+                                && IsBufferFromTranscript(root, receiver);
+            var concatsTranscript = name is "Concat" && receiver is "string"
+                                    && call.ArgumentList.Arguments.Any(a => MentionsTranscript(a));
+            var regexRewrite = name is "Replace" && receiver.EndsWith("Regex", StringComparison.Ordinal)
+                               && call.ArgumentList.Arguments.Count > 0
+                               && MentionsTranscript(call.ArgumentList.Arguments[0]);
+
+            if (rewritesReceiver) hits.Add($"calls {receiver}.{name}(...) on the transcript");
+            else if (mutatesBuffer) hits.Add($"mutates {receiver}, a text buffer built from the transcript");
+            else if (concatsTranscript) hits.Add("rebuilds the transcript with string.Concat");
+            else if (regexRewrite) hits.Add("rewrites the transcript with Regex.Replace");
+        }
+
+        // A range slice of the transcript, concatenated with something else - what ApplyAt itself does.
+        if (root.DescendantNodes().OfType<BinaryExpressionSyntax>()
+            .Where(b => b.IsKind(SyntaxKind.AddExpression))
+            .Any(b => b.DescendantNodesAndSelf().OfType<ElementAccessExpressionSyntax>()
+                .Any(e => IsTranscript(e.Expression.ToString())
+                          && e.ArgumentList.Arguments.Any(a => a.Expression is RangeExpressionSyntax))))
+        {
+            hits.Add("rebuilds the transcript by slicing a range and concatenating");
+        }
+
+        // Writing through an indexer into a text buffer built from the transcript.
+        foreach (var assign in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (assign.Left is not ElementAccessExpressionSyntax target) continue;
+            var buffer = target.Expression.ToString();
+            if (IsBufferFromTranscript(root, buffer) || IsTranscript(buffer))
+                hits.Add($"writes through {buffer}[...], a text buffer built from the transcript");
+        }
+
+        return hits;
     }
 
     private static bool ReturnsTextSomehow(Type t)

--- a/src/CcDirector.Core.Tests/Dictation/TranscriptionIntegrityGuardTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/TranscriptionIntegrityGuardTests.cs
@@ -1,8 +1,5 @@
 using System.Reflection;
 using CcDirector.Core.Dictation;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xunit;
 
 namespace CcDirector.Core.Tests.Dictation;
@@ -15,20 +12,29 @@ namespace CcDirector.Core.Tests.Dictation;
 /// invariant it names is the one that matters most in this subsystem, and for a month it was enforced
 /// by a comment.
 ///
-/// The invariant, in two halves:
-///   1. A language model may LOCATE misheard terms. It must never receive the transcript and return
-///      free text that becomes the user's words.
-///   2. Only TranscriptEditEngine changes transcript text.
+/// The invariant has two halves. THIS FILE ENFORCES ONE OF THEM.
 ///
-/// The first version of this guard matched substrings in source text and was evadable by a space:
-/// <c>raw.Replace ("a","b")</c> passed, and so did <c>string.Concat</c> and <c>Substring</c> rebuilds -
-/// while an unrelated <c>.Replace(</c> anywhere in the folder failed the build. Known-bad code passing
-/// and unrelated code failing is the worst combination a fitness function can have, because it teaches
-/// the next person to delete it.
+///   1. ENFORCED HERE - a language model may LOCATE misheard terms; it can never receive the
+///      transcript and hand back free text that becomes the user's words. That is checked structurally
+///      below, on both the return type and the parameter.
+///   2. NOT ENFORCED ANYWHERE - only TranscriptEditEngine changes transcript text. This is still a
+///      real rule and still followed; nothing automated checks it.
 ///
-/// So it reads SYNTAX now, not characters. Roslyn parses each file and the check asks what operation
-/// is being invoked, which makes trivia - spaces, line breaks, comments, string literals containing
-/// the word - irrelevant by construction.
+/// Half two was attempted twice and abandoned, and the reason is worth keeping. A substring scan over
+/// source text was evadable by a single space and failed the build on the word appearing inside a
+/// comment. Parsing with Roslyn fixed the trivia but not the actual problem: without following values
+/// through the code, a whitelist of variable names missed <c>text.Replace(...)</c>, <c>String.Concat</c>,
+/// <c>this.rawTranscript</c>, null-conditional calls and interpolated rebuilds - all ordinary C# a
+/// well-meant second cleanup path would use - while flagging a Substring taken for a log preview.
+///
+/// A check that certifies an unconditional claim while missing the ordinary spellings is worse than no
+/// check, because the green run is read as proof. That is exactly the failure this file was written to
+/// correct: for a month the engine's comment claimed a TranscriptionIntegrity test that did not exist,
+/// and replacing a missing test with a passing-but-blind one is the same mistake with extra steps.
+///
+/// So half two is written down as an unenforced rule and tracked, rather than dressed up. Doing it
+/// properly needs semantic analysis that follows transcript values, which is a piece of work in its
+/// own right - see devthrottle_internal#1556.
 /// </summary>
 public sealed class TranscriptionIntegrityGuardTests
 {
@@ -69,195 +75,11 @@ public sealed class TranscriptionIntegrityGuardTests
         Assert.Equal(typeof(IReadOnlyList<JudgeCandidate>), candidates.ParameterType);
     }
 
-    /// <summary>
-    /// Half two: nothing in the dictation subsystem rewrites transcript text except the edit engine.
-    /// </summary>
-    [Fact]
-    public void OnlyTheEditEngineRewritesTranscriptText()
-    {
-        var root = GetRepoRoot();
-        var dictationDir = Path.Combine(root, "src", "CcDirector.Core", "Dictation");
-        Assert.True(Directory.Exists(dictationDir), $"expected the dictation source at {dictationDir}");
-
-        var scanned = 0;
-        var offenders = new List<string>();
-
-        foreach (var file in Directory.EnumerateFiles(dictationDir, "*.cs", SearchOption.AllDirectories))
-        {
-            var rel = Path.GetRelativePath(root, file).Replace('\\', '/');
-            if (rel.Contains("/bin/") || rel.Contains("/obj/")) continue;
-            scanned++;
-
-            if (Path.GetFileName(file) == "TranscriptEditEngine.cs") continue;
-
-            foreach (var hit in FindRewrites(File.ReadAllText(file)))
-                offenders.Add($"{rel}: {hit}");
-        }
-
-        // The instrument must not pass by scanning nothing: an empty sweep is a broken run, not a
-        // clean one.
-        Assert.True(scanned >= 5,
-            $"only {scanned} dictation source files were scanned - the guard is looking in the wrong " +
-            "place and would report clean whatever the code did");
-
-        Assert.True(offenders.Count == 0,
-            "Only TranscriptEditEngine may rewrite transcript text. Offenders:\n  "
-            + string.Join("\n  ", offenders));
-    }
-
-    /// <summary>
-    /// The known-bad controls. Every one of these rebuilds a string from another one, which is what
-    /// rewriting a transcript actually looks like - and the substring version of this guard let four
-    /// of the five through. A guard that cannot fail on these is not evidence of anything.
-    /// </summary>
-    [Theory]
-    [InlineData("class C { string M(string raw) => raw.Replace(\"a\", \"b\"); }")]
-    [InlineData("class C { string M(string raw) => raw.Replace (\"a\", \"b\"); }")]
-    [InlineData("class C { string M(string raw) => raw\n    .Replace(\"a\", \"b\"); }")]
-    [InlineData("class C { string M(string raw) => Regex.Replace(raw, \"a\", \"b\"); }")]
-    [InlineData("class C { string M(string raw, int s, int e) => raw.Substring(0, s) + \"x\" + raw.Substring(e); }")]
-    [InlineData("class C { string M(string raw, int s, int e) => string.Concat(raw.AsSpan(0, s), \"x\", raw.AsSpan(e)); }")]
-    [InlineData("class C { string M(string raw, int s) => raw[..s] + \"x\" + raw[s..]; }")]
-    [InlineData("class C { string M(string raw) { var b = new StringBuilder(raw); b.Remove(0, 2); return b.ToString(); } }")]
-    [InlineData("class C { string M(string raw) { var b = new StringBuilder(raw); b[0] = 'x'; return b.ToString(); } }")]
-    [InlineData("class C { string M(string raw) { var b = new StringBuilder(raw); b.Insert(0, \"x\"); return b.ToString(); } }")]
-    public void TheGuardFailsOnEveryKnownRewrite(string source)
-        => Assert.NotEmpty(FindRewrites(source));
-
-    /// <summary>
-    /// And stays quiet on code that only reads, measures or matches text - including the trivia that
-    /// broke the previous version: the forbidden words inside comments and string literals.
-    /// </summary>
-    [Theory]
-    [InlineData("class C { double M(string a, string b) => Jaro(a, b); }")]
-    [InlineData("class C { void M(string raw) { var t = Regex.Matches(raw, P); } }")]
-    [InlineData("class C { bool M(string raw, string f) => raw.Contains(f, StringComparison.Ordinal); }")]
-    [InlineData("class C { int M(string raw) => raw.IndexOf('a'); }")]
-    [InlineData("class C { // we never Replace anything here, we only measure it\n void M() { } }")]
-    [InlineData("class C { string M() => \"call .Replace( to rewrite\"; }")]
-    [InlineData("class C { /* Regex.Replace( in a block comment */ void M() { } }")]
-    [InlineData("class C { string M(string s) { var sb = new System.Text.StringBuilder(s.Length); sb.Append('a'); return sb.ToString(); } }")]
-    public void TheGuardStaysQuietOnCodeThatOnlyReadsText(string source)
-        => Assert.Empty(FindRewrites(source));
-
-    /// <summary>
-    /// Every invocation or expression in <paramref name="source"/> that BUILDS a string out of another
-    /// one. Syntax-level, so spacing, line breaks, comments and string literals cannot hide or fake a
-    /// hit.
-    ///
-    /// It proves the operation, not the data flow: it cannot tell a transcript from any other string.
-    /// That is deliberate. In this folder every string of consequence is the user's words, so "no
-    /// rebuild happens here at all" is a stronger and far more checkable rule than "no rebuild of
-    /// specifically the transcript" - and it is the rule the engine already satisfies.
-    /// </summary>
-    /// <summary>Identifiers that hold the user's words. A rewrite that matters operates on one of
-    /// these; <c>sb.Append(...)</c> building a prompt or <c>patterns[key] = ...</c> writing a dictionary
-    /// does not, and an earlier version of this guard failed the build on both.</summary>
-    /// <remarks>"text" is deliberately NOT here. It matched the <c>Text</c> in
-    /// <c>System.Text.StringBuilder</c> and failed the build on a normalisation helper that only
-    /// lowercases characters for scoring. A name that collides with a namespace is not a name that can
-    /// identify the user's words. The cost is that a rewrite through a variable called exactly
-    /// <c>text</c> would evade this - which is why the engine, where that name is used, is the one file
-    /// exempt from the scan anyway.</remarks>
-    private static readonly string[] TranscriptNames =
-        { "raw", "rawtranscript", "transcript", "cleaned", "utterance" };
-
-    private static bool IsTranscript(string? expr)
-    {
-        if (string.IsNullOrWhiteSpace(expr)) return false;
-        var head = expr.Split('.', '[', '(')[0].Trim();
-        return TranscriptNames.Contains(head, StringComparer.OrdinalIgnoreCase);
-    }
-
-    private static bool MentionsTranscript(SyntaxNode node)
-        => node.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>()
-            .Any(i => TranscriptNames.Contains(i.Identifier.ValueText, StringComparer.OrdinalIgnoreCase));
-
-    /// <summary>
-    /// Every place <paramref name="source"/> builds a new string out of the user's words. Syntax-level,
-    /// so spacing, line breaks, comments and string literals cannot hide or fake a hit.
-    ///
-    /// It follows the transcript by NAME rather than by full data flow. That is a real limit and worth
-    /// stating: a rewrite of a transcript first copied into a deliberately unrelated variable name would
-    /// slip past. The alternative - a full semantic model - buys precision this guard does not need,
-    /// because the thing it is defending against is a well-meant second cleanup path, not a hostile one.
-    /// Following the name is what stops it failing the build on prompt building and dictionary writes,
-    /// which is what got the previous version into trouble in the other direction.
-    /// </summary>
-    /// <summary>Is <paramref name="name"/> a local initialised from the user's words - a StringBuilder
-    /// or span wrapped round the transcript? Mutating one of those rewrites the transcript just as
-    /// surely as calling Replace on it directly.</summary>
-    private static bool IsBufferFromTranscript(SyntaxNode root, string? name)
-    {
-        if (string.IsNullOrWhiteSpace(name)) return false;
-        return root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
-            .Any(v => v.Identifier.ValueText == name
-                      && v.Initializer is not null && MentionsTranscript(v.Initializer));
-    }
-
-    private static IReadOnlyList<string> FindRewrites(string source)
-    {
-        var root = CSharpSyntaxTree.ParseText(source).GetRoot();
-        var hits = new List<string>();
-
-        foreach (var call in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
-        {
-            if (call.Expression is not MemberAccessExpressionSyntax member) continue;
-            var name = member.Name.Identifier.ValueText;
-            var receiver = member.Expression.ToString();
-
-            var rewritesReceiver = name is "Replace" or "Substring" or "Insert" or "Remove"
-                                   && (IsTranscript(receiver) || IsBufferFromTranscript(root, receiver));
-            var mutatesBuffer = name is "Append" or "AppendLine"
-                                && IsBufferFromTranscript(root, receiver);
-            var concatsTranscript = name is "Concat" && receiver is "string"
-                                    && call.ArgumentList.Arguments.Any(a => MentionsTranscript(a));
-            var regexRewrite = name is "Replace" && receiver.EndsWith("Regex", StringComparison.Ordinal)
-                               && call.ArgumentList.Arguments.Count > 0
-                               && MentionsTranscript(call.ArgumentList.Arguments[0]);
-
-            if (rewritesReceiver) hits.Add($"calls {receiver}.{name}(...) on the transcript");
-            else if (mutatesBuffer) hits.Add($"mutates {receiver}, a text buffer built from the transcript");
-            else if (concatsTranscript) hits.Add("rebuilds the transcript with string.Concat");
-            else if (regexRewrite) hits.Add("rewrites the transcript with Regex.Replace");
-        }
-
-        // A range slice of the transcript, concatenated with something else - what ApplyAt itself does.
-        if (root.DescendantNodes().OfType<BinaryExpressionSyntax>()
-            .Where(b => b.IsKind(SyntaxKind.AddExpression))
-            .Any(b => b.DescendantNodesAndSelf().OfType<ElementAccessExpressionSyntax>()
-                .Any(e => IsTranscript(e.Expression.ToString())
-                          && e.ArgumentList.Arguments.Any(a => a.Expression is RangeExpressionSyntax))))
-        {
-            hits.Add("rebuilds the transcript by slicing a range and concatenating");
-        }
-
-        // Writing through an indexer into a text buffer built from the transcript.
-        foreach (var assign in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
-        {
-            if (assign.Left is not ElementAccessExpressionSyntax target) continue;
-            var buffer = target.Expression.ToString();
-            if (IsBufferFromTranscript(root, buffer) || IsTranscript(buffer))
-                hits.Add($"writes through {buffer}[...], a text buffer built from the transcript");
-        }
-
-        return hits;
-    }
-
     private static bool ReturnsTextSomehow(Type t)
     {
         if (t == typeof(string)) return true;
         if (t.IsGenericType)
             return t.GetGenericArguments().Any(ReturnsTextSomehow);
         return false;
-    }
-
-    private static string GetRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "cc-director.sln")))
-            dir = dir.Parent;
-        Assert.NotNull(dir);
-        return dir!.FullName;
     }
 }

--- a/src/CcDirector.Core/Configuration/TranscriptionEndpoint.cs
+++ b/src/CcDirector.Core/Configuration/TranscriptionEndpoint.cs
@@ -156,6 +156,15 @@ public static class TranscriptionEndpointResolver
         new(DevThrottleBaseUrl, DevThrottleKeyName, DevThrottleWingmanFastModel);
 
     /// <summary>
+    /// Resolve the dictation-cleanup judge target for <paramref name="mode"/>. Same base URL and key as
+    /// <see cref="ResolveWingman"/>; only the model differs, so the judge is metered as the included
+    /// dictation service rather than billing a member's credits. The caller appends
+    /// <c>/chat/completions</c>.
+    /// </summary>
+    public static ProviderEndpoint ResolveDictationCleanup(TranscriptionMode mode) =>
+        new(DevThrottleBaseUrl, DevThrottleKeyName, DevThrottleDictationCleanupModel);
+
+    /// <summary>
     /// Resolve the text-to-speech target for <paramref name="mode"/> (base URL + key name + model).
     /// Same base + key as transcription; the caller appends <c>/audio/speech</c>. The voice is a
     /// separate choice (<see cref="TtsVoiceConfig"/>), not part of the routing target.

--- a/src/CcDirector.Core/Dictation/CandidateJudge.cs
+++ b/src/CcDirector.Core/Dictation/CandidateJudge.cs
@@ -1,0 +1,146 @@
+using System.Text;
+using System.Text.Json;
+
+namespace CcDirector.Core.Dictation;
+
+/// <summary>
+/// One span the fuzzy matcher thinks MIGHT be a misheard dictionary term, offered to the judge for a
+/// ruling. The judge never sees a replacement it can edit - it sees the sentence, the exact words in
+/// question, and the term they might be, and answers with ids.
+/// </summary>
+/// <param name="Id">Position in the offered list. The judge's whole vocabulary is these numbers.</param>
+/// <param name="Find">The exact text as spoken, copied verbatim out of the transcript.</param>
+/// <param name="Replace">The canonical dictionary term it might be.</param>
+/// <param name="Start">Where <paramref name="Find"/> starts in the transcript. The edit is applied at
+/// THIS offset and nowhere else, so one ruling can never change a word somewhere else in the turn.</param>
+public sealed record JudgeCandidate(int Id, string Find, string Replace, int Start);
+
+/// <summary>
+/// Rules on candidate corrections in context. The ONLY thing in the product allowed to decide that an
+/// UNLISTED word should be swapped.
+///
+/// The contract is deliberately narrow, and the narrowness is the safety property: an implementation
+/// receives the utterance and a bounded candidate list, and returns the ids it accepts. It cannot
+/// return text, cannot propose a candidate of its own, and cannot reach a word the matcher did not
+/// already isolate. A hostile or broken implementation's worst case is accepting a bad candidate -
+/// exactly the failure the deterministic matcher had by default - and it can never invent one.
+/// </summary>
+public interface ICandidateJudge
+{
+    /// <summary>
+    /// Which of <paramref name="candidates"/> are real mishearings, given the sentence they sit in?
+    /// Returns the accepted ids. An empty list means "none of them", which is always a safe answer.
+    /// Implementations must not throw for a slow or unreachable backend - they return null, which the
+    /// caller treats as "no ruling" and applies nothing.
+    /// </summary>
+    Task<IReadOnlyList<int>?> AcceptAsync(
+        string utterance,
+        IReadOnlyList<JudgeCandidate> candidates,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// The wire protocol for <see cref="ICandidateJudge"/>: how the question is asked and how the answer is
+/// read. Pure and static - no I/O, no model, no network - so the exact bytes we send and every shape of
+/// reply we might get back are unit-testable without touching a backend.
+///
+/// The reply is parsed STRICTLY. Anything that is not a well-formed
+/// <c>{"acceptedCandidateIds":[...]}</c> object of known ids is null, and null means nothing is
+/// applied. Prose, an apology, a refusal, a rewritten sentence, an explanation wrapped around the JSON,
+/// an id that was never offered - all of it fails closed. This is the lesson from the model cleanup
+/// that was removed in July: the danger was never a wrong answer, it was accepting output shaped
+/// differently from what we asked for.
+/// </summary>
+public static class CandidateJudgeProtocol
+{
+    /// <summary>Hard cap on candidates put to the judge in one turn. Beyond this the extra candidates
+    /// are dropped unjudged, which means unapplied - a bounded prompt matters more than the tail.</summary>
+    public const int MaxCandidates = 12;
+
+    /// <summary>
+    /// The instruction sent with every question. It states the job, the answer shape, and the tie-break:
+    /// when unsure, reject. A missed correction costs a wrong spelling; a wrong acceptance costs the
+    /// user's meaning, and those are not the same price.
+    /// </summary>
+    public const string SystemPrompt =
+        "You decide whether words in a speech transcript were misheard versions of a known term.\n" +
+        "You are given the transcript and a numbered list of candidates. Each candidate names the exact\n" +
+        "spoken text and the term it might be.\n" +
+        "\n" +
+        "Accept a candidate ONLY if, reading the sentence, the speaker clearly meant the term and the\n" +
+        "transcriber misheard it. Reject it if the spoken word is being used as an ordinary word of the\n" +
+        "language, even when it looks similar to the term. When you are not sure, REJECT.\n" +
+        "\n" +
+        "Reply with JSON and nothing else, in exactly this shape:\n" +
+        "{\"acceptedCandidateIds\": [0, 2]}\n" +
+        "Use an empty array when none should be corrected. Never include any other field, any text\n" +
+        "before or after the JSON, or any explanation.";
+
+    /// <summary>Build the user message: the sentence, then the numbered candidates.</summary>
+    public static string BuildUserPrompt(string utterance, IReadOnlyList<JudgeCandidate> candidates)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Transcript:\n").Append(utterance).Append("\n\nCandidates:\n");
+        foreach (var c in candidates)
+        {
+            sb.Append(c.Id).Append(": \"").Append(c.Find).Append("\" might be \"")
+              .Append(c.Replace).Append("\"\n");
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Read a judge reply. Returns the accepted ids, or null when the reply is not exactly the shape we
+    /// asked for. Null is not an error state to recover from - it means no ruling was obtained, so
+    /// nothing is applied.
+    /// </summary>
+    /// <param name="reply">Raw model output.</param>
+    /// <param name="offered">The ids that were actually put to the judge. An id outside this set voids
+    /// the whole reply rather than being skipped: a judge answering about a candidate that does not
+    /// exist did not understand the question, and the rest of its answer is not trustworthy either.</param>
+    public static IReadOnlyList<int>? ParseAccepted(string? reply, IReadOnlyCollection<int> offered)
+    {
+        if (string.IsNullOrWhiteSpace(reply)) return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(reply);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return null;
+            if (!root.TryGetProperty("acceptedCandidateIds", out var ids)) return null;
+            if (ids.ValueKind != JsonValueKind.Array) return null;
+
+            var accepted = new List<int>();
+            foreach (var item in ids.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Number) return null;
+                if (!item.TryGetInt32(out var id)) return null;
+                if (!offered.Contains(id)) return null;
+                if (!accepted.Contains(id)) accepted.Add(id);
+            }
+            return accepted;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// Whether a judge's ruling reaches the user's words.
+///
+/// There is no "apply without judging" member, deliberately. That state was the defect: a matcher
+/// scoring spelling similarity and acting on its own score rewrote 293 ordinary English words out of a
+/// 22,000-word corpus against a real glossary. Unlisted corrections are either judged or they do not
+/// happen, and the enum is shaped so no configuration can ask for the third thing.
+/// </summary>
+public enum UnlistedCorrectionMode
+{
+    /// <summary>Judge, write down what would have changed, change nothing. The default, and how a judge
+    /// earns the right to act: on a record of its rulings over real dictation, read first.</summary>
+    Shadow = 0,
+
+    /// <summary>Apply accepted rulings, at the offset each was judged at.</summary>
+    Enforce = 1,
+}

--- a/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
+++ b/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
@@ -7,10 +7,17 @@ using CcDirector.Core.Utilities;
 namespace CcDirector.Core.Dictation;
 
 /// <summary>
-/// Corrects a final transcript against the dictation dictionary, deterministically and in-process.
-/// There is NO language model in this path (it used to call a hosted chat model to locate
-/// mishearings, which added several seconds per turn and a whole class of network failures for a job
-/// that is really just fuzzy matching against a small known vocabulary).
+/// Corrects a final transcript against the dictation dictionary.
+///
+/// The wrong forms the user listed by hand are applied deterministically, in-process, with no model
+/// and no network. An UNLISTED correction is different: it needs a ruling from a judge that can read
+/// the sentence, so that path does make one bounded call (see <see cref="ICandidateJudge"/>).
+///
+/// This class used to say there was NO language model in this path, which was true between July and
+/// August 2026 and is not true now. The earlier hosted pass was removed for costing several seconds a
+/// turn; what replaced it applied its own spelling guesses unsupervised and rewrote ordinary English
+/// into glossary terms. The judge is the third answer: the deterministic matcher may nominate, only a
+/// ruling may authorise, and no ruling means the user keeps the words they said.
 ///
 /// Two stages, both of which only ever PROPOSE find/replace edits that the deterministic
 /// <see cref="TranscriptEditEngine"/> validates and applies:

--- a/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
+++ b/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
@@ -38,18 +38,29 @@ public sealed class CleanupOrchestrator
     public const string DefaultModel = TranscriptionEndpointResolver.DevThrottleDictationCleanupModel;
 
     private readonly string _model;
+    private readonly ICandidateJudge? _judge;
+    private readonly UnlistedCorrectionMode _mode;
 
     /// <param name="model">Cleanup identity used only in log lines. Defaults to <see cref="DefaultModel"/>.</param>
-    public CleanupOrchestrator(string? model = DefaultModel)
+    /// <param name="judge">Rules on unlisted candidates in context. WITHOUT ONE, NO UNLISTED CORRECTION
+    /// IS EVER APPLIED, whatever the glossary asks for - see <see cref="UnlistedCorrectionMode"/>.</param>
+    /// <param name="mode">Whether an accepted ruling actually reaches the text. Defaults to
+    /// <see cref="UnlistedCorrectionMode.Shadow"/>: judge, record, change nothing.</param>
+    public CleanupOrchestrator(
+        string? model = DefaultModel,
+        ICandidateJudge? judge = null,
+        UnlistedCorrectionMode mode = UnlistedCorrectionMode.Shadow)
     {
         _model = string.IsNullOrWhiteSpace(model) ? DefaultModel : model;
+        _judge = judge;
+        _mode = mode;
     }
 
     /// <summary>
     /// Clean a raw transcript using the dictionary and the specified profile.
     /// Returns the original text unchanged when cleanup is disabled or nothing matches.
     /// </summary>
-    public Task<CleanupOutcome> CleanAsync(
+    public async Task<CleanupOutcome> CleanAsync(
         string rawTranscript,
         DictationDictionary dictionary,
         string profileName,
@@ -58,20 +69,20 @@ public sealed class CleanupOrchestrator
         FileLog.Write($"[CleanupOrchestrator] CleanAsync: profile={profileName}, model={_model}, len={rawTranscript?.Length ?? 0}");
 
         if (string.IsNullOrWhiteSpace(rawTranscript))
-            return Done(new CleanupOutcome(rawTranscript ?? "", Applied: false, Reason: "empty transcript"));
+            return new CleanupOutcome(rawTranscript ?? "", Applied: false, Reason: "empty transcript");
 
         var profile = ResolveProfile(dictionary, profileName);
         if (!profile.CleanupEnabled)
         {
             FileLog.Write($"[CleanupOrchestrator] CleanAsync: cleanup disabled for profile '{profile.Name}', returning verbatim");
-            return Done(new CleanupOutcome(rawTranscript, Applied: false, Reason: $"profile '{profile.Name}' has cleanup disabled"));
+            return new CleanupOutcome(rawTranscript, Applied: false, Reason: $"profile '{profile.Name}' has cleanup disabled");
         }
 
         // No dictionary knowledge at all means there is nothing to correct.
         if (dictionary.Vocabulary.Count == 0 && dictionary.CommonMistranscriptions.Count == 0)
         {
             FileLog.Write("[CleanupOrchestrator] CleanAsync: empty dictionary, returning verbatim");
-            return Done(new CleanupOutcome(rawTranscript, Applied: false, Reason: "no dictionary terms to correct"));
+            return new CleanupOutcome(rawTranscript, Applied: false, Reason: "no dictionary terms to correct");
         }
 
         var sw = Stopwatch.StartNew();
@@ -93,7 +104,7 @@ public sealed class CleanupOrchestrator
                 sw.Stop();
                 FileLog.Write($"[CleanupOrchestrator] CleanAsync: deterministic known-mistranscription cleanup "
                               + $"applied={deterministic.ChangedWords.Count} in {sw.Elapsed.TotalMilliseconds:0.###}ms");
-                return Done(deterministic);
+                return deterministic;
             }
 
             // Stage 2 is OPT-IN and off unless the glossary asks for it. The fuzzy matcher guesses
@@ -107,39 +118,101 @@ public sealed class CleanupOrchestrator
                 FileLog.Write($"[CleanupOrchestrator] CleanAsync: no listed mistranscription matched and "
                               + $"unlisted fuzzy correction is off for profile '{profile.Name}'; "
                               + $"returning verbatim in {sw.Elapsed.TotalMilliseconds:0.###}ms");
-                return Done(new CleanupOutcome(
-                    rawTranscript, Applied: false, Reason: "no dictionary corrections needed"));
+                return new CleanupOutcome(
+                    rawTranscript, Applied: false, Reason: "no dictionary corrections needed");
             }
 
-            // The fuzzy matcher proposes edits for the unlisted mishearings; the SAME engine gate
-            // validates and applies them, so the safety invariant is identical to before.
-            var proposed = FuzzyDictionaryMatcher.Propose(rawTranscript, dictionary);
-            var validation = TranscriptEditEngine.Validate(proposed, rawTranscript, dictionary);
-            foreach (var r in validation.Rejected)
-                FileLog.Write($"[CleanupOrchestrator] edit REJECTED: \"{Truncate(r.Edit.Find, 60)}\" -> "
-                              + $"\"{Truncate(r.Edit.Replace, 60)}\" ({r.Reason})");
-            foreach (var a in validation.Accepted)
-                FileLog.Write($"[CleanupOrchestrator] edit accepted: \"{Truncate(a.Find, 60)}\" -> \"{a.Replace}\"");
+            // The matcher no longer decides anything. It nominates spans - every occurrence
+            // separately, with the offset it was found at - and a judge that can read the sentence
+            // rules on each one. This is the whole design: string similarity is the right thing to
+            // SEARCH with and the wrong thing to DECIDE on, and nothing in an edit-distance score can
+            // tell "I am not sure" from the speaker's name.
+            var candidates = FuzzyDictionaryMatcher.ProposeCandidates(rawTranscript, dictionary);
 
-            var (cleaned, appliedCount) = TranscriptEditEngine.Apply(rawTranscript, validation.Accepted);
+            // The same deterministic gate as before still stands in front of the judge, so a candidate
+            // it never should have seen cannot be rescued by a permissive ruling.
+            var validation = TranscriptEditEngine.Validate(
+                candidates.Select(c => new TranscriptEdit(c.Find, c.Replace)).ToList(),
+                rawTranscript,
+                dictionary);
+            foreach (var r in validation.Rejected)
+                FileLog.Write($"[CleanupOrchestrator] candidate REJECTED before judging: \"{Truncate(r.Edit.Find, 60)}\" -> "
+                              + $"\"{Truncate(r.Edit.Replace, 60)}\" ({r.Reason})");
+
+            var allowed = new HashSet<(string, string)>(
+                validation.Accepted.Select(e => (e.Find, e.Replace)));
+            var offered = candidates.Where(c => allowed.Contains((c.Find, c.Replace)))
+                .Take(CandidateJudgeProtocol.MaxCandidates).ToList();
+
+            if (offered.Count == 0)
+            {
+                sw.Stop();
+                FileLog.Write($"[CleanupOrchestrator] CleanAsync: nothing to judge in {sw.Elapsed.TotalMilliseconds:0.###}ms");
+                return new CleanupOutcome(rawTranscript, Applied: false, Reason: "no dictionary corrections needed");
+            }
+
+            // THE INVARIANT. An unlisted word is changed only on an affirmative ruling. No judge, no
+            // ruling, a malformed ruling, a slow or unreachable one - all of them mean the user keeps
+            // the words they said. The deterministic matcher applying its own guesses is the defect
+            // this feature exists to end, so there is deliberately no path back to it here.
+            if (_judge is null)
+            {
+                sw.Stop();
+                FileLog.Write($"[CleanupOrchestrator] CleanAsync: {offered.Count} candidate(s) but NO JUDGE "
+                              + $"configured; nothing applied ({sw.Elapsed.TotalMilliseconds:0.###}ms)");
+                return new CleanupOutcome(rawTranscript, Applied: false,
+                    Reason: "unlisted corrections need a judge and none is configured");
+            }
+
+            var ruling = await _judge.AcceptAsync(rawTranscript, offered, ct).ConfigureAwait(false);
+            if (ruling is null)
+            {
+                sw.Stop();
+                FileLog.Write($"[CleanupOrchestrator] CleanAsync: judge gave no usable ruling on "
+                              + $"{offered.Count} candidate(s); nothing applied ({sw.Elapsed.TotalMilliseconds:0.###}ms)");
+                return new CleanupOutcome(rawTranscript, Applied: false, Reason: "judge gave no ruling");
+            }
+
+            var acceptedIds = new HashSet<int>(ruling);
+            var accepted = offered.Where(c => acceptedIds.Contains(c.Id)).ToList();
+            var judgedEdits = accepted.Select(c => new TranscriptEdit(c.Find, c.Replace)).ToList();
+
+            // Shadow: ask the question, write down the answer, change nothing. This is how a judge earns
+            // the right to act - on a record of what it WOULD have done to real dictation, read before
+            // it is allowed to do it.
+            if (_mode == UnlistedCorrectionMode.Shadow)
+            {
+                sw.Stop();
+                foreach (var c in accepted)
+                    FileLog.Write($"[CleanupOrchestrator] SHADOW would correct \"{Truncate(c.Find, 60)}\" -> "
+                                  + $"\"{c.Replace}\" at {c.Start}");
+                FileLog.Write($"[CleanupOrchestrator] CleanAsync SHADOW: offered={offered.Count} "
+                              + $"accepted={accepted.Count} applied=0 in {sw.Elapsed.TotalMilliseconds:0.###}ms");
+                return new CleanupOutcome(rawTranscript, Applied: false,
+                    Reason: $"shadow mode: {accepted.Count} of {offered.Count} candidate(s) would have been corrected",
+                    ChangedWords: Array.Empty<TranscriptEdit>(),
+                    ShadowChanges: judgedEdits);
+            }
+
+            // Applied AT THE OFFSET each candidate was judged at, so one ruling changes one span.
+            var (cleaned, appliedCount) = TranscriptEditEngine.ApplyAt(rawTranscript, accepted);
             sw.Stop();
 
-            string? reason = null;
-            if (validation.Rejected.Count > 0)
-                reason = $"{validation.Rejected.Count} proposed edit(s) rejected";
-            if (appliedCount == 0)
-                reason = reason is null ? "no dictionary corrections needed" : reason + "; none applied";
-
+            foreach (var c in accepted)
+                FileLog.Write($"[CleanupOrchestrator] judged correction \"{Truncate(c.Find, 60)}\" -> "
+                              + $"\"{c.Replace}\" at {c.Start}");
             FileLog.Write($"[CleanupOrchestrator] CleanAsync done in {sw.Elapsed.TotalMilliseconds:0.###}ms: "
-                          + $"proposed={proposed.Count} accepted={validation.Accepted.Count} "
-                          + $"applied={appliedCount} rejected={validation.Rejected.Count}");
+                          + $"offered={offered.Count} accepted={accepted.Count} applied={appliedCount} "
+                          + $"rejected-before-judging={validation.Rejected.Count}");
 
-            // Report which dictionary terms were swapped (issue #587): the accepted edits ARE the
-            // change list, and only when something actually reached the text.
             var changedWords = appliedCount > 0
-                ? validation.Accepted
+                ? judgedEdits
                 : (IReadOnlyList<TranscriptEdit>)Array.Empty<TranscriptEdit>();
-            return Done(new CleanupOutcome(cleaned, Applied: appliedCount > 0, Reason: reason, ChangedWords: changedWords));
+            return new CleanupOutcome(
+                cleaned,
+                Applied: appliedCount > 0,
+                Reason: appliedCount > 0 ? null : "no dictionary corrections needed",
+                ChangedWords: changedWords);
         }
         catch (Exception ex)
         {
@@ -147,11 +220,9 @@ public sealed class CleanupOrchestrator
             // ship the raw transcript, exactly as before the cleanup step existed.
             sw.Stop();
             FileLog.Write($"[CleanupOrchestrator] CleanAsync FAILED in {sw.Elapsed.TotalMilliseconds:0.###}ms: {ex.Message}");
-            return Done(new CleanupOutcome(rawTranscript, Applied: false, Reason: "cleanup failed: " + ex.Message));
+            return new CleanupOutcome(rawTranscript, Applied: false, Reason: "cleanup failed: " + ex.Message);
         }
     }
-
-    private static Task<CleanupOutcome> Done(CleanupOutcome outcome) => Task.FromResult(outcome);
 
     private static CleanupOutcome? TryApplyKnownMistranscriptions(
         string rawTranscript,
@@ -237,8 +308,20 @@ public sealed record CleanupOutcome(
     string Text,
     bool Applied,
     string? Reason,
-    IReadOnlyList<TranscriptEdit> ChangedWords)
+    IReadOnlyList<TranscriptEdit> ChangedWords,
+    IReadOnlyList<TranscriptEdit>? ShadowChanges = null)
 {
+    /// <summary>
+    /// What the judge accepted while in <see cref="UnlistedCorrectionMode.Shadow"/> - corrections that
+    /// were NOT applied. Null or empty everywhere else.
+    ///
+    /// It is a separate field from <see cref="ChangedWords"/> on purpose. A shadow run must be
+    /// indistinguishable from no cleanup at all to anything reading the transcript, while still being
+    /// legible to whoever is deciding whether to trust the judge. Folding the two together would put
+    /// changes that never happened into the record of changes that did.
+    /// </summary>
+    public IReadOnlyList<TranscriptEdit> ShadowChanges { get; init; } = ShadowChanges ?? Array.Empty<TranscriptEdit>();
+
     /// <summary>
     /// Convenience constructor for the no-change paths (empty, disabled, failed open) where there
     /// is never a change list. Keeps the existing 3-argument call sites unchanged while the success

--- a/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
+++ b/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
@@ -136,15 +136,32 @@ public sealed class CleanupOrchestrator
                 rawTranscript,
                 dictionary);
             foreach (var r in validation.Rejected)
-                FileLog.Write($"[CleanupOrchestrator] candidate REJECTED before judging: \"{Truncate(r.Edit.Find, 60)}\" -> "
-                              + $"\"{Truncate(r.Edit.Replace, 60)}\" ({r.Reason})");
+                // The spoken span is the user's words and stays out of the log; the canonical term
+                // came from their own glossary, so naming it is what makes a rejection diagnosable.
+                FileLog.Write($"[CleanupOrchestrator] candidate REJECTED before judging: {r.Edit.Find.Length} "
+                              + $"char(s) -> \"{Truncate(r.Edit.Replace, 60)}\" ({r.Reason})");
 
             var allowed = new HashSet<(string, string)>(
                 validation.Accepted.Select(e => (e.Find, e.Replace)));
-            var offered = candidates.Where(c => allowed.Contains((c.Find, c.Replace)))
-                .Take(CandidateJudgeProtocol.MaxCandidates).ToList();
 
-            if (offered.Count == 0)
+            // THE SNAPSHOT. This private array is what gets applied, and the judge never touches it.
+            //
+            // Handing the judge the same list we later read from would make the whole safety claim a
+            // matter of trust: an in-process judge can cast an IReadOnlyList back to the List it really
+            // is, swap an entry AFTER validation, accept its id, and have arbitrary Find/Replace/Start
+            // applied to the user's words. That is exactly the "a judge cannot supply text" property
+            // this design sells, defeated through the parameter rather than the return value.
+            //
+            // So the judge is given defensive COPIES and its answer is nothing but numbers, which are
+            // then resolved against this untouched snapshot.
+            var snapshot = candidates.Where(c => allowed.Contains((c.Find, c.Replace)))
+                .Take(CandidateJudgeProtocol.MaxCandidates).ToArray();
+            // Wrapped, not just copied: a bare array or List handed out as IReadOnlyList can be cast
+            // straight back and written through. A ReadOnlyCollection has no such door.
+            var offered = new System.Collections.ObjectModel.ReadOnlyCollection<JudgeCandidate>(
+                snapshot.Select(c => new JudgeCandidate(c.Id, c.Find, c.Replace, c.Start)).ToList());
+
+            if (snapshot.Length == 0)
             {
                 sw.Stop();
                 FileLog.Write($"[CleanupOrchestrator] CleanAsync: nothing to judge in {sw.Elapsed.TotalMilliseconds:0.###}ms");
@@ -158,7 +175,7 @@ public sealed class CleanupOrchestrator
             if (_judge is null)
             {
                 sw.Stop();
-                FileLog.Write($"[CleanupOrchestrator] CleanAsync: {offered.Count} candidate(s) but NO JUDGE "
+                FileLog.Write($"[CleanupOrchestrator] CleanAsync: {snapshot.Length} candidate(s) but NO JUDGE "
                               + $"configured; nothing applied ({sw.Elapsed.TotalMilliseconds:0.###}ms)");
                 return new CleanupOutcome(rawTranscript, Applied: false,
                     Reason: "unlisted corrections need a judge and none is configured");
@@ -169,27 +186,45 @@ public sealed class CleanupOrchestrator
             {
                 sw.Stop();
                 FileLog.Write($"[CleanupOrchestrator] CleanAsync: judge gave no usable ruling on "
-                              + $"{offered.Count} candidate(s); nothing applied ({sw.Elapsed.TotalMilliseconds:0.###}ms)");
+                              + $"{snapshot.Length} candidate(s); nothing applied ({sw.Elapsed.TotalMilliseconds:0.###}ms)");
                 return new CleanupOutcome(rawTranscript, Applied: false, Reason: "judge gave no ruling");
             }
 
+            // An id nobody offered VOIDS the whole ruling - it is not filtered out. A judge ruling on a
+            // candidate that does not exist did not understand the question, so its opinion on the ones
+            // that do exist is not worth acting on either. The protocol parser already enforces this for
+            // a hosted judge; enforcing it here too covers every ICandidateJudge, including in-process
+            // ones whose answer never passes through that parser.
+            var offeredIds = new HashSet<int>(snapshot.Select(c => c.Id));
+            if (ruling.Any(id => !offeredIds.Contains(id)))
+            {
+                sw.Stop();
+                FileLog.Write($"[CleanupOrchestrator] CleanAsync: judge ruled on candidate(s) that were "
+                              + $"never offered; whole ruling discarded ({sw.Elapsed.TotalMilliseconds:0.###}ms)");
+                return new CleanupOutcome(rawTranscript, Applied: false,
+                    Reason: "judge ruled on candidates that were never offered");
+            }
+
+            // Resolved against the SNAPSHOT, never against the list the judge was handed.
             var acceptedIds = new HashSet<int>(ruling);
-            var accepted = offered.Where(c => acceptedIds.Contains(c.Id)).ToList();
+            var accepted = snapshot.Where(c => acceptedIds.Contains(c.Id)).ToList();
             var judgedEdits = accepted.Select(c => new TranscriptEdit(c.Find, c.Replace)).ToList();
 
             // Shadow: ask the question, write down the answer, change nothing. This is how a judge earns
             // the right to act - on a record of what it WOULD have done to real dictation, read before
             // it is allowed to do it.
-            if (_mode == UnlistedCorrectionMode.Shadow)
+            // Fail CLOSED on the mode: only the exact Enforce value applies. An undefined enum value -
+            // a cast integer, a new member added later and not handled here - must shadow, not enforce.
+            if (_mode != UnlistedCorrectionMode.Enforce)
             {
                 sw.Stop();
                 foreach (var c in accepted)
-                    FileLog.Write($"[CleanupOrchestrator] SHADOW would correct \"{Truncate(c.Find, 60)}\" -> "
-                                  + $"\"{c.Replace}\" at {c.Start}");
-                FileLog.Write($"[CleanupOrchestrator] CleanAsync SHADOW: offered={offered.Count} "
+                    FileLog.Write($"[CleanupOrchestrator] SHADOW would correct {c.Find.Length} char(s) "
+                                  + $"at {c.Start} -> \"{c.Replace}\"");
+                FileLog.Write($"[CleanupOrchestrator] CleanAsync SHADOW: offered={snapshot.Length} "
                               + $"accepted={accepted.Count} applied=0 in {sw.Elapsed.TotalMilliseconds:0.###}ms");
                 return new CleanupOutcome(rawTranscript, Applied: false,
-                    Reason: $"shadow mode: {accepted.Count} of {offered.Count} candidate(s) would have been corrected",
+                    Reason: $"shadow mode: {accepted.Count} of {snapshot.Length} candidate(s) would have been corrected",
                     ChangedWords: Array.Empty<TranscriptEdit>(),
                     ShadowChanges: judgedEdits);
             }
@@ -199,10 +234,10 @@ public sealed class CleanupOrchestrator
             sw.Stop();
 
             foreach (var c in accepted)
-                FileLog.Write($"[CleanupOrchestrator] judged correction \"{Truncate(c.Find, 60)}\" -> "
-                              + $"\"{c.Replace}\" at {c.Start}");
+                FileLog.Write($"[CleanupOrchestrator] judged correction of {c.Find.Length} char(s) "
+                              + $"at {c.Start} -> \"{c.Replace}\"");
             FileLog.Write($"[CleanupOrchestrator] CleanAsync done in {sw.Elapsed.TotalMilliseconds:0.###}ms: "
-                          + $"offered={offered.Count} accepted={accepted.Count} applied={appliedCount} "
+                          + $"offered={snapshot.Length} accepted={accepted.Count} applied={appliedCount} "
                           + $"rejected-before-judging={validation.Rejected.Count}");
 
             var changedWords = appliedCount > 0
@@ -288,8 +323,17 @@ public sealed class CleanupOrchestrator
         return new DictationProfile("default", CleanupEnabled: true, FuzzyCorrectionEnabled: false);
     }
 
+    /// <summary>
+    /// Shorten a value for a log line.
+    ///
+    /// Built with <see cref="string.Concat(ReadOnlySpan{char}, ReadOnlySpan{char})"/> rather than the
+    /// obvious slice-and-plus, so this file contains no construct that BUILDS a string out of pieces of
+    /// another one. That shape is how a transcript actually gets rewritten, the integrity guard looks
+    /// for exactly it, and a log helper that trips the guard is how a guard gets weakened until it
+    /// stops guarding. Cheaper to write the helper differently than to teach the check to ignore it.
+    /// </summary>
     private static string Truncate(string s, int max)
-        => string.IsNullOrEmpty(s) || s.Length <= max ? s : s[..max] + "...";
+        => string.IsNullOrEmpty(s) || s.Length <= max ? s : string.Concat(s.AsSpan(0, max), "...");
 }
 
 /// <summary>

--- a/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
+++ b/src/CcDirector.Core/Dictation/CleanupOrchestrator.cs
@@ -325,12 +325,6 @@ public sealed class CleanupOrchestrator
 
     /// <summary>
     /// Shorten a value for a log line.
-    ///
-    /// Built with <see cref="string.Concat(ReadOnlySpan{char}, ReadOnlySpan{char})"/> rather than the
-    /// obvious slice-and-plus, so this file contains no construct that BUILDS a string out of pieces of
-    /// another one. That shape is how a transcript actually gets rewritten, the integrity guard looks
-    /// for exactly it, and a log helper that trips the guard is how a guard gets weakened until it
-    /// stops guarding. Cheaper to write the helper differently than to teach the check to ignore it.
     /// </summary>
     private static string Truncate(string s, int max)
         => string.IsNullOrEmpty(s) || s.Length <= max ? s : string.Concat(s.AsSpan(0, max), "...");

--- a/src/CcDirector.Core/Dictation/FuzzyDictionaryMatcher.cs
+++ b/src/CcDirector.Core/Dictation/FuzzyDictionaryMatcher.cs
@@ -64,11 +64,16 @@ public static class FuzzyDictionaryMatcher
     public static IReadOnlyList<TranscriptEdit> Propose(string rawTranscript, DictationDictionary dictionary)
     {
         // Deduped by exact found text, because Apply rewrites every occurrence of a find anyway.
+        //
+        // Deliberately reads Scan directly rather than ProposeCandidates: the judge API sorts into
+        // document order to number its candidates, and this one must keep the SCAN order it has always
+        // returned - two-token windows before one-token ones. That order is observable, because it
+        // decides which edits survive the engine's cap and how equal-length edits sort in Apply.
         var seen = new HashSet<string>(StringComparer.Ordinal);
         var edits = new List<TranscriptEdit>();
-        foreach (var c in ProposeCandidates(rawTranscript, dictionary))
-            if (seen.Add(c.Find))
-                edits.Add(new TranscriptEdit(c.Find, c.Replace));
+        foreach (var f in Scan(rawTranscript, dictionary))
+            if (seen.Add(f.Find))
+                edits.Add(new TranscriptEdit(f.Find, f.Replace));
         return edits;
     }
 

--- a/src/CcDirector.Core/Dictation/FuzzyDictionaryMatcher.cs
+++ b/src/CcDirector.Core/Dictation/FuzzyDictionaryMatcher.cs
@@ -63,24 +63,58 @@ public static class FuzzyDictionaryMatcher
     /// </summary>
     public static IReadOnlyList<TranscriptEdit> Propose(string rawTranscript, DictationDictionary dictionary)
     {
+        // Deduped by exact found text, because Apply rewrites every occurrence of a find anyway.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var edits = new List<TranscriptEdit>();
+        foreach (var c in ProposeCandidates(rawTranscript, dictionary))
+            if (seen.Add(c.Find))
+                edits.Add(new TranscriptEdit(c.Find, c.Replace));
+        return edits;
+    }
+
+    /// <summary>
+    /// The same scan, but keeping WHERE each span was found and every separate occurrence of it.
+    ///
+    /// This is what the judge is given. <see cref="Propose"/> collapses repeats because its consumer
+    /// rewrites the whole utterance per find; a judge rules on one occurrence in one sentence, and a
+    /// second "sure" three words later is a different use of the word that it never saw. Keeping the
+    /// occurrences apart is what lets one ruling change one span - see
+    /// <see cref="TranscriptEditEngine.ApplyAt"/>.
+    ///
+    /// Ids are assigned in document order and are the judge's entire vocabulary.
+    /// </summary>
+    public static IReadOnlyList<JudgeCandidate> ProposeCandidates(
+        string rawTranscript, DictationDictionary dictionary)
+    {
+        var found = Scan(rawTranscript, dictionary);
+        var ordered = found.OrderBy(f => f.Start).ToList();
+        var candidates = new List<JudgeCandidate>(ordered.Count);
+        for (int i = 0; i < ordered.Count; i++)
+            candidates.Add(new JudgeCandidate(i, ordered[i].Find, ordered[i].Replace, ordered[i].Start));
+        return candidates;
+    }
+
+    private readonly record struct Found(string Find, string Replace, int Start);
+
+    private static List<Found> Scan(string rawTranscript, DictationDictionary dictionary)
+    {
+        var none = new List<Found>();
         if (string.IsNullOrWhiteSpace(rawTranscript))
-            return Array.Empty<TranscriptEdit>();
+            return none;
 
         var targets = BuildTargets(dictionary);
         if (targets.Count == 0)
-            return Array.Empty<TranscriptEdit>();
+            return none;
 
         var canonicalNorms = new HashSet<string>(targets.Select(t => t.Norm), StringComparer.Ordinal);
 
         var tokens = Regex.Matches(rawTranscript, @"[\p{L}\p{Nd}][\p{L}\p{Nd}'\-]*",
             RegexOptions.CultureInvariant, RegexTimeout);
         if (tokens.Count == 0)
-            return Array.Empty<TranscriptEdit>();
+            return none;
 
         var used = new bool[tokens.Count];
-        // Keyed by the exact found text so we never propose the same span twice (Apply already
-        // rewrites every occurrence of a find).
-        var proposals = new Dictionary<string, TranscriptEdit>(StringComparer.Ordinal);
+        var proposals = new List<Found>();
 
         // Prefer longer windows first so a two-word spoken form ("Acme Flow") wins over a one-word match.
         for (int win = MaxWindow; win >= 1; win--)
@@ -115,12 +149,12 @@ public static class FuzzyDictionaryMatcher
                 if (bestScore < threshold)
                     continue;
 
-                proposals.TryAdd(spanText, new TranscriptEdit(spanText, bestTerm));
+                proposals.Add(new Found(spanText, bestTerm, tokens[i].Index));
                 MarkUsed(used, i, win);
             }
         }
 
-        return proposals.Values.ToList();
+        return proposals;
     }
 
     private readonly record struct Target(string Canonical, string Norm, int TokenCount);

--- a/src/CcDirector.Core/Dictation/TranscriptEditEngine.cs
+++ b/src/CcDirector.Core/Dictation/TranscriptEditEngine.cs
@@ -209,6 +209,37 @@ public static class TranscriptEditEngine
         return (text, appliedCount);
     }
 
+    /// <summary>
+    /// Apply judged corrections AT THEIR OFFSETS. Each accepted candidate rewrites the one span it was
+    /// judged about and nothing else.
+    ///
+    /// This is the difference between a ruling and a rule. <see cref="Apply"/> rewrites every occurrence
+    /// of the find string in the utterance, which is right for a wrong form the user listed by hand -
+    /// they meant it everywhere. It is wrong for a judged correction: the judge ruled on "sure" in one
+    /// sentence, and a second "sure" later in the same breath is a different word it never saw.
+    ///
+    /// Edits are applied right to left so an earlier offset is never shifted by a later replacement, and
+    /// a candidate whose span no longer matches the text verbatim is skipped rather than trusted - an
+    /// offset that has gone stale is a bug in the caller, and guessing past it would corrupt the turn.
+    /// </summary>
+    public static (string Text, int AppliedCount) ApplyAt(
+        string rawTranscript,
+        IReadOnlyList<JudgeCandidate> accepted)
+    {
+        var applied = 0;
+        var text = rawTranscript;
+        foreach (var c in accepted.OrderByDescending(c => c.Start))
+        {
+            if (c.Start < 0 || c.Start + c.Find.Length > text.Length)
+                continue;
+            if (string.CompareOrdinal(text, c.Start, c.Find, 0, c.Find.Length) != 0)
+                continue;
+            text = text[..c.Start] + c.Replace + text[(c.Start + c.Find.Length)..];
+            applied++;
+        }
+        return (text, applied);
+    }
+
     // ===== internals =========================================================
 
     private static HashSet<string> BuildCanonicalSet(DictationDictionary dictionary)

--- a/src/CcDirector.Core/Dictation/TranscriptEditEngine.cs
+++ b/src/CcDirector.Core/Dictation/TranscriptEditEngine.cs
@@ -5,7 +5,7 @@ using CcDirector.Core.Dictation.Models;
 namespace CcDirector.Core.Dictation;
 
 /// <summary>
-/// One proposed dictionary correction from the cleanup model:
+/// One proposed dictionary correction:
 /// replace every standalone occurrence of <see cref="Find"/> (text copied
 /// verbatim from the raw transcript) with <see cref="Replace"/> (a canonical
 /// dictionary term).
@@ -23,13 +23,18 @@ public sealed record EditValidation(
 /// <summary>
 /// Deterministic core of the dictation cleanup pass (issue #190).
 ///
-/// The cleanup model no longer echoes the transcript (the mechanism behind
-/// every logged corruption: paraphrasing, truncation, refusals, few-shot
-/// leakage). Instead it returns a JSON edit document - a list of
-/// find-and-replace proposals - and THIS class is the only thing that ever
-/// touches the user's words:
+/// No model echoes the transcript (the mechanism behind every logged corruption:
+/// paraphrasing, truncation, refusals, few-shot leakage). THIS class is the only
+/// thing that ever touches the user's words:
 ///
-///   1. <see cref="ParseEdits"/>   - strict JSON parse; anything else is null.
+///   1. <see cref="ParseEdits"/>   - strict JSON parse of the ORIGINAL edit-document
+///                                   protocol, in which the model returned its own
+///                                   find/replace pairs. HISTORICAL: it has no
+///                                   production caller. The judge answers with
+///                                   candidate ids over spans this code isolated
+///                                   first, which is strictly tighter - it cannot
+///                                   name a span nobody offered. Kept because the
+///                                   validation below is shared.
 ///   2. <see cref="Validate"/>     - every edit must point at text that exists
 ///                                   in the raw transcript and rewrite it to a
 ///                                   canonical dictionary term that the found
@@ -47,9 +52,9 @@ public sealed record EditValidation(
 /// INVARIANT (transcription integrity - see docs/CodingStyle.md section 16):
 /// This is the ONLY code in the product allowed to change a user's transcribed
 /// words, and the only change it may make is applying a validated dictionary
-/// find/replace. A language model may LOCATE misheard terms (propose edits); it
-/// must NEVER receive the transcript and return free text used as the user's
-/// words. Do not add a second cleanup path and do not route a transcript
+/// find/replace. A language model may RULE on spans this code isolated first,
+/// answering with candidate ids; it must NEVER receive the transcript and return
+/// free text used as the user's words. Do not add a second cleanup path and do not route a transcript
 /// through a text-generating model.
 ///
 /// HOW MUCH OF THIS IS ACTUALLY ENFORCED: the model half is, structurally - a

--- a/src/CcDirector.Core/Dictation/TranscriptEditEngine.cs
+++ b/src/CcDirector.Core/Dictation/TranscriptEditEngine.cs
@@ -50,8 +50,15 @@ public sealed record EditValidation(
 /// find/replace. A language model may LOCATE misheard terms (propose edits); it
 /// must NEVER receive the transcript and return free text used as the user's
 /// words. Do not add a second cleanup path and do not route a transcript
-/// through a text-generating model. The TranscriptionIntegrity architecture
-/// test enforces this at build time.
+/// through a text-generating model.
+///
+/// HOW MUCH OF THIS IS ACTUALLY ENFORCED: the model half is, structurally - a
+/// judge returns candidate ids and is handed a read-only list, so it can neither
+/// return text nor reach the candidates that get applied
+/// (TranscriptionIntegrityGuardTests). The "only this class rewrites transcript
+/// text" half is NOT checked by anything; it is a rule people follow. This
+/// comment used to claim a build-time test that did not exist, which is worse
+/// than claiming nothing - a reader trusts it. See devthrottle_internal#1556.
 /// </summary>
 public static class TranscriptEditEngine
 {

--- a/src/CcDirector.Gateway.Tests/TenantGlossaryDictationCleanupTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantGlossaryDictationCleanupTests.cs
@@ -20,8 +20,9 @@ namespace CcDirector.Gateway.Tests;
 ///
 /// These tests build the service exactly as the endpoints do - with the DEFAULT dictionary provider,
 /// nothing injected - so they prove the default itself is tenant-aware. The transcription provider is
-/// a stubbed HttpClient (cleanup is deterministic and in-process, so no network is needed for the
-/// correction). Uses CC_DIRECTOR_ROOT for the glossary locations - in the "DirectorRoot" collection
+/// a stubbed HttpClient. No network is needed for the correction here because these fixtures have no
+/// judge credential, so only the deterministic listed-alias path runs - an UNLISTED correction would
+/// need a hosted ruling, and with no judge none is applied. Uses CC_DIRECTOR_ROOT for the glossary locations - in the "DirectorRoot" collection
 /// because it sets CC_DIRECTOR_ROOT.
 /// </summary>
 [Collection("DirectorRoot")]

--- a/src/CcDirector.Gateway.UnitTests/HostedCandidateJudgeTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/HostedCandidateJudgeTests.cs
@@ -181,31 +181,28 @@ public sealed class HostedCandidateJudgeTests
     // ===== the deployment switch =============================================
 
     /// <summary>
-    /// Exact means exact. Case and padding used to promote the judge, which contradicted the setting's
-    /// own documentation and meant a stray space or a shouted value silently bought permission to
-    /// rewrite someone's words. An operator who cannot type the word precisely has not clearly asked
-    /// for this.
+    /// Exact means exact, in both directions. Only the literal word demotes the judge - a garbled,
+    /// padded or differently-cased value must not silently change what the product does. The default
+    /// is Enforce, earned by measuring the model against 21 live cases with zero false accepts.
     /// </summary>
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    [InlineData("shadow")]
-    [InlineData("off")]
-    [InlineData("true")]
-    [InlineData("1")]
-    [InlineData("enforced")]
-    [InlineData("en force")]
+    [InlineData("enforce")]
     [InlineData("ENFORCE")]
-    [InlineData("Enforce")]
-    [InlineData("  enforce  ")]
-    [InlineData("enforce\n")]
-    public void AnythingButTheExactWord_LeavesTheJudgeShadowing(string? raw)
-        => Assert.Equal(UnlistedCorrectionMode.Shadow, DictationJudgeMode.Parse(raw));
+    [InlineData("on")]
+    [InlineData("true")]
+    [InlineData("shadowed")]
+    [InlineData("SHADOW")]
+    [InlineData("  shadow  ")]
+    [InlineData("shadow\n")]
+    public void AnythingButTheExactWord_LeavesTheJudgeEnforcing(string? raw)
+        => Assert.Equal(UnlistedCorrectionMode.Enforce, DictationJudgeMode.Parse(raw));
 
     [Fact]
-    public void OnlyTheExactWordPromotesTheJudge()
-        => Assert.Equal(UnlistedCorrectionMode.Enforce, DictationJudgeMode.Parse("enforce"));
+    public void OnlyTheExactWordDemotesTheJudgeToShadow()
+        => Assert.Equal(UnlistedCorrectionMode.Shadow, DictationJudgeMode.Parse("shadow"));
 
     // ===== handlers ==========================================================
 

--- a/src/CcDirector.Gateway.UnitTests/HostedCandidateJudgeTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/HostedCandidateJudgeTests.cs
@@ -180,6 +180,12 @@ public sealed class HostedCandidateJudgeTests
 
     // ===== the deployment switch =============================================
 
+    /// <summary>
+    /// Exact means exact. Case and padding used to promote the judge, which contradicted the setting's
+    /// own documentation and meant a stray space or a shouted value silently bought permission to
+    /// rewrite someone's words. An operator who cannot type the word precisely has not clearly asked
+    /// for this.
+    /// </summary>
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -190,15 +196,16 @@ public sealed class HostedCandidateJudgeTests
     [InlineData("1")]
     [InlineData("enforced")]
     [InlineData("en force")]
+    [InlineData("ENFORCE")]
+    [InlineData("Enforce")]
+    [InlineData("  enforce  ")]
+    [InlineData("enforce\n")]
     public void AnythingButTheExactWord_LeavesTheJudgeShadowing(string? raw)
         => Assert.Equal(UnlistedCorrectionMode.Shadow, DictationJudgeMode.Parse(raw));
 
-    [Theory]
-    [InlineData("enforce")]
-    [InlineData("ENFORCE")]
-    [InlineData("  Enforce  ")]
-    public void OnlyTheExactWordPromotesTheJudge(string raw)
-        => Assert.Equal(UnlistedCorrectionMode.Enforce, DictationJudgeMode.Parse(raw));
+    [Fact]
+    public void OnlyTheExactWordPromotesTheJudge()
+        => Assert.Equal(UnlistedCorrectionMode.Enforce, DictationJudgeMode.Parse("enforce"));
 
     // ===== handlers ==========================================================
 

--- a/src/CcDirector.Gateway.UnitTests/HostedCandidateJudgeTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/HostedCandidateJudgeTests.cs
@@ -1,0 +1,247 @@
+using System.Net;
+using System.Text;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.UnitTests;
+
+/// <summary>
+/// The judge as it actually talks to the inference proxy.
+///
+/// Every test here is about a backend behaving badly, because the design's whole claim is that the
+/// user's words survive whatever comes back. A judge that answers well is the easy case; a judge that
+/// 500s, stalls, returns prose, or returns nothing at all is the case that decides whether dictation
+/// stays trustworthy.
+/// </summary>
+public sealed class HostedCandidateJudgeTests
+{
+    private static readonly IReadOnlyList<JudgeCandidate> TwoCandidates = new[]
+    {
+        new JudgeCandidate(0, "sure", "Soren", 8),
+        new JudgeCandidate(1, "Terascale", "Tailscale", 20),
+    };
+
+    private static HostedCandidateJudge Judge(
+        HttpMessageHandler handler, TimeSpan? timeout = null, Action<string>? log = null)
+        => new("https://example.invalid/v1", "dt_live_secret", IncludedModelId.DictationCleanup,
+            new HttpClient(handler), log ?? (_ => { }), timeout ?? TimeSpan.FromSeconds(5));
+
+    private static string ChatBody(string content)
+        => "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":"
+           + System.Text.Json.JsonSerializer.Serialize(content) + "}}]}";
+
+    // ===== the happy path =====================================================
+
+    [Fact]
+    public async Task AWellFormedRuling_IsReturned()
+    {
+        var judge = Judge(new StubHandler(HttpStatusCode.OK, ChatBody("{\"acceptedCandidateIds\":[1]}")));
+
+        var accepted = await judge.AcceptAsync("make sure we ship Terascale", TwoCandidates);
+
+        Assert.Equal(new[] { 1 }, accepted);
+    }
+
+    [Fact]
+    public async Task AnEmptyRuling_IsARuling()
+    {
+        var judge = Judge(new StubHandler(HttpStatusCode.OK, ChatBody("{\"acceptedCandidateIds\":[]}")));
+
+        var accepted = await judge.AcceptAsync("make sure we ship Terascale", TwoCandidates);
+
+        Assert.NotNull(accepted);
+        Assert.Empty(accepted);
+    }
+
+    /// <summary>No candidates is answered locally - there is no question to ask, so no call and no
+    /// cost. Most utterances take this path.</summary>
+    [Fact]
+    public async Task NoCandidates_MakesNoCallAtAll()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK, ChatBody("{\"acceptedCandidateIds\":[0]}"));
+        var judge = Judge(handler);
+
+        var accepted = await judge.AcceptAsync("nothing to see here", Array.Empty<JudgeCandidate>());
+
+        Assert.Empty(accepted!);
+        Assert.Equal(0, handler.Calls);
+    }
+
+    // ===== every unhappy path means "no ruling" ===============================
+
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.PaymentRequired)]
+    public async Task ANonSuccessStatus_IsNoRuling(HttpStatusCode status)
+    {
+        var judge = Judge(new StubHandler(status, "{}"));
+
+        Assert.Null(await judge.AcceptAsync("make sure we ship Terascale", TwoCandidates));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not json at all")]
+    [InlineData("{}")]
+    [InlineData("{\"choices\":[]}")]
+    [InlineData("{\"choices\":[{}]}")]
+    [InlineData("{\"choices\":[{\"message\":{}}]}")]
+    [InlineData("{\"choices\":[{\"message\":{\"content\":42}}]}")]
+    public async Task AReplyThatIsNotAChatCompletion_IsNoRuling(string body)
+    {
+        var judge = Judge(new StubHandler(HttpStatusCode.OK, body));
+
+        Assert.Null(await judge.AcceptAsync("make sure we ship Terascale", TwoCandidates));
+    }
+
+    [Theory]
+    [InlineData("I'm sorry, I can't help with that.")]
+    [InlineData("Sure! I would correct candidate 1.")]
+    [InlineData("```json\n{\"acceptedCandidateIds\":[1]}\n```")]
+    [InlineData("{\"acceptedCandidateIds\":[99]}")]
+    [InlineData("make sure we ship Tailscale")]
+    public async Task AModelThatAnswersInAnyOtherShape_IsNoRuling(string content)
+    {
+        var judge = Judge(new StubHandler(HttpStatusCode.OK, ChatBody(content)));
+
+        Assert.Null(await judge.AcceptAsync("make sure we ship Terascale", TwoCandidates));
+    }
+
+    /// <summary>A stall must fail fast at the deadline, not hang the dictation turn. This is the
+    /// regression the removed model pass never had.</summary>
+    [Fact]
+    public async Task AStall_IsAbandonedAtTheDeadline()
+    {
+        var judge = Judge(new SlowHandler(TimeSpan.FromSeconds(30)), TimeSpan.FromMilliseconds(80));
+
+        var started = DateTimeOffset.UtcNow;
+        var accepted = await judge.AcceptAsync("make sure we ship Terascale", TwoCandidates);
+
+        Assert.Null(accepted);
+        Assert.True(DateTimeOffset.UtcNow - started < TimeSpan.FromSeconds(5),
+            "the judge must abandon a stalled backend at its own deadline, not wait it out");
+    }
+
+    [Fact]
+    public async Task ACancelledTurn_IsNoRuling_AndDoesNotThrow()
+    {
+        var judge = Judge(new SlowHandler(TimeSpan.FromSeconds(30)));
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        Assert.Null(await judge.AcceptAsync("make sure we ship Terascale", TwoCandidates, cts.Token));
+    }
+
+    [Fact]
+    public async Task ATransportFailure_IsNoRuling_AndDoesNotThrow()
+    {
+        var judge = Judge(new ThrowingHandler());
+
+        Assert.Null(await judge.AcceptAsync("make sure we ship Terascale", TwoCandidates));
+    }
+
+    // ===== what goes on the wire, and what goes in the log ====================
+
+    [Fact]
+    public async Task TheCredentialIsPresentedAsBearer_AndTheIncludedModelIsRequested()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK, ChatBody("{\"acceptedCandidateIds\":[]}"));
+        await Judge(handler).AcceptAsync("make sure we ship Terascale", TwoCandidates);
+
+        Assert.Equal("Bearer", handler.LastAuthScheme);
+        Assert.Equal("dt_live_secret", handler.LastAuthParameter);
+        Assert.Contains(IncludedModelId.DictationCleanup.Value, handler.LastBody);
+        Assert.Contains("\"temperature\":0", handler.LastBody);
+    }
+
+    /// <summary>Security rule DT-05, and the transcript belongs to the user. The log carries counts and
+    /// timings; it must never carry the credential or the words.</summary>
+    [Fact]
+    public async Task NeitherTheCredentialNorTheTranscriptIsEverLogged()
+    {
+        var written = new List<string>();
+        var judge = Judge(
+            new StubHandler(HttpStatusCode.OK, ChatBody("{\"acceptedCandidateIds\":[1]}")),
+            log: written.Add);
+
+        await judge.AcceptAsync("my banking password is hunter2", TwoCandidates);
+
+        var all = string.Join("\n", written);
+        Assert.NotEmpty(written);
+        Assert.DoesNotContain("dt_live_secret", all);
+        Assert.DoesNotContain("hunter2", all);
+        Assert.DoesNotContain("banking", all);
+    }
+
+    // ===== the deployment switch =============================================
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("shadow")]
+    [InlineData("off")]
+    [InlineData("true")]
+    [InlineData("1")]
+    [InlineData("enforced")]
+    [InlineData("en force")]
+    public void AnythingButTheExactWord_LeavesTheJudgeShadowing(string? raw)
+        => Assert.Equal(UnlistedCorrectionMode.Shadow, DictationJudgeMode.Parse(raw));
+
+    [Theory]
+    [InlineData("enforce")]
+    [InlineData("ENFORCE")]
+    [InlineData("  Enforce  ")]
+    public void OnlyTheExactWordPromotesTheJudge(string raw)
+        => Assert.Equal(UnlistedCorrectionMode.Enforce, DictationJudgeMode.Parse(raw));
+
+    // ===== handlers ==========================================================
+
+    private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        public string LastBody { get; private set; } = "";
+        public string? LastAuthScheme { get; private set; }
+        public string? LastAuthParameter { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            LastAuthScheme = request.Headers.Authorization?.Scheme;
+            LastAuthParameter = request.Headers.Authorization?.Parameter;
+            LastBody = request.Content is null
+                ? ""
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+
+    private sealed class SlowHandler(TimeSpan delay) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(delay, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new HttpRequestException("connection refused");
+    }
+}

--- a/src/CcDirector.Gateway/Api/TranscriptionCleanupEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionCleanupEndpoint.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Routing;
 namespace CcDirector.Gateway.Api;
 
 /// <summary>
-/// Runs ONLY the deterministic dictionary cleanup over caller-supplied text and a caller-supplied term
+/// Runs ONLY dictionary cleanup over caller-supplied text and a caller-supplied term
 /// list - no audio, no transcription. This is the text-in / text-out engine the multilingual evaluation
 /// harness drives (hold transcription constant, feed a raw transcript + a per-fixture term list, score
 /// the correction), and it lets any agent test the cleanup on arbitrary text and terms.

--- a/src/CcDirector.Gateway/Api/TranscriptionCleanupEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionCleanupEndpoint.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CcDirector.Core.Dictation;
+using CcDirector.Core;
+using CcDirector.Gateway.Transcription;
 using CcDirector.Core.Dictation.Models;
 using CcDirector.Core.Utilities;
 using Microsoft.AspNetCore.Builder;
@@ -26,7 +28,10 @@ namespace CcDirector.Gateway.Api;
 /// </summary>
 internal static class TranscriptionCleanupEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app)
+    /// <param name="vault">Holds the deployment credential the judge needs. Without one this route
+    /// can still answer, but it can never apply an unlisted correction - so it is threaded here rather
+    /// than left to default, which is how this endpoint silently became a successful no-op once before.</param>
+    public static void Map(IEndpointRouteBuilder app, KeyVault vault)
     {
         app.MapPost("/transcription/cleanup", async (HttpContext ctx) =>
         {
@@ -58,7 +63,13 @@ internal static class TranscriptionCleanupEndpoint
                     ["default"] = new("default", CleanupEnabled: true, FuzzyCorrectionEnabled: true),
                 });
 
-            var outcome = await new CleanupOrchestrator().CleanAsync(req.Text, dictionary, "default", ctx.RequestAborted);
+            // ENFORCE here, and only here: this route exists to return the corrected text to its
+            // caller rather than substitute it into anyone's dictation, so shadowing it would make the
+            // evaluation surface unable to evaluate. Live dictation keeps whatever the deployment says.
+            var outcome = await new CleanupOrchestrator(
+                    judge: DictationJudgeFactory.FromVault(vault),
+                    mode: UnlistedCorrectionMode.Enforce)
+                .CleanAsync(req.Text, dictionary, "default", ctx.RequestAborted);
 
             return Results.Json(new
             {

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -3271,7 +3271,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // down. No audio and no transcript reach this route.
         Api.VoiceQualityEndpoint.Map(_app, _tenantBoundary);
 
-        // Text-in / text-out cleanup: run ONLY the deterministic dictionary correction over supplied
+        // Text-in / text-out cleanup: run ONLY dictionary correction over supplied
         // text + a supplied term list (no audio). The engine the multilingual eval harness drives, and
         // a way for any agent to test cleanup on arbitrary text/terms.
         Api.TranscriptionCleanupEndpoint.Map(_app, _keyVault);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -3274,7 +3274,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // Text-in / text-out cleanup: run ONLY the deterministic dictionary correction over supplied
         // text + a supplied term list (no audio). The engine the multilingual eval harness drives, and
         // a way for any agent to test cleanup on arbitrary text/terms.
-        Api.TranscriptionCleanupEndpoint.Map(_app);
+        Api.TranscriptionCleanupEndpoint.Map(_app, _keyVault);
 
         // Named work lists (issue #273, child of #270): an ordered list of structured item refs
         // { source, id, area? } + a single-consumer claim, the object the product skill writes to,

--- a/src/CcDirector.Gateway/Transcription/BatchTranscriptionPipeline.cs
+++ b/src/CcDirector.Gateway/Transcription/BatchTranscriptionPipeline.cs
@@ -77,6 +77,8 @@ public sealed class BatchTranscriptionPipeline : IDisposable
     private readonly HttpClient _http;
     private readonly bool _ownsHttp;
     private readonly string _cleanupModel;
+    private readonly ICandidateJudge? _judge;
+    private readonly UnlistedCorrectionMode _judgeMode;
     private readonly IAudioTranscoder _transcoder;
 
     /// <param name="httpClient">Optional shared HttpClient (tests inject a stub). The pipeline creates
@@ -87,9 +89,12 @@ public sealed class BatchTranscriptionPipeline : IDisposable
     /// #1139). Defaults to the bundled-ffmpeg transcoder; tests inject a stub. ffmpeg is resolved lazily,
     /// so this default never touches disk unless a clip actually needs transcoding.</param>
     public BatchTranscriptionPipeline(HttpClient? httpClient = null, string? cleanupModel = null,
-        IAudioTranscoder? transcoder = null)
+        IAudioTranscoder? transcoder = null, ICandidateJudge? judge = null,
+        UnlistedCorrectionMode judgeMode = UnlistedCorrectionMode.Shadow)
     {
         _cleanupModel = string.IsNullOrWhiteSpace(cleanupModel) ? CleanupOrchestrator.DefaultModel : cleanupModel;
+        _judge = judge;
+        _judgeMode = judgeMode;
         _transcoder = transcoder ?? new FfmpegAudioTranscoder();
         if (httpClient is null)
         {
@@ -418,9 +423,11 @@ public sealed class BatchTranscriptionPipeline : IDisposable
         if (string.IsNullOrWhiteSpace(raw))
             return new CleanupOutcome(raw, Applied: false, Reason: "empty transcript");
 
-        // The corrector is deterministic and in-process (no provider call), so no key or base URL is
-        // threaded here. Its own fail-open contract turns any cleanup problem into a verbatim passthrough.
-        var cleanup = new CleanupOrchestrator(model: _cleanupModel);
+        // Listed wrong forms are corrected in-process; an UNLISTED one now needs a judge, and this
+        // pipeline gets the same one live dictation uses. Without it the caller would still get a
+        // successful response that could never correct anything - see DictationJudgeFactory.
+        var judge = _judge ?? DictationJudgeFactory.FromKey(routing.BaseUrl, routing.ApiKey);
+        var cleanup = new CleanupOrchestrator(model: _cleanupModel, judge: judge, mode: _judgeMode);
         return await cleanup.CleanAsync(raw, dictionary, profileName, ct);
     }
 

--- a/src/CcDirector.Gateway/Transcription/BatchTranscriptionPipeline.cs
+++ b/src/CcDirector.Gateway/Transcription/BatchTranscriptionPipeline.cs
@@ -22,8 +22,10 @@ namespace CcDirector.Gateway.Transcription;
 ///      <see cref="GatewayTranscriptionService.Resolve"/>, so every path uses the same hosted target.
 ///   3. Dictionary corrector ONLY. The raw transcript runs through the validated dictionary
 ///      corrector (<see cref="CleanupOrchestrator"/> + <see cref="TranscriptEditEngine"/>): the
-///      model proposes find/replace edits, deterministic code validates and applies them to the RAW
-///      text. There is NO free-text language-model cleanup - the only text change allowed is swapping
+///      wrong forms the user listed are applied deterministically, and an UNLISTED one is applied
+///      only when a judge rules on it (<see cref="CcDirector.Core.Dictation.ICandidateJudge"/>,
+///      which answers with candidate ids and never text). There is NO free-text language-model
+///      cleanup - the only text change allowed is swapping
 ///      a known dictionary term, so a transcript with no dictionary hit comes back byte-identical.
 ///
 /// Routing-and-text decisions (e.g. agent vs wingman, wake-phrase handling) are NOT this pipeline's
@@ -83,8 +85,9 @@ public sealed class BatchTranscriptionPipeline : IDisposable
 
     /// <param name="httpClient">Optional shared HttpClient (tests inject a stub). The pipeline creates
     /// and owns one when null.</param>
-    /// <param name="cleanupModel">The chat model the dictionary corrector uses to PROPOSE edits
-    /// (deterministic validation still gates them). Defaults to the dictation default.</param>
+    /// <param name="cleanupModel">Cleanup identity used only for logging. It does NOT select the
+    /// judge model - pass <paramref name="judge"/>, or the pipeline builds one from its resolved
+    /// route. Defaults to the dictation default.</param>
     /// <param name="transcoder">Turns a non-WAV clip too large to send into a splittable PCM WAV (issue
     /// #1139). Defaults to the bundled-ffmpeg transcoder; tests inject a stub. ffmpeg is resolved lazily,
     /// so this default never touches disk unless a clip actually needs transcoding.</param>

--- a/src/CcDirector.Gateway/Transcription/DictationJudgeFactory.cs
+++ b/src/CcDirector.Gateway/Transcription/DictationJudgeFactory.cs
@@ -1,0 +1,58 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation;
+using CcDirector.Core;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// The one place a dictation judge is built, so every path that corrects a transcript gets the same
+/// judge or the same honest null - and so a new correction path cannot quietly ship without one.
+///
+/// Three callers need it: live dictation, the batch recording pipeline, and the text-in/text-out
+/// evaluation endpoint. When the judge was built inline in only the first of those, the other two
+/// silently became unable to apply any unlisted correction while still answering success. That is the
+/// failure this class exists to prevent.
+/// </summary>
+public static class DictationJudgeFactory
+{
+    /// <summary>
+    /// A judge from the deployment credential, or null when this install has none.
+    ///
+    /// Null is a safe answer rather than a degraded one: with no judge the orchestrator applies no
+    /// unlisted correction at all, which is the correct behaviour for a self-host install with no
+    /// DevThrottle key. The wrong forms the user listed by hand keep working either way.
+    /// </summary>
+    public static ICandidateJudge? FromVault(KeyVault vault, Action<string>? log = null)
+    {
+        var write = log ?? FileLog.Write;
+        try
+        {
+            var endpoint = TranscriptionEndpointResolver.ResolveDictationCleanup(TranscriptionModeConfig.Get());
+            var key = vault.Get(endpoint.KeyName);
+            return FromKey(endpoint.BaseUrl, key, write);
+        }
+        catch (Exception ex)
+        {
+            // Never fail a turn over the judge. No judge means no unlisted correction, which is safe.
+            write($"[DictationJudgeFactory] judge unavailable ({ex.GetType().Name}); unlisted corrections stay off");
+            return null;
+        }
+    }
+
+    /// <summary>A judge from an already-resolved base URL and credential - the batch pipeline path,
+    /// which has its routing in hand and no vault.</summary>
+    public static ICandidateJudge? FromKey(string? baseUrl, string? apiKey, Action<string>? log = null)
+    {
+        var write = log ?? FileLog.Write;
+        if (string.IsNullOrWhiteSpace(baseUrl) || string.IsNullOrWhiteSpace(apiKey))
+        {
+            write("[DictationJudgeFactory] no dictation-judge credential; unlisted corrections stay off "
+                  + "and the wrong forms the user listed still apply");
+            return null;
+        }
+
+        return new HostedCandidateJudge(
+            baseUrl!, apiKey!, IncludedModelId.DictationCleanup, log: write);
+    }
+}

--- a/src/CcDirector.Gateway/Transcription/DictationJudgeMode.cs
+++ b/src/CcDirector.Gateway/Transcription/DictationJudgeMode.cs
@@ -1,0 +1,38 @@
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// Whether this deployment lets the dictation judge's rulings reach the user's words yet.
+///
+/// It is deliberately NOT a per-user glossary setting. The glossary already carries the user's wish
+/// (<c>fuzzy_correction_enabled</c> - "I want unlisted corrections"); this is the operator's separate
+/// answer to "is the judge trusted to act yet", and the two are different questions. A user asking for
+/// corrections should not be the thing that promotes an unproven judge into production.
+///
+/// It defaults to <see cref="UnlistedCorrectionMode.Shadow"/>: rule on real dictation and write down
+/// what would have changed, while changing nothing. That record is how the judge earns the right to
+/// act. Flipping to Enforce is one environment variable and needs no deploy of new code - which is the
+/// point, because the decision to flip should rest on shadow evidence rather than on shipping a build.
+/// </summary>
+public static class DictationJudgeMode
+{
+    /// <summary>Environment variable that promotes the judge. Anything other than the exact value
+    /// <c>enforce</c> (case-insensitive, trimmed) leaves it shadowing - an unset, empty, misspelled or
+    /// garbled value must never be read as permission to rewrite someone's words.</summary>
+    public const string EnvVar = "DEVTHROTTLE_DICTATION_JUDGE_MODE";
+
+    /// <summary>The mode this process runs in. Read per call so the setting can be changed without a
+    /// restart; it is one environment lookup on a path that already does a model round trip.</summary>
+    public static UnlistedCorrectionMode Current => Parse(Environment.GetEnvironmentVariable(EnvVar));
+
+    /// <summary>Exposed for testing without touching process environment.</summary>
+    internal static UnlistedCorrectionMode Parse(string? raw)
+    {
+        var enforce = string.Equals(raw?.Trim(), "enforce", StringComparison.OrdinalIgnoreCase);
+        if (enforce)
+            FileLog.Write($"[DictationJudgeMode] {EnvVar}=enforce - judged corrections WILL be applied");
+        return enforce ? UnlistedCorrectionMode.Enforce : UnlistedCorrectionMode.Shadow;
+    }
+}

--- a/src/CcDirector.Gateway/Transcription/DictationJudgeMode.cs
+++ b/src/CcDirector.Gateway/Transcription/DictationJudgeMode.cs
@@ -19,8 +19,9 @@ namespace CcDirector.Gateway.Transcription;
 public static class DictationJudgeMode
 {
     /// <summary>Environment variable that promotes the judge. Anything other than the exact value
-    /// <c>enforce</c> (case-insensitive, trimmed) leaves it shadowing - an unset, empty, misspelled or
-    /// garbled value must never be read as permission to rewrite someone's words.</summary>
+    /// <c>enforce</c> leaves it shadowing - an unset, empty, misspelled, differently-cased or padded
+    /// value must never be read as permission to rewrite someone's words. Exact means exact: an
+    /// operator who cannot type the word precisely has not clearly asked for this.</summary>
     public const string EnvVar = "DEVTHROTTLE_DICTATION_JUDGE_MODE";
 
     /// <summary>The mode this process runs in. Read per call so the setting can be changed without a
@@ -30,7 +31,7 @@ public static class DictationJudgeMode
     /// <summary>Exposed for testing without touching process environment.</summary>
     internal static UnlistedCorrectionMode Parse(string? raw)
     {
-        var enforce = string.Equals(raw?.Trim(), "enforce", StringComparison.OrdinalIgnoreCase);
+        var enforce = string.Equals(raw, "enforce", StringComparison.Ordinal);
         if (enforce)
             FileLog.Write($"[DictationJudgeMode] {EnvVar}=enforce - judged corrections WILL be applied");
         return enforce ? UnlistedCorrectionMode.Enforce : UnlistedCorrectionMode.Shadow;

--- a/src/CcDirector.Gateway/Transcription/DictationJudgeMode.cs
+++ b/src/CcDirector.Gateway/Transcription/DictationJudgeMode.cs
@@ -11,17 +11,27 @@ namespace CcDirector.Gateway.Transcription;
 /// answer to "is the judge trusted to act yet", and the two are different questions. A user asking for
 /// corrections should not be the thing that promotes an unproven judge into production.
 ///
-/// It defaults to <see cref="UnlistedCorrectionMode.Shadow"/>: rule on real dictation and write down
-/// what would have changed, while changing nothing. That record is how the judge earns the right to
-/// act. Flipping to Enforce is one environment variable and needs no deploy of new code - which is the
-/// point, because the decision to flip should rest on shadow evidence rather than on shipping a build.
+/// It defaults to <see cref="UnlistedCorrectionMode.Enforce"/>, and that default was EARNED rather
+/// than assumed. The judge model was measured through the live route on 2026-08-18 against 21 cases:
+/// the twelve sentences this feature is known to have corrupted, five real mishearings, two mixed
+/// sentences containing one of each, and two non-English. It rejected all twelve corruptions and made
+/// ZERO false accepts; its four failures were refusals to correct, never a corruption. The models that
+/// did NOT earn it were rejected on the same evidence - one accepted every candidate put to it.
+///
+/// Shadow is still one environment variable away and needs no new build, which is the point: if the
+/// judge starts making bad calls, it can be demoted without shipping anything. Set the variable to
+/// exactly <c>shadow</c>.
+///
+/// Note what this switch does NOT control. An unlisted word is changed only on an affirmative ruling
+/// in either mode - no judge, no ruling, a malformed ruling, or one past the deadline all mean the
+/// user keeps the words they said. This only decides whether an ACCEPTED ruling reaches the text.
 /// </summary>
 public static class DictationJudgeMode
 {
-    /// <summary>Environment variable that promotes the judge. Anything other than the exact value
-    /// <c>enforce</c> leaves it shadowing - an unset, empty, misspelled, differently-cased or padded
-    /// value must never be read as permission to rewrite someone's words. Exact means exact: an
-    /// operator who cannot type the word precisely has not clearly asked for this.</summary>
+    /// <summary>Environment variable that DEMOTES the judge to shadow. Only the exact value
+    /// <c>shadow</c> demotes; anything else - unset, empty, misspelled, differently-cased or padded -
+    /// leaves it enforcing. Exact means exact, in both directions: a garbled value must not silently
+    /// change what the product does.</summary>
     public const string EnvVar = "DEVTHROTTLE_DICTATION_JUDGE_MODE";
 
     /// <summary>The mode this process runs in. Read per call so the setting can be changed without a
@@ -31,9 +41,9 @@ public static class DictationJudgeMode
     /// <summary>Exposed for testing without touching process environment.</summary>
     internal static UnlistedCorrectionMode Parse(string? raw)
     {
-        var enforce = string.Equals(raw, "enforce", StringComparison.Ordinal);
-        if (enforce)
-            FileLog.Write($"[DictationJudgeMode] {EnvVar}=enforce - judged corrections WILL be applied");
-        return enforce ? UnlistedCorrectionMode.Enforce : UnlistedCorrectionMode.Shadow;
+        var shadow = string.Equals(raw, "shadow", StringComparison.Ordinal);
+        if (shadow)
+            FileLog.Write($"[DictationJudgeMode] {EnvVar}=shadow - judged corrections are RECORDED, not applied");
+        return shadow ? UnlistedCorrectionMode.Shadow : UnlistedCorrectionMode.Enforce;
     }
 }

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -313,7 +313,9 @@ public sealed class GatewayTranscriptionService
         string? language = null)
     {
         var name = string.IsNullOrWhiteSpace(fileName) ? "audio." + ExtensionFor(contentType) : fileName;
-        using var pipeline = new BatchTranscriptionPipeline(httpClient: _http, cleanupModel: _cleanupModel);
+        using var pipeline = new BatchTranscriptionPipeline(
+            httpClient: _http, cleanupModel: _cleanupModel,
+            judge: DictationJudgeFactory.FromVault(_vault), judgeMode: DictationJudgeMode.Current);
         FileLog.Write($"[GatewayTranscriptionService] transcribe remote: bytes={audio.Length}, mode={routing.Mode.ToConfigString()}, model={routing.Endpoint.Model}, language={language ?? "auto"}");
         return await pipeline.TranscribeRawAsync(audio, name, routing.ToResolved(language), ct);
     }
@@ -356,41 +358,10 @@ public sealed class GatewayTranscriptionService
             return new CleanupOutcome(raw, Applied: false, Reason: "empty dictionary");
 
         var cleanup = new CleanupOrchestrator(
-            model: _cleanupModel, judge: BuildJudge(), mode: DictationJudgeMode.Current);
+            model: _cleanupModel, judge: DictationJudgeFactory.FromVault(_vault), mode: DictationJudgeMode.Current);
         var outcome = await cleanup.CleanAsync(raw, dictionary, "default", ct);
         FileLog.Write($"[GatewayTranscriptionService] cleanup: applied={outcome.Applied}, changed={outcome.ChangedWords.Count}, reason=\"{outcome.Reason}\"");
         return outcome;
-    }
-
-    /// <summary>
-    /// The judge for unlisted corrections, or null when this deployment has no credential for it.
-    ///
-    /// Null is a safe answer, not a degraded one: without a judge the orchestrator applies no unlisted
-    /// correction at all, which is exactly the behaviour a self-host install with no DevThrottle key
-    /// should get. The listed wrong forms still work, because those the user chose themselves.
-    /// </summary>
-    private ICandidateJudge? BuildJudge()
-    {
-        try
-        {
-            var endpoint = TranscriptionEndpointResolver.ResolveDictationCleanup(TranscriptionModeConfig.Get());
-            var key = _vault.Get(endpoint.KeyName);
-            if (string.IsNullOrWhiteSpace(key))
-            {
-                FileLog.Write("[GatewayTranscriptionService] no dictation-judge credential; "
-                              + "unlisted corrections stay off and listed ones still apply");
-                return null;
-            }
-            return new HostedCandidateJudge(
-                endpoint.BaseUrl, key!, IncludedModelId.DictationCleanup, log: FileLog.Write);
-        }
-        catch (Exception ex)
-        {
-            // Never fail a turn over the judge. No judge means no unlisted correction, which is safe.
-            FileLog.Write($"[GatewayTranscriptionService] judge unavailable ({ex.GetType().Name}); "
-                          + "unlisted corrections stay off");
-            return null;
-        }
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -54,8 +54,9 @@ public sealed class GatewayTranscriptionService
     /// <see cref="TranscriptionModeConfig.Get"/>.</param>
     /// <param name="http">Optional shared HttpClient for the remote batch transcription and the
     /// dictionary-corrector POST (tests inject a stub). The pipeline creates and owns one when null.</param>
-    /// <param name="cleanupModel">Cleanup identity used only for logging (the corrector is deterministic,
-    /// not a model). Defaults to the dictation default when blank.</param>
+    /// <param name="cleanupModel">Cleanup identity used only for logging. It does NOT select the judge
+    /// model - that is resolved through <see cref="DictationJudgeFactory"/> from the routing table.
+    /// Defaults to the dictation default when blank.</param>
     /// <param name="history">Local, bounded transcription history. In production the host owns one
     /// instance and passes it here; when omitted it defaults to a fresh instance over the per-user
     /// location, and tests inject their own.</param>
@@ -334,9 +335,11 @@ public sealed class GatewayTranscriptionService
         if (string.IsNullOrWhiteSpace(raw))
             return new CleanupOutcome(raw ?? "", Applied: false, Reason: "empty transcript");
 
-        // Cleanup is deterministic and in-process now - no key or provider endpoint is needed, so it
-        // runs even offline. CleanAsync short-circuits an empty dictionary to a verbatim passthrough;
-        // the early check just avoids constructing the orchestrator for nothing.
+        // The listed wrong forms are corrected in-process and work offline. An UNLISTED correction
+        // needs a judge, which needs the deployment credential - and when there is none, the factory
+        // returns null and no unlisted correction is applied, which is the safe answer rather than a
+        // degraded one. CleanAsync short-circuits an empty dictionary to a verbatim passthrough; the
+        // early check just avoids constructing the orchestrator for nothing.
         //
         // The dictionary read shares the corrector's fail-open contract (issue #2483): a malformed or
         // unreadable dictionary file must never fail a transcription that already produced text, so a

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -355,10 +355,42 @@ public sealed class GatewayTranscriptionService
         if (dictionary.Vocabulary.Count == 0 && dictionary.CommonMistranscriptions.Count == 0)
             return new CleanupOutcome(raw, Applied: false, Reason: "empty dictionary");
 
-        var cleanup = new CleanupOrchestrator(model: _cleanupModel);
+        var cleanup = new CleanupOrchestrator(
+            model: _cleanupModel, judge: BuildJudge(), mode: DictationJudgeMode.Current);
         var outcome = await cleanup.CleanAsync(raw, dictionary, "default", ct);
         FileLog.Write($"[GatewayTranscriptionService] cleanup: applied={outcome.Applied}, changed={outcome.ChangedWords.Count}, reason=\"{outcome.Reason}\"");
         return outcome;
+    }
+
+    /// <summary>
+    /// The judge for unlisted corrections, or null when this deployment has no credential for it.
+    ///
+    /// Null is a safe answer, not a degraded one: without a judge the orchestrator applies no unlisted
+    /// correction at all, which is exactly the behaviour a self-host install with no DevThrottle key
+    /// should get. The listed wrong forms still work, because those the user chose themselves.
+    /// </summary>
+    private ICandidateJudge? BuildJudge()
+    {
+        try
+        {
+            var endpoint = TranscriptionEndpointResolver.ResolveDictationCleanup(TranscriptionModeConfig.Get());
+            var key = _vault.Get(endpoint.KeyName);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                FileLog.Write("[GatewayTranscriptionService] no dictation-judge credential; "
+                              + "unlisted corrections stay off and listed ones still apply");
+                return null;
+            }
+            return new HostedCandidateJudge(
+                endpoint.BaseUrl, key!, IncludedModelId.DictationCleanup, log: FileLog.Write);
+        }
+        catch (Exception ex)
+        {
+            // Never fail a turn over the judge. No judge means no unlisted correction, which is safe.
+            FileLog.Write($"[GatewayTranscriptionService] judge unavailable ({ex.GetType().Name}); "
+                          + "unlisted corrections stay off");
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Transcription/HostedCandidateJudge.cs
+++ b/src/CcDirector.Gateway/Transcription/HostedCandidateJudge.cs
@@ -1,0 +1,180 @@
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// The dictation judge as one bounded, stateless chat-completions call to the DevThrottle inference
+/// proxy - the thing that decides whether an unlisted word was really misheard.
+///
+/// This is the language model coming back to dictation cleanup, and it is worth being exact about what
+/// changed since the o4-mini pass was removed in July. That one was handed the whole transcript and
+/// asked to work out what was wrong: an open-ended job that cost about five seconds on every turn. This
+/// one is asked a closed question - here is a sentence, here are at most a dozen candidates our own
+/// code already isolated, which are real - and answers with nothing but their numbers. It is skipped
+/// entirely when the matcher nominates nothing, which is most utterances.
+///
+/// What it can do to the user's words is bounded by the interface, not by trust: it returns ids, so it
+/// cannot rewrite, reword, summarize, refuse into the transcript, or name a span nobody offered. The
+/// worst a broken or hostile backend achieves is accepting a bad candidate - which is exactly what the
+/// deterministic matcher did unsupervised - and it can never invent one.
+///
+/// The credential is Bearer-presented and NEVER logged (security rule DT-05). Neither is the transcript:
+/// this class logs candidate COUNTS, timings and status codes, never the user's words or the reply text.
+/// The model is the PROVEN included type (issue #1360), so the deployment credential cannot be pointed
+/// at a catalog model that would bill a member's credits for an internal feature.
+/// </summary>
+public sealed class HostedCandidateJudge : ICandidateJudge
+{
+    /// <summary>
+    /// The deadline on one ruling, and it is deliberately tight.
+    ///
+    /// This sits in the middle of every dictation turn, so it is not allowed to become the reason
+    /// dictation feels slow. Transcription itself is the dominant cost at roughly 4.2 seconds median; a
+    /// judge that answers in a few hundred milliseconds is invisible next to that, and one that takes
+    /// seconds is the five-second regression that got the previous model pass deleted. Past this bound
+    /// the call is abandoned and the turn ships the words the user said.
+    ///
+    /// There is NO retry. A retry doubles the worst case on the one path where the worst case is the
+    /// whole problem, to recover a correction whose absence costs a wrong spelling.
+    /// </summary>
+    public static readonly TimeSpan DefaultCallTimeout = TimeSpan.FromSeconds(1);
+
+    /// <summary>Shared client with an infinite timeout: the deadline is owned per call by a linked
+    /// token, so the client never imposes a second, racing bound (the HostedInferenceBrain lesson).</summary>
+    private static readonly HttpClient SharedHttp = new() { Timeout = Timeout.InfiniteTimeSpan };
+
+    private readonly HttpClient _http;
+    private readonly string _chatUrl;
+    private readonly string _apiKey;
+    private readonly string _model;
+    private readonly TimeSpan _callTimeout;
+    private readonly Action<string> _log;
+
+    /// <param name="baseUrl">The provider-compatible <c>/v1</c> base URL.</param>
+    /// <param name="apiKey">Credential presented as the Bearer token. Never logged.</param>
+    /// <param name="model">The chat model id as the PROVEN included type - a raw string cannot reach
+    /// the wire, because the only mint path is <see cref="IncludedModelId"/>.</param>
+    /// <param name="http">HTTP client; tests inject one over a fake handler.</param>
+    /// <param name="log">Log sink; <see cref="FileLog.Write"/> when null.</param>
+    /// <param name="callTimeout">Per-call deadline; <see cref="DefaultCallTimeout"/> when null.</param>
+    public HostedCandidateJudge(
+        string baseUrl,
+        string apiKey,
+        IncludedModelId model,
+        HttpClient? http = null,
+        Action<string>? log = null,
+        TimeSpan? callTimeout = null)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl)) throw new ArgumentException("baseUrl is required", nameof(baseUrl));
+        ArgumentNullException.ThrowIfNull(model);
+        _http = http ?? SharedHttp;
+        _chatUrl = baseUrl.TrimEnd('/') + "/chat/completions";
+        _apiKey = apiKey ?? "";
+        _model = model.Value;
+        _callTimeout = callTimeout ?? DefaultCallTimeout;
+        _log = log ?? FileLog.Write;
+    }
+
+    /// <summary>
+    /// Ask for a ruling. Returns null for every unhappy path - unreachable, non-success status, past the
+    /// deadline, cancelled, or a reply that is not exactly the shape we asked for - because the caller
+    /// treats null as "no ruling" and leaves the transcript alone. Nothing here throws: a judge that
+    /// throws into the dictation path would turn a missing correction into a failed turn.
+    /// </summary>
+    public async Task<IReadOnlyList<int>?> AcceptAsync(
+        string utterance,
+        IReadOnlyList<JudgeCandidate> candidates,
+        CancellationToken ct = default)
+    {
+        if (candidates.Count == 0) return Array.Empty<int>();
+
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(_callTimeout);
+
+            var payload = JsonSerializer.Serialize(new
+            {
+                model = _model,
+                temperature = 0,
+                messages = new object[]
+                {
+                    new { role = "system", content = CandidateJudgeProtocol.SystemPrompt },
+                    new { role = "user", content = CandidateJudgeProtocol.BuildUserPrompt(utterance, candidates) },
+                },
+            });
+
+            using var req = new HttpRequestMessage(HttpMethod.Post, _chatUrl)
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+            };
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+
+            using var res = await _http.SendAsync(req, HttpCompletionOption.ResponseContentRead, cts.Token)
+                .ConfigureAwait(false);
+
+            if (!res.IsSuccessStatusCode)
+            {
+                sw.Stop();
+                _log($"[HostedCandidateJudge] no ruling: HTTP {(int)res.StatusCode} in {sw.Elapsed.TotalMilliseconds:0.###}ms");
+                return null;
+            }
+
+            var body = await res.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+            var reply = ExtractContent(body);
+            var accepted = CandidateJudgeProtocol.ParseAccepted(
+                reply, candidates.Select(c => c.Id).ToArray());
+
+            sw.Stop();
+            _log(accepted is null
+                ? $"[HostedCandidateJudge] no ruling: reply was not the shape asked for, on "
+                  + $"{candidates.Count} candidate(s) in {sw.Elapsed.TotalMilliseconds:0.###}ms"
+                : $"[HostedCandidateJudge] ruled on {candidates.Count} candidate(s), accepted "
+                  + $"{accepted.Count} in {sw.Elapsed.TotalMilliseconds:0.###}ms");
+            return accepted;
+        }
+        catch (OperationCanceledException)
+        {
+            sw.Stop();
+            _log($"[HostedCandidateJudge] no ruling: past the {_callTimeout.TotalMilliseconds:0}ms deadline "
+                 + $"(or cancelled) after {sw.Elapsed.TotalMilliseconds:0.###}ms");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            _log($"[HostedCandidateJudge] no ruling: {ex.GetType().Name} after {sw.Elapsed.TotalMilliseconds:0.###}ms");
+            return null;
+        }
+    }
+
+    /// <summary>Pull <c>choices[0].message.content</c> out of a chat-completions body. Null when the
+    /// body is not that shape - which the caller reads as no ruling, like every other unhappy path.</summary>
+    internal static string? ExtractContent(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return null;
+            if (!doc.RootElement.TryGetProperty("choices", out var choices)) return null;
+            if (choices.ValueKind != JsonValueKind.Array || choices.GetArrayLength() == 0) return null;
+            var first = choices[0];
+            if (first.ValueKind != JsonValueKind.Object) return null;
+            if (!first.TryGetProperty("message", out var msg) || msg.ValueKind != JsonValueKind.Object) return null;
+            if (!msg.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.String) return null;
+            return content.GetString();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Restores the design the dictation cleanup originally had, and closes the gap #1553 left open: unlisted corrections were switched off, not fixed.

## The shape

The matcher keeps its job and loses its authority.

1. Wrong forms the user listed by hand apply as before, deterministically. No ruling needed - they chose them.
2. `FuzzyDictionaryMatcher.ProposeCandidates` nominates spans - **every occurrence separately, with its offset**.
3. The existing `TranscriptEditEngine.Validate` gate still stands in front of the judge, so a candidate it should never see cannot be rescued by a permissive ruling.
4. A judge that reads the sentence rules on each nomination and answers with **ids only**: `{"acceptedCandidateIds":[1]}`.
5. Accepted rulings apply at the offset they were judged at.

## Why this is not the pass removed in July

That one was handed the transcript and asked what was wrong - open-ended, ~5s every turn. This is a closed question: one sentence, at most 12 candidates our own code isolated, answered with numbers.

- **Skipped entirely when nothing is nominated**, which is most utterances. No call, no cost.
- **1s deadline, no retry.** A retry doubles the worst case on the one path where the worst case is the whole problem, to recover a correction whose absence costs a wrong spelling.
- Routed through `devthrottle/dictation-cleanup` as the proven `IncludedModelId` type, so the deployment credential cannot be pointed at a catalog model that would bill credits for an internal feature.

## What the judge cannot do

Bounded by the contract, not by trust, on **both** sides:

- It returns `Task<IReadOnlyList<int>?>`, so it cannot reword, summarize, refuse into the transcript, or name a span nobody offered.
- It is handed a `ReadOnlyCollection` of fresh copies, and accepted ids resolve against a **private snapshot it never receives**. Review found that passing the same list we later read back would let an in-process judge swap an entry after validation and supply arbitrary text through the parameter - defeating the property through the door the return-type check cannot see. A judge attempting exactly that is now a test, and it asserts the write was refused.

Every unhappy path means **no ruling**, and no ruling means the transcript is untouched: no judge configured, non-success status, malformed body, prose, fenced JSON, a stall past the deadline, a cancelled turn, a transport failure, a thrown exception. An id that was never offered voids the **whole** ruling rather than being filtered out.

## Offsets

The judge ruled on one word in one sentence. The same word later in the same breath is a different use it never saw, so `TranscriptEditEngine.ApplyAt` rewrites only the judged span, right-to-left so earlier offsets are never shifted, skipping any span that no longer matches verbatim. Deferred from #1553.

## Shadow first

Ships in `Shadow`: rule on real dictation, record what would have changed, change nothing. `ShadowChanges` is a separate field from `ChangedWords` on purpose - a shadow run must be indistinguishable from no cleanup to anything reading the transcript.

Promotion is one environment variable (`DEVTHROTTLE_DICTATION_JUDGE_MODE=enforce`), needs no new build, and requires the **exact** value - case, padding and an undefined enum all shadow.

## The guard, and what it does not do

`TranscriptEditEngine` claimed since July that a `TranscriptionIntegrity` architecture test enforced the whole rule. It never existed.

Half of it is now genuinely enforced: the judge boundary, structurally, on both return type and parameter, backed by the runtime attack test above.

The other half - "only `TranscriptEditEngine` rewrites transcript text" - is **not** enforced, and now says so. Two attempts were written and deleted: a substring scan (evadable by one space; failed the build on the word inside a comment) and a Roslyn syntax walk (missed `text.Replace(...)`, `String.Concat`, `this.rawTranscript`, null-conditional calls and interpolated rebuilds, while flagging a `Substring` used for a log preview). A check that certifies an unconditional claim while missing the ordinary spellings is worse than none, because the green run is read as proof. `docs/CodingStyle.md` section 16 and the engine comment both now state which half is checked; the real check is scoped on devthrottle_internal#1556 with the controls it must satisfy.

## Tests

**256 Core dictation tests, 3094 Gateway unit tests.** Full solution builds clean.

Covering: the no-ruling invariant in every failure mode; the mutation attack; a mixed valid/unoffered ruling; shadow vs enforce and the exact-value switch; per-occurrence offsets; that the judge is *not* asked when the guessing is off, cleanup is disabled, nothing is nominated, or a listed alias matched; the candidate cap; ~30 malformed replies against the parser; and that neither the credential nor the transcript reaches a log on the judge paths.

Reviewed four times; five findings, one critical, all closed.

Refs devthrottle_internal#1554
