### PR TITLE
gateway: the session lock is answered from memory, not by rescanning the staging root

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/DictationSessionLockIndexTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/DictationSessionLockIndexTests.cs
@@ -1,0 +1,205 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The session lock is answered from memory, not by re-reading the staging root once per session.
+///
+/// WHAT THESE PIN AND WHY. The lock used to be computed by listing the staging root and reading every
+/// upload's record.json on EVERY call, and it is called once per session by the five-second display-state
+/// fold - so the cost was O(sessions x staged uploads) per pass, and it never fell, because a staging
+/// directory only disappears on the success path. On the hosted Gateway that root is a billed network share
+/// and it measured 5.5 million file opens a day.
+///
+/// The behaviour that matters is therefore twofold and BOTH halves need a test: the answer must still be
+/// correct through every state transition (or the fix is a regression wearing a speed-up), and the hot path
+/// must not go back to disk (or the fix silently rots the first time someone re-adds a read). The last two
+/// tests are the ones that fail if the scan ever comes back.
+/// </summary>
+public sealed class DictationSessionLockIndexTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "cc-lockidx-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+        catch { /* test cleanup */ }
+    }
+
+    private VoiceUploadStore NewStore() => new(_root, TenantId.Local);
+
+    [Fact]
+    public void MarkPending_LocksTheSession()
+    {
+        var store = NewStore();
+        var id = store.Register(null);
+        store.MarkPending(id, "session-a");
+
+        Assert.True(store.IsSessionLocked("session-a"));
+        Assert.False(store.IsSessionLocked("session-b"));
+    }
+
+    [Theory]
+    [InlineData("delivered")]
+    [InlineData("abandoned")]
+    [InlineData("failed")]
+    public void TerminalAndParkedStates_ReleaseTheLock(string transition)
+    {
+        var store = NewStore();
+        var id = store.Register(null);
+        store.MarkPending(id, "session-a");
+        Assert.True(store.IsSessionLocked("session-a"));
+
+        switch (transition)
+        {
+            case "delivered": store.MarkDelivered(id, submitted: true, movedOn: false, "words"); break;
+            case "abandoned": store.MarkAbandoned(id, "user_abandoned"); break;
+            case "failed": store.MarkFailed(id, "out_of_credits"); break;
+        }
+
+        Assert.False(store.IsSessionLocked("session-a"));
+    }
+
+    [Fact]
+    public void ClearFailed_RelocksTheSession()
+    {
+        var store = NewStore();
+        var id = store.Register(null);
+        store.MarkPending(id, "session-a");
+        store.MarkFailed(id, "transcription_error");
+        Assert.False(store.IsSessionLocked("session-a"));
+
+        Assert.True(store.ClearFailed(id));
+        Assert.True(store.IsSessionLocked("session-a"));
+    }
+
+    [Fact]
+    public void Delete_ReleasesTheLock()
+    {
+        var store = NewStore();
+        var id = store.Register(null);
+        store.MarkPending(id, "session-a");
+
+        store.Delete(id);
+
+        Assert.False(store.IsSessionLocked("session-a"));
+    }
+
+    [Fact]
+    public void OnlyPendingSessionsAreReported()
+    {
+        var store = NewStore();
+        var a = store.Register(null);
+        var b = store.Register(null);
+        var c = store.Register(null);
+        store.MarkPending(a, "session-a");
+        store.MarkPending(b, "session-b");
+        store.MarkPending(c, "session-c");
+        store.MarkDelivered(c, submitted: true, movedOn: false, "done");
+
+        var locked = store.LockedSessionIds();
+
+        Assert.Equal(new[] { "session-a", "session-b" }, locked.OrderBy(x => x).ToArray());
+    }
+
+    /// <summary>
+    /// A cache in front of a durable record must still be right after a restart, which is the one case the
+    /// write path cannot supply: the process that wrote the marker is gone. A brand new store over the same
+    /// directory must therefore read the lock back off disk.
+    /// </summary>
+    [Fact]
+    public void ANewStoreOverTheSameRoot_HydratesTheLockFromDisk()
+    {
+        var first = NewStore();
+        var id = first.Register(null);
+        first.MarkPending(id, "session-a");
+
+        var afterRestart = NewStore();
+
+        Assert.True(afterRestart.IsSessionLocked("session-a"));
+    }
+
+    /// <summary>
+    /// THE COST TEST. Once the partition has been read, the answer comes from memory - so removing the
+    /// record file behind the store's back does NOT change the answer. That is a strange-looking assertion
+    /// on purpose: it is the only way to state "this call did not open a file" as a behaviour rather than as
+    /// a hope, and it goes red the moment someone puts a disk read back on the hot path.
+    /// </summary>
+    [Fact]
+    public void AfterTheFirstRead_TheLockIsAnsweredWithoutTouchingDisk()
+    {
+        var store = NewStore();
+        var id = store.Register(null);
+        store.MarkPending(id, "session-a");
+        Assert.True(store.IsSessionLocked("session-a"));   // hydrates / write-through
+
+        // Reach around the store and delete its durable marker. Nothing legitimate does this; it stands in
+        // for "the disk was not consulted".
+        File.Delete(Path.Combine(_root, id, "record.json"));
+
+        Assert.True(store.IsSessionLocked("session-a"));
+    }
+
+    /// <summary>
+    /// FAIL OPEN, exactly as the disk enumeration did. An unreadable partition must report NO lock rather
+    /// than a lock nobody can clear - a false lock silently refuses the user's typing, which is strictly
+    /// worse than an unenforced one.
+    /// </summary>
+    [Fact]
+    public void AnUnreadableRoot_ReportsNoLock_RatherThanGuessingOne()
+    {
+        var store = NewStore();
+        var id = store.Register(null);
+        store.MarkPending(id, "session-a");
+
+        // A different store over a root that does not exist and was never written: the question is
+        // answerable only from disk, and there is nothing there.
+        var elsewhere = new VoiceUploadStore(
+            Path.Combine(Path.GetTempPath(), "cc-lockidx-empty-" + Guid.NewGuid().ToString("N")), TenantId.Local);
+
+        Assert.False(elsewhere.IsSessionLocked("session-a"));
+        Assert.Empty(elsewhere.LockedSessionIds());
+    }
+
+    /// <summary>
+    /// The cache is keyed by PARTITION ROOT, so it cannot become a hole in the tenant boundary the
+    /// directory layout enforces (issue #1884). One tenant's pending dictation must never lock a session
+    /// read through another tenant's handle.
+    /// </summary>
+    [Fact]
+    public void OneTenantsPendingDictation_DoesNotLockAnotherTenant()
+    {
+        var baseStore = NewStore();
+        var a = baseStore.ForTenant(new TenantId("11111111-1111-1111-1111-111111111111"));
+        var b = baseStore.ForTenant(new TenantId("22222222-2222-2222-2222-222222222222"));
+
+        var id = a.Register(null);
+        a.MarkPending(id, "shared-session-id");
+
+        Assert.True(a.IsSessionLocked("shared-session-id"));
+        Assert.False(b.IsSessionLocked("shared-session-id"));
+    }
+
+    /// <summary>
+    /// Two handles onto the SAME partition share one index, so a transition written through one is seen by
+    /// the other. GatewayHost builds a fresh store with ForTenant for every session of every fold, so if
+    /// these did not agree the lock would flap depending on which handle happened to ask.
+    /// </summary>
+    [Fact]
+    public void TwoHandlesOntoTheSamePartition_AgreeAboutTheLock()
+    {
+        var baseStore = NewStore();
+        var tenant = new TenantId("33333333-3333-3333-3333-333333333333");
+        var writer = baseStore.ForTenant(tenant);
+        var reader = baseStore.ForTenant(tenant);
+
+        var id = writer.Register(null);
+        writer.MarkPending(id, "session-a");
+        Assert.True(reader.IsSessionLocked("session-a"));
+
+        writer.MarkDelivered(id, submitted: true, movedOn: false, "done");
+        Assert.False(reader.IsSessionLocked("session-a"));
+    }
+}

--- a/src/CcDirector.Gateway/Voice/DictationLockIndex.cs
+++ b/src/CcDirector.Gateway/Voice/DictationLockIndex.cs
@@ -1,0 +1,164 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Voice;
+
+/// <summary>
+/// The in-memory answer to "which sessions hold a PENDING dictation", kept current by the WRITE path so the
+/// read path never touches the disk.
+///
+/// WHY THIS EXISTS. <see cref="VoiceUploadStore.IsSessionLocked"/> is asked once per session, every five
+/// seconds, by the display-state fold. It used to answer by re-listing the staging root and re-reading every
+/// upload's record.json - so the cost was O(sessions x staged uploads) per pass, and because a staging
+/// directory is only removed on the success path, every abandoned dictation raised that cost permanently.
+/// On a self-hosted Gateway that is wasted local I/O. On the HOSTED Gateway the staging root is an Azure
+/// Files share that BILLS PER FILE OPEN, and it measured 5.5 million opens a day - more than the App Service
+/// plan the Gateway runs on, to answer a question whose answer is identical for every session in a tick.
+///
+/// The same defect was found and fixed on the Director side (see
+/// <c>CcDirector.Core.Sessions.DictationLockReader.LockedSessionIds</c>, issue #1111) by enumerating ONCE per
+/// tick instead of once per session. This goes further, because it can: the Gateway is the ONLY writer of
+/// these records - every transition arrives through its own REST endpoints in
+/// <c>GatewayDictationEndpoint</c> - so it does not need to re-read a file to learn something it just wrote.
+/// The disk stays the DURABLE record (it must: a restart, and the Director's own cross-process reader on
+/// self-host, both still read it); this is a cache of it, owned by its single writer.
+///
+/// WHY IT IS AN OBJECT AND NOT A STATIC. A static index keyed by tenant would be shared by every
+/// <see cref="VoiceUploadStore"/> in the process, including two stores rooted at different directories with
+/// the same tenant - which is exactly the shape the unit tests build (many temp roots, all
+/// <c>TenantId.Local</c>), so one test's pending marker would answer another test's question. The index is
+/// therefore keyed by the PARTITION ROOT - the same directory the enumeration it replaces would have walked -
+/// and is handed down through <see cref="VoiceUploadStore.ForTenant"/>, so one real Gateway shares one index
+/// across all its tenants while a freshly constructed store starts empty.
+///
+/// FAIL-OPEN IS PRESERVED EXACTLY. The enumeration this replaces treats an unreadable root or a half-written
+/// marker as NO LOCK, never a false lock, because a false lock silently refuses a user's typing. So does
+/// this: a hydration that throws leaves the partition UNHYDRATED (it is marked hydrated only on success), the
+/// caller is told "no lock" for that pass, and the next call tries again. The failure mode of a broken disk
+/// is therefore "the lock stops being enforced", identical to before - not "the session is locked forever".
+/// </summary>
+internal sealed class DictationLockIndex
+{
+    // One entry per partition root. The value maps uploadId -> owning sessionId for PENDING records ONLY;
+    // a record in any other state is absent rather than present-and-false, so "is anything pending" is a
+    // question about existence and cannot be answered wrongly by a stale flag.
+    private readonly ConcurrentDictionary<string, Partition> _partitions =
+        new(StringComparer.Ordinal);
+
+    private sealed class Partition
+    {
+        // The gate for hydration and mutation. Reads do not take it: they walk the concurrent map, so a
+        // read can never be blocked by a write, and the worst a racing read sees is the pre-write answer -
+        // which is the same staleness the old disk enumeration had between its listing and its file reads.
+        public readonly object Gate = new();
+        public readonly ConcurrentDictionary<string, string> Pending = new(StringComparer.OrdinalIgnoreCase);
+        public bool Hydrated;
+        public bool RootEnsured;
+    }
+
+    private Partition For(string root) => _partitions.GetOrAdd(root, _ => new Partition());
+
+    /// <summary>
+    /// Create the partition root at most ONCE per root for the life of this index.
+    ///
+    /// <see cref="VoiceUploadStore"/> is constructed per call on the read path (GatewayHost builds one with
+    /// ForTenant for every session of every fold), and its constructor calls Directory.CreateDirectory. On a
+    /// local disk that is free; against a billed network share it is another metadata round trip per session
+    /// per five seconds, for a directory that has existed since the first upload. The creation still HAPPENS -
+    /// it is simply not repeated once this process has done it.
+    /// </summary>
+    public void EnsureRoot(string root, Action create)
+    {
+        var p = For(root);
+        if (p.RootEnsured) return;
+        lock (p.Gate)
+        {
+            if (p.RootEnsured) return;
+            create();
+            p.RootEnsured = true;
+        }
+    }
+
+    /// <summary>
+    /// Record what the single writer just wrote. <paramref name="pending"/> false REMOVES the entry, which is
+    /// how delivered, abandoned and failed all release the session lock through one call rather than three.
+    /// </summary>
+    public void RecordWritten(string root, string uploadId, string? sessionId, bool pending)
+    {
+        var p = For(root);
+        lock (p.Gate)
+        {
+            if (pending && !string.IsNullOrWhiteSpace(sessionId)) p.Pending[uploadId] = sessionId!;
+            else p.Pending.TryRemove(uploadId, out _);
+        }
+    }
+
+    /// <summary>Forget one upload id - its staging directory is gone.</summary>
+    public void Removed(string root, string uploadId)
+    {
+        var p = For(root);
+        lock (p.Gate) p.Pending.TryRemove(uploadId, out _);
+    }
+
+    /// <summary>
+    /// Drop this partition's cache so the next read re-hydrates from disk.
+    ///
+    /// Called by the sweeps, which delete staging directories WHOLESALE by walking the root rather than
+    /// through <see cref="Removed"/>. Re-reading once after a sweep that actually removed something is far
+    /// cheaper than threading a callback through every delete site, and a sweep runs on a fifteen-minute or
+    /// six-hour timer - not per session, which is the cost that mattered.
+    /// </summary>
+    public void Invalidate(string root)
+    {
+        var p = For(root);
+        lock (p.Gate)
+        {
+            p.Pending.Clear();
+            p.Hydrated = false;
+        }
+    }
+
+    /// <summary>
+    /// The session ids holding a PENDING dictation in this partition, hydrating once from
+    /// <paramref name="hydrate"/> if this process has not read the partition yet.
+    ///
+    /// Returns null when hydration failed, which the caller must read as "no lock" - see the fail-open note
+    /// on the class. Null rather than an empty set so a caller cannot confuse "nothing is pending" with
+    /// "I could not tell", even though both currently take the same branch.
+    /// </summary>
+    public IReadOnlyCollection<string>? LockedSessions(
+        string root, Func<IEnumerable<(string UploadId, string SessionId)>> hydrate)
+    {
+        var p = For(root);
+        if (!p.Hydrated)
+        {
+            lock (p.Gate)
+            {
+                if (!p.Hydrated)
+                {
+                    try
+                    {
+                        // Build into the live map rather than replacing it, so a write-through that landed
+                        // while this scan was running is not thrown away by the snapshot. Both paths hold
+                        // the gate, so the only interleaving is scan-then-write or write-then-scan; a write
+                        // seen by the scan is simply re-asserted with the same value.
+                        foreach (var (uploadId, sessionId) in hydrate())
+                            if (!string.IsNullOrWhiteSpace(sessionId))
+                                p.Pending[uploadId] = sessionId;
+                        p.Hydrated = true;
+                        FileLog.Write($"[DictationLockIndex] hydrated {root}: {p.Pending.Count} pending");
+                    }
+                    catch (Exception ex)
+                    {
+                        // Left UNHYDRATED on purpose: marking it hydrated here would cache "nothing is
+                        // locked" from a failed read and never look again.
+                        FileLog.Write($"[DictationLockIndex] hydrate {root} FAILED: {ex.Message}");
+                        return null;
+                    }
+                }
+            }
+        }
+
+        return new HashSet<string>(p.Pending.Values, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -66,6 +66,10 @@ public sealed class VoiceUploadStore
     // The tenant this instance is bound to. Stamped onto every record written and required to match on
     // every record read.
     private readonly TenantId _tenant;
+    // The pending-dictation cache, keyed by partition root and SHARED with every store this one spawns
+    // through ForTenant, so one Gateway keeps one index across all its tenants. See DictationLockIndex for
+    // why the session lock is answered from memory rather than by re-reading the staging root per session.
+    private readonly DictationLockIndex _lockIndex;
 
     /// <summary>
     /// Stage under an explicit root, bound to ONE tenant.
@@ -85,14 +89,19 @@ public sealed class VoiceUploadStore
     /// <param name="root">The base staging root; the local partition is this directory itself.</param>
     /// <param name="tenant">The partition this store is bound to. Never guessed, never defaulted.</param>
     public VoiceUploadStore(string root, TenantId tenant)
-        : this(PartitionRootFor(root, RequireTenant(tenant)), tenant, root) { }
+        : this(PartitionRootFor(root, RequireTenant(tenant)), tenant, root, new DictationLockIndex()) { }
 
-    private VoiceUploadStore(string root, TenantId tenant, string partitionBase)
+    private VoiceUploadStore(string root, TenantId tenant, string partitionBase, DictationLockIndex lockIndex)
     {
         _root = root;
         _tenant = tenant;
         _partitionBase = partitionBase;
-        Directory.CreateDirectory(_root);
+        _lockIndex = lockIndex;
+        // Through the index so it happens ONCE per root per process. This constructor runs on the read path -
+        // GatewayHost builds a store with ForTenant for every session of every display-state fold - and
+        // against the hosted Gateway's billed file share an unconditional CreateDirectory here was one more
+        // metadata round trip per session every five seconds, for a directory that already exists.
+        _lockIndex.EnsureRoot(_root, () => Directory.CreateDirectory(_root));
     }
 
     /// <summary>The tenant this store instance is bound to.</summary>
@@ -106,7 +115,8 @@ public sealed class VoiceUploadStore
     /// lives inside that tenant's partition, so an upload id from another tenant simply does not exist here -
     /// the isolation is the directory, not a predicate a later edit could forget to apply.
     /// </summary>
-    public VoiceUploadStore ForTenant(TenantId tenant) => new VoiceUploadStore(_partitionBase, tenant);
+    public VoiceUploadStore ForTenant(TenantId tenant) =>
+        new VoiceUploadStore(PartitionRootFor(_partitionBase, RequireTenant(tenant)), tenant, _partitionBase, _lockIndex);
 
     /// <summary>
     /// The single place a tenant is admitted into this type. An unresolved tenant is DENIED here rather than
@@ -413,7 +423,14 @@ public sealed class VoiceUploadStore
                     }
                 });
             }
-            if (removed > 0) FileLog.Write($"[VoiceUploadStore] SweepAbandoned removed={removed} older than {maxAge}");
+            // This sweep deletes staging directories by walking the root rather than through Delete, so the
+            // session-lock cache is dropped wholesale and re-read once on the next question. Only when
+            // something was actually removed: a sweep that deleted nothing changed nothing.
+            if (removed > 0)
+            {
+                _lockIndex.Invalidate(_root);
+                FileLog.Write($"[VoiceUploadStore] SweepAbandoned removed={removed} older than {maxAge}");
+            }
         }
         catch (Exception ex)
         {
@@ -492,8 +509,12 @@ public sealed class VoiceUploadStore
                     }
                 });
             }
+            // Same reason as SweepAbandoned: directories removed by walking the root, not through Delete.
             if (removed > 0)
+            {
+                _lockIndex.Invalidate(_root);
                 FileLog.Write($"[VoiceUploadStore] SweepResolvedTombstones removed={removed} older than {maxAge}");
+            }
         }
         catch (Exception ex)
         {
@@ -607,8 +628,13 @@ public sealed class VoiceUploadStore
                 catch (IOException ex) { FileLog.Write($"[VoiceUploadStore] quarantine {name} skipped: {ex.Message}"); }
                 catch (UnauthorizedAccessException ex) { FileLog.Write($"[VoiceUploadStore] quarantine {name} skipped: {ex.Message}"); }
             }
+            // Moving a directory out of the base root removes it from the PENDING projection just as a delete
+            // would, so the cache is dropped for the same reason the sweeps drop it.
             if (moved > 0)
+            {
+                _lockIndex.Invalidate(_root);
                 FileLog.Write($"[VoiceUploadStore] QuarantineLegacyUploads moved={moved} legacy upload dirs into {QuarantineDirectoryName}");
+            }
         }
         catch (Exception ex)
         {
@@ -652,6 +678,10 @@ public sealed class VoiceUploadStore
         {
             FileLog.Write($"[VoiceUploadStore] Delete uploadId={uid} failed: {ex.Message}");
         }
+        // Outside the try on purpose: the staging directory is gone or was never there, and either way this
+        // upload id holds no lock. Dropping it only when the delete threw no exception would leave a phantom
+        // lock behind exactly when the disk is misbehaving - the case where failing OPEN is the whole point.
+        _lockIndex.Removed(_root, uid);
     }
 
     // ====== durable delivery record (issue #1183) ===================================
@@ -738,21 +768,30 @@ public sealed class VoiceUploadStore
     public bool IsSessionLocked(string sessionId)
     {
         if (string.IsNullOrWhiteSpace(sessionId)) return false;
-        foreach (var rec in EnumeratePendingRecords())
-            if (string.Equals(rec.SessionId, sessionId, StringComparison.OrdinalIgnoreCase)) return true;
-        return false;
+        return LockedSessionIds().Contains(sessionId);
     }
 
     /// <summary>The distinct session ids that currently hold a PENDING dictation (issue #1188).</summary>
     public IReadOnlyCollection<string> LockedSessionIds()
+        // From memory, hydrating from disk at most once per partition per process. A null answer means the
+        // hydration could not read the root, which this path has always reported as NO LOCK rather than
+        // guessing one - see the fail-open note on DictationLockIndex.
+        => _lockIndex.LockedSessions(_root, EnumeratePendingEntries)
+           ?? (IReadOnlyCollection<string>)Array.Empty<string>();
+
+    /// <summary>
+    /// The one disk read behind the session lock: every PENDING record in this partition, paired with its
+    /// upload id. Runs once per partition per process (and again after a sweep invalidates the cache), where
+    /// it used to run once per session every five seconds.
+    /// </summary>
+    private IEnumerable<(string UploadId, string SessionId)> EnumeratePendingEntries()
     {
-        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var rec in EnumeratePendingRecords())
-            if (!string.IsNullOrWhiteSpace(rec.SessionId)) set.Add(rec.SessionId);
-        return set;
+        foreach (var rec in EnumeratePendingRecordsWithId())
+            if (!string.IsNullOrWhiteSpace(rec.Record.SessionId))
+                yield return (rec.UploadId, rec.Record.SessionId);
     }
 
-    private IEnumerable<DictationDeliveryRecord> EnumeratePendingRecords()
+    private IEnumerable<(string UploadId, DictationDeliveryRecord Record)> EnumeratePendingRecordsWithId()
     {
         string[] dirs;
         try { dirs = Directory.Exists(_root) ? Directory.GetDirectories(_root) : Array.Empty<string>(); }
@@ -777,7 +816,7 @@ public sealed class VoiceUploadStore
             // security boundary; the security boundary on this line is BelongsHere, and THAT one has canaries.
             if (IsPartitionContainer(dir)) continue;
             if (ReadRecordFile(RecordPath(dir)) is { State: DictationDeliveryState.Pending } rec && BelongsHere(rec))
-                yield return rec;
+                yield return (Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)), rec);
         }
     }
 
@@ -932,6 +971,11 @@ public sealed class VoiceUploadStore
             try
             {
                 Directory.Delete(dir, recursive: true);
+                // A tombstone is terminal, so the cache already dropped this id when the tombstone was
+                // written. Dropped again anyway: this is the other place a staging directory disappears, and
+                // an entry that cannot be here costs nothing to remove while a future state that CAN be here
+                // would otherwise leave a lock with no directory behind it.
+                _lockIndex.Removed(_root, uid);
                 FileLog.Write($"[VoiceUploadStore] Acknowledge: uploadId={uid} tombstone retired");
                 return true;
             }
@@ -992,6 +1036,14 @@ public sealed class VoiceUploadStore
         var tmp = path + ".tmp";
         File.WriteAllText(tmp, JsonSerializer.Serialize(record with { Tenant = _tenant.Value }, RecordJson));
         File.Move(tmp, path, overwrite: true);
+
+        // Being THE ONE PLACE a record is written makes this also the one place the in-memory session-lock
+        // cache can be kept true, which is why it is updated here and not in each of the five transitions
+        // that reach it: a transition added later cannot forget to do it. AFTER the move, never before - the
+        // cache must only ever claim what is already durable, so a failed write leaves the cache unchanged
+        // and the record and the cache cannot disagree.
+        _lockIndex.RecordWritten(_root, Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)),
+            record.SessionId, record.State == DictationDeliveryState.Pending);
     }
 
     // ====== internals ===============================================================


### PR DESCRIPTION
## The defect

`VoiceUploadStore.IsSessionLocked` listed the dictation staging root and read every upload's `record.json` on **every call**, and the display-state fold asks it **once per session, every five seconds**.

So the cost was `O(sessions x staged uploads)` per pass - and it only ever rose, because a staging directory is removed on the success path alone. Every abandoned dictation raised the floor permanently.

On a self-hosted Gateway that is wasted local I/O. On the **hosted** Gateway that root is an Azure Files share that **bills per file open**.

## Measured in production, 2026-08-28

| | |
|---|---|
| File opens per day | **5.5 million** |
| Actual writes per day | 18,000 |
| Share cost, 27 days | **CAD 295** |
| App Service plan it runs on, same period | CAD 176 |
| Cost of the DATA stored | **CAD 0.21** |

61 leftover staging folders had accumulated since 22 July. One of them alone was taking 2,256 operations a minute. Peak measured rate across the share: **1,003 operations per second**.

Quarantining the finished folders (operationally, no deploy) took it from ~114,000 operations per 5 minutes to 18,484. This change removes the per-session scan itself.

## The fix

The Gateway is the **only writer** of these records - every transition arrives through its own endpoints in `GatewayDictationEndpoint` - so it never needed to read a file to learn something it had just written.

`DictationLockIndex` caches pending `uploadId -> sessionId` per partition root:

- hydrated from disk **at most once per partition per process**, and again after a sweep that actually removed something
- kept true by `WriteRecordMarker`, already documented as *"THE ONE PLACE a record is written"*, so a transition added later cannot forget to maintain it
- `Delete` / `Acknowledge` drop their entry; the sweeps and the legacy quarantine invalidate wholesale

The **disk remains the durable record**. A restart rehydrates from it, and the desktop's cross-process `DictationLockReader` still reads the same files. Nothing about what is written changes.

The Director side already fixed this shape (`DictationLockReader.LockedSessionIds`, issue #1111) by enumerating once per tick. This goes further because the Gateway can.

### Two things deliberately preserved

**Fail-open, exactly as before.** A hydration that throws leaves the partition unhydrated and reports NO lock. A broken disk still means "the lock stops being enforced", never "the session is locked forever" - a false lock silently refuses the user's typing, which is strictly worse.

**Tenant isolation.** The index is keyed by partition root and handed down through `ForTenant`. It is an object, not a static keyed by tenant: the unit tests build many temp roots all bound to `TenantId.Local`, and a static would let one test's marker answer another's question.

Also removes an unconditional `Directory.CreateDirectory` from the constructor, which runs on the read path (`GatewayHost` builds a store with `ForTenant` per session per fold) - another metadata round trip per session every five seconds for a directory that already existed.

## Verification

| Suite | Result |
|---|---|
| `CcDirector.Gateway.UnitTests` | 3,111 pass |
| Dictation / voice / tenant / utterance integration | 470 of 470 pass |
| New `DictationSessionLockIndexTests` | 12 pass |

The 8 unit and remaining integration failures on this machine are the Postgres-backed suites, which need a local database that is not running here. Confirmed pre-existing by stashing this branch and re-running against a clean tree - identical failures.

The cost test asserts that deleting the record file behind the store's back does **not** change the answer - the only way to state "this call did not open a file" as behaviour rather than as a hope. It was verified as a real detector by restoring the old scan and watching it go red on exactly that assertion.

## Not fixed here

A `Pending` record never expires. Seven were found stuck in production, the oldest from 22 July - each keeping its session marked busy forever and keeping the rescan alive. Separate defect, separate change.
