### PR TITLE
dictation: an empty recording no longer retries forever

### DIFF
--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -1921,8 +1921,15 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
  *  than re-drive forever. EVERYTHING outside this list (network, provider 502/504, busy session, out of
  *  credits) stays retryable/held. Default is retryable; only these reasons are permanent.
  *   - "audio-too-large": the clip is over the provider's per-request byte cap and cannot be split as-sent.
- *   - "unsupported-format": the audio is a format the Gateway cannot decode or split. */
-export type PermanentDictationReason = "audio-too-large" | "unsupported-format";
+ *   - "unsupported-format": the audio is a format the Gateway cannot decode or split.
+ *   - "empty-recording": the on-device copy was read SUCCESSFULLY and contained ZERO BYTES, so there is no
+ *     audio to send. Decided entirely on the device, before any network work - see the empty-audio guard in
+ *     uploadDictationToSession. Permanent because the bytes are the input: re-reading the same empty copy
+ *     produces the same nothing however often it is asked. A read that THROWS is deliberately NOT this - it
+ *     says nothing about the length, so it stays held and retryable
+ *     (DICTATION_HELD_UNREADABLE_MESSAGE). Do not widen this reason to cover it: parking a recording that a
+ *     later read would have recovered strands it, and tells the user it was empty when it was not. */
+export type PermanentDictationReason = "audio-too-large" | "unsupported-format" | "empty-recording";
 
 /** Outcome of one dictation delivery attempt.
  *  - `terminal` true: the server made a final decision (injected the turn, or deliberately dropped it as
@@ -1987,6 +1994,14 @@ export interface DictationUploadArgs {
  *  background driver keeps trying - never "was not transcribed", because it is held, not lost. */
 export const DICTATION_HELD_NO_CONNECTION_MESSAGE =
   "No connection - your recording is saved and will keep trying.";
+
+/** The held line for a recording whose saved copy could not be READ on this attempt - the read threw rather
+ *  than coming back empty. Held, deliberately: a read can fail under browser storage or memory pressure and
+ *  succeed on the next attempt, so this must never claim the recording is empty or gone. A read that comes
+ *  back zero-length IS permanent and takes the parked "empty-recording" path instead; only the throw lands
+ *  here, because a throw tells us nothing about how long the recording is. */
+export const DICTATION_HELD_UNREADABLE_MESSAGE =
+  "Couldn't read the saved recording just now - it is still on your device and delivery will keep trying.";
 
 /** The held line when transcription credits ran out: kept, and it sends once credits are available.
  *  This wording is reachable ONLY from the direct-API `insufficient_credits` state (the Gateway maps
@@ -2060,7 +2075,33 @@ export async function uploadDictationToSession(
   }
 
   // 2. Read the whole clip from the (already durable) on-device copy and plan its bounded chunks.
-  const bytes = new Uint8Array(await args.audio.arrayBuffer());
+  //
+  // THE EMPTY-AUDIO GUARD. planUploadChunks documents that "a zero-length payload yields no ranges (the
+  // caller guards empty audio upstream)" - and until this guard existed, THIS caller did not. A clip whose
+  // on-device copy read back as zero bytes therefore planned NO chunks, uploaded nothing, and sent the
+  // server totalChunks:0, which the complete endpoint correctly refuses with a 400. A 400 is not one of the
+  // allow-listed permanent reasons, so it fell through to the retryable/held arm and the clip re-drove
+  // forever: the phone showed "Saved - still sending" for a recording that could never be sent, and the
+  // Gateway collected a staging directory holding a delivery record and no audio. That residue is how this
+  // was found - three of them registered in one second, none with a single byte behind it.
+  //
+  // ZERO LENGTH AND A FAILED READ ARE NOT THE SAME THING, and collapsing them is a defect of its own.
+  //   - A read that SUCCEEDS and yields zero bytes is permanent: the bytes are the input, and re-reading
+  //     the same empty copy produces the same nothing however many times it is asked.
+  //   - A read that THROWS says nothing about the length. A perfectly good recording can fail to read under
+  //     browser storage or memory pressure and read fine on the next attempt, so parking it would strand a
+  //     recording that automatic delivery would have recovered - and would tell the user "there was nothing
+  //     to send" about audio that is still there. That claim would be false, which is the same sin as the
+  //     "Saved - still sending" it replaced, only in the other direction.
+  // So a throw stays HELD and keeps retrying, with a reason that says what actually happened.
+  let bytes: Uint8Array;
+  try {
+    bytes = new Uint8Array(await args.audio.arrayBuffer());
+  } catch {
+    return held(DICTATION_HELD_UNREADABLE_MESSAGE);
+  }
+  if (bytes.length === 0) return permanent("empty-recording");
+
   const ranges = planUploadChunks(bytes.length, MAX_UPLOAD_CHUNK_BYTES);
   const total = ranges.length;
   const completeBody = {

--- a/packages/client-core/src/api/dictationEmptyAudio.test.ts
+++ b/packages/client-core/src/api/dictationEmptyAudio.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { uploadDictationToSession, type DictationUploadArgs } from "./client";
+
+// The empty-audio guard in uploadDictationToSession.
+//
+// WHAT WENT WRONG. planUploadChunks documents that "a zero-length payload yields no ranges (the caller
+// guards empty audio upstream)", and this caller did not guard. A clip whose on-device copy read back as
+// zero bytes therefore planned no chunks, uploaded nothing, and sent the server totalChunks:0 - which the
+// complete endpoint correctly refuses with a 400. A 400 is not an allow-listed permanent reason, so the
+// outcome fell through to the retryable/held arm and the driver re-drove the clip forever. On the phone
+// that reads as "Saved - still sending" on a recording that can never be sent; on the Gateway it leaves a
+// staging directory holding a delivery record and no audio, which is how it was found.
+//
+// The contract these tests hold: empty or unreadable audio is decided ON THE DEVICE, is PERMANENT (the
+// clip parks and the auto-loop stops), and never reaches the network as a malformed completion.
+
+const UPLOAD_ID = "33333333-3333-3333-3333-333333333333";
+
+function fakeResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function argsWithAudio(audio: Blob): DictationUploadArgs {
+  return {
+    sessionId: "11111111-1111-1111-1111-111111111111",
+    uploadId: UPLOAD_ID,
+    audio,
+    before: "",
+    after: "",
+    prefix: "",
+    baselineBufferBytes: 0,
+    resumed: true,
+  };
+}
+
+interface Call {
+  url: string;
+  method: string;
+}
+
+// A server that behaves exactly as the real one does for a healthy clip: register succeeds, the FIRST
+// complete reports the chunk still missing (nothing is staged yet), the chunk is accepted, and the second
+// complete delivers. Every call is recorded so a test can prove the guard stopped before any of it.
+function mockFetch(): Call[] {
+  const calls: Call[] = [];
+  let completes = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown, init?: { method?: string }) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      calls.push({ url, method });
+      if (url.includes("/dictation/upload")) return fakeResponse(200, { upload_id: UPLOAD_ID });
+      if (url.includes("/complete")) {
+        completes += 1;
+        if (completes === 1) return fakeResponse(409, { missing: [0] });
+        return fakeResponse(200, { submitted: true, transcript: "hello" });
+      }
+      if (url.includes("/chunk/")) return fakeResponse(200, { ok: true });
+      if (url.includes("/ack")) return fakeResponse(200, { ok: true });
+      throw new Error("unexpected fetch: " + url);
+    }),
+  );
+  return calls;
+}
+
+const completed = (calls: Call[]): boolean => calls.some((c) => c.url.includes("/complete"));
+const uploadedAChunk = (calls: Call[]): boolean => calls.some((c) => c.url.includes("/chunk/"));
+
+describe("the empty-audio guard (a recording with no bytes must never hold forever)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("parks a ZERO-BYTE recording instead of holding it, and never completes with totalChunks:0", async () => {
+    const calls = mockFetch();
+
+    const result = await uploadDictationToSession(argsWithAudio(new Blob([], { type: "audio/webm" })));
+
+    // Permanent, so the driver PARKS: the audio is kept, the auto-loop stops, and the user is told.
+    expect(result.permanent).toBe(true);
+    expect(result.permanentReason).toBe("empty-recording");
+    // Not held. This is the exact confusion that produced the forever-spinner.
+    expect(result.terminal).toBe(false);
+    expect(result.submitted).toBe(false);
+    // The malformed completion never leaves the device.
+    expect(completed(calls)).toBe(false);
+    expect(uploadedAChunk(calls)).toBe(false);
+  });
+
+  it("KEEPS RETRYING a recording whose copy could not be read - a failed read is not an empty recording", async () => {
+    // A read that throws says nothing about how long the recording is. A good clip can fail to read under
+    // browser storage or memory pressure and read fine next time, so parking it would strand a recording
+    // that automatic delivery would have recovered - and would tell the user it was empty, which is false.
+    // Only a read that SUCCEEDS and returns zero bytes is permanent.
+    const unreadable = {
+      type: "audio/webm",
+      arrayBuffer: async () => {
+        throw new Error("NotReadableError: the requested file could not be read");
+      },
+    } as unknown as Blob;
+    const calls = mockFetch();
+
+    const result = await uploadDictationToSession(argsWithAudio(unreadable));
+
+    expect(result.permanent).toBeUndefined();
+    expect(result.terminal).toBe(false);
+    // And it says what actually happened, rather than claiming the recording was empty or gone.
+    expect(result.error).toBe(
+      "Couldn't read the saved recording just now - it is still on your device and delivery will keep trying.",
+    );
+    expect(completed(calls)).toBe(false);
+    expect(uploadedAChunk(calls)).toBe(false);
+  });
+
+  it("leaves a NORMAL recording completely alone - it uploads and completes as before", async () => {
+    // The guard must be exact. Run it against known-good audio so a future widening that swallowed real
+    // recordings would fail here rather than in someone's session.
+    const calls = mockFetch();
+
+    const result = await uploadDictationToSession(argsWithAudio(new Blob(["some real audio bytes"], { type: "audio/webm" })));
+
+    expect(result.permanent).toBeUndefined();
+    expect(result.terminal).toBe(true);
+    expect(result.submitted).toBe(true);
+    expect(uploadedAChunk(calls)).toBe(true);
+    expect(completed(calls)).toBe(true);
+  });
+});

--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -115,6 +115,72 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+describe("the empty-capture gate (an empty recording must never enter the durable queue)", () => {
+  // The root cause of the forever-spinner. DictationRecorder returns `new Blob(this.chunks, ...)`, which is
+  // ZERO BYTES when the recorder delivered no chunks. Nothing guarded it, so an empty clip was queued like
+  // any other and then re-driven forever - it can never produce a chunk, so the Gateway can never complete
+  // it, and the phone said "Saved - still sending" about a recording that did not exist. Every Send surface
+  // goes through this one function, so this is the one gate that covers all of them.
+  const emptyCapture: CapturedUtterance = { blob: new Blob([]), recordedMs: 1000, prefixText: "" };
+
+  it("refuses a zero-byte capture: nothing is queued, nothing is uploaded, and the user is told", async () => {
+    const onFailed = vi.fn();
+    const onError = vi.fn();
+
+    await backgroundTranscribeAndSend("sid", emptyCapture, { onFailed, onError });
+
+    // Never queued. This is what stops the loop existing at all, rather than stopping it later.
+    expect(savePending).not.toHaveBeenCalled();
+    expect(uploadDictationToSession).not.toHaveBeenCalled();
+    // LOUD, and a different error. "failed" renders the red role="alert" strip that never clears itself;
+    // "unheard" would be the grey role="status" cousin, and "held" is the amber lie this replaces.
+    const status = allDictationStatuses().find((s) => s.sessionId === "sid");
+    expect(status?.phase).toBe("failed");
+    expect(status?.retryable).toBe(false);
+    expect(status?.error).toBe(
+      "Recording failed - it captured no audio, so nothing was sent and nothing is being retried. Check the microphone is working and record it again.",
+    );
+    // The host's own error surface fires too, so the message is not confined to the strip.
+    expect(onError).toHaveBeenCalledWith(status?.error);
+    // Nothing was queued, so any typed text the dialog cleared must come back - same contract as the
+    // no-durable-store path, the other case where the clip is not queued.
+    expect(onFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails IMMEDIATELY - before the decode, the durable write, or any network work", async () => {
+    // The complaint this fixes is not only that it retried, but that it took all evening to say anything.
+    // There is nothing to wait for: transcription is server-side, and a clip with no bytes has nothing to
+    // upload, so the verdict is available on the device at once and is delivered at once.
+    await backgroundTranscribeAndSend("sid", emptyCapture);
+
+    // The status is already published with no timers advanced and no promises pumped beyond the call.
+    expect(allDictationStatuses().find((s) => s.sessionId === "sid")?.phase).toBe("failed");
+    expect(savePending).not.toHaveBeenCalled();
+    expect(uploadDictationToSession).not.toHaveBeenCalled();
+  });
+
+  it("no Gateway staging is ever created for an empty capture, and no timer is left behind", async () => {
+    await backgroundTranscribeAndSend("sid", emptyCapture);
+
+    // The registration that left a delivery record with no audio behind it on the Gateway never happens.
+    expect(uploadDictationToSession).not.toHaveBeenCalled();
+    // And nothing is scheduled: the clip is finished, not waiting.
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+    expect(uploadDictationToSession).not.toHaveBeenCalled();
+    expect(savePending).not.toHaveBeenCalled();
+  });
+
+  it("a recording WITH audio is untouched by the gate", async () => {
+    // The gate must be exact: one byte is a recording, and it takes the normal durable path.
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+
+    await backgroundTranscribeAndSend("sid", captured);
+
+    expect(savePending).toHaveBeenCalled();
+    expect(uploadDictationToSession).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("backgroundTranscribeAndSend", () => {
   it("persists the audio to the durable store BEFORE any network work", async () => {
     vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
@@ -419,6 +485,38 @@ describe("parking permanently-failed clips (#1184)", () => {
       "This recording is too long to transcribe right now; it is saved on your device and you can retry it.",
     );
     // The forever-loop is gone: advancing well past the hard-retry window triggers no further attempt.
+    const callsBefore = vi.mocked(uploadDictationToSession).mock.calls.length;
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(vi.mocked(uploadDictationToSession).mock.calls.length).toBe(callsBefore);
+  });
+
+  it("an EMPTY recording parks with its own honest sentence, not the too-long one", async () => {
+    // The empty-audio guard (see dictationEmptyAudio.test.ts) returns this outcome. What the user is told
+    // matters as much as the parking: the old behaviour said "Saved - still sending" forever, and the
+    // default park wording would now say the clip is "too long", which is a second wrong answer. It must
+    // say the recording came back empty and that nothing is in flight.
+    vi.mocked(uploadDictationToSession).mockResolvedValue({
+      terminal: false,
+      submitted: false,
+      movedOn: false,
+      transcript: "",
+      permanent: true,
+      permanentReason: "empty-recording",
+    });
+
+    await backgroundTranscribeAndSend("sid", captured);
+
+    const savedId = vi.mocked(savePending).mock.calls[0][0].id;
+    expect(deletePending).not.toHaveBeenCalled();
+    const parkedSave = vi.mocked(savePending).mock.calls.find((c) => c[0].parkedReason);
+    expect(parkedSave?.[0].parkedReason).toBe("empty-recording");
+    const status = statusFor(savedId);
+    expect(status?.phase).toBe("parked");
+    expect(status?.retryable).toBe(true);
+    expect(status?.error).toBe(
+      "This recording came back empty on this device, so there was nothing to send. Nothing is in flight - you can retry it, or record it again.",
+    );
+    // And the forever-loop that started all this is gone.
     const callsBefore = vi.mocked(uploadDictationToSession).mock.calls.length;
     await vi.advanceTimersByTimeAsync(30_000);
     expect(vi.mocked(uploadDictationToSession).mock.calls.length).toBe(callsBefore);

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -51,10 +51,21 @@ const PARKED_TOO_LARGE_MESSAGE =
   "This recording is too long to transcribe right now; it is saved on your device and you can retry it.";
 const PARKED_UNSUPPORTED_FORMAT_MESSAGE =
   "This recording is in a format we can't transcribe right now; it is saved on your device and you can retry it.";
+// The empty-recording line, for a durable copy that was read SUCCESSFULLY and held zero bytes. It says the
+// one thing the old forever-spinner never did: this clip has no audio behind it, so waiting will not
+// deliver it. Retry is still on the strip because that is parked's contract and the copy is still on the
+// device - but a copy that really is empty will simply park again, which is honest, and far better than an
+// amber "still sending" that was never true. A copy that could not be READ is NOT this: that stays held and
+// keeps retrying by itself (DICTATION_HELD_UNREADABLE_MESSAGE), because a failed read says nothing about
+// how long the recording is and parking it would strand audio that is still there.
+const PARKED_EMPTY_RECORDING_MESSAGE =
+  "This recording came back empty on this device, so there was nothing to send. Nothing is in flight - you can retry it, or record it again.";
 
 // The plain saved-and-retryable line for a parked clip, chosen by the allow-listed reason on the record.
 function parkMessage(reason: string | undefined): string {
-  return reason === "unsupported-format" ? PARKED_UNSUPPORTED_FORMAT_MESSAGE : PARKED_TOO_LARGE_MESSAGE;
+  if (reason === "unsupported-format") return PARKED_UNSUPPORTED_FORMAT_MESSAGE;
+  if (reason === "empty-recording") return PARKED_EMPTY_RECORDING_MESSAGE;
+  return PARKED_TOO_LARGE_MESSAGE;
 }
 
 // The dropped-as-stale lines (issue #1590). Plain English, and honest about what happened: the session moved
@@ -64,6 +75,14 @@ const DROPPED_WITH_TRANSCRIPT_MESSAGE =
 const DROPPED_NO_TRANSCRIPT_MESSAGE =
   "The session moved on before this recording arrived, so it wasn't sent. Your recording is saved on your device and you can try again.";
 const UNHEARD_MESSAGE = "Nothing was heard in that recording, so nothing was sent.";
+// The empty-CAPTURE line, for a clip that arrived from the recorder with no bytes in it at all. Deliberately
+// not the unheard sentence above: that one means the server listened and heard no speech, which is a fact
+// about the words. This one means the microphone handed us nothing, which is a fact about the device - so it
+// points at the microphone, because a user whose recordings keep coming back empty needs to know where to
+// look rather than being told twice that they were silent. It says NOTHING WAS SENT in as many words,
+// because the failure it replaces spent an evening claiming the opposite.
+const EMPTY_CAPTURE_MESSAGE =
+  "Recording failed - it captured no audio, so nothing was sent and nothing is being retried. Check the microphone is working and record it again.";
 const SEND_ANYWAY_FAILED_MESSAGE =
   "Couldn't send that just now. Your words are still here - try again.";
 
@@ -153,6 +172,49 @@ export async function backgroundTranscribeAndSend(
   hooks: BackgroundSendHooks = {},
 ): Promise<void> {
   ensureRetryListeners();
+
+  // THE EMPTY-CAPTURE GATE - the root cause, refused at the door.
+  //
+  // DictationRecorder builds its clip with `new Blob(this.chunks, ...)`, and when the recorder delivered no
+  // chunks - the microphone produced nothing, or Send arrived before the first chunk did - that Blob is ZERO
+  // BYTES. Nothing between there and here checked, and all four Send surfaces (the phone's controls, the
+  // Cockpit composer, Voice mode, the Voice tab) hand their capture straight to this function. So an empty
+  // recording was written to the durable queue like any other, and then driven forever: it can never produce
+  // a chunk, so the Gateway can never complete it, so the clip retried for as long as the app was open while
+  // the phone said "Saved - still sending". It also registered a staging directory on the Gateway for every
+  // attempt - a delivery record with no audio behind it, which is the residue this was found through.
+  //
+  // Refusing it HERE rather than in each caller is the point: one gate covers all four surfaces, and it is
+  // the last place before the durable write, so an unsendable clip never enters the queue at all. Nothing is
+  // queued, so there is nothing to retry, nothing to cancel, and no staging on the Gateway.
+  //
+  // IT FAILS LOUDLY AND AT ONCE. The phase is "failed", not "unheard": "unheard" is the quiet grey cousin
+  // that means the server listened and heard no speech, and it renders role="status". This did not reach a
+  // server and is not a fact about the words - the device handed us nothing - so it renders the red
+  // role="alert" strip that never clears itself, and fires the host's onError as well, exactly like the
+  // other case where a clip cannot be queued at all (durable storage missing). The user gets one clear,
+  // immediate, DIFFERENT error instead of an amber "Saved - still sending" that was never true.
+  //
+  // Immediately means immediately: before the decode, before the durable write, before any network work.
+  // Transcription is server-side, so a clip with no bytes has nothing to transcribe and nothing to upload;
+  // there is no outcome worth waiting for and no reason to make the user watch a spinner discover it.
+  // onFailed still runs, so any typed text the dialog cleared comes straight back.
+  //
+  // The client's own empty-audio guard (uploadDictationToSession) stays as the backstop below this one: it
+  // covers the different case of a clip that was queued whole and whose on-device copy later reads back
+  // empty or unreadable. This gate stops the queue being polluted; that one stops a polluted queue looping.
+  if (captured.blob.size === 0) {
+    publishDictationStatus({
+      sessionId,
+      uploadId: crypto.randomUUID(),
+      phase: "failed",
+      retryable: false,
+      error: EMPTY_CAPTURE_MESSAGE,
+    });
+    hooks.onError?.(EMPTY_CAPTURE_MESSAGE);
+    hooks.onFailed?.();
+    return;
+  }
 
   // Decode the clip ONCE here - the screen has already closed, so this is off the critical path - to do
   // two things the Send path previously skipped:

--- a/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreReadBackTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreReadBackTests.cs
@@ -1,0 +1,77 @@
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The read-back check in <see cref="VoiceUploadStore"/>.
+///
+/// WHAT IT DEFENDS AGAINST. Assemble's completeness gate measures every staged chunk and refuses the upload
+/// unless all of them are present and non-empty. On 2026-08-27 the hosted Gateway passed that gate with a
+/// chunk measured at 871,724 bytes and then READ the same file back as zero bytes - twice, within five
+/// seconds, on the Azure Files share the staging lives on. The empty assembly reached the completion path,
+/// which responds to empty audio by DELETING the staging, so one bad read discarded audio the user had
+/// already uploaded. The phone recovered only because it still held the on-device copy and sent the same
+/// bytes a third time; the user saw "Saved - still sending" throughout.
+///
+/// The values in the first case are the ones actually observed, not invented ones. The fault itself is a
+/// storage-layer inconsistency that cannot be staged on a local filesystem, so what is tested here is the
+/// DECISION taken when it happens - against a known-bad input, rather than only against a healthy one.
+/// </summary>
+public class VoiceUploadStoreReadBackTests
+{
+    [Fact]
+    public void ReadBackVerdict_ReadIsShortOfTheMeasurement_ReportsIncompleteAndKeepsStaging()
+    {
+        // The exact shape of the 2026-08-27 event: one chunk, measured 871,724 bytes, read back as zero.
+        var verdict = VoiceUploadStore.ReadBackVerdict("5d609a3dd0414a9da89cb8131bf993cc", index: 0, measured: 871_724, read: 0, totalChunks: 1);
+
+        Assert.NotNull(verdict);
+        // Incomplete, NOT ok-with-empty-audio: incomplete is the contract that makes the client re-send and
+        // leaves the staged bytes in place. An empty Ok is what deleted the recording.
+        Assert.Equal("incomplete", verdict!.Value.Status);
+        Assert.Null(verdict.Value.Audio);
+        // Every index is named, because a read that disagreed with the measurement tells us nothing about
+        // which chunk was misread - so all of them are re-sent.
+        Assert.Equal(new[] { 0 }, verdict.Value.Missing);
+    }
+
+    [Fact]
+    public void ReadBackVerdict_MultiChunkMismatch_NamesEveryIndexToResend()
+    {
+        var verdict = VoiceUploadStore.ReadBackVerdict("upload", index: 1, measured: 7_019_564, read: 4_000_000, totalChunks: 3);
+
+        Assert.NotNull(verdict);
+        Assert.Equal("incomplete", verdict!.Value.Status);
+        Assert.Equal(new[] { 0, 1, 2 }, verdict.Value.Missing);
+    }
+
+    [Fact]
+    public void ReadBackVerdict_ReadMatchesTheMeasurement_AllowsAssemblyToProceed()
+    {
+        // The healthy path must stay completely out of the way: null means "no objection, carry on".
+        Assert.Null(VoiceUploadStore.ReadBackVerdict("upload", index: 0, measured: 871_724, read: 871_724, totalChunks: 1));
+    }
+
+    [Fact]
+    public void ReadBackVerdict_IsPerChunk_SoTwoFaultsCannotCancelEachOtherOut()
+    {
+        // The reason this is checked per chunk and not on the assembled total. Chunk 0 measured 100 and read
+        // 0; chunk 1 measured 100 and read 200. The SUM agrees exactly (200 == 200), so a total-only check
+        // would accept a scrambled recording and send it to the transcriber. Each chunk is judged alone, so
+        // both of these are caught.
+        Assert.NotNull(VoiceUploadStore.ReadBackVerdict("upload", index: 0, measured: 100, read: 0, totalChunks: 2));
+        Assert.NotNull(VoiceUploadStore.ReadBackVerdict("upload", index: 1, measured: 100, read: 200, totalChunks: 2));
+    }
+
+    [Fact]
+    public void ReadBackVerdict_ReadIsLONGERThanTheMeasurement_IsAlsoRefused()
+    {
+        // A read longer than the measurement is the same class of fault (a stale directory entry, a chunk
+        // rewritten under us) and is equally unsafe to transcribe. The check is equality, not a floor.
+        var verdict = VoiceUploadStore.ReadBackVerdict("upload", index: 0, measured: 1_000, read: 2_000, totalChunks: 1);
+
+        Assert.NotNull(verdict);
+        Assert.Equal("incomplete", verdict!.Value.Status);
+    }
+}

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -326,11 +326,17 @@ public sealed class VoiceUploadStore
         // issue #592): every index 0..totalChunks-1 must be present AND non-empty. A missing OR
         // zero-byte chunk is "incomplete" - the result names the exact indices to re-send and NO
         // assembled clip is produced, so a truncated upload is refused, never transcribed.
+        // ONE stat per chunk, not two. FileInfo caches what it read, so Exists and Length below are the same
+        // observation - which matters here beyond tidiness: this gate's measurement is what the read-back
+        // check compares against, and on a share that can answer two identical stats differently, measuring
+        // with a second call would make the check argue with itself instead of with the read.
         var missing = new List<int>();
+        var measured = new long[totalChunks];
         for (var i = 0; i < totalChunks; i++)
         {
-            var path = ChunkPath(dir, i);
-            if (!File.Exists(path) || new FileInfo(path).Length == 0) missing.Add(i);
+            var info = new FileInfo(ChunkPath(dir, i));
+            if (!info.Exists || info.Length == 0) { missing.Add(i); continue; }
+            measured[i] = info.Length;
         }
         if (missing.Count > 0)
         {
@@ -342,9 +348,16 @@ public sealed class VoiceUploadStore
         for (var i = 0; i < totalChunks; i++)
         {
             var part = await File.ReadAllBytesAsync(ChunkPath(dir, i), ct);
+            // PER CHUNK, not on the total. Comparing only the sum lets two faults cancel out: one chunk
+            // measured 100 reading 0 and another measured 100 reading 200 agree perfectly in aggregate, and
+            // a scrambled recording would sail through into the transcriber. Each chunk is checked against
+            // its own measurement, the moment it is read.
+            var verdict = ReadBackVerdict(uid, i, measured[i], part.LongLength, totalChunks);
+            if (verdict is not null) return verdict.Value;
             assembled.Write(part, 0, part.Length);
         }
         var bytes = assembled.ToArray();
+
         FileLog.Write($"[VoiceUploadStore] Assemble: uploadId={uid} chunks={totalChunks} totalBytes={bytes.Length}");
         return AssembleResult.Ok(bytes);
     }
@@ -524,6 +537,40 @@ public sealed class VoiceUploadStore
             Directory.CreateDirectory(dir);
             Directory.SetLastWriteTimeUtc(dir, DateTime.UtcNow);
         });
+    }
+
+    /// <summary>
+    /// THE READ-BACK CHECK, applied to ONE chunk. The completeness gate in <see cref="AssembleAsync"/>
+    /// measures every chunk and refuses the upload unless all of them are present and non-empty. If the bytes
+    /// we then READ for a chunk do not match that chunk's own measurement, the READ is wrong - not the upload
+    /// - and the difference must never be mistaken for a short or empty recording.
+    ///
+    /// Deliberately per chunk rather than on the assembled total: two faults can cancel out in a sum (one
+    /// chunk measured 100 reading 0, another measured 100 reading 200) and a scrambled recording would then
+    /// pass a total-only check and reach the transcriber.
+    ///
+    /// This is not hypothetical. The hosted Gateway stages uploads on an Azure Files share, and on 2026-08-27
+    /// a chunk that measured 871,724 bytes read back as ZERO twice inside five seconds; the same share
+    /// reported a 177 MB log file as 0 bytes to stat while a full read returned all 177 MB. The caller's
+    /// empty-audio arm responds to an empty assembly by DELETING the staging, so a single bad read was
+    /// enough to throw away audio the user had already uploaded successfully. It only looked survivable
+    /// because the phone still held the on-device copy and pushed the same bytes up a third time.
+    ///
+    /// Returning INCOMPLETE instead puts it back on the path built for exactly this: the client re-sends the
+    /// named chunks, the staged bytes are KEPT, and a transient read costs one retry rather than a recording.
+    /// Null means the read agreed with the measurement and assembly may proceed.
+    ///
+    /// Internal so it can be exercised against a known-bad pair - the trigger is a storage fault that cannot
+    /// be reproduced on a local filesystem, so the decision is tested even though the fault cannot be staged.
+    /// </summary>
+    internal static AssembleResult? ReadBackVerdict(string uid, int index, long measured, long read, int totalChunks)
+    {
+        if (read == measured) return null;
+        FileLog.Write($"[VoiceUploadStore] Assemble: uploadId={uid} READ-BACK MISMATCH on chunk {index} " +
+            $"measured={measured} read={read} - treating as incomplete, staging KEPT");
+        // Every index, not just this one: a read that disagreed with its measurement tells us nothing about
+        // whether the other chunks read correctly, so the whole clip is re-sent rather than half-trusted.
+        return AssembleResult.Incomplete(Enumerable.Range(0, totalChunks).ToList());
     }
 
     /// <summary>


### PR DESCRIPTION
## What was wrong

A recording that captured no audio was written to the durable send queue like any other and then driven forever. With no bytes it plans no upload chunks and sends the Gateway `totalChunks: 0`, which the complete endpoint correctly refuses with a 400 (`GatewayDictationEndpoint.cs:266`). A 400 is not on the client's permanent-failure allow-list, so it fell through to the retryable arm and re-drove.

The phone showed *Saved - still sending* all evening about a recording that could never be sent. On the Gateway it left a staging directory holding a delivery record and no audio for every attempt - three of them registered in one second, none with a byte behind it, which is how this was found.

## Three guards, each at the level that owns the problem

**The door.** `DictationRecorder` builds its clip as `new Blob(this.chunks)`, which is zero bytes when no chunks were delivered. `backgroundTranscribeAndSend` now refuses that at the single point all four Send surfaces pass through, before the durable write - so an unsendable clip never enters the queue. It fails loudly and immediately: `phase: "failed"` (the red `role="alert"` strip that never auto-clears), the host's `onError`, and the typed text handed back. Nothing queued, so nothing to retry, nothing to cancel, no staging.

**The backstop.** `uploadDictationToSession` guards the clip it is about to send, for one queued whole whose copy degraded later. A copy that reads back successfully at zero bytes is permanent and parks. A read that *throws* stays held and keeps retrying - a failed read says nothing about the recording's length, so parking it would strand audio that is still there.

**The server.** `VoiceUploadStore` keeps the completeness gate's per-chunk measurements and compares each against what was actually read. On the hosted Gateway a chunk measured 871,724 bytes read back as zero twice inside five seconds; the empty assembly reached the caller, whose empty-audio arm calls `store.Delete(uploadId)` - so one bad read discarded audio already uploaded successfully. A mismatch is now reported incomplete: the client re-sends, the staged bytes are kept. Per chunk, not on the total, because two faults can cancel out in a sum.

## Testing

| Suite | Result |
|---|---|
| client-core | 969 pass |
| cockpit | 282 pass |
| mobile | 3 pass |
| Typechecks (all three workspaces) | clean |
| Gateway unit tests | 3,111 pass, 2 skipped |
| Core.Tests (parked) | 4,374 pass |
| Gateway.Tests (parked) | see below |

New tests cover the empty-capture gate (nothing queued, loud failure, immediate, and a real recording untouched), the backstop's split between a zero-length read and a thrown read, and `ReadBackVerdict` against the exact measured/read pair observed in production plus the compensating-error case.

The eight `HostedSchemaRefusesAnUnownedRowTests` failures seen on this machine were an absent Postgres rig, not this change: `CC_GATEWAY_TEST_PG_STATS_CONNECTION` was set in the User environment while nothing listened on the port, and the suite's skip-gate checks only that the variable is set, not that the rig is reachable. With a rig up (`scripts/pg-stats-proof-rig.ps1`) all eight pass.

Reviewed by an agent of a different family, which found two real defects that are fixed here: collapsing a thrown read into the permanent empty case, and comparing assembled totals rather than per-chunk lengths.
