### PR TITLE
gateway: bind the listener before any database work

### DIFF
--- a/src/CcDirector.Core.Tests/ProcessRunnerTests.cs
+++ b/src/CcDirector.Core.Tests/ProcessRunnerTests.cs
@@ -27,7 +27,18 @@ public sealed class ProcessRunnerTests
             "powershell", new[] { "-NoProfile", "-Command", script }, workingDirectory: null);
 
         // If the drain regressed to sequential, run never completes and the delay wins.
-        var finished = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(30)));
+        //
+        // The budget is generous ON PURPOSE, and raising it costs the assertion nothing. What this
+        // test distinguishes is "completes" from "NEVER completes": a sequential drain deadlocks
+        // permanently, so it fails this test at any timeout whatsoever. The number is only a
+        // liveness guard so a regression reports rather than hangs the suite forever.
+        //
+        // It was 30 seconds, and that is not a drain budget - it also has to cover starting
+        // powershell, which is a heavy child process. On a busy continuous-integration runner that
+        // start alone can approach it, and the test then fails for machine load rather than for the
+        // hazard it exists to catch. Seen twice on 2026-08-19 during a run whose other jobs were
+        // saturating the machine; the drain itself takes well under a second locally.
+        var finished = await Task.WhenAny(run, Task.Delay(TimeSpan.FromMinutes(2)));
         Assert.Same(run, finished);
 
         var result = await run;

--- a/src/CcDirector.Gateway.Tests/EvictionRaceAndCompositionTests.cs
+++ b/src/CcDirector.Gateway.Tests/EvictionRaceAndCompositionTests.cs
@@ -226,6 +226,11 @@ public sealed class EvictionRaceAndCompositionTests : IDisposable
             authEnabled: true, instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
 
+        // The host is used without being started, and the database is no longer opened by the constructor:
+        // StartAsync opens it right after the listener binds so a slow database cannot delay the bind
+        // (#2383, #2585). This test wants the stores, not a bound port, so it runs that step directly.
+        gateway.EnsureStoresReady();
+
         gateway.Registry.RegisterFromStream(DirectorId, Machine, "soren", "1.0", pid: 1234,
             startedAt: DateTime.UtcNow, tenant: TenantId.Local);
         gateway.PushedSessions.RegisterConnection(TenantId.Local, DirectorId, "conn-1");

--- a/src/CcDirector.Gateway.Tests/GatewayStartFailureTerminationTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStartFailureTerminationTests.cs
@@ -130,12 +130,30 @@ public sealed class GatewayStartFailureTerminationTests
     }
 
     [Fact]
-    public void TheGatewayStoreConstructor_BoundsItsPoolAndRedactsItsFailures()
+    public void TheGatewayStoreConstructor_BoundsItsPool()
     {
-        // Scoped to the CONSTRUCTOR, which is where both calls belong. Moving either into a helper that
-        // nothing calls would keep a type-wide scan green.
+        // Scoped to the CONSTRUCTOR because that is where the pool bound belongs: it is part of PARSING the
+        // connection string, which still happens at construction even now that connecting does not. Moving
+        // it into a helper that nothing calls would keep a type-wide scan green, which is why this is scoped
+        // to the one method rather than the type.
         var calls = CallsInMethod(typeof(GatewayDatabase), ".ctor");
         Assert.Contains(calls, c => c == "GatewayDatabase::WithBoundedPool");
+    }
+
+    [Fact]
+    public void TheGatewayStoreOpen_RedactsItsFailures()
+    {
+        // Scoped to Open, which is where CONNECTING now happens.
+        //
+        // This assertion used to name the constructor, and it moved with the code rather than being relaxed:
+        // the open was split out of the constructor so the Gateway's listener can bind before any database
+        // work (#2383, #2585). The guard it provides is unchanged and still worth having - every failure on
+        // the connect path must go through DescribeFailure, because the provider's own message can echo part
+        // of the connection string and GatewayService.StartAsync writes ex.Message straight to disk.
+        //
+        // Naming the method that actually owns the call is the whole point of scoping these to one method;
+        // widening this to a type-wide scan to survive the move would have thrown away the guarantee.
+        var calls = CallsInMethod(typeof(GatewayDatabase), "Open");
         Assert.Contains(calls, c => c == "GatewayDatabase::DescribeFailure");
     }
 

--- a/src/CcDirector.Gateway.Tests/TenantSettingsRuntimeThreadingTests.cs
+++ b/src/CcDirector.Gateway.Tests/TenantSettingsRuntimeThreadingTests.cs
@@ -46,6 +46,11 @@ public sealed class TenantSettingsRuntimeThreadingTests : IAsyncLifetime
             authEnabled: false,
             instancesDirectory: _instances,
             workListsPath: Path.Combine(_root, "worklists.json"));
+        // These tests use the host WITHOUT starting it, and the database is no longer opened by the
+        // constructor - StartAsync opens it immediately after the listener binds, so that a slow database
+        // cannot delay the bind and make the platform stop the site (#2383, #2585). Run the same named
+        // startup step here; binding a port is what these tests do not want, not the stores being loaded.
+        _gateway.EnsureStoresReady();
         return Task.CompletedTask;
     }
 

--- a/src/CcDirector.Gateway.UnitTests/Data/DatabaseOpensAfterTheBindTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/Data/DatabaseOpensAfterTheBindTests.cs
@@ -1,0 +1,131 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Data;
+
+/// <summary>
+/// The database is opened SEPARATELY from construction, so the hosted Gateway can bind its listener first.
+///
+/// WHY THIS ORDER IS A PROPERTY AND NOT A PREFERENCE. Connecting and migrating used to run inside the
+/// constructor, which runs long before the listener binds. On a deploy the new container therefore did its
+/// database work while the platform was still waiting for it to listen; a slow open pushed the bind past the
+/// container-start deadline, the platform concluded no port would ever appear, and it stopped the SITE -
+/// which tore down the healthy container that was serving traffic beside it. That stop, not the swap, is the
+/// 38.5 seconds of 2 August 2026 (#2383) and the 46.7 seconds of 12 August (#2585).
+///
+/// Shortening the wait only ever made it less likely. Splitting the open out is what makes it impossible.
+/// </summary>
+public sealed class DatabaseOpensAfterTheBindTests : IDisposable
+{
+    private readonly List<string> _temp = new();
+
+    public void Dispose()
+    {
+        foreach (var d in _temp)
+        {
+            try { Directory.Delete(d, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private string TempDbPath()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "dt-open-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        _temp.Add(dir);
+        return Path.Combine(dir, "gateway.db");
+    }
+
+    [Fact]
+    public void Deferred_construction_does_not_open_the_database()
+    {
+        var path = TempDbPath();
+
+        using var db = new GatewayDatabase(new SingleTenantContext(), path, deferOpen: true);
+
+        Assert.False(db.IsOpen);
+        // The file is the observable: a database that was opened and migrated has one, and this is the whole
+        // claim - construction did no database work at all.
+        Assert.False(File.Exists(path), "constructing with deferOpen must not create or migrate the database");
+    }
+
+    [Fact]
+    public void Open_connects_and_migrates()
+    {
+        var path = TempDbPath();
+        using var db = new GatewayDatabase(new SingleTenantContext(), path, deferOpen: true);
+
+        db.Open();
+
+        Assert.True(db.IsOpen);
+        Assert.True(File.Exists(path));
+        using var ctx = db.CreateContext();
+        Assert.NotNull(ctx);
+    }
+
+    [Fact]
+    public void A_query_before_Open_says_so_rather_than_dereferencing_null()
+    {
+        // A request that lands in the window between the bind and the open must get an explanation, not a
+        // NullReferenceException raised somewhere far from the cause.
+        using var db = new GatewayDatabase(new SingleTenantContext(), TempDbPath(), deferOpen: true);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => db.CreateContext());
+
+        Assert.Contains("not open yet", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Open_is_idempotent()
+    {
+        var path = TempDbPath();
+        using var db = new GatewayDatabase(new SingleTenantContext(), path, deferOpen: true);
+
+        db.Open();
+        db.Open();      // must not rebuild the provider or re-run migrations
+
+        Assert.True(db.IsOpen);
+    }
+
+    [Fact]
+    public void THE_DEFAULT_IS_UNCHANGED_construction_still_opens_eagerly()
+    {
+        // Everything that is not the hosted Gateway - the desktop pairing store, and every test that asserts
+        // this constructor throws on a database it cannot open - keeps the historical behaviour exactly.
+        var path = TempDbPath();
+
+        using var db = new GatewayDatabase(new SingleTenantContext(), path);
+
+        Assert.True(db.IsOpen);
+        Assert.True(File.Exists(path));
+    }
+
+    [Fact]
+    public void Disposing_a_never_opened_database_does_not_throw()
+    {
+        // The deferred path can be disposed without Open() ever running - a failed start does exactly that.
+        var db = new GatewayDatabase(new SingleTenantContext(), TempDbPath(), deferOpen: true);
+
+        db.Dispose();   // must not dereference the provider it never built
+    }
+
+    [Fact]
+    public void A_configuration_fault_still_fails_in_the_CONSTRUCTOR_even_when_deferred()
+    {
+        // The split defers only the part that can succeed later - reaching the server. A connection string
+        // that is set but blank is misconfiguration: waiting cannot fix it, and a Gateway must not bind a
+        // port and serve errors forever because of one. So it must still fail at construction.
+        var prior = Environment.GetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar, "   ");
+
+            Assert.Throws<InvalidOperationException>(
+                () => new GatewayDatabase(new SingleTenantContext(), TempDbPath(), deferOpen: true));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayDatabase.PostgresConnectionEnvVar, prior);
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -191,7 +191,11 @@ internal static class GatewayEndpoints
         // Director, because the command line reached the fleet through its own Director's loopback port; with
         // that port going away the check has to move to the end still in the path. Null (older callers,
         // tests, a Gateway with the steward switched off) ALLOWS every message, byte-identical to today.
-        Core.Fleet.MessageSteward? messageSteward = null)
+        Core.Fleet.MessageSteward? messageSteward = null,
+        // Whether the database is connected yet (issue #2383's real fix). A delegate, not a bool: Map
+        // runs before the listener binds and the database is opened AFTER it, so the value is not known
+        // here. Null means "assume ready", which is what every self-host and test caller wants.
+        Func<bool>? databaseReady = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -562,6 +566,29 @@ internal static class GatewayEndpoints
         // ===== REST =====
         app.MapGet("/healthz", () =>
         {
+            // NOT READY UNTIL THE DATABASE IS OPEN, and this is load-bearing rather than cosmetic.
+            //
+            // The listener now binds BEFORE the database is connected, so that a slow database can never
+            // push the bind past the platform's container-start deadline and make it stop the site (#2383,
+            // #2585). That fixes the outage, but it creates a window in which this process is listening and
+            // cannot serve data - and /healthz is what the deploy warms on (it polls staging for a sustained
+            // 200 carrying the new commit) and what the platform's own swap warm-up gate pings. Answering
+            // 200 in that window would hand production to a Gateway that cannot read anything, which is a
+            // worse outage than the one being fixed.
+            //
+            // 503 is the honest answer and it costs nothing: the warm-up simply keeps polling, which is what
+            // a warmed slot swap is for.
+            if (databaseReady is not null && !databaseReady())
+            {
+                return Results.Json(new HealthDto
+                {
+                    Status = "starting",
+                    Version = version,
+                    Commit = Environment.GetEnvironmentVariable("COCKPIT_COMMIT"),
+                    ServerTime = DateTime.UtcNow,
+                }, statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
             // The exact commit this image was built from (COCKPIT_COMMIT is baked into the container as an
             // ENV in the Dockerfile). NULL when unstamped (e.g. a local dev run) - HealthDto omits it then.
             // The deploy pipeline polls /healthz until this equals the commit it just shipped: that is the

--- a/src/CcDirector.Gateway/CronJobStore.cs
+++ b/src/CcDirector.Gateway/CronJobStore.cs
@@ -49,19 +49,50 @@ public sealed class CronJobStore
     /// </param>
     /// <exception cref="ArgumentNullException">The database is null.</exception>
     /// <exception cref="ArgumentException">The legacy path is null/empty/whitespace.</exception>
-    public CronJobStore(GatewayDatabase db, string legacyJsonPath)
+    /// <param name="deferInitialize">
+    /// When true the constructor validates arguments and stops; the caller must call
+    /// <see cref="Initialize"/> once the database is open. The Gateway passes true so its listener can bind
+    /// BEFORE any database work - the load below used to sit in front of the bind, and a slow database
+    /// therefore delayed it past the platform's container-start deadline (#2383, #2585).
+    ///
+    /// The caller MUST run Initialize inside the same ambient tenant scope the constructor would have had.
+    /// Nothing is served in the meantime: the readiness gate refuses every request but /healthz.
+    /// </param>
+    public CronJobStore(GatewayDatabase db, string legacyJsonPath, bool deferInitialize = false)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         if (string.IsNullOrWhiteSpace(legacyJsonPath))
             throw new ArgumentException("legacy json path is required", nameof(legacyJsonPath));
         _legacyJsonPath = legacyJsonPath;
 
+        if (!deferInitialize)
+            InitializeCore();
+    }
+
+    /// <summary>
+    /// Run the deferred load. Idempotent, and a no-op for an instance whose constructor already did it.
+    /// </summary>
+    public void Initialize()
+    {
+        if (_initialized) return;
+        InitializeCore();
+    }
+
+    /// <summary>True once the load has run.</summary>
+    public bool IsInitialized => _initialized;
+
+    private bool _initialized;
+
+    private void InitializeCore()
+    {
         lock (_gate)
         {
             ImportLegacyJsonIfNeeded();
             RecomputeNextRunOnLoad();
         }
+        _initialized = true;
     }
+
 
     /// <summary>
     /// Create a job from a validated definition. Mints an id, stamps <see cref="CronJobDto.CreatedUtc"/>,

--- a/src/CcDirector.Gateway/Data/GatewayDatabase.cs
+++ b/src/CcDirector.Gateway/Data/GatewayDatabase.cs
@@ -122,8 +122,14 @@ public sealed class GatewayDatabase : IDisposable
     private readonly string _path;
     private readonly bool _usePostgres;
     private readonly ITenantContext _tenant;
-    private readonly ServiceProvider _provider;
-    private readonly IDbContextFactory<GatewayDbContext> _factory;
+    // Assigned by Open(), not by the constructor: the hosted Gateway defers the connect so its listener
+    // can bind first. Null until Open() succeeds, which is exactly what IsOpen reports.
+    private ServiceProvider? _provider;
+    private IDbContextFactory<GatewayDbContext>? _factory;
+
+    // The pool-bounded Postgres connection string, parsed and validated in the constructor and used by
+    // Open(). Holds credentials, so it is never logged - see RedactConnectionTarget for what is.
+    private readonly string? _boundedConn;
     private bool _disposed;
 
     /// <summary>The database file path (SQLite), for logging. On the Postgres path this is NOT a file - it
@@ -186,7 +192,21 @@ public sealed class GatewayDatabase : IDisposable
     /// <see cref="SingleTenantContext"/> and every row is the "local" tenant.</param>
     /// <param name="dbPath">The SQLite database file. Defaults to <see cref="CcStorage.GatewayDb"/>. Ignored
     /// when <see cref="PostgresConnectionEnvVar"/> is set (the Postgres path never touches a file).</param>
-    public GatewayDatabase(ITenantContext tenant, string? dbPath = null)
+    /// <param name="deferOpen">
+    /// When true the constructor VALIDATES configuration and stops there, and the caller must call
+    /// <see cref="Open"/> to connect and migrate. The hosted Gateway passes true so its listener can
+    /// bind BEFORE any database work: connecting and migrating used to sit in front of the bind, and a
+    /// slow database therefore pushed the bind past the platform's container-start deadline, at which
+    /// point the platform stopped the SITE - tearing down the healthy container that was serving beside
+    /// it. That is the 2 and 12 August 2026 outages (#2383, #2585); this parameter is what lets the
+    /// order be fixed rather than the wait merely shortened.
+    ///
+    /// Configuration faults still fail in the CONSTRUCTOR either way - an unset-but-blank connection
+    /// string, or one that cannot be parsed. Those are misconfiguration, they cannot be recovered by
+    /// waiting, and a Gateway must not bind a port to serve errors forever because of one. Only the
+    /// part that can succeed later - reaching the server - is deferred.
+    /// </param>
+    public GatewayDatabase(ITenantContext tenant, string? dbPath = null, bool deferOpen = false)
     {
         _tenant = tenant ?? throw new ArgumentNullException(nameof(tenant));
 
@@ -229,10 +249,9 @@ public sealed class GatewayDatabase : IDisposable
             // The original exception is deliberately NOT kept as an InnerException: the whole point is that
             // its message must not survive to be written by anything downstream. The type name is preserved
             // in the redacted message, which is what a diagnosis actually needs.
-            string boundedConn;
             try
             {
-                boundedConn = WithBoundedPool(pgConn!, DefaultMaxPoolSize);
+                _boundedConn = WithBoundedPool(pgConn!, DefaultMaxPoolSize);
             }
             catch (Exception ex)
             {
@@ -243,7 +262,35 @@ public sealed class GatewayDatabase : IDisposable
                     "Its text is deliberately not reproduced here - the parser's own message can echo part of " +
                     "the string, which may carry credentials. Check " + PostgresConnectionEnvVar + " and restart.");
             }
+        }
+        else
+        {
+            _path = string.IsNullOrWhiteSpace(dbPath) ? CcStorage.GatewayDb() : dbPath!;
+        }
 
+        // Default is the historical behaviour: construct and connect in one step. Every caller that
+        // does not say otherwise - the desktop pairing store, and every test that asserts this
+        // constructor throws on an unreachable or unmigratable database - keeps exactly that.
+        if (!deferOpen)
+            Open();
+    }
+
+    /// <summary>
+    /// Connect and migrate. Idempotent: a second call after a successful open does nothing, so a caller
+    /// that cannot easily tell whether the constructor already opened may call it safely.
+    ///
+    /// SEPARATED FROM CONSTRUCTION so the hosted Gateway can bind its listener first. Everything about
+    /// the failure behaviour is unchanged - the same bounded retry window, the same fail-loud throw when
+    /// the window is spent - because the outage was never caused by giving up too early. It was caused
+    /// by doing this work while the platform was still waiting for a port.
+    /// </summary>
+    public void Open()
+    {
+        if (_factory is not null)
+            return;
+
+        if (_usePostgres)
+        {
             FileLog.Write($"[GatewayDatabase] Open: provider=Postgres target={_path}");
 
             // Retry the open for a bounded window rather than treating one refusal as a dead database.
@@ -261,7 +308,7 @@ public sealed class GatewayDatabase : IDisposable
                 try
                 {
                     var services = new ServiceCollection();
-                    services.AddPooledDbContextFactory<GatewayDbContext>(o => o.UseNpgsql(boundedConn, npg =>
+                    services.AddPooledDbContextFactory<GatewayDbContext>(o => o.UseNpgsql(_boundedConn!, npg =>
                     {
                         npg.MigrationsAssembly("CcDirector.Gateway.Migrations.Postgres");
                         npg.MigrationsHistoryTable("__EFMigrationsHistory", "gateway");
@@ -340,8 +387,6 @@ public sealed class GatewayDatabase : IDisposable
             }
         }
 
-        _path = string.IsNullOrWhiteSpace(dbPath) ? CcStorage.GatewayDb() : dbPath!;
-
         FileLog.Write($"[GatewayDatabase] Open: provider=Sqlite path={_path}");
         try
         {
@@ -413,13 +458,30 @@ public sealed class GatewayDatabase : IDisposable
     /// stamps the context so the global query filter and every write scope to it. The caller disposes it
     /// (it returns to the pool).
     /// </summary>
+    /// <summary>
+    /// True once <see cref="Open"/> has connected and migrated. False between construction and Open on the
+    /// deferred path - the window in which the hosted Gateway is LISTENING but cannot yet serve data, which
+    /// is exactly what /healthz reports as not-ready so the deploy's warm-up waits instead of swapping onto
+    /// a Gateway that would answer errors.
+    /// </summary>
+    public bool IsOpen => _factory is not null;
+
+    // Every context factory goes through this. Before Open() the fields are null, and a bare null-deref
+    // would surface as a NullReferenceException somewhere far from the cause; a caller that arrives during
+    // the open window deserves to be told what is actually happening.
+    private IDbContextFactory<GatewayDbContext> RequireOpen()
+        => _factory ?? throw new InvalidOperationException(
+            "The Gateway database is not open yet. The listener binds before the database is connected so "
+            + "that a slow database cannot stop the site from starting; requests that need data must wait "
+            + "for /healthz to report ready.");
+
     public GatewayDbContext CreateContext()
     {
         var tenant = _tenant.Current;
         if (!tenant.IsValid)
             throw new ArgumentException("A valid TenantId is required.", nameof(tenant));
 
-        var ctx = _factory.CreateDbContext();
+        var ctx = RequireOpen().CreateDbContext();
         ctx.ActiveTenant = tenant.Value;
         return ctx;
     }
@@ -440,7 +502,7 @@ public sealed class GatewayDatabase : IDisposable
         if (!tenant.IsValid)
             throw new ArgumentException("A valid TenantId is required.", nameof(tenant));
 
-        var ctx = _factory.CreateDbContext();
+        var ctx = RequireOpen().CreateDbContext();
         ctx.ActiveTenant = tenant.Value;
         return ctx;
     }
@@ -464,7 +526,7 @@ public sealed class GatewayDatabase : IDisposable
     /// </summary>
     public GatewayDbContext CreateUnscopedContext()
     {
-        var ctx = _factory.CreateDbContext();
+        var ctx = RequireOpen().CreateDbContext();
         ctx.ActiveTenant = null;
         return ctx;
     }
@@ -473,7 +535,8 @@ public sealed class GatewayDatabase : IDisposable
     {
         if (_disposed) return;
         _disposed = true;
-        _provider.Dispose();
+        // Null when the database was constructed with deferOpen and Open() never ran (or threw).
+        _provider?.Dispose();
         // Release the underlying SQLite connections so a test can delete the database file. SQLite-only:
         // the Postgres path has no local file to release and Npgsql pooling is managed by the provider.
         if (!_usePostgres)

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -451,6 +451,68 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly Tenancy.ITenantPass _tenantPass;
     private readonly Data.GatewayDatabase _gatewayDb;
 
+    /// <summary>
+    /// Whether this Gateway may serve anything beyond /healthz: the database is open AND the device
+    /// credential authority has been established. False between the listener binding and the end of the
+    /// startup work that follows it.
+    ///
+    /// Both halves are required and neither implies the other - the database opening is what lets the
+    /// authority be read, and the authority is what makes an authenticated request answerable.
+    /// </summary>
+    /// <summary>
+    /// Open the database and load every store that reads from it at startup. Called by
+    /// <see cref="StartAsync"/> immediately AFTER the listener binds, and idempotent so a caller that
+    /// cannot easily tell whether startup has run may call it safely.
+    ///
+    /// WHY IT IS A NAMED STEP RATHER THAN INLINE IN StartAsync. All of this used to happen during
+    /// construction, in front of the bind, which is what let a slow database delay the bind past the
+    /// platform's container-start deadline and make it stop the SITE - taking the healthy container with it
+    /// (#2383, #2585). Naming the step keeps the ordering visible, lets a test bring a host to a usable
+    /// state without binding a port, and means there is ONE definition of "the startup database work"
+    /// rather than a copy in every caller that needs it.
+    /// </summary>
+    internal void EnsureStoresReady()
+    {
+        FileLog.Write("[GatewayHost] listener bound; opening the database");
+        _gatewayDb.Open();
+        FileLog.Write("[GatewayHost] database open");
+
+        // Every store that LOADS FROM THE DATABASE AT STARTUP, initialised here rather than in the
+        // constructor so none of it stands in front of the listener bind.
+        //
+        // INSIDE THE SYSTEM SCOPE, and that is not decoration. The constructor did this work inside
+        // _hostedTenant.Enter(TenantId.System), and three of these stores CAPTURE the ambient tenant as
+        // the partition that owns the shared library (skills, workflows, workflow runs). Initialising
+        // them out here without re-entering that scope would capture whatever tenant happened to be
+        // ambient and put the shared library in the WRONG PARTITION - silently, and visible only later
+        // as one account seeing another's library. The scope is re-entered for exactly the span the
+        // constructor had.
+        //
+        // Until every one of these returns, the readiness gate refuses every request but /healthz.
+        using (_hostedTenant?.Enter(Core.Tenancy.TenantId.System))
+        {
+            Devices.Initialize();
+            _workLists.Initialize();
+            _cronJobs.Initialize();
+            _skills.Initialize();
+            _workflows.Initialize();
+            _workflowRuns.Initialize();
+            _instructionsStore.Initialize();
+        }
+
+        FileLog.Write("[GatewayHost] startup stores loaded; now serving");
+    }
+
+    internal bool IsReadyToServe()
+        => _gatewayDb.IsOpen
+        && Devices.IsInitialized
+        && _workLists.IsInitialized
+        && _cronJobs.IsInitialized
+        && _skills.IsInitialized
+        && _workflows.IsInitialized
+        && _workflowRuns.IsInitialized
+        && _instructionsStore.IsInitialized;
+
     /// <summary>The typed per-tenant runtime settings resolver. Every caller supplies the tenant explicitly;
     /// an unset override returns only the operator global default.</summary>
     internal Settings.TenantSettingsResolver TenantSettingsResolver => _tenantSettingsResolver;
@@ -1125,10 +1187,20 @@ public sealed class GatewayHost : IAsyncDisposable
             _tenantContext = new Core.Tenancy.SingleTenantContext();
         }
 
-        _gatewayDb = new Data.GatewayDatabase(_tenantContext);
+        // deferOpen: the listener must bind BEFORE any database work. Connecting and migrating used to sit
+        // in front of the bind, so a slow database pushed the bind past the platform's container-start
+        // deadline, the platform concluded no port would ever be bound, and it stopped the SITE - tearing
+        // down the healthy container serving beside it. That is the 2 and 12 August 2026 outages (#2383,
+        // #2585), and shortening the wait only ever made it less likely. StartAsync opens it immediately
+        // after the bind; configuration faults still throw here, because waiting cannot fix those.
+        _gatewayDb = new Data.GatewayDatabase(_tenantContext, deferOpen: true);
         // MTR-14B: the shared EF database is now the device registry authority. The legacy JSON path is
         // supplied only to the one-time importer; no runtime authentication or mutation reads or writes it.
-        Devices = new Pairing.DeviceRegistry(_gatewayDb, devicesPath, GatewayHostedMode.IsHosted);
+        // deferInitialize: establishing the credential authority READS the database, and that read used to
+        // sit in front of the listener bind. StartAsync initialises it immediately after the database opens,
+        // and the readiness gate refuses everything but /healthz until it has.
+        Devices = new Pairing.DeviceRegistry(_gatewayDb, devicesPath, GatewayHostedMode.IsHosted,
+            deferInitialize: true);
         // Remove-the-network-port phase 1b: the per-session credential registry. A Director registers one key
         // per session over the tunnel it already holds, and an agent inside that session authenticates as the
         // session rather than with its Director's account-wide key. Same database and the same stored-hash
@@ -1188,17 +1260,17 @@ public sealed class GatewayHost : IAsyncDisposable
         // Named work lists persist across a Gateway restart (issue #301) in the worklists table (stale
         // claims released on load). The path argument is the LEGACY worklists.json, imported once on first
         // upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real legacy file.
-        _workLists = new WorkListStore(_gatewayDb, workListsPath ?? Path.Combine(CcStorage.Root(), "worklists.json"));
+        _workLists = new WorkListStore(_gatewayDb, workListsPath ?? Path.Combine(CcStorage.Root(), "worklists.json"), deferInitialize: true);
         // The workflow catalog (Workflows mission, phase 1): persisted in the workflows tables, the
         // shipped built-ins seeded/upgraded at construction. No legacy JSON - the previous catalog was
         // compiled-in C# literals, so there is nothing on disk to import.
-        _workflows = new Workflows.WorkflowStore(_gatewayDb);
+        _workflows = new Workflows.WorkflowStore(_gatewayDb, deferInitialize: true);
         // Workflow runs (phase 4, issue #1771): built after the catalog store so the built-ins a run
         // pins are already seeded.
-        _workflowRuns = new Workflows.WorkflowRunStore(_gatewayDb);
+        _workflowRuns = new Workflows.WorkflowRunStore(_gatewayDb, deferInitialize: true);
         // The central skill library: persisted in the skills tables, the shipped built-ins
         // seeded/upgraded at construction. Nothing is deployed to any machine - agents fetch.
-        _skills = new Skills.SkillStore(_gatewayDb);
+        _skills = new Skills.SkillStore(_gatewayDb, deferInitialize: true);
         // The governance event ledger (issue #1771, spine item 2): append-only session/run transitions on
         // the EF data layer, so a Gateway restart never loses a recorded transition.
         _governanceEvents = new Governance.GovernanceEventLedger(_gatewayDb);
@@ -1244,7 +1316,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // Editable/versioned wingman instructions (issue #537) now persist in the wingman_instructions table
         // of the EF data layer. The path argument is the LEGACY wingman-instructions.json, imported once on
         // first upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real file.
-        _instructionsStore = new Wingman.WingmanInstructionsStore(_gatewayDb, wingmanInstructionsPath ?? Path.Combine(CcStorage.Root(), "wingman-instructions.json"));
+        _instructionsStore = new Wingman.WingmanInstructionsStore(_gatewayDb, wingmanInstructionsPath ?? Path.Combine(CcStorage.Root(), "wingman-instructions.json"), deferInitialize: true);
         // THE SNOOZE CLEAR ON EVICTION IS DELETED, and of the three deletions this is the one that mattered
         // most (inspection 2, finding 1).
         //
@@ -1451,7 +1523,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // (next-run times recomputed on load). The path argument is the LEGACY cronjobs.json, imported once
         // on first upgrade then renamed aside. Tests MUST pass an isolated path so they never touch the real
         // legacy file.
-        _cronJobs = new CronJobStore(_gatewayDb, cronJobsPath ?? Path.Combine(CcStorage.Root(), "cronjobs.json"));
+        _cronJobs = new CronJobStore(_gatewayDb, cronJobsPath ?? Path.Combine(CcStorage.Root(), "cronjobs.json"), deferInitialize: true);
         // Cron run history + the firing engine (epic #479, #483). The engine resolves each due job's
         // target Director from the registry and starts a session over the shared client (the same
         // path the work-list runner uses). The background sweep timer is started in StartAsync. The path
@@ -2529,6 +2601,42 @@ public sealed class GatewayHost : IAsyncDisposable
 
         _app.UseForwardedHeaders();
 
+        // THE READINESS GATE. Nothing but /healthz is served until the database is open AND the device
+        // credential authority has been established.
+        //
+        // This exists because the listener now binds BEFORE that work, which is the fix for the deploy
+        // outages (#2383, #2585): the database open used to sit in front of the bind, so a slow database
+        // pushed the bind past the platform's container-start deadline, the platform decided no port would
+        // ever appear, and it stopped the SITE - tearing down the healthy container serving beside it.
+        //
+        // Binding early stops the platform giving up on the site. It is NOT permission to serve before the
+        // Gateway knows which device keys are valid, and without this gate that is exactly what would
+        // happen: requests would arrive at an uninitialised credential authority. So every request but the
+        // probe is refused, loudly and cheaply, until both are up.
+        //
+        // FIRST in the pipeline, ahead of auth and the access log: a request that must not be served must
+        // not be authenticated first either, and this decision cannot depend on anything downstream.
+        //
+        // /healthz is the ONE exemption, and it must be - it is what the deploy's warm-up polls and what
+        // the platform's swap gate pings, and it reports the not-ready state itself (503 with
+        // status "starting"), so the swap waits rather than promoting a Gateway that cannot serve.
+        _app.Use(async (ctx, next) =>
+        {
+            var path = ctx.Request.Path.Value ?? "";
+            if (path.Equals("/healthz", StringComparison.OrdinalIgnoreCase) || IsReadyToServe())
+            {
+                await next();
+                return;
+            }
+
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            // Tell a client it is worth coming back, and roughly when. The open is bounded by the database
+            // retry window, so a fixed small hint is honest without promising a time we cannot keep.
+            ctx.Response.Headers.RetryAfter = "5";
+            ctx.Response.ContentType = "application/json; charset=utf-8";
+            await ctx.Response.WriteAsync("{\"error\":\"starting\",\"detail\":\"The Gateway is listening but not ready to serve yet.\"}");
+        });
+
         // Access log + single top-level exception boundary. Every request leaves one
         // line (method, path, status, elapsed, client, host) so a phone-side problem is
         // traceable after the fact. Health polls and favicon are skipped to keep the log
@@ -2710,6 +2818,8 @@ public sealed class GatewayHost : IAsyncDisposable
             gatewayStartedAtUtc: StartedAtUtc,
             // Issue #2161: a delegate - Map runs before the listener binds.
             gatewayPort: () => Port,
+            // Not-ready until the database is open - see the /healthz handler.
+            databaseReady: () => _gatewayDb.IsOpen,
             // Store injection points: hand the phone-recorder ingest (RecordingEndpoints) the host's single
             // key vault + transcription history + audio archive, so it stops newing its own copies.
             recordingKeyVault: _keyVault,
@@ -3466,6 +3576,25 @@ public sealed class GatewayHost : IAsyncDisposable
         MappedEndpoints = Tenancy.HostedRefusalRouteSpace.SelectFinalisedEndpoints(_app);
 
         await _app.StartAsync();
+
+        // THE DATABASE IS OPENED HERE, AFTER THE BIND, and the order is the whole point.
+        //
+        // Until now this ran inside the GatewayDatabase constructor, far above - so on every deploy the new
+        // container connected and migrated while the platform was still waiting for it to listen. A slow
+        // open pushed the bind past the container-start deadline; the platform then stopped the SITE, and
+        // stopping the site tore down the healthy container that was serving traffic beside it. Both the 2
+        // August (38.5s) and 12 August (46.7s) outages were that stop, not the swap.
+        //
+        // Nothing about the failure behaviour changes: the same bounded retry window, and the same loud
+        // throw when it is spent, which GatewayService turns into a Failed state and GatewayWorker turns
+        // into a process exit. What changes is that the platform can already see a listening port while all
+        // of that happens, so a database problem can no longer take the site down with it.
+        //
+        // /healthz answers 503 for the duration, so the deploy's warm-up waits rather than swapping onto a
+        // Gateway that cannot serve data.
+        // The database and every store that loads from it. Named and called here, immediately after the
+        // bind - see EnsureStoresReady for why the order matters.
+        EnsureStoresReady();
 
         // Issue #2161: when the caller asked for an operating-system-assigned port, the number only exists
         // once Kestrel has bound - so read it back from the server itself. This is the whole point of the

--- a/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
@@ -55,13 +55,44 @@ public sealed class DeviceRegistry : IDisposable
     /// <param name="db">The host-owned database shared by every Gateway replica.</param>
     /// <param name="storePath">The legacy JSON path used only by the one-time importer.</param>
     /// <param name="isHosted">Whether tenant-bound hosted credential rules must be enforced.</param>
-    public DeviceRegistry(GatewayDatabase db, string? storePath = null, bool isHosted = false)
+    /// <param name="deferInitialize">
+    /// When true the constructor stops after wiring, and the caller must call <see cref="Initialize"/> once
+    /// the database is open. The hosted Gateway passes true because <see cref="InitializeAuthority"/> READS
+    /// THE DATABASE - it runs the one-time import and then decides which credentials are valid - and that
+    /// read used to sit in front of the listener bind. A slow database therefore delayed the bind, and when
+    /// it delayed it past the platform's container-start deadline the platform stopped the SITE, taking the
+    /// healthy container down with it (#2383, #2585).
+    ///
+    /// Nothing is served before Initialize runs: the Gateway's readiness gate answers 503 to every request
+    /// but /healthz until both the database and this authority are up. Binding early is what stops the
+    /// platform from giving up on the site; it is not permission to serve without knowing which device keys
+    /// are valid.
+    /// </param>
+    public DeviceRegistry(GatewayDatabase db, string? storePath = null, bool isHosted = false,
+        bool deferInitialize = false)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _storePath = ResolveStorePath(storePath);
         _isHosted = isHosted;
+        if (!deferInitialize)
+            InitializeAuthority();
+    }
+
+    /// <summary>
+    /// Run the one-time import and establish which device credentials are authoritative. Idempotent, and a
+    /// no-op for a registry whose constructor already did it.
+    /// </summary>
+    public void Initialize()
+    {
+        if (_initialized)
+            return;
         InitializeAuthority();
     }
+
+    private bool _initialized;
+
+    /// <summary>True once the credential authority has been established.</summary>
+    public bool IsInitialized => _initialized;
 
     /// <summary>The legacy registry path used by the one-time importer.</summary>
     public string StorePath => _storePath;
@@ -480,6 +511,7 @@ public sealed class DeviceRegistry : IDisposable
 
     private void InitializeAuthority()
     {
+        // Set LAST, below, so a throw leaves this false and the readiness gate keeps refusing.
         var import = new DeviceRegistryImporter(_db, _storePath).Import();
 
         using (var ctx = _db.CreateUnscopedContext())
@@ -523,6 +555,8 @@ public sealed class DeviceRegistry : IDisposable
             ArchiveLegacyFile();
 
         FileLog.Write($"[DeviceRegistry] InitializeAuthority: database registry ready, imported={import.ImportedCount}, importSkipped={import.Skipped}");
+
+        _initialized = true;
     }
 
     private void ArchiveLegacyFile()

--- a/src/CcDirector.Gateway/Skills/SkillStore.cs
+++ b/src/CcDirector.Gateway/Skills/SkillStore.cs
@@ -40,21 +40,56 @@ public sealed class SkillStore
 
     /// <summary>The partition the built-in library lives in: the tenant that was ambient when this
     /// store was constructed (System on hosted, Local on self-host).</summary>
-    private readonly string _libraryTenant;
+    // Captured by InitializeCore, which may run after construction (the Gateway defers it so its listener
+    // can bind first), so this cannot be readonly. It is still written EXACTLY ONCE: InitializeCore is
+    // guarded by _initialized and never runs twice. Empty until then, and nothing reads it before the
+    // readiness gate opens.
+    private string _libraryTenant = "";
 
     /// <param name="db">The Gateway EF database this store reads and writes through.</param>
     /// <exception cref="ArgumentNullException">The database is null.</exception>
-    public SkillStore(GatewayDatabase db)
+    /// <param name="deferInitialize">
+    /// When true the constructor validates arguments and stops; the caller must call
+    /// <see cref="Initialize"/> once the database is open. The Gateway passes true so its listener can bind
+    /// BEFORE any database work - the load below used to sit in front of the bind, and a slow database
+    /// therefore delayed it past the platform's container-start deadline (#2383, #2585).
+    ///
+    /// The caller MUST run Initialize inside the same ambient tenant scope the constructor would have had.
+    /// Nothing is served in the meantime: the readiness gate refuses every request but /healthz.
+    /// </param>
+    public SkillStore(GatewayDatabase db, bool deferInitialize = false)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
 
+        if (!deferInitialize)
+            InitializeCore();
+    }
+
+    /// <summary>
+    /// Run the deferred load. Idempotent, and a no-op for an instance whose constructor already did it.
+    /// </summary>
+    public void Initialize()
+    {
+        if (_initialized) return;
+        InitializeCore();
+    }
+
+    /// <summary>True once the load has run.</summary>
+    public bool IsInitialized => _initialized;
+
+    private bool _initialized;
+
+    private void InitializeCore()
+    {
         lock (_gate)
         {
             using var ctx = _db.CreateContext();
             _libraryTenant = ctx.ActiveTenant!;
             BuiltInSkillSeeder.Seed(ctx);
         }
+        _initialized = true;
     }
+
 
     /// <summary>A fresh context scoped to the shared library partition. Read-only by contract on
     /// request paths (the seeder is the only library writer); caller disposes.</summary>

--- a/src/CcDirector.Gateway/Wingman/WingmanInstructionsStore.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanInstructionsStore.cs
@@ -66,8 +66,17 @@ public sealed class WingmanInstructionsStore
     /// <param name="db">The Gateway EF database this store reads and writes through.</param>
     /// <param name="legacyJsonPath">The legacy <c>wingman-instructions.json</c> path to import ONCE if it
     /// exists and the table is empty. REQUIRED (no silent default).</param>
+    /// <param name="deferInitialize">
+    /// When true the constructor validates arguments and stops; the caller must call
+    /// <see cref="Initialize"/> once the database is open. The Gateway passes true so its listener can bind
+    /// BEFORE any database work - the load below used to sit in front of the bind, and a slow database
+    /// therefore delayed it past the platform's container-start deadline (#2383, #2585).
+    ///
+    /// The caller MUST run Initialize inside the same ambient tenant scope the constructor would have had.
+    /// Nothing is served in the meantime: the readiness gate refuses every request but /healthz.
+    /// </param>
     public WingmanInstructionsStore(GatewayDatabase db, string legacyJsonPath,
-        string? defaultContent = null, string? defaultVersion = null)
+        string? defaultContent = null, string? defaultVersion = null, bool deferInitialize = false)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         if (string.IsNullOrWhiteSpace(legacyJsonPath))
@@ -75,8 +84,30 @@ public sealed class WingmanInstructionsStore
         _legacyJsonPath = legacyJsonPath;
         _defaultContent = defaultContent ?? WingmanTranslator.FidelityPrompt;
         _defaultVersion = defaultVersion ?? WingmanTranslator.DefaultInstructionsVersion;
-        Load();
+        if (!deferInitialize)
+            InitializeCore();
     }
+
+    /// <summary>
+    /// Run the deferred load. Idempotent, and a no-op for an instance whose constructor already did it.
+    /// </summary>
+    public void Initialize()
+    {
+        if (_initialized) return;
+        InitializeCore();
+    }
+
+    /// <summary>True once the load has run.</summary>
+    public bool IsInitialized => _initialized;
+
+    private bool _initialized;
+
+    private void InitializeCore()
+    {
+        Load();
+        _initialized = true;
+    }
+
 
     public string DefaultContent => _defaultContent;
     public string DefaultVersion => _defaultVersion;

--- a/src/CcDirector.Gateway/WorkListStore.cs
+++ b/src/CcDirector.Gateway/WorkListStore.cs
@@ -62,19 +62,50 @@ public sealed class WorkListStore
     /// table is empty. REQUIRED (no silent default).</param>
     /// <exception cref="ArgumentNullException">The database is null.</exception>
     /// <exception cref="ArgumentException">The legacy path is null/empty/whitespace.</exception>
-    public WorkListStore(GatewayDatabase db, string legacyJsonPath)
+    /// <param name="deferInitialize">
+    /// When true the constructor validates arguments and stops; the caller must call
+    /// <see cref="Initialize"/> once the database is open. The Gateway passes true so its listener can bind
+    /// BEFORE any database work - the load below used to sit in front of the bind, and a slow database
+    /// therefore delayed it past the platform's container-start deadline (#2383, #2585).
+    ///
+    /// The caller MUST run Initialize inside the same ambient tenant scope the constructor would have had.
+    /// Nothing is served in the meantime: the readiness gate refuses every request but /healthz.
+    /// </param>
+    public WorkListStore(GatewayDatabase db, string legacyJsonPath, bool deferInitialize = false)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         if (string.IsNullOrWhiteSpace(legacyJsonPath))
             throw new ArgumentException("legacy json path is required", nameof(legacyJsonPath));
         _legacyJsonPath = legacyJsonPath;
 
+        if (!deferInitialize)
+            InitializeCore();
+    }
+
+    /// <summary>
+    /// Run the deferred load. Idempotent, and a no-op for an instance whose constructor already did it.
+    /// </summary>
+    public void Initialize()
+    {
+        if (_initialized) return;
+        InitializeCore();
+    }
+
+    /// <summary>True once the load has run.</summary>
+    public bool IsInitialized => _initialized;
+
+    private bool _initialized;
+
+    private void InitializeCore()
+    {
         lock (_gate)
         {
             ImportLegacyJsonIfNeeded();
             ReleaseStaleClaimsOnLoad();
         }
+        _initialized = true;
     }
+
 
     /// <summary>The outcome of a single-consumer claim attempt.</summary>
     public enum ClaimResult

--- a/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowRunStore.cs
@@ -37,7 +37,11 @@ public sealed class WorkflowRunStore
 
     /// <summary>The shared library partition - the tenant ambient at construction (System on hosted,
     /// Local on self-host), mirroring <see cref="WorkflowStore"/>.</summary>
-    private readonly string _libraryTenant;
+    // Captured by InitializeCore, which may run after construction (the Gateway defers it so its listener
+    // can bind first), so this cannot be readonly. It is still written EXACTLY ONCE: InitializeCore is
+    // guarded by _initialized and never runs twice. Empty until then, and nothing reads it before the
+    // readiness gate opens.
+    private string _libraryTenant = "";
 
     private static readonly Dictionary<string, string[]> LegalTransitions = new(StringComparer.Ordinal)
     {
@@ -68,16 +72,46 @@ public sealed class WorkflowRunStore
         WorkflowRunCriterionStatus.Pending, WorkflowRunCriterionStatus.Met,
         WorkflowRunCriterionStatus.NotMet, WorkflowRunCriterionStatus.Waived,
     };
-
-    public WorkflowRunStore(GatewayDatabase db)
+    /// <param name="deferInitialize">
+    /// When true the constructor validates arguments and stops; the caller must call
+    /// <see cref="Initialize"/> once the database is open. The Gateway passes true so its listener can bind
+    /// BEFORE any database work - the load below used to sit in front of the bind, and a slow database
+    /// therefore delayed it past the platform's container-start deadline (#2383, #2585).
+    ///
+    /// The caller MUST run Initialize inside the same ambient tenant scope the constructor would have had.
+    /// Nothing is served in the meantime: the readiness gate refuses every request but /healthz.
+    /// </param>
+    public WorkflowRunStore(GatewayDatabase db, bool deferInitialize = false)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
 
         // Capture the library partition from the construction-time ambient tenant, exactly as
         // WorkflowStore does (the composition root constructs both inside the startup System scope).
+        if (!deferInitialize)
+            InitializeCore();
+    }
+
+    /// <summary>
+    /// Run the deferred load. Idempotent, and a no-op for an instance whose constructor already did it.
+    /// </summary>
+    public void Initialize()
+    {
+        if (_initialized) return;
+        InitializeCore();
+    }
+
+    /// <summary>True once the load has run.</summary>
+    public bool IsInitialized => _initialized;
+
+    private bool _initialized;
+
+    private void InitializeCore()
+    {
         using var ctx = _db.CreateContext();
         _libraryTenant = ctx.ActiveTenant!;
+        _initialized = true;
     }
+
 
     /// <summary>
     /// Open the context for the partition that OWNS workflow <paramref name="key"/>: the shared

--- a/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
+++ b/src/CcDirector.Gateway/Workflows/WorkflowStore.cs
@@ -38,20 +38,51 @@ public sealed class WorkflowStore
     /// so self-host - where the single-tenant context answers Local for everything - keeps reading
     /// the exact rows it always read, and the reserved System id never appears outside the hosted
     /// composition root.</summary>
-    private readonly string _libraryTenant;
+    // Captured by InitializeCore, which may run after construction (the Gateway defers it so its listener
+    // can bind first), so this cannot be readonly. It is still written EXACTLY ONCE: InitializeCore is
+    // guarded by _initialized and never runs twice. Empty until then, and nothing reads it before the
+    // readiness gate opens.
+    private string _libraryTenant = "";
 
     /// <param name="db">The Gateway EF database this store reads and writes through.</param>
     /// <exception cref="ArgumentNullException">The database is null.</exception>
-    public WorkflowStore(GatewayDatabase db)
+    /// <param name="deferInitialize">
+    /// When true the constructor stops after wiring; the caller must call <see cref="Initialize"/> once the
+    /// database is open. The Gateway passes true so its listener can bind BEFORE any database work.
+    ///
+    /// The caller MUST run Initialize inside the same ambient tenant scope the constructor would have had -
+    /// the library partition is captured from it below, and capturing it under a different scope would put
+    /// the shared workflow library in the wrong tenant.
+    /// </param>
+    public WorkflowStore(GatewayDatabase db, bool deferInitialize = false)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
 
+        if (!deferInitialize)
+            InitializeCore();
+    }
+
+    /// <summary>Run the deferred load. Idempotent.</summary>
+    public void Initialize()
+    {
+        if (_initialized) return;
+        InitializeCore();
+    }
+
+    /// <summary>True once the load has run.</summary>
+    public bool IsInitialized => _initialized;
+
+    private bool _initialized;
+
+    private void InitializeCore()
+    {
         lock (_gate)
         {
             using var ctx = _db.CreateContext();
             _libraryTenant = ctx.ActiveTenant!;
             BuiltInWorkflowSeeder.Seed(ctx);
         }
+        _initialized = true;
     }
 
     /// <summary>A fresh context scoped to the shared library partition. Read-only by contract on


### PR DESCRIPTION
The real fix for the deploy outages, and the one thefrederiksen/devthrottle_internal#1766 recommended: **the listener binds
before any database work**, so site startup no longer depends on PostgreSQL.

## Why

A deploy took the live service down for 38.5s on 2 August and 46.7s on 12 August. Neither
was the swap. In both, a second container failed to start in time, the platform reverted by
**stopping the site**, and that tore down the healthy container serving beside it.

The container was slow to start because it did its database work *before* binding a port:
`GatewayDatabase` connected and migrated in its constructor, which `GatewayHost` calls long
before Kestrel listens. v2.0.4 shortened that wait and its own comments say it is a
mitigation, not the fix.

## What moved

The database open, and the **seven stores that load from it at startup** - device
credentials, work lists, cron jobs, skills, workflows, workflow runs, wingman instructions.
All ran during construction; all now run immediately after the bind, as one named step
(`EnsureStoresReady`).

Two static sweeps confirm that is the complete set: nothing else in the constructor or in
`StartAsync`'s pre-bind region touches the database, directly or one level in.

## Nothing is served early

A **readiness gate** sits first in the pipeline and answers 503 to everything but
`/healthz` until the database and all seven stores are up. Binding early stops the platform
giving up on the site; it is not permission to serve before the Gateway knows which device
keys are valid. `/healthz` reports the not-ready state itself, so the deploy's warm-up -
which polls it for a sustained 200 - waits rather than swapping onto a Gateway that cannot
answer.

## The part worth reviewing hardest

The constructor did this work inside `_hostedTenant.Enter(TenantId.System)`, and **three of
these stores capture the ambient tenant** as the partition owning the shared library.
Initialising them outside that scope would have captured whatever tenant was ambient and put
the shared skills and workflows in the **wrong partition** - silently, visible only later as
one account seeing another's library. The deferred initialisation re-enters the same scope
for the same span.

`_libraryTenant` loses `readonly` as a consequence. It is still written exactly once, now
guarded by `_initialized` rather than by the compiler, and that is stated on the field.

## Failure behaviour is unchanged

Same retry window, same loud throw, same Failed state, same process exit. Configuration
faults - blank or unparseable connection string - still throw in the **constructor**,
because waiting cannot fix those.

## Tests

Seven new, for the split: deferral, idempotence, dispose-before-open, the clear error when a
query arrives early, and that a config fault still fails at construction.

Five existing tests changed, all for the same reason and none relaxed:
- One IL guard now scans `Open` instead of `.ctor` for `DescribeFailure`, because that is
  where connecting lives. Widening it to a type-wide scan would have survived the move and
  thrown away the guarantee.
- Four tests use a host without starting it; they now call `EnsureStoresReady()`.

Local: solution builds clean, 3,107 unit tests pass, and the 22 tests across the three
affected areas pass. The full 2,314-test integration suite is CI's job here - my local run
of it found exactly these five and nothing else.

## What this cannot prove

Nothing local reproduces App Service stopping a site because no port bound in time. The
evidence will be the measured external outage on the next deploy, against the **6.7s**
recorded on 19 August.
