### PR TITLE
voice: the judge decides each candidate on its own

### DIFF
--- a/src/CcDirector.Core.Tests/Dictation/CandidateJudgeProtocolTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/CandidateJudgeProtocolTests.cs
@@ -123,6 +123,16 @@ public sealed class CandidateJudgeProtocolTests
         Assert.Contains("acceptedCandidateIds", CandidateJudgeProtocol.SystemPrompt);
     }
 
+    /// <summary>
+    /// Pinned because removing it brought a measured defect back. Without the independence
+    /// instruction the judge accepted "store" as the speaker's name in a sentence that also
+    /// contained a real mishearing - accepting one candidate primed it to accept the rest, in two
+    /// live runs out of three. With it, three runs over 21 cases gave zero false accepts.
+    /// </summary>
+    [Fact]
+    public void TheInstructionTellsTheJudgeToDecideEachCandidateOnItsOwn()
+        => Assert.Contains("INDEPENDENTLY", CandidateJudgeProtocol.SystemPrompt);
+
     // ===== applying at an offset ==============================================
 
     [Fact]

--- a/src/CcDirector.Core/Dictation/CandidateJudge.cs
+++ b/src/CcDirector.Core/Dictation/CandidateJudge.cs
@@ -61,6 +61,17 @@ public static class CandidateJudgeProtocol
     /// The instruction sent with every question. It states the job, the answer shape, and the tie-break:
     /// when unsure, reject. A missed correction costs a wrong spelling; a wrong acceptance costs the
     /// user's meaning, and those are not the same price.
+    ///
+    /// The independence paragraph is there because of a MEASURED failure, not a hunch. Without it the
+    /// judge was consistently wrong on one shape: a sentence containing a real mishearing alongside
+    /// ordinary words. "make sure Mindsey knows about the store" - it correctly accepted Mindsey and
+    /// then accepted "store" as the speaker's name in the same breath, in two live runs out of three.
+    /// Accepting one candidate was priming it to accept the rest. With the paragraph, three
+    /// consecutive runs over 21 live cases produced ZERO false accepts.
+    ///
+    /// It costs recall - the judge now declines some genuine mishearings it used to catch. That is the
+    /// trade this feature exists to make, and it is cheaper than it looks: a term the user cares about
+    /// ends up in their glossary, where stage one corrects it deterministically without ever asking.
     /// </summary>
     public const string SystemPrompt =
         "You decide whether words in a speech transcript were misheard versions of a known term.\n" +
@@ -70,6 +81,10 @@ public static class CandidateJudgeProtocol
         "Accept a candidate ONLY if, reading the sentence, the speaker clearly meant the term and the\n" +
         "transcriber misheard it. Reject it if the spoken word is being used as an ordinary word of the\n" +
         "language, even when it looks similar to the term. When you are not sure, REJECT.\n" +
+        "\n" +
+        "Judge each candidate INDEPENDENTLY. Accepting one says nothing about the others: a sentence often\n" +
+        "contains one genuine mishearing alongside several ordinary words that merely resemble terms.\n" +
+        "Decide each one on its own as if it were the only candidate.\n" +
         "\n" +
         "Reply with JSON and nothing else, in exactly this shape:\n" +
         "{\"acceptedCandidateIds\": [0, 2]}\n" +


### PR DESCRIPTION
Live measurement through the real route found a **consistent** false accept - not noise.

`make sure Mindsey knows about the store` -> the judge correctly accepted `Mindsey`, then accepted **`store` as the speaker's name** in the same breath. Two runs out of three. Accepting one candidate was priming it to accept the rest, on exactly the shape most likely in real dictation: a sentence carrying one real mishearing alongside ordinary words.

One paragraph fixes it:

> Judge each candidate INDEPENDENTLY. Accepting one says nothing about the others...

**Three consecutive runs, 21 live cases, zero false accepts.** Every remaining failure is a refusal to correct, never a corruption. p50 529ms.

## The cost

Recall. The judge now also declines some genuine mishearings it used to catch (`Terascale`->`Tailscale`). That is the trade the feature exists to make - and it is cheaper than it looks, because a term the user cares about ends up in their glossary, where stage one corrects it deterministically without ever asking the judge.

## Why it is pinned by a test

A prompt line with no obvious purpose is what a later tidy-up deletes. The test carries the failure it prevents.

257 Core dictation tests pass.

Refs devthrottle_internal#1554