### PR TITLE
gateway: a stale PENDING dictation is abandoned so its session unlocks

### DIFF
--- a/src/CcDirector.Gateway.Tests/DictationTombstoneSweepWiringTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationTombstoneSweepWiringTests.cs
@@ -19,9 +19,18 @@ namespace CcDirector.Gateway.Tests;
 ///
 /// WHAT MUST SURVIVE MATTERS MORE THAN WHAT IS REMOVED. This sweep is deliberately not
 /// <see cref="VoiceUploadStore.SweepAbandoned"/>, which deletes any aged upload directory without reading
-/// its state. A PENDING record holds a live session lock and guards audio still owed, and FAILED can be
-/// restored to PENDING by ClearFailed - so age-deleting either would silently unlock a session or drop a
-/// dictation. Those assertions are the point of this test, not the deletion.
+/// its state. FAILED can be restored to PENDING by ClearFailed, and a record still inside its window may yet
+/// be re-driven by its client - so age-deleting either would drop a dictation. Those assertions are the
+/// point of this test, not the deletion.
+///
+/// A STALE PENDING RECORD IS NOW ABANDONED IN PLACE, AND THIS TEST CHANGED TO SAY SO. It used to assert that
+/// an aged PENDING record survived untouched, and that was right while nothing bounded it. It was also how
+/// seven of them came to be stuck on the hosted Gateway on 2026-08-28, the oldest five weeks old, each still
+/// refusing human input on a session nobody could unlock. <see cref="VoiceUploadStore.ExpireStalePending"/>
+/// now abandons one that has been silent past its bound: the directory and its tombstone SURVIVE (so a late
+/// client cannot re-drive the id), the state becomes ABANDONED with a reason that names the server as the
+/// cause, and the session lock is released. A FRESH pending record is still untouchable - that half of the
+/// old contract is unchanged and is asserted below.
 ///
 /// Only the SCHEDULE is compressed. The thirty-day age cut-off is production's own, and the records are aged
 /// into the past on disk, so what runs here is the deployed retention rule rather than a shortened copy.
@@ -70,12 +79,16 @@ public sealed class DictationTombstoneSweepWiringTests : IAsyncLifetime
 
         // ---- everything below must SURVIVE, however old ----
 
-        // PENDING holds a live session lock and audio still owed. Age-deleting it would silently un-orange a
-        // session and drop a dictation that was still coming. This is the assertion that separates this
-        // sweep from the blunt age sweep next door.
-        var pendingOld = WriteRecord(root, "Pending", old);
-        // FAILED is explicitly NOT terminal - ClearFailed can restore it to PENDING.
+        // A PENDING record still inside its silence window holds a live session lock and audio still coming.
+        // Nothing may touch it, however busy the sweep is. This is the assertion that separates this sweep
+        // from the blunt age sweep next door.
+        var pendingFresh = WriteRecord(root, "Pending", DateTime.UtcNow.AddHours(-1));
+        // FAILED is explicitly NOT terminal - ClearFailed can restore it to PENDING - and it holds no session
+        // lock, so the stale-pending expiry must leave it alone too.
         var failedOld = WriteRecord(root, "Failed", old);
+        // A PENDING record that has been SILENT far past its bound. No client is coming back for this, and
+        // until it is resolved its session cannot be typed into. It must be abandoned IN PLACE.
+        var pendingStale = WriteRecord(root, "Pending", old);
         // Inside the window: the client may still legitimately re-drive this id.
         var deliveredFresh = WriteRecord(root, "Delivered", recent);
         // Unreadable: a half-written marker is never proof of anything, so it is left alone.
@@ -101,10 +114,25 @@ public sealed class DictationTombstoneSweepWiringTests : IAsyncLifetime
             "nothing in production is running the tombstone sweep");
         Assert.False(Directory.Exists(abandonedOld), "a stale ABANDONED tombstone was not retired");
 
-        Assert.True(Directory.Exists(pendingOld),
-            "the sweep deleted a PENDING record - that silently unlocks a session and drops audio still owed");
+        Assert.True(Directory.Exists(pendingFresh),
+            "the sweep touched a PENDING record inside its silence window - that unlocks a session and drops " +
+            "audio that was still coming");
+        Assert.Contains("Pending", File.ReadAllText(Path.Combine(pendingFresh, "record.json")));
         Assert.True(Directory.Exists(failedOld),
             "the sweep deleted a FAILED record, which ClearFailed can still restore to PENDING");
+        Assert.Contains("Failed", File.ReadAllText(Path.Combine(failedOld, "record.json")));
+
+        // The stale one is ABANDONED IN PLACE, not deleted: the session unlocks, but the tombstone stays so a
+        // late client cannot re-drive the id, and it names the SERVER as the cause rather than the user.
+        var expiredWithin = await WaitUntilStateIs(pendingStale, "Abandoned", TimeSpan.FromSeconds(20));
+        Assert.True(expiredWithin,
+            $"the running Gateway never released the stale PENDING record at {pendingStale} - nothing in " +
+            "production is expiring them, so its session stays locked against human input forever");
+        Assert.True(Directory.Exists(pendingStale),
+            "the stale PENDING record was DELETED rather than abandoned - the tombstone must survive so a " +
+            "late client cannot re-drive the upload id");
+        Assert.Contains(VoiceUploadStore.StalePendingReason,
+            File.ReadAllText(Path.Combine(pendingStale, "record.json")));
         Assert.True(Directory.Exists(deliveredFresh),
             "the sweep deleted a tombstone inside the retention window, weakening the de-dupe guarantee");
         Assert.True(Directory.Exists(corruptOld),
@@ -127,6 +155,24 @@ public sealed class DictationTombstoneSweepWiringTests : IAsyncLifetime
             $"\"Reason\":null,\"SessionId\":\"{Guid.NewGuid()}\"}}");
         Directory.SetLastWriteTimeUtc(dir, lastWriteUtc);
         return dir;
+    }
+
+    /// <summary>
+    /// Wait for a record to reach a state. Polled rather than asserted once, for the same reason
+    /// <see cref="WaitUntilGone"/> is: the sweep runs on the Gateway's own timer, so the test must wait for
+    /// production to act rather than call anything itself.
+    /// </summary>
+    private static async Task<bool> WaitUntilStateIs(string dir, string state, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        var path = Path.Combine(dir, "record.json");
+        while (DateTime.UtcNow < deadline)
+        {
+            try { if (File.ReadAllText(path).Contains($"\"State\":\"{state}\"")) return true; }
+            catch { /* mid-write; try again */ }
+            await Task.Delay(100);
+        }
+        return false;
     }
 
     private static async Task<bool> WaitUntilGone(string dir, TimeSpan timeout)

--- a/src/CcDirector.Gateway.UnitTests/ExpireStalePendingDictationTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/ExpireStalePendingDictationTests.cs
@@ -1,0 +1,172 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// A PENDING dictation that no client is coming back for must stop holding its session locked.
+///
+/// PENDING deliberately never auto-releases for a LIVE dictation (issue #1188) and these tests do not
+/// weaken that - the fresh-record and activity cases below are what pin it. What they add is a bound on a
+/// DEAD one: the record clears only when the client delivers or abandons, so a client that simply never
+/// returns left the marker on disk forever. Seven were found stuck on the hosted Gateway on 2026-08-28, the
+/// oldest five weeks old, each still refusing human input on a session nobody could unlock.
+/// </summary>
+public sealed class ExpireStalePendingDictationTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "cc-stalepending-" + Guid.NewGuid().ToString("N"));
+    private readonly VoiceUploadStore _store;
+
+    public ExpireStalePendingDictationTests() => _store = new VoiceUploadStore(_root, TenantId.Local);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+        catch { /* test cleanup */ }
+    }
+
+    private static readonly TimeSpan Day = TimeSpan.FromHours(24);
+
+    private void Age(string uploadId, TimeSpan by)
+        => Directory.SetLastWriteTimeUtc(Path.Combine(_root, uploadId), DateTime.UtcNow - by);
+
+    [Fact]
+    public void AStalePendingRecord_IsAbandoned_AndItsSessionUnlocks()
+    {
+        var id = _store.Register(null);
+        _store.MarkPending(id, "session-a");
+        Age(id, TimeSpan.FromHours(30));
+
+        Assert.True(_store.IsSessionLocked("session-a"));
+
+        Assert.Equal(1, _store.ExpireStalePending(Day));
+
+        Assert.False(_store.IsSessionLocked("session-a"));
+    }
+
+    /// <summary>
+    /// It is an ABANDON, not a delete: the tombstone survives (so a late client cannot re-drive the upload
+    /// id) and it says the SERVER timed this out rather than the user giving up on it.
+    /// </summary>
+    [Fact]
+    public void TheExpiredRecordLeavesATombstoneSayingWhy()
+    {
+        var id = _store.Register(null);
+        _store.MarkPending(id, "session-a");
+        Age(id, TimeSpan.FromDays(40));
+
+        _store.ExpireStalePending(Day);
+
+        var json = File.ReadAllText(Path.Combine(_root, id, "record.json"));
+        Assert.Contains("Abandoned", json);
+        Assert.Contains(VoiceUploadStore.StalePendingReason, json);
+        Assert.DoesNotContain("user_abandoned", json);
+    }
+
+    [Fact]
+    public void AFreshPendingRecord_IsLeftAlone()
+    {
+        var id = _store.Register(null);
+        _store.MarkPending(id, "session-a");
+
+        Assert.Equal(0, _store.ExpireStalePending(Day));
+
+        Assert.True(_store.IsSessionLocked("session-a"));
+        Assert.True(_store.IsPending(id));
+    }
+
+    /// <summary>
+    /// THE ONE THAT PROTECTS A LIVE USER. Age is measured from last ACTIVITY, and every register, resume,
+    /// chunk and assemble refreshes it - so a client still working, however slowly, pushes its own deadline
+    /// out and is never expired mid-dictation. Only silence ages.
+    /// </summary>
+    [Fact]
+    public void ActivityOnAnOldUpload_PushesTheDeadlineOut()
+    {
+        var id = _store.Register(null);
+        _store.MarkPending(id, "session-a");
+        Age(id, TimeSpan.FromDays(9));
+
+        // The client comes back and resumes: re-registering the same id is the resume path, and it stamps
+        // the same last-activity signal the sweep judges by.
+        _store.Register(id);
+
+        Assert.Equal(0, _store.ExpireStalePending(Day));
+        Assert.True(_store.IsSessionLocked("session-a"));
+    }
+
+    /// <summary>
+    /// FAILED is a user-retryable pause that holds NO session lock, so ageing it out would cancel a retry
+    /// the user was offered rather than release a lock nobody can clear. Left alone on purpose.
+    /// </summary>
+    [Fact]
+    public void AFailedRecord_IsNotExpired()
+    {
+        var id = _store.Register(null);
+        _store.MarkPending(id, "session-a");
+        _store.MarkFailed(id, "out_of_credits");
+        Age(id, TimeSpan.FromDays(40));
+
+        Assert.Equal(0, _store.ExpireStalePending(Day));
+
+        var json = File.ReadAllText(Path.Combine(_root, id, "record.json"));
+        Assert.Contains("Failed", json);
+        Assert.True(_store.ClearFailed(id));   // still retryable
+    }
+
+    [Theory]
+    [InlineData("delivered")]
+    [InlineData("abandoned")]
+    public void AlreadyTerminalRecords_AreNotTouched(string state)
+    {
+        var id = _store.Register(null);
+        _store.MarkPending(id, "session-a");
+        if (state == "delivered") _store.MarkDelivered(id, submitted: true, movedOn: false, "words");
+        else _store.MarkAbandoned(id, "user_abandoned");
+        Age(id, TimeSpan.FromDays(40));
+
+        Assert.Equal(0, _store.ExpireStalePending(Day));
+
+        var json = File.ReadAllText(Path.Combine(_root, id, "record.json"));
+        Assert.DoesNotContain(VoiceUploadStore.StalePendingReason, json);
+    }
+
+    /// <summary>
+    /// The expiry runs inside ONE tenant's partition. Another tenant's stuck record is not this pass's to
+    /// resolve - the directory partition is the boundary, and a sweep that reached across it would be the
+    /// one place tenant isolation is enforced by a predicate someone could forget.
+    /// </summary>
+    [Fact]
+    public void ItDoesNotReachIntoAnotherTenantsPartition()
+    {
+        var a = _store.ForTenant(new TenantId("11111111-1111-1111-1111-111111111111"));
+        var b = _store.ForTenant(new TenantId("22222222-2222-2222-2222-222222222222"));
+
+        var idB = b.Register(null);
+        b.MarkPending(idB, "session-b");
+        Directory.SetLastWriteTimeUtc(Path.Combine(b.Root, idB), DateTime.UtcNow.AddDays(-40));
+
+        Assert.Equal(0, a.ExpireStalePending(Day));
+
+        Assert.True(b.IsSessionLocked("session-b"));
+    }
+
+    /// <summary>
+    /// Expiring discards the staged audio, exactly as a user-driven abandon does - the words are gone, so
+    /// keeping the bytes would be recorded speech with no purpose and no retention bound.
+    /// </summary>
+    [Fact]
+    public async Task ExpiringDiscardsTheStagedAudio()
+    {
+        var id = _store.Register(null);
+        _store.MarkPending(id, "session-a");
+        await _store.StoreChunkAsync(id, 0, new byte[] { 1, 2, 3, 4 }, null);
+        Assert.NotEmpty(Directory.GetFiles(Path.Combine(_root, id), "*.part"));
+
+        Age(id, TimeSpan.FromDays(40));
+        _store.ExpireStalePending(Day);
+
+        Assert.Empty(Directory.GetFiles(Path.Combine(_root, id), "*.part"));
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -720,6 +720,20 @@ public sealed class GatewayHost : IAsyncDisposable
     // immortal. The ack remains the real retirement path and retires records in seconds; this only catches
     // what the ack has permanently lost.
     private static readonly TimeSpan DictationTombstoneMaxAge = TimeSpan.FromDays(30);
+    // WHY TWENTY-FOUR HOURS, and why it is NOT the thirty days above. That number protects a tombstone,
+    // where keeping too long costs almost nothing. This one bounds a PENDING record, where keeping too long
+    // costs the user their session: PENDING locks the session against human input, so every extra hour is an
+    // hour the owner cannot type into a session that no client is coming back to. The risk is inverted
+    // again, so the number is too.
+    //
+    // It is measured against LAST ACTIVITY, not creation, and every register, resume, chunk and assemble
+    // refreshes it - so this is twenty-four hours of pure SILENCE, not twenty-four hours of dictating. A live
+    // dictation is minutes; a client retrying over a bad connection still touches its staging and pushes its
+    // own deadline out. A day of nothing means the client is gone: the app was closed, the phone replaced, or
+    // the upload died against a full disk (which is exactly how seven of these came to be stuck on hosted on
+    // 2026-08-28, the oldest five weeks old). Generous enough that no returning client is cut off, bounded
+    // enough that a lock nobody can clear lasts a day rather than forever.
+    private static readonly TimeSpan StalePendingMaxAge = TimeSpan.FromHours(24);
     /// <summary>
     /// Test seam: overrides the dictation tombstone sweep schedule (first tick and period). Null in
     /// production, assigned only by tests. It exists for the same reason its voice-turn sibling does - the
@@ -3748,7 +3762,13 @@ public sealed class GatewayHost : IAsyncDisposable
                     _tenantPass.ForEachTenant(() =>
                     {
                         if (_tenantPass.Current is not { } tenant) return; // deny: no scope -> sweep nothing
-                        _dictationUploads.ForTenant(tenant).SweepResolvedTombstones(DictationTombstoneMaxAge);
+                        var uploads = _dictationUploads.ForTenant(tenant);
+                        // Release stale session locks BEFORE retiring tombstones: expiring turns a PENDING
+                        // record into an ABANDONED one, and running it first means the tombstone sweep in the
+                        // same pass can age out anything that was already past both bounds, instead of
+                        // leaving it for the next tick six hours later.
+                        uploads.ExpireStalePending(StalePendingMaxAge);
+                        uploads.SweepResolvedTombstones(DictationTombstoneMaxAge);
                     });
                 }
                 catch (Exception ex) { FileLog.Write($"[GatewayHost] dictation tombstone sweep error: {ex.Message}"); }
@@ -3756,7 +3776,8 @@ public sealed class GatewayHost : IAsyncDisposable
             null, dictationTombstoneSchedule, dictationTombstoneSchedule);
         FileLog.Write($"[GatewayHost] dictation tombstone sweep started: every " +
             $"{dictationTombstoneSchedule.TotalHours:0.###}h, retiring unacknowledged terminal records older " +
-            $"than {DictationTombstoneMaxAge.TotalDays:0.###} days (PENDING is never swept)");
+            $"than {DictationTombstoneMaxAge.TotalDays:0.###} days, and abandoning PENDING records with no " +
+            $"activity for {StalePendingMaxAge.TotalHours:0.###}h so their session lock is released");
 
         // Remove-the-network-port phase 1b: retire lapsed session keys. This is HOUSEKEEPING, and saying so
         // matters - a lapsed key is ALREADY refused, because the expiry is checked on every resolution, so

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -544,6 +544,96 @@ public sealed class VoiceUploadStore
         => state is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned;
 
     /// <summary>
+    /// Abandon PENDING dictations that have shown no activity for <paramref name="maxAge"/>, releasing the
+    /// session lock they hold. Returns how many were expired.
+    ///
+    /// WHY A PENDING RECORD NEEDED A BOUND AT ALL. PENDING is the durable "there are undelivered words here"
+    /// marker, and it deliberately NEVER auto-releases - that is the whole point of issue #1188, and nothing
+    /// here changes it for a live dictation. But nothing released it for a DEAD one either: the record clears
+    /// only when the client delivers or explicitly abandons, so a client that simply never comes back - the
+    /// app closed, the phone replaced, a transcription that failed while the staging disk was full - left the
+    /// marker on disk forever. Seven were found stuck on the hosted Gateway on 2026-08-28, the oldest FIVE
+    /// WEEKS old, each still holding its session locked against human input. A lock nobody alive can clear is
+    /// not durability, it is a session the owner can no longer type into.
+    ///
+    /// IT IS AN ABANDON, NOT A DELETE, AND THAT IS THE POINT. Expiring writes the ordinary ABANDONED
+    /// tombstone through <see cref="MarkAbandoned"/> - the same transition the user's own "give up" button
+    /// takes. So the session unlocks, the heavy chunk bytes are discarded, a small marker survives saying
+    /// WHY, the upload id stays de-duplicated, and the existing tombstone sweep retires the marker later on
+    /// its own schedule. Deleting the directory outright would skip the tombstone and let a late client
+    /// re-drive an upload id the server had forgotten.
+    ///
+    /// AGE IS LAST ACTIVITY, NOT CREATION. It reads the same directory timestamp
+    /// <see cref="EnsureFreshStaging"/> stamps on every register, resume, chunk and assemble, so a client
+    /// that is still working - however slowly, however often it reconnects - keeps pushing its own deadline
+    /// out and is never expired mid-dictation. Only silence ages.
+    ///
+    /// POSITIVELY ADMIT, and re-read INSIDE the gate, exactly as the two sweeps above do: only a canonical
+    /// upload-id directory is a candidate, and the state and age are re-read under the upload's own lock, so
+    /// a delivery landing between the enumeration and the decision wins rather than being overwritten by a
+    /// stale verdict.
+    /// </summary>
+    public int ExpireStalePending(TimeSpan maxAge)
+    {
+        var expired = 0;
+        var cutoff = DateTime.UtcNow - maxAge;
+        try
+        {
+            foreach (var dir in Directory.EnumerateDirectories(_root))
+            {
+                var name = Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                if (!IsCanonicalUploadDirName(name)) continue;
+
+                WithRecordLock(name, () =>
+                {
+                    try
+                    {
+                        if (!Directory.Exists(dir)) return;
+
+                        var record = ReadRecordFile(RecordPath(dir));
+                        // No marker, unreadable, or any state but PENDING: not ours. FAILED is left alone on
+                        // purpose - it holds no session lock (IsPending is false while FAILED) and it is an
+                        // explicit user-retryable pause, so ageing it out would cancel a retry the user was
+                        // offered rather than release a lock nobody can clear.
+                        if (record is not { State: DictationDeliveryState.Pending }) return;
+                        if (!BelongsHere(record)) return;               // another tenant's record: never ours to resolve
+                        if (Directory.GetLastWriteTimeUtc(dir) >= cutoff) return;
+
+                        // The ordinary abandon transition. Re-enters this upload's gate, which is a Monitor
+                        // and therefore reentrant on this thread.
+                        MarkAbandoned(name, StalePendingReason);
+                        expired++;
+                        FileLog.Write($"[VoiceUploadStore] ExpireStalePending abandoned uploadId={name} " +
+                            $"session={record.SessionId} (PENDING with no activity for more than {maxAge}; " +
+                            "its session lock is released)");
+                    }
+                    catch (Exception ex)
+                    {
+                        FileLog.Write($"[VoiceUploadStore] ExpireStalePending dir={dir} failed: {ex.Message}");
+                    }
+                });
+            }
+            // No Invalidate here: MarkAbandoned goes through WriteRecordMarker, which drops each expired id
+            // from the session-lock cache as it is written. Invalidating as well would force a needless
+            // re-read of the whole partition.
+            if (expired > 0)
+                FileLog.Write($"[VoiceUploadStore] ExpireStalePending expired={expired} stale PENDING records older than {maxAge}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[VoiceUploadStore] ExpireStalePending failed: {ex.Message}");
+        }
+        return expired;
+    }
+
+    /// <summary>
+    /// The reason stamped on an expired PENDING record. A distinct value, not the user's "user_abandoned":
+    /// an operator reading the tombstone must be able to tell a dictation the USER gave up on from one the
+    /// SERVER timed out, because only the second one means words were taken away from someone.
+    /// </summary>
+    public const string StalePendingReason = "expired_no_activity";
+
+    /// <summary>
     /// Create the staging directory for an upload if it does not exist and stamp its last-activity signal to
     /// now, ATOMICALLY under the upload's gate. This is the one place activity is recorded, so every caller
     /// that represents a live client (register, a resume, a chunk, an assemble) refreshes the same signal the


### PR DESCRIPTION
## The defect

`PENDING` is the durable "there are undelivered words here" marker, and it deliberately never auto-releases (issue #1188). But nothing released it for a **dead** dictation either - the record clears only when the client delivers or explicitly abandons.

So a client that simply never comes back left the marker on disk **forever**: the app closed, the phone replaced, or an upload that died against a full staging disk.

**Seven were found stuck on the hosted Gateway on 2026-08-28, the oldest five weeks old** (22 July), each still holding its session locked against human input. Three belonged to other accounts. A lock nobody alive can clear is not durability - it is a session the owner can no longer type into.

They were also the last thing keeping the dictation staging root being read at all, after #2607 removed the per-session rescan.

## The fix

`ExpireStalePending` abandons a `PENDING` record that has been **silent** past its bound.

**It is an abandon, not a delete, and that is the point.** It takes the ordinary `MarkAbandoned` transition - the same one the user's own "give up" button takes - so the session unlocks, the chunk bytes are discarded, a small tombstone survives saying *why*, the upload id stays de-duplicated, and the existing tombstone sweep retires the marker later on its own schedule. Deleting the directory outright would skip the tombstone and let a late client re-drive an id the server had forgotten.

The reason code is `expired_no_activity`, deliberately distinct from the user's `user_abandoned`: an operator reading a tombstone must be able to tell a dictation the **user** gave up on from one the **server** timed out, because only the second one means words were taken away from someone.

### Age is last activity, not creation

It reads the same directory timestamp `EnsureFreshStaging` stamps on every register, resume, chunk and assemble. A client still working - however slowly, however often it reconnects - keeps pushing its own deadline out and is **never expired mid-dictation**. Only silence ages.

### Why 24 hours, and not the 30 days next door

Thirty days protects a *tombstone*, where keeping too long costs almost nothing. This bounds a *PENDING* record, where keeping too long costs the user their session - every extra hour is an hour the owner cannot type into a session no client is returning to. The risk is inverted, so the number is too. A live dictation is minutes; a day of pure silence means the client is gone.

### FAILED is left alone, on purpose

It holds no session lock (`IsPending` is false while `FAILED`) and it is an explicit user-retryable pause. Ageing it out would cancel a retry the user was offered rather than release a lock nobody can clear.

Wired into the existing six-hourly dictation sweep rather than a new timer, and run **before** the tombstone sweep so anything past both bounds resolves in one pass.

## The wiring test changed contract, deliberately

`DictationTombstoneSweepWiringTests` used to assert that an aged `PENDING` record **survived untouched**. That was correct while nothing bounded it - and it is exactly how those seven became immortal.

It now asserts the stale one is **abandoned in place** (directory and tombstone survive, state becomes `Abandoned`, reason names the server), while a **fresh** pending record is still untouchable. That half of the old contract is unchanged and is asserted explicitly.

That test boots a real `GatewayHost` and waits for production to act - it never calls the sweep itself, because a test that calls it passes whether or not anything in production runs it.

## Verification

| Suite | Result |
|---|---|
| `CcDirector.Gateway.UnitTests` | 3,125 pass |
| Dictation / voice / tenant / utterance integration | 470 of 470 pass |
| New `ExpireStalePendingDictationTests` | 9 pass |

The 8 unit failures are the Postgres-backed suites needing a local database not running on this machine - confirmed pre-existing against a clean tree.

**Verified as a real detector:** removing the `ExpireStalePending` call from `GatewayHost` makes the wiring test go red on exactly the "nothing in production is expiring them" assertion. The method existing is not the claim; production calling it is.

## Effect on the seven live records

Nothing manual is needed. Once deployed, the first sweep abandons them, their sessions unlock, and the staged audio is discarded.
