### PR TITLE
docs(deploy): the deploy gate never waited for a pending check

### DIFF
--- a/.claude/skills/deploy-hosted-gateway/SKILL.md
+++ b/.claude/skills/deploy-hosted-gateway/SKILL.md
@@ -32,14 +32,27 @@ version numbers, release notes, tags, or the mailing list.
 - **A person authorizes the go-live.** Starting this deploy pushes new code to
   the live service. Get an explicit go from the human before you start it. Do not
   start it on your own initiative.
-- **It will only ship green main.** The run refuses, in seconds and before it
-  touches anything, if it was started against any ref other than `refs/heads/main`,
-  or if the commit being shipped has a check that failed or has not finished. If it
-  refuses for a pending check, wait for continuous integration and start it again. This is the one
-  wait the no-waiting rule (CLAUDE.md 5a) does not cover, and it is not our policy: 5a governs
-  whether a MERGE is held open, while this is the deploy workflow's own refusal to push unverified
-  code to a live service. Since every merge to main now gets its own run that cannot be evicted,
-  that check will actually finish - before, it could be cancelled and then never go green at all.
+- **It ships main, and never a commit whose checks have FAILED.** The run refuses, in
+  seconds and before it touches anything, if it was started against any ref other than
+  `refs/heads/main`, or if a check on the commit being shipped has COMPLETED and did
+  not pass. Both refusals sit ahead of the Azure login and the build, so a refused
+  deploy costs seconds and touches nothing.
+- **A check that has not finished is NOT a refusal, and this deploy does not wait for
+  one.** The run lists the pending checks and carries straight on, because a pending
+  check is an absence of information rather than evidence of a fault. A commit with no
+  checks at all is not refused either. Local verification is the gate; continuous
+  integration is the backstop that reports afterwards. CLAUDE.md 5a says that about
+  MERGES; the workflow reaches the same conclusion on its own account for deploys.
+
+  This bullet said the opposite for twenty-five days, and the cost was real. The
+  wait-for-CI wording was written on 2 August 2026 at 17:06 (#2389); the gate stopped
+  behaving that way at 22:12 the SAME DAY (#2406, "stop the gate waiting for CI -
+  refuse a FAILED check, never a pending one"). The step is even named "Refuse to
+  deploy a commit whose checks have FAILED". Anyone who trusted this page instead of
+  reading the workflow parked a deploy behind an hour of .NET CI that nothing asked
+  for. If this page and
+  `.github/workflows/deploy-hosted-gateway.yml` ever disagree again, the workflow is
+  the truth and this page is the defect.
 - **It does not set up any infrastructure.** The Azure resource group, container
   registry, database connection, and storage are already provisioned and persist
   across deploys. This deploy only: rebuild the image, point the live service at

--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -153,12 +153,23 @@ jobs:
           fi
           echo "Ref check passed: deploying refs/heads/main at ${{ steps.short.outputs.short }}."
 
-      # 2. GREEN ONLY. Nothing previously checked that the commit being shipped had passing tests -
+      # 2. NOTHING RED. Nothing previously checked that the commit being shipped had passing tests -
       #    a red commit on main was as deployable as a green one. Ask GitHub for this exact commit's
-      #    check runs and refuse unless every completed one succeeded. A commit whose checks have not
-      #    finished is also refused: "not yet known to be good" is not "good", and the deploy can be
-      #    re-run in a few minutes. Queued or in-progress runs are reported so the refusal is
-      #    actionable rather than mysterious.
+      #    check runs and refuse if any COMPLETED one did not pass.
+      #
+      #    A check that has NOT FINISHED is not a refusal, and this step does not wait for one. It
+      #    lists the pending checks and carries on, because a pending check is an absence of
+      #    information rather than evidence of a fault. A commit with no check runs at all is not
+      #    refused either.
+      #
+      #    THIS COMMENT USED TO SAY THE OPPOSITE, for twenty-five days after the code below stopped
+      #    agreeing with it. It claimed a commit whose checks had not finished was "also refused",
+      #    which was true only until #2406 ("stop the gate waiting for CI - refuse a FAILED check,
+      #    never a pending one") landed on 2026-08-02 and left the prose behind. A stale comment
+      #    directly above the code it describes is worse than none: it was read as the contract, and
+      #    it sent deploys to the back of an hour of .NET CI that this step never asked for. The step
+      #    name is the short version - refuse a commit whose checks have FAILED - and the code below
+      #    is the long one. Neither this comment nor the runbook outranks them.
       - name: Refuse to deploy a commit whose checks have FAILED
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The deploy runbook told you the workflow refuses a commit whose checks have not finished, and to "wait for continuous integration and start it again". The workflow does not do that, and has not for twenty-five days.

What it actually does: refuses a check that **COMPLETED** and did not pass; **lists** a pending check and carries straight on (`echo "NOTE: these checks have not finished, and the deploy is NOT waiting for them:"`); and does not refuse a commit with no checks at all. The step is named **"Refuse to deploy a commit whose checks have FAILED"**.

## How it drifted

| When | What |
| --- | --- |
| 2026-08-02 17:06 | the wait-for-CI wording lands in the skill (#2389) |
| 2026-08-02 22:12 | the gate stops behaving that way (#2406 - "stop the gate waiting for CI - refuse a FAILED check, never a pending one") |
| for the 25 days since | both pieces of prose keep saying the old thing |

## Both copies, because the defect was never one page

- **the runbook bullet** in `.claude/skills/deploy-hosted-gateway/SKILL.md` - what an agent reads before it deploys. Split into what actually refuses, and a bullet saying plainly that an unfinished check is not a refusal and the deploy does not wait for one.
- **the comment block** at `.github/workflows/deploy-hosted-gateway.yml:156`, sitting directly above the code it contradicted. A stale comment there is worse than none: it reads as the contract. Rewritten to match the code, and it now names the workflow as the truth if the two ever diverge again.

The cost is not hypothetical - this was found by following the page, which parks a deploy behind an hour of .NET CI that nothing asked for.

## Verification

Comment and markdown only, and that is proven rather than asserted:

- every changed line in the `.yml` begins with `#` (`git diff -U0` filtered for non-comment changes returns nothing);
- loading the file before and after and comparing the parsed structures returns **equal**, so the executable workflow is unchanged;
- the YAML still parses and all three refusal steps are intact;
- both files are ASCII-clean.

Swept both repos for other copies of the claim. The only other mention is `devthrottle_internal/CLAUDE.md:87`, which already says "refuses a commit whose checks have FAILED" and is correct.

The repository's local gate (`scripts\test-local.ps1`) covers no part of this change - there is no executable delta for it to run against.
