### PR TITLE
ci: the deploy outage budget is ten seconds, not five

### DIFF
--- a/.claude/skills/deploy-hosted-gateway/SKILL.md
+++ b/.claude/skills/deploy-hosted-gateway/SKILL.md
@@ -103,9 +103,20 @@ starts, five while the old slot stops, and about ten in which Directors show
 yellow and reconnect on their own - both slots share one worker, so starting and
 stopping the spare disturbs production.
 
+**Measured, so you know what normal looks like:** two consecutive healthy deploys
+came in at **6.7s** (2026-08-19, run 32280188992) and **6.6s** (2026-08-20, run
+32321987703) of longest external outage, with the swap window itself at 0.0s both
+times. The second carried the change that moved the database open behind the port
+bind, and it did not shift the number - which is how we know this cost is the slot
+churn on a shared worker, not application startup. So around six or seven seconds
+is what a good deploy costs here. The budget was five, which failed every deploy
+and left the gate unable to tell a normal one from the two below; the owner set it
+to ten on 2026-08-20 - "if the time gets over 10 seconds, then we start dealing
+with it".
+
 **And a deploy can be far worse than that, from a cause the swap number does not
 cover.** On 12 August 2026 one took the live service off the air for **46.7
-seconds** against a five-second budget (issue #2585) - worse than the 38.5-second
+seconds** against what was then a five-second budget (issue #2585) - worse than the 38.5-second
 failure above, and eight days after this section was written to prevent a repeat.
 Neither outage was the cutover. In both, a second container failed its own
 startup, the platform reverted by stopping the SITE, and stopping the site tore
@@ -115,7 +126,7 @@ So if `/healthz` does not answer `200` immediately after the run goes green,
 something went wrong with the hand-off. Say so; do not wait it out.
 
 **A failed run is a report, not a protection.** The watch job fails if the
-external outage exceeds five seconds, and it did fail on 12 August - users were
+external outage exceeds **ten seconds**, and it did fail on 12 August - users were
 dark for 46.7 seconds regardless. A green run means production stayed inside the
 budget; a red one tells you afterwards that it did not. Neither prevents an
 outage, so never present a green run as proof that deploying is free.

--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -594,14 +594,32 @@ jobs:
         if: needs.deploy.outputs.readiness_outcome == 'healthy'
         env:
           WATCH_SECONDS: '600'
-          # FIVE, not thirty (issue #2383). A healthy deploy costs about ZERO - runs 30702895726,
-          # 30698993031 and 30679971846 each measured "Longest unavailable stretch: 0.0s" across the
-          # full watch - because the warmed hand-off is what the extra App Service tier was bought for.
-          # So this is not a cost curve to leave slack in: either the hand-off happened and the number
-          # is a rounding error, or it did not and the number is tens of seconds. Thirty sat squarely
-          # in the gap and would have passed a twenty-nine-second outage as a green deploy. Anything
-          # above a couple of seconds means the hand-off did not happen and is worth failing over.
-          MAX_ACCEPTABLE_OUTAGE_SECONDS: '5'
+          # TEN. Owner ruling 2026-08-20: "if the time gets over 10 seconds, then we start dealing
+          # with it."
+          #
+          # This was FIVE, on the reasoning that a healthy deploy costs about zero because three
+          # earlier runs each measured "Longest unavailable stretch: 0.0s". That reasoning conflated
+          # two different numbers, and measurement has since separated them:
+          #
+          #   swap_window_gap_seconds   - the cutover itself. Still 0.0s. The warmed hand-off works.
+          #   external_outage_seconds   - what a caller experiences across the WHOLE watch, which also
+          #                               covers the spare slot starting and the old slot stopping.
+          #                               Both slots share one worker, so that churn disturbs
+          #                               production whether or not the app is quick to boot.
+          #
+          # The zero readings were the first number. The second measured 6.7s on 2026-08-19 (run
+          # 32280188992) and 6.6s on 2026-08-20 (run 32321987703) - two consecutive HEALTHY deploys,
+          # one of them carrying the change that moved the database open behind the port bind, which
+          # did not shift it. So ~6-7s is what a good deploy costs here, not a sign of a failed
+          # hand-off.
+          #
+          # At five, every deploy failed, and a gate that is always red cannot tell 6.6s from the
+          # 38.5s (#2383) and 46.7s (#2585) outages it exists to catch - which is the whole reason
+          # thirty was rejected. Ten passes a normal deploy and still fails those two loudly.
+          #
+          # This is a REPORTING threshold, not a promise: exceeding it fails the run after the fact.
+          # It has never prevented an outage and does not now.
+          MAX_ACCEPTABLE_OUTAGE_SECONDS: '10'
         run: |
           STATE_LOG=/tmp/site-state.log; : > "$STATE_LOG"
           echo "Watching for ${WATCH_SECONDS}s past the swap (the failure window is 2-4 minutes out)..."


### PR DESCRIPTION
Owner ruling, 2026-08-20: *"if the time gets over 10 seconds, then we start dealing with it."*

## Why five was wrong

Five was set on the reasoning that a healthy deploy costs about zero, because three earlier
runs each measured `Longest unavailable stretch: 0.0s`. That conflated two numbers the
workflow already reports separately:

| | what it measures | now |
|---|---|---|
| `swap_window_gap_seconds` | the cutover itself | **0.0s** - the warmed hand-off works |
| `external_outage_seconds` | what a caller sees across the whole watch, including the spare slot starting and the old slot stopping | **~6.6s** |

Both slots share one worker, so that churn disturbs production however fast the app boots.
The zero readings were the first number; the budget is checked against the second.

## The measurements

Two consecutive **healthy** deploys: **6.7s** (19 Aug, run 32280188992) and **6.6s** (20
Aug, run 32321987703). The second carried the change that moved the database open behind the
port bind - and it did not shift the number, which is how we know this cost is slot churn
rather than application startup.

## What that did to the gate

Five failed **every** deploy. A gate that is always red cannot distinguish 6.6 seconds from
the **38.5s** (#2383) and **46.7s** (#2585) outages it exists to catch - which is exactly the
objection that got thirty rejected, arriving from the other side.

Ten passes a normal deploy and still fails those two loudly.

## Also in this commit

The runbook stated the five-second figure in two places; both are corrected rather than left
to drift. It now also records what a normal deploy **measures**, so the next reader knows
what good looks like instead of inferring it from a red run.

Still a reporting threshold, not a promise: it fails the run after the fact. It has never
prevented an outage and does not now.
