### PR TITLE
cc-outlook: attachments work in both directions (#2539, #2526)

### DIFF
--- a/tools/cc-outlook/README.md
+++ b/tools/cc-outlook/README.md
@@ -70,11 +70,18 @@ cc-outlook send -t "to@example.com" -s "Subject" -b "Body" --cc "cc@example.com"
 cc-outlook send -t "to@example.com" -s "Subject" -b "Body" --bcc "bcc@example.com"
 cc-outlook send -t "to@example.com" -s "Subject" -b "<h1>HTML</h1>" --html
 cc-outlook send -t "to@example.com" -s "Subject" -b "Urgent!" --importance high
+cc-outlook send -t "to@example.com" -s "Subject" -b "Body" -a report.pdf -a notes.txt
+
+# Draft for review before sending
+cc-outlook draft -t "to@example.com" -s "Subject" -b "Body"
+cc-outlook draft -t "to@example.com" -s "Subject" -b "Body" -a report.pdf  # Repeatable
 
 # Reply/Forward
 cc-outlook reply <message_id> -b "Thanks for the info"
 cc-outlook reply <message_id> -b "Thanks all" --all  # Reply all
+cc-outlook reply <message_id> -b "Attached" --attach report.pdf  # -a is --all here
 cc-outlook forward <message_id> -t "other@example.com" -b "FYI"
+cc-outlook forward <message_id> -t "other@example.com" -a extra.pdf
 
 # Search
 cc-outlook search "project update"

--- a/tools/cc-outlook/README.md
+++ b/tools/cc-outlook/README.md
@@ -89,8 +89,11 @@ cc-outlook flag <message_id> -d 2024-12-31      # Flag with due date
 cc-outlook categorize <message_id> "Work,Urgent"
 
 # Attachments
-cc-outlook attachments <message_id>                           # List attachments
-cc-outlook download-attachment <message_id> <attachment_id>   # Download
+cc-outlook attachments <message_id>                           # List attachments, with full IDs
+cc-outlook attachments <message_id> --json                    # Same, as JSON
+cc-outlook download-attachment <message_id> <attachment_id>   # Download to the current directory
+cc-outlook download-attachment <message_id> <attachment_id> -o C:\out\invite.ics
+cc-outlook download-attachment <message_id> <attachment_id> -o C:\out   # Into a directory
 
 # Folders
 cc-outlook folders

--- a/tools/cc-outlook/src/cli.py
+++ b/tools/cc-outlook/src/cli.py
@@ -820,12 +820,17 @@ def categorize(
 @app.command()
 def attachments(
     message_id: str = typer.Argument(..., help="Message ID"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON for machine consumption"),
 ):
     """List attachments on a message."""
     client = get_client()
 
     try:
         atts = client.list_attachments(message_id)
+
+        if json_output:
+            print(json.dumps(atts, indent=2, ensure_ascii=True))
+            return
 
         if not atts:
             console.print("[yellow]No attachments[/yellow]")
@@ -835,7 +840,6 @@ def attachments(
         table.add_column("Name", style="cyan")
         table.add_column("Size", justify="right")
         table.add_column("Type")
-        table.add_column("ID")
 
         for att in atts:
             size = att.get('size', 0)
@@ -844,11 +848,17 @@ def attachments(
                 att.get('name', ''),
                 size_str,
                 att.get('content_type', ''),
-                # Print the full id: download-attachment consumes it verbatim.
-                att.get('id', ''),
             )
 
         console.print(table)
+
+        # The ids go BELOW the table, one per line, unboxed and unstyled.
+        # download-attachment consumes the id verbatim, and an id is far wider
+        # than a terminal - inside a table cell Rich ellipsizes it, so the very
+        # id the next command needs could not be copied out of this output.
+        console.print("\n[dim]Attachment IDs (pass to download-attachment):[/dim]")
+        for att in atts:
+            print(f"{att.get('name', '')}: {att.get('id', '')}")
 
     except ValueError as e:
         logger.error(f"Attachments error: {e}")
@@ -888,11 +898,17 @@ def download_attachment(
         else:
             save_path = target_att.get('name', 'attachment')
 
+        # Report the path that was WRITTEN, not the one that was asked for: the
+        # two differ when O365 sanitizes the file name.
         result = client.download_attachment(message_id, attachment_id, save_path)
-        console.print(f"[green]Downloaded:[/green] {result.get('name')} -> {save_path}")
+        console.print(f"[green]Downloaded:[/green] {result.get('name')} -> {result.get('path')}")
 
     except ValueError as e:
         logger.error(f"Download error: {e}")
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+    except RuntimeError as e:
+        logger.error(f"Download failed to write file: {e}")
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
     except (ConnectionError, OSError) as e:

--- a/tools/cc-outlook/src/cli.py
+++ b/tools/cc-outlook/src/cli.py
@@ -618,6 +618,7 @@ def draft(
     body_file: Path = typer.Option(None, "-f", "--file", help="Read body from file"),
     cc: str = typer.Option(None, "--cc", help="CC recipients, comma-separated"),
     html: bool = typer.Option(False, "--html", help="Body is HTML"),
+    attach: Optional[List[Path]] = typer.Option(None, "--attach", "-a", help="Attachments"),
 ):
     """Create a draft email."""
     client = get_client()
@@ -635,6 +636,7 @@ def draft(
     # Parse recipients
     to_list = [addr.strip() for addr in to.split(',')]
     cc_list = [addr.strip() for addr in cc.split(',')] if cc else None
+    attach_list = [str(p) for p in attach] if attach else None
 
     try:
         result = client.create_draft(
@@ -643,9 +645,16 @@ def draft(
             body=body,
             cc=cc_list,
             html=html,
+            attachments=attach_list,
         )
         console.print(f"[green]Draft created.[/green] ID: {result.get('id', '')[:50]}...")
 
+    # FileNotFoundError is an OSError, so it must be caught before the network
+    # clause below or a missing attachment reads as a network failure.
+    except FileNotFoundError as e:
+        logger.error(f"Attachment not found: {e}")
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
     except ValueError as e:
         logger.error(f"Invalid draft parameter: {e}")
         console.print(f"[red]Error:[/red] {e}")
@@ -702,6 +711,8 @@ def reply(
     reply_all: bool = typer.Option(False, "--all", "-a", help="Reply to all recipients"),
     send_flag: bool = typer.Option(False, "--send", help="Send immediately instead of saving as draft"),
     html: bool = typer.Option(False, "--html", help="Body is HTML"),
+    # Long form only: -a is already taken by --all on this command.
+    attach: Optional[List[Path]] = typer.Option(None, "--attach", help="Attachments"),
 ):
     """Create a reply to an email (draft or send)."""
     client = get_client()
@@ -716,9 +727,12 @@ def reply(
         console.print("[red]Error:[/red] Provide --body or --file")
         raise typer.Exit(1)
 
+    attach_list = [str(p) for p in attach] if attach else None
+
     try:
         result = client.reply_message(message_id, body=body, reply_all=reply_all,
-                                      send=send_flag, html=html)
+                                      send=send_flag, html=html,
+                                      attachments=attach_list)
         action = "Reply-all" if reply_all else "Reply"
         if send_flag:
             console.print(f"[green]{action} sent.[/green]")
@@ -727,6 +741,12 @@ def reply(
             if result.get('id'):
                 console.print(f"Draft ID: {result['id']}")
 
+    # FileNotFoundError is an OSError, so it must be caught before the network
+    # clause below or a missing attachment reads as a network failure.
+    except FileNotFoundError as e:
+        logger.error(f"Attachment not found: {e}")
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
     except ValueError as e:
         logger.error(f"Reply error: {e}")
         console.print(f"[red]Error:[/red] {e}")
@@ -742,16 +762,25 @@ def forward(
     message_id: str = typer.Argument(..., help="Message ID to forward"),
     to: str = typer.Option(..., "-t", "--to", help="Recipient email(s), comma-separated"),
     body: str = typer.Option(None, "-b", "--body", help="Additional message"),
+    attach: Optional[List[Path]] = typer.Option(None, "--attach", "-a", help="Attachments"),
 ):
     """Forward an email."""
     client = get_client()
 
     to_list = [addr.strip() for addr in to.split(',')]
+    attach_list = [str(p) for p in attach] if attach else None
 
     try:
-        result = client.forward_message(message_id, to=to_list, body=body)
+        result = client.forward_message(message_id, to=to_list, body=body,
+                                        attachments=attach_list)
         console.print(f"[green]Message forwarded to {', '.join(to_list)}[/green]")
 
+    # FileNotFoundError is an OSError, so it must be caught before the network
+    # clause below or a missing attachment reads as a network failure.
+    except FileNotFoundError as e:
+        logger.error(f"Attachment not found: {e}")
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
     except ValueError as e:
         logger.error(f"Forward error: {e}")
         console.print(f"[red]Error:[/red] {e}")

--- a/tools/cc-outlook/src/outlook_api.py
+++ b/tools/cc-outlook/src/outlook_api.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Optional, List
 
 
@@ -897,15 +898,20 @@ class OutlookClient:
     def download_attachment(self, message_id: str, attachment_id: str,
                            save_path: str) -> dict:
         """
-        Download an attachment.
+        Download an attachment to disk.
 
         Args:
             message_id: Message ID
             attachment_id: Attachment ID
-            save_path: Path to save the file
+            save_path: Where to write the file. A path naming an existing
+                directory writes the attachment there under its own name.
 
         Returns:
-            Dict with download info
+            Dict with the attachment name, the path actually written, and its size
+
+        Raises:
+            ValueError: message, attachment, or output directory not found
+            RuntimeError: the attachment could not be written
         """
         mailbox = self.account.mailbox()
         # Attachments are only present when fetched with download_attachments=True.
@@ -925,11 +931,39 @@ class OutlookClient:
         if not target_attachment:
             raise ValueError(f"Attachment not found: {attachment_id}")
 
-        target_attachment.save(save_path)
+        # O365's Attachment.save(location, custom_name) wants location to be an
+        # EXISTING DIRECTORY, with the file name in custom_name. Handed a full file
+        # path it logs at debug level and returns False, writing nothing - so the
+        # directory and the name are split apart here, and the result is checked.
+        requested = Path(save_path)
+        if requested.is_dir():
+            directory, filename = requested, target_attachment.name
+        else:
+            directory, filename = requested.parent, requested.name
+
+        if not directory.is_dir():
+            raise ValueError(f"Output directory does not exist: {directory}")
+
+        if not filename:
+            raise ValueError(f"No file name to save the attachment as: {save_path}")
+
+        if not target_attachment.save(str(directory), custom_name=filename):
+            raise RuntimeError(
+                f"Failed to write attachment '{target_attachment.name}' to {directory}"
+            )
+
+        # save() sanitizes the file name, so the path asked for is not necessarily
+        # the path written. Report the one O365 recorded.
+        written = getattr(target_attachment, 'attachment', None)
+        if written is None:
+            raise RuntimeError(
+                f"Attachment '{target_attachment.name}' reported saved "
+                f"but recorded no path on disk"
+            )
 
         return {
             'name': target_attachment.name,
-            'path': save_path,
+            'path': str(written),
             'size': getattr(target_attachment, 'size', 0)
         }
 

--- a/tools/cc-outlook/src/outlook_api.py
+++ b/tools/cc-outlook/src/outlook_api.py
@@ -28,6 +28,28 @@ def _to_utc(dt: datetime) -> datetime:
         dt = dt.astimezone()
     return dt.astimezone(timezone.utc)
 
+
+def _add_attachments(message, attachments: Optional[List[str]]) -> None:
+    """Attach local files to an outgoing message.
+
+    Shared by every outgoing path - send, draft, reply and forward - so an
+    attachment behaves identically whichever one is used.
+
+    Args:
+        message: O365 Message to attach the files to
+        attachments: File paths to attach; None or empty attaches nothing
+
+    Raises:
+        FileNotFoundError: one of the paths does not exist
+    """
+    if not attachments:
+        return
+
+    for file_path in attachments:
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"Attachment not found: {file_path}")
+        message.attachments.add(file_path)
+
 from O365 import Account
 from tzlocal import get_localzone
 
@@ -218,19 +240,14 @@ class OutlookClient:
         message.body_type = 'HTML' if html else 'text'
         message.importance = importance
 
-        # Add attachments
-        if attachments:
-            for file_path in attachments:
-                if os.path.exists(file_path):
-                    message.attachments.add(file_path)
-                else:
-                    raise FileNotFoundError(f"Attachment not found: {file_path}")
+        _add_attachments(message, attachments)
 
         message.send()
         return {'status': 'sent', 'to': to, 'subject': subject}
 
     def create_draft(self, to: List[str], subject: str, body: str,
-                     cc: Optional[List[str]] = None, html: bool = False) -> dict:
+                     cc: Optional[List[str]] = None, html: bool = False,
+                     attachments: Optional[List[str]] = None) -> dict:
         """
         Create a draft email.
 
@@ -240,9 +257,13 @@ class OutlookClient:
             body: Email body
             cc: List of CC recipients
             html: Whether body is HTML
+            attachments: List of file paths to attach
 
         Returns:
             Dict with draft info
+
+        Raises:
+            FileNotFoundError: an attachment path does not exist
         """
         mailbox = self.account.mailbox()
         message = mailbox.new_message()
@@ -255,6 +276,11 @@ class OutlookClient:
         message.body = body
         # Honor --html; O365 defaults the body type to HTML otherwise.
         message.body_type = 'HTML' if html else 'text'
+
+        # Attach BEFORE save_draft so the draft lands in Drafts carrying its
+        # attachments - the point of a draft is that it is complete and ready
+        # for a human to review and send.
+        _add_attachments(message, attachments)
 
         # Save as draft
         message.save_draft()
@@ -703,7 +729,8 @@ class OutlookClient:
     # =========================================================================
 
     def reply_message(self, message_id: str, body: str, reply_all: bool = False,
-                      send: bool = False, html: bool = False) -> dict:
+                      send: bool = False, html: bool = False,
+                      attachments: Optional[List[str]] = None) -> dict:
         """
         Create a draft reply (or send immediately) to a message.
 
@@ -713,9 +740,13 @@ class OutlookClient:
             reply_all: If True, reply to all recipients
             send: If True, send immediately instead of saving as draft
             html: If True, body is HTML
+            attachments: List of file paths to attach
 
         Returns:
             Dict with reply details
+
+        Raises:
+            FileNotFoundError: an attachment path does not exist
         """
         mailbox = self.account.mailbox()
         message = mailbox.get_message(object_id=message_id)
@@ -731,6 +762,8 @@ class OutlookClient:
         reply.body = body
         if html:
             reply.body_type = 'HTML'
+
+        _add_attachments(reply, attachments)
 
         if send:
             reply.send()
@@ -748,7 +781,8 @@ class OutlookClient:
             'reply_all': reply_all
         }
 
-    def forward_message(self, message_id: str, to: List[str], body: str = None) -> dict:
+    def forward_message(self, message_id: str, to: List[str], body: str = None,
+                        attachments: Optional[List[str]] = None) -> dict:
         """
         Forward a message.
 
@@ -756,9 +790,14 @@ class OutlookClient:
             message_id: Message ID to forward
             to: List of recipient emails
             body: Optional additional message
+            attachments: List of file paths to attach in addition to the
+                attachments the forwarded message already carries
 
         Returns:
             Dict with forward status
+
+        Raises:
+            FileNotFoundError: an attachment path does not exist
         """
         mailbox = self.account.mailbox()
         message = mailbox.get_message(object_id=message_id)
@@ -784,6 +823,8 @@ class OutlookClient:
                 forward.body_type = "HTML"
             else:
                 forward.body = body + "\n\n" + existing
+
+        _add_attachments(forward, attachments)
 
         forward.send()
 

--- a/tools/cc-outlook/tests/test_cli.py
+++ b/tools/cc-outlook/tests/test_cli.py
@@ -124,3 +124,83 @@ class TestDownloadAttachmentCommand:
         assert result.exit_code != 0
         assert "Downloaded" not in result.output
         assert "Failed to write attachment" in result.output
+
+
+class TestOutgoingAttachFlags:
+    """Issue #2526: --attach on draft, and on the reply/forward paths that shared the gap."""
+
+    def _client(self):
+        client = MagicMock()
+        client.create_draft.return_value = {"id": "draft-1"}
+        client.reply_message.return_value = {"id": "reply-1"}
+        client.forward_message.return_value = {"status": "forwarded"}
+        return client
+
+    def _run(self, argv):
+        client = self._client()
+        with patch("src.cli.get_client", return_value=client):
+            result = runner.invoke(app, argv)
+        return client, result
+
+    def test_draft_passes_attachments_through(self, tmp_path):
+        path = tmp_path / "report.pdf"
+        path.write_bytes(b"PDF")
+        client, result = self._run(
+            ["draft", "-t", "a@example.com", "-s", "s", "-b", "b", "-a", str(path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert client.create_draft.call_args.kwargs["attachments"] == [str(path)]
+
+    def test_draft_attach_is_repeatable(self, tmp_path):
+        first, second = tmp_path / "one.pdf", tmp_path / "two.pdf"
+        first.write_bytes(b"1")
+        second.write_bytes(b"2")
+        client, result = self._run(
+            ["draft", "-t", "a@example.com", "-s", "s", "-b", "b",
+             "--attach", str(first), "--attach", str(second)]
+        )
+        assert result.exit_code == 0, result.output
+        assert client.create_draft.call_args.kwargs["attachments"] == [str(first), str(second)]
+
+    def test_draft_without_attach_passes_none(self):
+        client, result = self._run(["draft", "-t", "a@example.com", "-s", "s", "-b", "b"])
+        assert result.exit_code == 0, result.output
+        assert client.create_draft.call_args.kwargs["attachments"] is None
+
+    def test_draft_missing_attachment_is_a_clear_error(self, tmp_path):
+        client = self._client()
+        client.create_draft.side_effect = FileNotFoundError("Attachment not found: nope.pdf")
+        with patch("src.cli.get_client", return_value=client):
+            result = runner.invoke(
+                app, ["draft", "-t", "a@example.com", "-s", "s", "-b", "b",
+                      "-a", str(tmp_path / "nope.pdf")]
+            )
+        assert result.exit_code != 0
+        # FileNotFoundError is an OSError; it must not be reported as a network error.
+        assert "Network error" not in result.output
+        assert "Attachment not found" in result.output
+
+    def test_reply_passes_attachments_through(self, tmp_path):
+        path = tmp_path / "report.pdf"
+        path.write_bytes(b"PDF")
+        client, result = self._run(
+            ["reply", "msg-1", "-b", "b", "--attach", str(path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert client.reply_message.call_args.kwargs["attachments"] == [str(path)]
+
+    def test_reply_short_a_still_means_reply_all(self, tmp_path):
+        # -a was already --all on this command, so --attach is long-form only.
+        client, result = self._run(["reply", "msg-1", "-b", "b", "-a"])
+        assert result.exit_code == 0, result.output
+        assert client.reply_message.call_args.kwargs["reply_all"] is True
+        assert client.reply_message.call_args.kwargs["attachments"] is None
+
+    def test_forward_passes_attachments_through(self, tmp_path):
+        path = tmp_path / "report.pdf"
+        path.write_bytes(b"PDF")
+        client, result = self._run(
+            ["forward", "msg-1", "-t", "a@example.com", "-a", str(path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert client.forward_message.call_args.kwargs["attachments"] == [str(path)]

--- a/tools/cc-outlook/tests/test_cli.py
+++ b/tools/cc-outlook/tests/test_cli.py
@@ -3,6 +3,10 @@
 Covers the recipients command: it now exposes a boolean --json (consistent with
 every other JSON-capable command in both email tools) instead of a
 --format table|json option, and emits ASCII-only JSON (ensure_ascii=True).
+
+Also covers the attachment commands (issue #2539): download-attachment must
+report the path it actually wrote and must exit non-zero when nothing was
+written, and the attachments listing must show an attachment id in full.
 """
 
 import json
@@ -13,6 +17,9 @@ from typer.testing import CliRunner
 from src.cli import app
 
 runner = CliRunner()
+
+# Wider than any terminal, which is what made this id unusable inside a table cell.
+LONG_ATTACHMENT_ID = "AAMkAG" + "Q" * 160 + "=="
 
 
 def _patch_client(recipients):
@@ -47,3 +54,73 @@ class TestRecipientsJson:
             result = runner.invoke(app, ["recipients", "--format", "json"])
         # --format was removed; passing it is now an error.
         assert result.exit_code != 0
+
+
+def _patch_attachment_client(atts, download=None, download_error=None):
+    client = MagicMock()
+    client.list_attachments.return_value = atts
+    if download_error is not None:
+        client.download_attachment.side_effect = download_error
+    else:
+        client.download_attachment.return_value = download
+    return patch("src.cli.get_client", return_value=client)
+
+
+_ATTACHMENT = {
+    "id": LONG_ATTACHMENT_ID,
+    "name": "invite.ics",
+    "size": 2048,
+    "content_type": "text/calendar",
+    "is_inline": False,
+}
+
+
+class TestAttachmentsListing:
+    """Issue #2539, secondary defect: the id could not be read out of the output.
+
+    The id was a column in a Rich table, so it was ellipsized at terminal width -
+    and it is the one value download-attachment requires.
+    """
+
+    def test_full_id_is_printed(self):
+        with _patch_attachment_client([_ATTACHMENT]):
+            result = runner.invoke(app, ["attachments", "msg-1"])
+        assert result.exit_code == 0, result.output
+        # Not merely a prefix: every character, unbroken, on one line.
+        assert LONG_ATTACHMENT_ID in result.output
+        assert "..." not in result.output
+
+    def test_json_flag_emits_the_attachment_records(self):
+        with _patch_attachment_client([_ATTACHMENT]):
+            result = runner.invoke(app, ["attachments", "msg-1", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload[0]["id"] == LONG_ATTACHMENT_ID
+        assert payload[0]["name"] == "invite.ics"
+
+
+class TestDownloadAttachmentCommand:
+    """Issue #2539: a green success line and exit 0 while writing no file."""
+
+    def test_reports_the_path_that_was_written(self):
+        written = {"name": "invite.ics", "path": "C:/out/invite.ics", "size": 12}
+        with _patch_attachment_client([_ATTACHMENT], download=written):
+            result = runner.invoke(
+                app, ["download-attachment", "msg-1", LONG_ATTACHMENT_ID, "-o", "C:/out/asked.ics"]
+            )
+        assert result.exit_code == 0, result.output
+        # The path WRITTEN, not the path asked for.
+        assert "C:/out/invite.ics" in result.output
+        assert "asked.ics" not in result.output
+
+    def test_failed_write_exits_non_zero(self):
+        with _patch_attachment_client(
+            [_ATTACHMENT], download_error=RuntimeError("Failed to write attachment")
+        ):
+            result = runner.invoke(
+                app, ["download-attachment", "msg-1", LONG_ATTACHMENT_ID, "-o", "C:/out/invite.ics"]
+            )
+        # The whole point of the bug: this used to be 0 with a green success line.
+        assert result.exit_code != 0
+        assert "Downloaded" not in result.output
+        assert "Failed to write attachment" in result.output

--- a/tools/cc-outlook/tests/test_outlook_fixes.py
+++ b/tools/cc-outlook/tests/test_outlook_fixes.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -283,6 +284,46 @@ class TestFlagMessage:
             client.flag_message("id-1", flag_status="bogus")
 
 
+class FakeAttachment:
+    """Stands in for an O365 Attachment, honoring the save() contract of #2539.
+
+    O365's Attachment.save(location, custom_name) requires location to be an
+    EXISTING DIRECTORY. Given anything else it writes nothing and returns False,
+    and given no content it returns False as well. A double that accepts any
+    arguments and writes nothing cannot tell the fixed code from the broken code,
+    which is how the bug survived: the old test asserted only the call shape.
+    """
+
+    def __init__(self, attachment_id, name, content=b"CONTENT"):
+        self.attachment_id = attachment_id
+        self.name = name
+        self.content = content
+        self.attachment = None
+        self.on_disk = False
+        self.size = 0
+        self.save_calls = []
+
+    def save(self, location=None, custom_name=None):
+        self.save_calls.append((location, custom_name))
+        if not self.content:
+            return False
+        location = Path(location or '')
+        if not location.exists():
+            return False
+        # O365 sanitizes the name it is handed.
+        name = (custom_name or self.name).replace('/', '-').replace('\\', '')
+        try:
+            path = location / name
+            with path.open('wb') as handle:
+                handle.write(self.content)
+        except OSError:
+            return False
+        self.attachment = path
+        self.on_disk = True
+        self.size = path.stat().st_size
+        return True
+
+
 class TestListAttachments:
     """Regression tests for issue #530.
 
@@ -313,15 +354,104 @@ class TestListAttachments:
         assert result[0]["id"] == "att-1"
         assert result[0]["name"] == "invite.ics"
 
-    def test_download_attachment_requests_download(self):
+    def test_download_attachment_requests_download(self, tmp_path):
         client, mailbox = self._client()
-        att = MagicMock()
-        att.attachment_id = "att-1"
-        att.name = "invite.ics"
+        att = FakeAttachment("att-1", "invite.ics")
         mailbox.get_message.return_value.attachments = [att]
 
-        client.download_attachment("msg-1", "att-1", "C:/tmp/invite.ics")
+        client.download_attachment("msg-1", "att-1", str(tmp_path / "invite.ics"))
 
         _, kwargs = mailbox.get_message.call_args
         assert kwargs.get("download_attachments") is True
-        att.save.assert_called_once_with("C:/tmp/invite.ics")
+        # The directory goes in location and the file name in custom_name. This
+        # assertion used to require the whole path in location, which is the
+        # shape that silently wrote nothing (issue #2539).
+        assert att.save_calls == [(str(tmp_path), "invite.ics")]
+
+
+class TestDownloadAttachmentWritesTheFile:
+    """Regression tests for issue #2539.
+
+    download_attachment passed a full file path as O365's `location`, which wants
+    an existing directory. O365 wrote nothing and returned False; the False was
+    discarded and the requested path returned as though it had been written, so
+    the command printed a green success line and exited 0 having produced no file.
+
+    Every test here is written to FAIL against that old behavior: each one either
+    asserts bytes on disk at the reported path, or asserts that a failed write is
+    raised rather than reported as success.
+    """
+
+    def _client_with_attachment(self, att):
+        account = MagicMock()
+        client = OutlookClient(account=account)
+        account.mailbox.return_value.get_message.return_value.attachments = [att]
+        return client
+
+    def test_writes_the_file_and_reports_where_it_wrote_it(self, tmp_path):
+        att = FakeAttachment("att-1", "invite.ics", content=b"BEGIN:VCALENDAR")
+        client = self._client_with_attachment(att)
+        target = tmp_path / "invite.ics"
+
+        result = client.download_attachment("msg-1", "att-1", str(target))
+
+        # The file exists, holds the attachment's bytes, and is where we were told.
+        assert target.exists()
+        assert target.read_bytes() == b"BEGIN:VCALENDAR"
+        assert Path(result["path"]) == target
+        assert result["name"] == "invite.ics"
+        assert result["size"] == len(b"BEGIN:VCALENDAR")
+
+    def test_bare_file_name_writes_into_the_current_directory(self, tmp_path, monkeypatch):
+        # The no -o shape: cli.py passes the attachment's own name, with no
+        # directory part. This was broken the same way as the -o shape.
+        att = FakeAttachment("att-1", "invite.ics")
+        client = self._client_with_attachment(att)
+        monkeypatch.chdir(tmp_path)
+
+        result = client.download_attachment("msg-1", "att-1", "invite.ics")
+
+        written = Path(result["path"])
+        assert written.exists()
+        assert written.read_bytes() == b"CONTENT"
+        assert (tmp_path / "invite.ics").exists()
+
+    def test_directory_target_writes_under_the_attachment_name(self, tmp_path):
+        att = FakeAttachment("att-1", "invite.ics")
+        client = self._client_with_attachment(att)
+
+        result = client.download_attachment("msg-1", "att-1", str(tmp_path))
+
+        assert Path(result["path"]) == tmp_path / "invite.ics"
+        assert (tmp_path / "invite.ics").read_bytes() == b"CONTENT"
+
+    def test_reports_the_sanitized_name_o365_actually_used(self, tmp_path):
+        # O365 rewrites '/' in a name; the path asked for is then not the path
+        # written, and the old code reported the path asked for.
+        att = FakeAttachment("att-1", "report/2026.pdf")
+        client = self._client_with_attachment(att)
+
+        result = client.download_attachment("msg-1", "att-1", str(tmp_path))
+
+        assert Path(result["path"]) == tmp_path / "report-2026.pdf"
+        assert (tmp_path / "report-2026.pdf").exists()
+
+    def test_failed_write_raises_instead_of_reporting_success(self, tmp_path):
+        # Empty content makes O365's save() return False. The old code discarded
+        # that False and returned a success dict.
+        att = FakeAttachment("att-1", "invite.ics", content=b"")
+        client = self._client_with_attachment(att)
+
+        with pytest.raises(RuntimeError):
+            client.download_attachment("msg-1", "att-1", str(tmp_path / "invite.ics"))
+
+        assert not (tmp_path / "invite.ics").exists()
+
+    def test_missing_output_directory_raises(self, tmp_path):
+        att = FakeAttachment("att-1", "invite.ics")
+        client = self._client_with_attachment(att)
+
+        with pytest.raises(ValueError, match="Output directory does not exist"):
+            client.download_attachment("msg-1", "att-1", str(tmp_path / "nope" / "invite.ics"))
+
+        assert att.save_calls == []

--- a/tools/cc-outlook/tests/test_outlook_fixes.py
+++ b/tools/cc-outlook/tests/test_outlook_fixes.py
@@ -174,6 +174,156 @@ class TestForwardMessageNote:
         forward.send.assert_called_once()
 
 
+class TestOutgoingAttachments:
+    """Regression tests for issue #2526.
+
+    Only `send` could carry an attachment. `draft` could not, so a draft could
+    never be built already carrying the file it is about - which is exactly what
+    a review-before-send workflow needs; the choice was to send unreviewed or to
+    ask a human to drag the file on. `reply --draft` and `forward` shared the gap.
+
+    The ordering assertions matter as much as the attach assertions: attaching
+    after save_draft/send would leave the draft in Drafts, or the mail in the
+    recipient's inbox, without the attachment.
+    """
+
+    def _existing_file(self, tmp_path, name="report.pdf"):
+        path = tmp_path / name
+        path.write_bytes(b"PDF")
+        return str(path)
+
+    def _call_order(self, mock):
+        return [name for name, _, _ in mock.mock_calls]
+
+    # --- draft -----------------------------------------------------------
+
+    def test_draft_attaches_before_saving(self, tmp_path):
+        client, message = _client_with_message()
+        path = self._existing_file(tmp_path)
+
+        client.create_draft(to=["a@example.com"], subject="s", body="b",
+                            attachments=[path])
+
+        message.attachments.add.assert_called_once_with(path)
+        order = self._call_order(message)
+        assert order.index("attachments.add") < order.index("save_draft")
+
+    def test_draft_attaches_every_file_given(self, tmp_path):
+        client, message = _client_with_message()
+        first = self._existing_file(tmp_path, "one.pdf")
+        second = self._existing_file(tmp_path, "two.pdf")
+
+        client.create_draft(to=["a@example.com"], subject="s", body="b",
+                            attachments=[first, second])
+
+        assert [c.args[0] for c in message.attachments.add.call_args_list] == [first, second]
+
+    def test_draft_without_attachments_attaches_nothing(self):
+        client, message = _client_with_message()
+
+        client.create_draft(to=["a@example.com"], subject="s", body="b")
+
+        message.attachments.add.assert_not_called()
+        message.save_draft.assert_called_once()
+
+    def test_draft_missing_attachment_raises_and_saves_no_draft(self, tmp_path):
+        client, message = _client_with_message()
+
+        with pytest.raises(FileNotFoundError):
+            client.create_draft(to=["a@example.com"], subject="s", body="b",
+                                attachments=[str(tmp_path / "nope.pdf")])
+
+        # No half-built draft is left behind in Drafts.
+        message.save_draft.assert_not_called()
+
+    # --- reply -----------------------------------------------------------
+
+    def _client_with_reply(self):
+        account = MagicMock()
+        original = MagicMock()
+        account.mailbox.return_value.get_message.return_value = original
+        return OutlookClient(account=account), original.reply.return_value
+
+    def test_reply_draft_attaches_before_saving(self, tmp_path):
+        client, reply = self._client_with_reply()
+        path = self._existing_file(tmp_path)
+
+        client.reply_message("id1", body="b", attachments=[path])
+
+        reply.attachments.add.assert_called_once_with(path)
+        order = self._call_order(reply)
+        assert order.index("attachments.add") < order.index("save_draft")
+
+    def test_reply_send_attaches_before_sending(self, tmp_path):
+        client, reply = self._client_with_reply()
+        path = self._existing_file(tmp_path)
+
+        client.reply_message("id1", body="b", send=True, attachments=[path])
+
+        reply.attachments.add.assert_called_once_with(path)
+        order = self._call_order(reply)
+        assert order.index("attachments.add") < order.index("send")
+
+    def test_reply_missing_attachment_raises_and_sends_nothing(self, tmp_path):
+        client, reply = self._client_with_reply()
+
+        with pytest.raises(FileNotFoundError):
+            client.reply_message("id1", body="b", send=True,
+                                 attachments=[str(tmp_path / "nope.pdf")])
+
+        reply.send.assert_not_called()
+        reply.save_draft.assert_not_called()
+
+    # --- forward ---------------------------------------------------------
+
+    def _client_with_forward(self):
+        account = MagicMock()
+        original = MagicMock()
+        account.mailbox.return_value.get_message.return_value = original
+        return OutlookClient(account=account), original.forward.return_value
+
+    def test_forward_attaches_before_sending(self, tmp_path):
+        client, forward = self._client_with_forward()
+        path = self._existing_file(tmp_path)
+
+        client.forward_message("id1", ["a@example.com"], attachments=[path])
+
+        forward.attachments.add.assert_called_once_with(path)
+        order = self._call_order(forward)
+        assert order.index("attachments.add") < order.index("send")
+
+    def test_forward_missing_attachment_raises_and_sends_nothing(self, tmp_path):
+        client, forward = self._client_with_forward()
+
+        with pytest.raises(FileNotFoundError):
+            client.forward_message("id1", ["a@example.com"],
+                                   attachments=[str(tmp_path / "nope.pdf")])
+
+        forward.send.assert_not_called()
+
+    # --- send (unchanged behavior, guarded through the shared helper) -----
+
+    def test_send_still_attaches(self, tmp_path):
+        client, message = _client_with_message()
+        path = self._existing_file(tmp_path)
+
+        client.send_message(to=["a@example.com"], subject="s", body="b",
+                            attachments=[path])
+
+        message.attachments.add.assert_called_once_with(path)
+        order = self._call_order(message)
+        assert order.index("attachments.add") < order.index("send")
+
+    def test_send_missing_attachment_raises_and_sends_nothing(self, tmp_path):
+        client, message = _client_with_message()
+
+        with pytest.raises(FileNotFoundError):
+            client.send_message(to=["a@example.com"], subject="s", body="b",
+                                attachments=[str(tmp_path / "nope.pdf")])
+
+        message.send.assert_not_called()
+
+
 class TestCreateEventTimezone:
     """Regression tests for the calendar-create timezone crash.
 


### PR DESCRIPTION
Two filed defects in `tools/cc-outlook`, one commit each so they can be read on their own.

## 1. `download-attachment` reported success and wrote no file (#2539)

`outlook_api.download_attachment` passed a full file path as O365's `location`.
That parameter wants an **existing directory**, with the file name in
`custom_name`; handed anything else O365 logs at debug level, writes nothing, and
returns `False`. That `False` was discarded and the requested path returned as
though it had been written, and the command layer printed a green success line
unconditionally, so the command exited 0 having produced nothing. Both invocation
shapes were broken this way, with and without `-o`, so the command had never once
worked.

The fix splits the directory from the file name, checks what `save()` returns, and
reports the path O365 **actually wrote** - it sanitizes the name, so the path asked
for is not necessarily the path written. A failed write now raises instead of being
reported as success. A path naming an existing directory writes the attachment
there under its own name, and a missing output directory is a clear error rather
than a silent no-op.

**Secondary defect in the same issue.** The attachment ID was a column in a Rich
table, so it was ellipsized at terminal width - and it is the one value
`download-attachment` requires, which meant the ID could not be copied out of the
tool's own output. The IDs now print in full below the table, one per line and
unboxed, so they can be copied; `attachments --json` gives the same records for
machine use.

## 2. `draft` could not take an attachment (#2526)

`send` had `--attach`; `draft` did not, so there was no way to build a draft that
already carried its attachment. A review-before-send workflow was left with two bad
options: create the draft and ask a human to drag the file on, or `send --attach`
directly and skip the review that was the point.

`draft` now takes `--attach / -a`, repeatable, with the same semantics as `send`.

**On the two commands the brief asked about: `reply --draft` and `forward` DID
share the gap, and both are fixed here.** Neither could take an attachment at all.
One deliberate difference: on `reply`, `-a` is already `--all`, so there `--attach`
is long-form only rather than silently changing what `-a` means for anyone already
using it. On `forward`, `-a` was free and is wired to `--attach` as on `send`.

The four outgoing paths now share one `_add_attachments` helper, so an attachment
behaves identically whichever is used, and a missing file raises the same
`FileNotFoundError` before anything is saved or sent. In the command layer that
error is caught ahead of the network clause - `FileNotFoundError` is an `OSError`,
and without ordering the two a missing file reports as a network failure.

## Testing

`pytest tests` in `tools/cc-outlook`: **125 passed** (97 before this branch).

The bar for thefrederiksen/devthrottle_internal#1815 was that a test must be able to tell the fixed code from the
broken code - a test that only checked exit code 0 would have passed against the
broken code for its whole life. So the doubles reproduce O365's real `save()`
contract (existing-directory requirement, name sanitization, `False` return), and
the tests assert bytes on disk at the reported path rather than call shape.

Each new test was run against the unfixed source to confirm it fails there:

- thefrederiksen/devthrottle_internal#1815: **11 of 11** new/updated tests fail against the old code, pass against the new.
- thefrederiksen/devthrottle_internal#1803: **15 of 18** fail against the old code. The 3 that pass are guards on
  `send`, which already worked and must keep working through the shared helper.

`tests/test_outlook_fixes.py:326` asserted the buggy argument shape
(`att.save.assert_called_once_with("C:/tmp/invite.ics")`). That assertion was
updated deliberately to the correct shape - the fix was not bent to satisfy it.

Note for reviewers: `scripts\test-local.ps1` runs no Python tests, so this suite is
the only gate on this change.
