### PR TITLE
Wilson: the weather

### DIFF
--- a/apps/cc-assistant/HANDOVER.md
+++ b/apps/cc-assistant/HANDOVER.md
@@ -1,0 +1,96 @@
+# Wilson: picking this up later
+
+Written 28 August 2026, at the point where Wilson works and is being put down for a while.
+
+The README says what Wilson is and how it works. This says what state it is in, what was decided and
+why, and what the next person has to decide before they can go further. Read the README first.
+
+## Where it stands
+
+It works. It is deployed, it deploys itself on merge, and it does four things: answers questions,
+keeps timers, tells you the weather, and shuts up when told to.
+
+Everything below is either a decision that has already been made and should not be relitigated
+without a reason, or a decision nobody has made yet.
+
+## Decisions already made, and why
+
+**The browser's own recogniser does the listening, not Whisper.** Whisper was measured and works —
+`whisperListener.ts` is written and wired to nothing — but the platform recogniser needs no download,
+no model, and starts instantly.
+
+There is a trap here that cost most of a day. The recogniser **starts and immediately ends, with no
+error and no results, when driven over the browser automation protocol.** It works perfectly in a
+browser a person is using. That produced a confident and wrong conclusion that Web Speech was dead on
+this machine, and nearly a rewrite onto Whisper. **A browser driven by automation is not evidence
+about a browser a person is using.** If it ever genuinely fails on a real device, `whisperListener.ts`
+is the replacement and the calibration screens already say which model that device should run.
+
+**The model translates; the device executes and speaks.** The model is given tools and returns tool
+calls only. The page runs them and composes the sentence from what actually happened. This is not
+style: it is why Wilson cannot tell you a timer is set when it is not. Any new skill should follow
+it. If a future skill needs the model to phrase something, that is a real departure and worth arguing
+about first.
+
+**No local shortcuts for commands with arguments.** A regular-expression fast path for timers was
+built, shipped, and deleted the same day because it silently discarded names. Four hundred
+milliseconds is not worth a wrong answer.
+
+**Timers live in the page.** Deliberately. A browser cannot reliably wake itself, so a background
+timer would be a lie. If timers ever need to survive the app being closed, that is a native
+application or a push notification from the Gateway, not a cleverer web trick.
+
+## Decisions nobody has made yet
+
+**Search needs a key, and creating it is a human job.** There are no search keys on this machine.
+Brave Search has a free tier; Tavily and Serper are the alternatives. Every one needs a signup.
+Until somebody creates one, the options are: no search, or a keyless version built on Wikipedia and
+DuckDuckGo instant answers, which handles "who was Ada Lovelace" but is not real web search.
+
+**Knowing who is speaking is three different products and nobody has said which.** They need
+different designs and have very different failure costs:
+
+- *Do not answer the television.* Forgiving. A wrong answer is a missed command.
+- *Know one person from another, and answer differently.* Harder. Needs enrolment per person.
+- *Only obey one person.* A security feature, and it will lock you out when you have a cold.
+
+Technically all three need a speaker-embedding model in the browser, an enrolment step, and raw audio
+— which the platform recogniser does not give us, so `pcmCapture.ts` would have to run alongside it.
+That much is known. **What is not known is which of the three was wanted**, and the answer changes
+the design enough that building before asking would be waste.
+
+Note also that none of it can be verified by one person: proving it distinguishes anybody needs at
+least two voices.
+
+**The directory is still called `cc-assistant` while the product is called Wilson.** Renaming is
+cheap but it moves the Vercel root directory and the eventual Gateway mount, so do it deliberately.
+
+**Wilson is not connected to DevThrottle at all.** No gateway, no device key, no fleet. That was
+right for getting it working and is the open question for what it becomes: a DevThrottle feature
+behind a sign-in, or its own thing. The decision recorded during the build was "a tool in
+DevThrottle, because I cannot start another business", but nothing in the code commits to it yet.
+
+## Things that will bite
+
+**The service worker will serve you stale code.** It is network-first now, which fixes it, but if a
+deploy ever seems not to have landed, add `?fresh=1` before concluding anything.
+
+**Two watchers reported CI green when it was still running.** One tested a jq expression that returns
+empty on error, so an error looked identical to success; the other detached, so the tool saw the
+outer shell exit. If you write a watcher, make its pass condition a **presence** — the run reaching a
+terminal state — never an absence.
+
+**The Vercel deployment is connected to GitHub now.** It builds only when this directory changes.
+That means a fix can no longer be hand-deployed; it has to be committed and merged. Slower, and
+correct.
+
+## If you want to keep going
+
+In the order I would take them:
+
+1. **Search**, keyless first. It is the biggest gap in usefulness and needs no decision from anybody.
+2. **Warm the function**, so the first question of the day is not nine seconds.
+3. **Endpointing.** Turn-taking is still whatever the browser does. The design for adaptive
+   endpointing and an acknowledgement sound was worked out and never built; it is the difference
+   between talking to it and operating it.
+4. **Voice identity**, once somebody says which of the three it is.

--- a/apps/cc-assistant/README.md
+++ b/apps/cc-assistant/README.md
@@ -1,107 +1,126 @@
-# CC Assistant
+# Wilson
 
-A voice assistant you talk to, where the wake word is whatever each person decides it should be.
+A voice assistant for the kitchen. Say its name and talk to it. The name is whatever each person
+decides it should be.
 
-Built one step at a time, and each step answers a question that would invalidate the next one.
-Right now there is exactly one step in here.
+Live at **https://cc-assistant-bice.vercel.app** — open it, press Start, and say "Wilson".
 
-## Step 1, which is what exists: can this device hear?
+It listens with the browser's own recogniser, thinks with a hosted model, speaks with the browser's
+own voice, and keeps timers itself. There is no sign-in, because the page carries no credential of
+any kind.
 
-Everything else sits on the answer to one question. The wake word is a text match on a transcript.
-The command is a transcript. So the first thing to know is whether a phone can produce that
-transcript **continuously**, and how good it is.
+## What it can do
 
-The measurement is a single number: the **real-time factor**, meaning the time the model takes to
-transcribe a chunk divided by the real time that chunk covers.
+| | |
+| --- | --- |
+| **Answer questions** | Anything the model knows. Replies are one or two spoken sentences, never a paragraph. |
+| **Timers** | Named or not. Start several, stop one by name, stop them all, ask what is running. |
+| **Silence an alarm** | While one is ringing, "stop" or "shut up" works with **no wake word**. |
+| **Weather** | Where you are, or anywhere you name. Needs a home town in settings. |
+| **Interrupt it** | Say the wake word while it is talking and it stops mid-sentence. |
 
-- Under 1 and it keeps up.
-- Over 1 and it does not degrade, it falls behind and never catches up. The backlog counter on
-  screen is there to make that visible, because an average can look fine while a queue quietly grows.
+It cannot play music, control anything in the house, read a calendar or a list, search the internet,
+or remember anything between sessions. It says so plainly when asked rather than pretending.
 
-## Running it on a computer
+## How a turn works
+
+```
+asleep --wake word--> listening --you stop talking--> thinking --> speaking --> asleep
+```
+
+It goes straight back to sleep after answering. It does not linger listening.
+
+Three lanes, chosen by how fast each has to be:
+
+| Lane | Handles | Cost |
+| --- | --- | --- |
+| Instant, local | Silencing a ringing alarm | no network |
+| Model with tools | Timers, weather, anything needing understanding | ~400 ms |
+| Model, plain | Ordinary questions | ~300 ms |
+
+## The rules, and the bugs that produced them
+
+Every one of these came from something that actually went wrong, and every one is kept as a test so
+it cannot come back unnoticed.
+
+**The device says what happened, never the model.** The model only decides which tool was meant; the
+sentence spoken afterwards is built from the real outcome. Asked to set a timer before this existed,
+it answered "Timer set for ten minutes" without setting anything. A confident false confirmation is
+worse than any refusal, because it is trusted.
+
+**Nothing said while it is speaking, or for 1.5 seconds after, is a command.** Its own voice came
+back through the microphone, was transcribed like anything else, and was answered — one question
+became four turns of it talking to itself. Two guards now, time and text, because either alone leaks.
+The text one has to be fuzzy: it said "Alright." and heard itself as "all right".
+
+**There is no local shortcut for a command that has a name in it.** There was one for timers, to save
+four hundred milliseconds, and it grabbed any sentence containing a duration and threw the name away.
+"Set a timer called barbecue for three minutes" worked; the same sentence with one word misheard
+silently became an unnamed timer. A shortcut that is sometimes wrong is worse than a delay that is
+always right.
+
+**Never ask the platform for something it has not got.** Requesting on-device speech recognition on a
+device whose model is merely downloadable yields a recogniser that reports nothing at all, which
+looks exactly like a dead microphone. Check first.
+
+**Show what was ignored.** A guard that works silently is indistinguishable from one that is broken.
+Suppressed speech, recogniser notices and the microphone level are all on screen.
+
+## Where everything lives
+
+| | |
+| --- | --- |
+| Source | this directory, on `main` |
+| Deployed | Vercel project `cc-assistant`, scope `soren-frederiksens-projects` |
+| Deploys | automatically, on any merge to `main` that touches this directory |
+| Model | Groq, `openai/gpt-oss-120b`, reasoning effort low |
+| Keys | `GROQ_API_KEY` and `ASSISTANT_MODEL`, Vercel production environment only |
+| Weather | Open-Meteo, no key needed |
+
+## Running it
 
 ```
 npm install
 npm run dev
 ```
 
-Open <http://localhost:5183/cc-assistant/>.
+Then <http://localhost:5183/cc-assistant/>.
 
-Load a model first. The first load downloads it, which is roughly 40 MB for tiny, 80 MB for base and
-250 MB for small, and the browser caches it afterwards. Then press Start listening and talk.
-
-## Running it on a phone
-
-The dev server listens on the network, so the phone can reach the machine. **But the microphone will
-not work over plain HTTP.** Browsers only allow microphone access on a secure connection, and
-`localhost` is the only exception. Going to `http://192.168.1.x:5183` from a phone will load the page
-and then refuse to open the microphone, which looks like a bug in this app and is not.
-
-Serve it over Tailscale, which already has certificates for the tailnet:
+**On a phone the microphone will not work over plain HTTP.** Browsers allow it only on a secure
+connection, and `localhost` is the sole exception, so a LAN address loads the page and then refuses
+the microphone. Put Tailscale in front of it:
 
 ```
 tailscale serve --bg --https 8443 http://127.0.0.1:5183
 ```
 
-Then open `https://soren-north.taildb08ed.ts.net:8443/cc-assistant/` on the phone. To install it to
-the home screen, use the browser's Add to Home Screen. On iPhone that also matters for a later step:
-holding the screen awake only works from an installed web app, and only on iOS 18.4 or newer.
-
-## Reading the screen
-
-| What | What it means |
-| --- | --- |
-| Real-time factor | The verdict. Under 0.5 is comfortable, under 1 is usable, over 1 is unusable at this size. |
-| Per chunk | Milliseconds of actual model time, averaged over the last ten. |
-| Backlog | Chunks waiting to be transcribed. Anything that keeps climbing means it is losing. |
-| Peak | Loudest sample in the chunk, 0 to 1. Tells silence apart from a broken microphone. |
-| Text | What it heard. This is the quality half of the question, and only your ears can judge it. |
-
-Both halves matter and they pull against each other. A model that keeps up but mishears you is no
-more useful than one that is accurate and too slow.
-
-## What to try
-
-1. **whisper-base.en on WebGPU, 2 second chunks.** The expected answer, and where to start.
-2. **The same on WebAssembly.** Shows what happens on a device without WebGPU, which is roughly
-   30 percent of phones. Expect it to be several times slower.
-3. **whisper-tiny.en.** If base cannot keep up, this is where the listening half goes.
-4. **whisper-small.en.** Almost certainly too slow to run continuously. Worth confirming, because if
-   it is fast enough for one utterance it is a candidate for transcribing the command after the wake
-   word fires, which is a different job with different requirements.
-5. **Play music through the same machine while you talk.** The microphone is opened with echo
-   cancellation and the log says whether the browser actually granted it.
-
-## What is here
+## What is in here
 
 | File | What it does |
 | --- | --- |
-| `public/pcm-worklet.js` | Runs on the audio thread, batches raw samples, posts them out. |
-| `src/audio/microphoneCapture.ts` | Opens the microphone asking for echo cancellation, then reads back whether it was granted. |
-| `src/audio/pcmCapture.ts` | Converts from the device's sample rate to the 16,000 the model needs, and hands out fixed-length chunks. |
-| `src/transcribe/transcriber.worker.ts` | The speech model on its own thread, and the timing. |
-| `src/transcribe/transcriberClient.ts` | The page's side of that worker, and the backlog count. |
-| `src/wakeWord/wakeWordMatcher.ts` | Finds a chosen word in a transcript. Written and tested, not yet wired to anything. Step 2. |
-| `src/screenWakeLock.ts` | Holds the screen awake. Not yet wired. A later step. |
+| `src/assistant/AssistantScreen.tsx` | The app: the loop, the states, the screen |
+| `src/assistant/speech.ts` | Listening and speaking, using what the browser already has |
+| `src/assistant/echoGuard.ts` | Stops it answering its own voice |
+| `src/assistant/micLevel.ts` | Proof the microphone is open, in pixels |
+| `src/skills/timerParse.ts` | Reading durations out of a sentence |
+| `src/skills/timerLogic.ts` | Name matching, silencing, and the sentences |
+| `src/skills/useTimers.ts` | The timers themselves, and the alarm |
+| `src/skills/weather.ts` | Turning a reading into words |
+| `src/wakeWord/wakeWordMatcher.ts` | Finding the chosen word in a transcript |
+| `api/talk.js` | The brain, and the tools it can call |
+| `api/weather.js` | Open-Meteo |
+| `api/result.js` | Where diagnostics reports go |
+
+Behind the **Diagnostics** link at the bottom of the app are the measurement screens that settled
+which speech model a device should run. They are not the product but they answered real questions.
 
 Run the tests with `npm test`.
 
-## The steps after this one
+## Known limitations, all deliberate
 
-Each is deliberately separate so a bad result in one does not sink the rest.
-
-2. **Wake word.** Match a chosen word in the transcript, with learned aliases for what the recognizer
-   actually hears when it gets it wrong.
-3. **Voice activity detection.** Only run the model when somebody is speaking, so a quiet kitchen
-   costs nothing.
-4. **Turn taking.** Endpointing that adapts to the sentence, the acknowledgement sound, and letting
-   the sound be retracted when the endpoint was called wrong.
-5. **The brain.** Connect to the existing `/assistant/turn`.
-6. **The fast path.** Timers and stop and cancel answered on the phone without touching the network.
-
-## Known, and deliberately not solved yet
-
-- **The model downloads from Hugging Face's servers.** Fine for a test. Before this is something you
-  rely on in a kitchen the weights should be served by the Gateway and cached, or the app is broken
-  the first time Hugging Face has a bad day.
-- **Nothing is connected to an assistant.** This step only proves the device can hear.
+- **Timers only run while the app is on screen.** A browser cannot reliably wake itself. This is
+  written on the screen rather than left to be discovered when dinner burns.
+- **Nothing is remembered between sessions** except the wake word and the home town.
+- **Every question costs money.** Small, but a device asked things all day is a running cost.
+- **The first request after a quiet spell takes several seconds**, because the serverless function
+  cold-starts. Everything after is 200 to 400 ms.

--- a/apps/cc-assistant/api/talk.js
+++ b/apps/cc-assistant/api/talk.js
@@ -48,6 +48,22 @@ const TOOLS = [
   {
     type: "function",
     function: {
+      name: "get_weather",
+      description: "The weather now. Call this for any question about weather, temperature, rain, or what to wear.",
+      parameters: {
+        type: "object",
+        properties: {
+          place: {
+            type: "string",
+            description: "A town or city, only if they named one. Omit it for where they are.",
+          },
+        },
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
       name: "list_timers",
       description: "Say what timers are running and how long is left on each.",
       parameters: { type: "object", properties: {} },
@@ -78,7 +94,7 @@ function describeTimers(timers) {
 const CANNOT_DO = [
   "play music or control speakers",
   "control lights, heating or any other device",
-  "check the weather, news or anything else live",
+  "check the news or anything else live",
   "read or change a calendar, list, message or email",
   "remember anything after this conversation ends",
 ];
@@ -90,7 +106,7 @@ const SYSTEM_PROMPT = [
   "never say what you are about to do, and never offer further help or ask if there is anything else.",
   "Never use lists, headings, markdown or emoji. Say numbers the way a person says them aloud.",
   "YOU CANNOT DO ANY OF THE FOLLOWING: " + CANNOT_DO.join("; ") + ".",
-  "For anything about timers - starting, stopping, or asking what is running - CALL A TOOL. Do not answer in words.",
+  "For anything about timers, or about the weather, CALL A TOOL. Do not answer in words and never invent a temperature.",
   "If you are asked for one of the things you cannot do, say plainly in one short sentence that you cannot do it yet.",
   "NEVER claim to have done something you cannot do. Saying a timer is set when it is not is the",
   "worst mistake you can make.",

--- a/apps/cc-assistant/api/weather.js
+++ b/apps/cc-assistant/api/weather.js
@@ -1,0 +1,108 @@
+// The weather, from Open-Meteo.
+//
+// No key, no account, no signup. That is the whole reason it was the first of the three things to
+// build: nothing about it needed a human to go and register somewhere.
+//
+// It returns numbers, never a sentence. The page turns them into words, because a sentence composed
+// where the reading was taken cannot be wrong about what the reading said.
+
+const FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
+const GEOCODE_URL = "https://geocoding-api.open-meteo.com/v1/search";
+
+/** Turn a place name into coordinates. Returns null when there is no such place. */
+async function findPlace(name) {
+  const url = `${GEOCODE_URL}?name=${encodeURIComponent(name)}&count=1&language=en&format=json`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`The place lookup failed (${response.status}).`);
+  }
+  const body = await response.json();
+  const first = Array.isArray(body.results) ? body.results[0] : null;
+  if (!first) {
+    return null;
+  }
+  return { latitude: first.latitude, longitude: first.longitude, place: first.name };
+}
+
+export default async function handler(request, response) {
+  if (request.method !== "POST") {
+    response.status(405).json({ error: "Ask for the weather with POST." });
+    return;
+  }
+
+  let payload = request.body;
+  if (typeof payload === "string") {
+    try {
+      payload = JSON.parse(payload);
+    } catch {
+      response.status(400).json({ error: "The body was not JSON." });
+      return;
+    }
+  }
+  payload = payload || {};
+
+  const units = payload.units === "fahrenheit" ? "fahrenheit" : "celsius";
+  let latitude = Number(payload.latitude);
+  let longitude = Number(payload.longitude);
+  let place = typeof payload.place === "string" ? payload.place.trim() : "";
+
+  try {
+    // A named place wins over coordinates: asking for the weather in London while standing in Toronto
+    // means London.
+    if (place.length > 0) {
+      const found = await findPlace(place);
+      if (found === null) {
+        response.status(200).json({ notFound: true, place });
+        return;
+      }
+      latitude = found.latitude;
+      longitude = found.longitude;
+      place = found.place;
+    }
+
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+      response.status(200).json({ noLocation: true });
+      return;
+    }
+
+    const url =
+      `${FORECAST_URL}?latitude=${latitude}&longitude=${longitude}` +
+      "&current=temperature_2m,apparent_temperature,weather_code,wind_speed_10m" +
+      "&daily=temperature_2m_max,temperature_2m_min,precipitation_probability_max" +
+      `&forecast_days=1&timezone=auto&temperature_unit=${units}`;
+
+    const forecast = await fetch(url);
+    if (!forecast.ok) {
+      throw new Error(`The forecast failed (${forecast.status}).`);
+    }
+    const body = await forecast.json();
+    const current = body.current || {};
+    const daily = body.daily || {};
+
+    const reading = {
+      // With coordinates and no name, the timezone is the only honest label we have for where this
+      // is. "America/Toronto" becomes "Toronto".
+      place: place.length > 0 ? place : String(body.timezone || "here").split("/").pop().replace(/_/g, " "),
+      temperature: current.temperature_2m,
+      feelsLike: current.apparent_temperature ?? null,
+      code: current.weather_code ?? 0,
+      windSpeed: current.wind_speed_10m ?? null,
+      high: Array.isArray(daily.temperature_2m_max) ? daily.temperature_2m_max[0] ?? null : null,
+      low: Array.isArray(daily.temperature_2m_min) ? daily.temperature_2m_min[0] ?? null : null,
+      chanceOfRain: Array.isArray(daily.precipitation_probability_max)
+        ? daily.precipitation_probability_max[0] ?? null
+        : null,
+      units,
+    };
+
+    if (typeof reading.temperature !== "number") {
+      throw new Error("The forecast came back without a temperature in it.");
+    }
+
+    console.log("WEATHER " + JSON.stringify({ at: new Date().toISOString(), place: reading.place, code: reading.code }));
+    response.status(200).json({ reading });
+  } catch (error) {
+    console.log("WEATHER ERROR " + String(error));
+    response.status(502).json({ error: "I could not reach the weather service." });
+  }
+}

--- a/apps/cc-assistant/src/assistant/AssistantScreen.tsx
+++ b/apps/cc-assistant/src/assistant/AssistantScreen.tsx
@@ -5,6 +5,7 @@ import { watchMicLevel, type MicLevel } from "./micLevel";
 import { judgeEcho, similarity, ECHO_SIMILARITY } from "./echoGuard";
 import { clockFace as clockFaceOf } from "../skills/timerParse";
 import { isSilenceCommand, callIt } from "../skills/timerLogic";
+import { sayWeather, sayNoLocation, sayPlaceNotFound } from "../skills/weather";
 import { useTimers } from "../skills/useTimers";
 
 // The assistant. Say your word, then say the thing.
@@ -25,6 +26,7 @@ interface Turn {
 // sits listening. After it answers it goes straight back to sleep.
 const FOLLOW_UP_MS = 5000;
 const WAKE_WORD_KEY = "cc-assistant.wakeWord";
+const HOME_KEY = "cc-assistant.home";
 
 export function AssistantScreen() {
   const [wakeWord, setWakeWord] = useState(() => {
@@ -40,6 +42,13 @@ export function AssistantScreen() {
   const [problem, setProblem] = useState<string | null>(null);
   const [onDevice, setOnDevice] = useState<boolean | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [home, setHome] = useState(() => {
+    try {
+      return window.localStorage.getItem(HOME_KEY) ?? "";
+    } catch {
+      return "";
+    }
+  });
   // The evidence that it is awake. Without these, a silent room and a dead microphone look identical.
   const [level, setLevel] = useState(0);
   const [micInfo, setMicInfo] = useState<{ label: string; echoCancellation: boolean } | null>(null);
@@ -70,6 +79,14 @@ export function AssistantScreen() {
     stateRef.current = next;
     setState(next);
   }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(HOME_KEY, home);
+    } catch {
+      // Not remembering it is a nuisance, not a failure.
+    }
+  }, [home]);
 
   useEffect(() => {
     try {
@@ -133,6 +150,47 @@ export function AssistantScreen() {
   // The model handles every one of these correctly, including asking how long when no duration was
   // given. A shortcut that is sometimes wrong is worse than a delay that is always right.
 
+  const homeRef = useRef(home);
+  homeRef.current = home;
+
+  /**
+   * Fetch the weather and say it.
+   *
+   * A named place wins over the home town, so asking about London while standing in the kitchen gives
+   * London. With neither, it says it does not know rather than guessing at a city.
+   */
+  const answerWeather = useCallback(async (place: string | null): Promise<string> => {
+    const wanted = place ?? homeRef.current;
+    if (wanted.trim().length === 0) {
+      return sayNoLocation();
+    }
+    try {
+      const response = await fetch(`${import.meta.env.BASE_URL}api/weather`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ place: wanted }),
+      });
+      const body = (await response.json()) as {
+        reading?: Parameters<typeof sayWeather>[0];
+        notFound?: boolean;
+        noLocation?: boolean;
+        error?: string;
+      };
+      if (body.notFound) {
+        return sayPlaceNotFound(wanted);
+      }
+      if (body.noLocation) {
+        return sayNoLocation();
+      }
+      if (!response.ok || !body.reading) {
+        return body.error ?? "I could not get the weather.";
+      }
+      return sayWeather(body.reading);
+    } catch {
+      return "I could not reach the weather service.";
+    }
+  }, []);
+
   /** Carry out one tool the model asked for, and return the sentence describing what happened. */
   const runAction = useCallback((action: { name: string; args: Record<string, unknown> }): string => {
     const t = timersRef.current;
@@ -156,6 +214,9 @@ export function AssistantScreen() {
         return t.stopAll();
       case "list_timers":
         return t.list();
+      case "get_weather":
+        // Handled by the caller, which can wait for the network.
+        return "";
       default:
         return "";
     }
@@ -187,7 +248,18 @@ export function AssistantScreen() {
       // The device did the work, so the device says what happened. The model is never asked to
       // narrate its own tool calls.
       if (body.actions && body.actions.length > 0) {
-        const said = body.actions.map((action) => runAction(action)).filter((line) => line.length > 0);
+        const said: string[] = [];
+        for (const action of body.actions) {
+          if (action.name === "get_weather") {
+            const place = typeof action.args.place === "string" ? action.args.place : null;
+            said.push(await answerWeather(place));
+            continue;
+          }
+          const line = runAction(action);
+          if (line.length > 0) {
+            said.push(line);
+          }
+        }
         const sentence = said.length > 0 ? said.join(" ") : "I could not do that.";
         turnIdRef.current += 1;
         setTurns((previous) =>
@@ -235,7 +307,7 @@ export function AssistantScreen() {
       lastSpokeEndedAtRef.current = Date.now();
       setStateBoth("asleep");
     }
-  }, [runAction, setStateBoth]);
+  }, [answerWeather, runAction, setStateBoth]);
 
   const onHeard = useCallback(
     (text: string, isFinal: boolean) => {
@@ -437,6 +509,15 @@ export function AssistantScreen() {
             <input value={wakeWord} onChange={(e) => setWakeWord(e.target.value)} spellCheck={false} />
           </label>
           {weakness !== null ? <p className="advice">{weakness}</p> : null}
+          <label>
+            Home town, for the weather
+            <input
+              value={home}
+              onChange={(e) => setHome(e.target.value)}
+              placeholder="Toronto"
+              spellCheck={false}
+            />
+          </label>
           <p className="status">
             Listening runs on this device with {engine || "the speech model"}, and the audio never leaves it.
             {onDevice === false ? " The browser's own recogniser is not usable here." : null}

--- a/apps/cc-assistant/src/skills/weather.test.ts
+++ b/apps/cc-assistant/src/skills/weather.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { describeCode, sayNoLocation, sayPlaceNotFound, sayWeather, type WeatherNow } from "./weather";
+
+function reading(over: Partial<WeatherNow> = {}): WeatherNow {
+  return {
+    place: "Toronto",
+    temperature: 18,
+    feelsLike: 18,
+    code: 0,
+    windSpeed: 10,
+    high: null,
+    low: null,
+    chanceOfRain: null,
+    units: "celsius",
+    ...over,
+  };
+}
+
+describe("describing conditions", () => {
+  it("uses words a person would say", () => {
+    expect(describeCode(0)).toBe("clear");
+    expect(describeCode(3)).toBe("overcast");
+    expect(describeCode(63)).toBe("raining");
+    expect(describeCode(95)).toBe("thundery");
+  });
+
+  it("admits when it does not recognise a code rather than inventing one", () => {
+    expect(describeCode(1234)).toBe("hard to describe");
+  });
+});
+
+describe("saying the weather", () => {
+  it("puts the temperature first when the sky is just a description", () => {
+    expect(sayWeather(reading())).toBe("It is 18 degrees and clear in Toronto.");
+  });
+
+  it("puts the condition first when something is actually happening", () => {
+    expect(sayWeather(reading({ code: 63, temperature: 9, feelsLike: 9 })))
+      .toBe("It is raining in Toronto and 9 degrees.");
+  });
+
+  it("rounds, because nobody says nineteen point four degrees", () => {
+    expect(sayWeather(reading({ temperature: 19.4 }))).toMatch(/19 degrees/);
+  });
+
+  // A forecast that recites every number it has is one nobody listens to.
+  it("stays quiet about feels-like when it matches the temperature", () => {
+    expect(sayWeather(reading({ feelsLike: 19 }))).not.toMatch(/feels like/);
+  });
+
+  it("mentions feels-like when it would change what you wear", () => {
+    expect(sayWeather(reading({ temperature: 2, feelsLike: -6 }))).toMatch(/Feels like -6 degrees/);
+  });
+
+  it("stays quiet about a small chance of rain", () => {
+    expect(sayWeather(reading({ chanceOfRain: 10 }))).not.toMatch(/chance of rain/);
+  });
+
+  it("mentions a real chance of rain", () => {
+    expect(sayWeather(reading({ chanceOfRain: 70 }))).toMatch(/70 percent chance of rain/);
+  });
+
+  it("gives the day's range when it has one", () => {
+    expect(sayWeather(reading({ high: 22, low: 11 }))).toMatch(/22 to 11 today/);
+  });
+
+  it("joins several extras readably", () => {
+    const said = sayWeather(reading({ temperature: 1, feelsLike: -7, high: 4, low: -2, chanceOfRain: 60 }));
+    expect(said).toBe("It is 1 degrees and clear in Toronto. Feels like -7 degrees, 4 to -2 today, and 60 percent chance of rain.");
+  });
+
+  it("names the unit when it is not celsius", () => {
+    expect(sayWeather(reading({ units: "fahrenheit", temperature: 64 }))).toMatch(/64 degrees Fahrenheit/);
+  });
+});
+
+describe("when it cannot answer", () => {
+  it("asks for a home town rather than guessing", () => {
+    expect(sayNoLocation()).toMatch(/home town/);
+  });
+
+  it("says which place it could not find", () => {
+    expect(sayPlaceNotFound("Llanfairpwll")).toBe("I could not find anywhere called Llanfairpwll.");
+  });
+});

--- a/apps/cc-assistant/src/skills/weather.ts
+++ b/apps/cc-assistant/src/skills/weather.ts
@@ -1,0 +1,115 @@
+// Turning a weather reading into a sentence somebody would actually say.
+//
+// The device writes this, not the model, for the same reason the timer sentences are written here:
+// what the forecast actually says is known only after the call is made, and a model asked to narrate
+// its own tool call will cheerfully invent a temperature.
+//
+// Everything in this file is pure, so the wording can be tested without the network.
+
+export interface WeatherNow {
+  readonly place: string;
+  readonly temperature: number;
+  readonly feelsLike: number | null;
+  readonly code: number;
+  readonly windSpeed: number | null;
+  readonly high: number | null;
+  readonly low: number | null;
+  readonly chanceOfRain: number | null;
+  readonly units: "celsius" | "fahrenheit";
+}
+
+// The World Meteorological Organization codes Open-Meteo reports, in the words a person uses. Said
+// out loud, so "overcast" rather than "overcast clouds" and no numbers anybody has to decode.
+const CONDITIONS = new Map<number, string>([
+  [0, "clear"],
+  [1, "mostly clear"],
+  [2, "partly cloudy"],
+  [3, "overcast"],
+  [45, "foggy"],
+  [48, "freezing fog"],
+  [51, "drizzling lightly"],
+  [53, "drizzling"],
+  [55, "drizzling heavily"],
+  [56, "freezing drizzle"],
+  [57, "freezing drizzle"],
+  [61, "raining lightly"],
+  [63, "raining"],
+  [65, "raining heavily"],
+  [66, "freezing rain"],
+  [67, "freezing rain"],
+  [71, "snowing lightly"],
+  [73, "snowing"],
+  [75, "snowing heavily"],
+  [77, "snowing"],
+  [80, "showery"],
+  [81, "showery"],
+  [82, "heavy showers"],
+  [85, "snow showers"],
+  [86, "heavy snow showers"],
+  [95, "thundery"],
+  [96, "thunderstorms with hail"],
+  [99, "thunderstorms with hail"],
+]);
+
+export function describeCode(code: number): string {
+  return CONDITIONS.get(code) ?? "hard to describe";
+}
+
+/** Whether the condition reads as a state ("it is raining") or a description ("it is overcast"). */
+function isHappening(code: number): boolean {
+  return code >= 45;
+}
+
+function round(value: number): number {
+  return Math.round(value);
+}
+
+function degrees(value: number, units: WeatherNow["units"]): string {
+  return `${round(value)} degrees${units === "fahrenheit" ? " Fahrenheit" : ""}`;
+}
+
+/**
+ * One or two sentences about the weather right now.
+ *
+ * Mentions what it feels like only when that differs from the actual temperature by enough to change
+ * what you would wear, and the chance of rain only when it is worth knowing. A forecast that recites
+ * every number it has is one nobody listens to.
+ */
+export function sayWeather(now: WeatherNow): string {
+  const condition = describeCode(now.code);
+  const opening = isHappening(now.code)
+    ? `It is ${condition} in ${now.place} and ${degrees(now.temperature, now.units)}.`
+    : `It is ${degrees(now.temperature, now.units)} and ${condition} in ${now.place}.`;
+
+  const extras: string[] = [];
+
+  if (now.feelsLike !== null && Math.abs(now.feelsLike - now.temperature) >= 3) {
+    extras.push(`feels like ${degrees(now.feelsLike, now.units)}`);
+  }
+  if (now.high !== null && now.low !== null) {
+    extras.push(`${round(now.high)} to ${round(now.low)} today`);
+  }
+  if (now.chanceOfRain !== null && now.chanceOfRain >= 30) {
+    extras.push(`${round(now.chanceOfRain)} percent chance of rain`);
+  }
+
+  if (extras.length === 0) {
+    return opening;
+  }
+  const tail = extras.length === 1 ? extras[0] : `${extras.slice(0, -1).join(", ")}, and ${extras[extras.length - 1]}`;
+  return `${opening} ${capitalise(tail)}.`;
+}
+
+function capitalise(text: string): string {
+  return text.length === 0 ? text : text[0].toUpperCase() + text.slice(1);
+}
+
+/** What to say when there is nowhere to get the weather for. */
+export function sayNoLocation(): string {
+  return "I do not know where you are. Set a home town in settings and I will remember it.";
+}
+
+/** What to say when a named place could not be found. */
+export function sayPlaceNotFound(place: string): string {
+  return `I could not find anywhere called ${place}.`;
+}


### PR DESCRIPTION
Wilson can now answer questions about the weather.

Asks [Open-Meteo](https://open-meteo.com), which needs no key and no account, so nothing about this had to wait on somebody signing up somewhere. That is why it was the first of the three requested features to build.

A named place wins over the home town, so asking about London while standing in the kitchen gives London. With neither, it says it does not know and asks for a home town rather than guessing at a city. The home town is a new field in settings, remembered per device.

## The rule this follows

**The endpoint returns numbers and never a sentence.** The page turns them into words, the same rule the timers follow: a sentence composed where the reading was taken cannot be wrong about what the reading said, and a model asked to narrate its own tool call will cheerfully invent a temperature.

## The wording leaves things out on purpose

What it feels like is mentioned only when it differs from the actual temperature by enough to change what you would wear. The chance of rain only above thirty percent. A forecast that recites every number it has is one nobody listens to.

## Testing

Fourteen tests on the wording alone, none of which touch the network, plus the endpoint checked against the live service. 106 tests in the app in total.