### PR TITLE
Wilson: a faster brain, and a way to look things up

### DIFF
--- a/apps/cc-assistant/HANDOVER.md
+++ b/apps/cc-assistant/HANDOVER.md
@@ -42,10 +42,21 @@ application or a push notification from the Gateway, not a cleverer web trick.
 
 ## Decisions nobody has made yet
 
-**Search needs a key, and creating it is a human job.** There are no search keys on this machine.
-Brave Search has a free tier; Tavily and Serper are the alternatives. Every one needs a signup.
-Until somebody creates one, the options are: no search, or a keyless version built on Wikipedia and
-DuckDuckGo instant answers, which handles "who was Ada Lovelace" but is not real web search.
+**Search is done (29 August), and it needed no key.** Groq has web search built into the
+gpt-oss models (`tools: [{ type: "browser_search" }]`), so the `look_up` tool in `api/talk.js` is
+answered by a second call to `openai/gpt-oss-120b` with search on. The fast model decides when to
+call it; there is no classifier in front. Measured: 2-3 seconds for a live price, correct where the
+plain model had invented one. Citation markers are stripped before speech.
+
+**The fast model is now `qwen/qwen3.6-27b`, reasoning off** (was gpt-oss-120b on low). About 200 ms
+a turn and right on arithmetic. Two traps found choosing it, both kept in the code comments:
+gpt-oss on low reasoning can spend the whole token budget thinking and return an empty answer, and
+`qwen/qwen3.8-27b` says "I'm setting a timer" in words instead of calling the tool, every time.
+qwen3.6 did the same one time in three until the prompt said outright that words are not a timer;
+with that line it was eleven for eleven. Any model change must re-run that check.
+
+**The Groq account is on the free tier (8,000 tokens a minute).** That, not the model, was behind
+several failures during testing. The Dev tier is a click in the console and a human decision.
 
 **Knowing who is speaking is three different products and nobody has said which.** They need
 different designs and have very different failure costs:

--- a/apps/cc-assistant/README.md
+++ b/apps/cc-assistant/README.md
@@ -17,10 +17,11 @@ any kind.
 | **Timers** | Named or not. Start several, stop one by name, stop them all, ask what is running. |
 | **Silence an alarm** | While one is ringing, "stop" or "shut up" works with **no wake word**. |
 | **Weather** | Where you are, or anywhere you name. Needs a home town in settings. |
+| **Look things up** | Anything live or recent: prices, news, results, who holds a job. Takes two or three seconds because it searches the web. |
 | **Interrupt it** | Say the wake word while it is talking and it stops mid-sentence. |
 
-It cannot play music, control anything in the house, read a calendar or a list, search the internet,
-or remember anything between sessions. It says so plainly when asked rather than pretending.
+It cannot play music, control anything in the house, read a calendar or a list, or remember anything
+between sessions. It says so plainly when asked rather than pretending.
 
 ## How a turn works
 
@@ -35,8 +36,12 @@ Three lanes, chosen by how fast each has to be:
 | Lane | Handles | Cost |
 | --- | --- | --- |
 | Instant, local | Silencing a ringing alarm | no network |
-| Model with tools | Timers, weather, anything needing understanding | ~400 ms |
-| Model, plain | Ordinary questions | ~300 ms |
+| Fast model with tools | Timers, weather, ordinary questions | ~200 ms |
+| Search model | Anything live, recent, or the fast model is unsure of | 2-3 s |
+
+The fast model routes by itself: when it decides a question needs looking up it calls the `look_up`
+tool, and the server answers that with a second, slower model that has Groq's built-in web search.
+There is no separate classifier in front, because that would add a round trip to every turn.
 
 ## The rules, and the bugs that produced them
 
@@ -73,8 +78,8 @@ Suppressed speech, recogniser notices and the microphone level are all on screen
 | Source | this directory, on `main` |
 | Deployed | Vercel project `cc-assistant`, scope `soren-frederiksens-projects` |
 | Deploys | automatically, on any merge to `main` that touches this directory |
-| Model | Groq, `openai/gpt-oss-120b`, reasoning effort low |
-| Keys | `GROQ_API_KEY` and `ASSISTANT_MODEL`, Vercel production environment only |
+| Model | Groq, `qwen/qwen3.6-27b` with reasoning off; `openai/gpt-oss-120b` with `browser_search` for look-ups |
+| Keys | `GROQ_API_KEY`, optionally `ASSISTANT_MODEL` and `ASSISTANT_SEARCH_MODEL`, Vercel production environment only |
 | Weather | Open-Meteo, no key needed |
 
 ## Running it
@@ -86,13 +91,23 @@ npm run dev
 
 Then <http://localhost:5183/cc-assistant/>.
 
+The functions under `api/` do not run locally; `vite.config.ts` proxies every `/api` call to the
+deployed copy on Vercel, so the local page has the real brain and the real keys. Set
+`ASSISTANT_API_ORIGIN` to send them somewhere else.
+
 **On a phone the microphone will not work over plain HTTP.** Browsers allow it only on a secure
 connection, and `localhost` is the sole exception, so a LAN address loads the page and then refuses
-the microphone. Put Tailscale in front of it:
+the microphone. Put Tailscale in front of a built copy:
 
 ```
+npm run build
+npx vite preview --port 5183 --host
 tailscale serve --bg --https 8443 http://127.0.0.1:5183
 ```
+
+Then on the phone: <https://soren-north.taildb08ed.ts.net:8443/cc-assistant/>. Tailscale cannot
+proxy straight to Vercel, because it keeps the tailnet name as the Host header and Vercel answers
+`DEPLOYMENT_NOT_FOUND`; the local server in between is what rewrites it.
 
 ## What is in here
 
@@ -122,5 +137,8 @@ Run the tests with `npm test`.
   written on the screen rather than left to be discovered when dinner burns.
 - **Nothing is remembered between sessions** except the wake word and the home town.
 - **Every question costs money.** Small, but a device asked things all day is a running cost.
+- **The Groq account is on the free tier: 8,000 tokens a minute.** A turn costs several hundred, so
+  a burst of questions, or a look-up, can hit the limit; Wilson then says it is rate limited. The
+  Dev tier in the Groq console lifts it.
 - **The first request after a quiet spell takes several seconds**, because the serverless function
   cold-starts. Everything after is 200 to 400 ms.

--- a/apps/cc-assistant/api/talk.js
+++ b/apps/cc-assistant/api/talk.js
@@ -4,11 +4,28 @@
 // credential of any kind, which is also why this app needs no sign-in.
 //
 // Groq because first-token latency is what a conversation feels, and it is the fastest thing
-// available on this account. Reasoning effort is held low on purpose: this is a kitchen, not a
-// research assistant, and a model that thinks for four seconds about a timer has failed at the only
-// thing that matters here.
+// available on this account.
+//
+// TWO MODELS, ONE ROUTE. The fast model answers everything it can on its own and decides which tool
+// was meant. Measured on 29 August: qwen3.6-27b answered a kitchen question in about 200 ms with
+// reasoning off, got the arithmetic right, and made the timer tool call eleven times out of eleven
+// once the prompt spelled out that words are not a timer. qwen3.8-27b, newer and just as fast, said
+// "I'm setting a timer called barbecue" in words on every try and set nothing. gpt-oss-120b on low reasoning
+// was slower and, on a question that needed a moment's thought, spent the whole token budget thinking
+// and returned an EMPTY answer - which the kitchen heard as "the model returned nothing to say".
+//
+// Anything live, recent, or that the fast model is unsure of goes through the look_up tool, which is
+// answered by a second, slower call with Groq's built-in web search. Two to three seconds instead of
+// two hundred milliseconds, but right instead of invented: without search, gpt-oss-20b stated a gold
+// price two thousand dollars off as plain fact. A wrong answer said confidently is the failure this
+// whole design exists to avoid, so the slow path is worth its wait and only paid when needed.
+//
+// There is deliberately no separate "router" call in front. A classifier hop would add a round trip
+// to EVERY turn to save it on the few; the fast model routing by tool call costs nothing extra.
 
 const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
+const FAST_MODEL = "qwen/qwen3.6-27b";
+const SEARCH_MODEL = "openai/gpt-oss-120b";
 
 // The tools. The model decides WHAT was asked for; the device decides what happened and says so.
 // Nothing here returns a result to the model, because the model never composes the spoken sentence -
@@ -69,7 +86,79 @@ const TOOLS = [
       parameters: { type: "object", properties: {} },
     },
   },
+  {
+    type: "function",
+    function: {
+      name: "look_up",
+      description:
+        "Look something up on the web. Call this for anything happening now or recently (news, prices, sport results, who currently holds a job, what is open), anything that may have changed since your training, and any fact you are not sure of. Do not guess at these; look them up. Never call it for timers, the weather, or general knowledge you are sure of.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "What to search for, as a short search query." },
+        },
+        required: ["query"],
+      },
+    },
+  },
 ];
+
+// Search results come back with reference markers like [1+L12-L18] in the model's own bracket
+// notation, which uses the CJK lenticular brackets U+3010 and U+3011. Spoken aloud they are noise,
+// so they are removed before anything reaches a voice. Built from code points so this file stays ASCII.
+const OPEN_BRACKET = String.fromCharCode(0x3010);
+const CLOSE_BRACKET = String.fromCharCode(0x3011);
+const CITATION_MARKER = new RegExp(OPEN_BRACKET + "[^" + CLOSE_BRACKET + "]*" + CLOSE_BRACKET, "g");
+
+function cleanSpoken(text) {
+  return text.replace(CITATION_MARKER, "").replace(/\s+([.,;:!?])/g, "$1").replace(/\s+/g, " ").trim();
+}
+
+// "none" is a Qwen setting; the gpt-oss family rejects it with a 400 and wants "low" at the least.
+// So an ASSISTANT_MODEL override to gpt-oss keeps working, at the cost of a little thinking.
+function reasoningEffortFor(model) {
+  return model.startsWith("openai/gpt-oss") ? "low" : "none";
+}
+
+/** One call to Groq. Returns the parsed body, or throws with the upstream status and detail. */
+async function complete(key, body) {
+  const upstream = await fetch(GROQ_URL, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!upstream.ok) {
+    const detail = await upstream.text();
+    const error = new Error(`The model refused the request (${upstream.status}).`);
+    error.status = upstream.status;
+    error.detail = detail.slice(0, 400);
+    throw error;
+  }
+  return upstream.json();
+}
+
+/**
+ * The slow path: answer one question with live web search.
+ *
+ * The search model is told the original question AND the fast model's query, and is held to the same
+ * one-sentence spoken rule. Reasoning is low because the search itself is where the time goes.
+ */
+async function lookUp(key, question, query, history) {
+  const body = await complete(key, {
+    model: process.env.ASSISTANT_SEARCH_MODEL || SEARCH_MODEL,
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT + " You have web search. Use it, then answer from what you found, in one spoken sentence. Say when the information is from, if it matters." },
+      ...history,
+      { role: "user", content: `${question}\n\n(Search for: ${query})` },
+    ],
+    tools: [{ type: "browser_search" }],
+    reasoning_effort: "low",
+    max_tokens: 1200,
+    temperature: 0.2,
+  });
+  const message = body?.choices?.[0]?.message ?? {};
+  return cleanSpoken(typeof message.content === "string" ? message.content : "");
+}
 
 /** The timers currently running, described for the model so it can resolve "the pasta one". */
 function describeTimers(timers) {
@@ -94,7 +183,6 @@ function describeTimers(timers) {
 const CANNOT_DO = [
   "play music or control speakers",
   "control lights, heating or any other device",
-  "check the news or anything else live",
   "read or change a calendar, list, message or email",
   "remember anything after this conversation ends",
 ];
@@ -107,6 +195,9 @@ const SYSTEM_PROMPT = [
   "Never use lists, headings, markdown or emoji. Say numbers the way a person says them aloud.",
   "YOU CANNOT DO ANY OF THE FOLLOWING: " + CANNOT_DO.join("; ") + ".",
   "For anything about timers, or about the weather, CALL A TOOL. Do not answer in words and never invent a temperature.",
+  "You have no way to start, stop or read a timer except by calling the tool. Words like 'I'll set a timer' or 'timer set' do nothing and are a lie. Call the tool instead, every time, even for a bare 'ten minute timer'.",
+  "For anything live, recent, or that you are not certain of, call look_up rather than guessing. A confident wrong answer is worse than a short wait.",
+  "Your knowledge has a cutoff and the world moved on. Who currently holds any office or job, prices, scores, news, what is open, the latest anything: ALWAYS look_up, never answer from memory.",
   "If you are asked for one of the things you cannot do, say plainly in one short sentence that you cannot do it yet.",
   "NEVER claim to have done something you cannot do. Saying a timer is set when it is not is the",
   "worst mistake you can make.",
@@ -156,28 +247,24 @@ export default async function handler(request, response) {
   const timerState = describeTimers(payload.timers);
   messages[0] = { role: "system", content: SYSTEM_PROMPT + " " + timerState };
 
-  const model = process.env.ASSISTANT_MODEL || "openai/gpt-oss-120b";
+  const model = process.env.ASSISTANT_MODEL || FAST_MODEL;
   const startedAt = Date.now();
 
   try {
-    const upstream = await fetch(GROQ_URL, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
-      body: JSON.stringify({ model, messages, tools: TOOLS, tool_choice: "auto", reasoning_effort: "low", max_tokens: 200, temperature: 0.3 }),
+    // Reasoning is OFF for the fast model. This is a kitchen: a model that thinks for four seconds
+    // about a timer has failed at the only thing that matters, and one that thinks its whole token
+    // budget away answers with silence.
+    const body = await complete(key, {
+      model,
+      messages,
+      tools: TOOLS,
+      tool_choice: "auto",
+      reasoning_effort: reasoningEffortFor(model),
+      max_tokens: 300,
+      temperature: 0.3,
     });
-
-    if (!upstream.ok) {
-      const detail = await upstream.text();
-      console.log("TALK UPSTREAM FAILED " + upstream.status + " " + detail.slice(0, 400));
-      response.status(502).json({ error: `The model refused the request (${upstream.status}).` });
-      return;
-    }
-
-    const body = await upstream.json();
     const message = body?.choices?.[0]?.message ?? {};
-    const elapsedMs = Date.now() - startedAt;
 
-    // A tool call means the device has work to do and will say what happened itself.
     const rawCalls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
     const actions = [];
     for (const call of rawCalls) {
@@ -194,15 +281,36 @@ export default async function handler(request, response) {
       actions.push({ name, args });
     }
 
+    // look_up is the one tool the SERVER runs, because the answer is words, not a device action.
+    // It takes precedence over anything else in the same turn: a person who asked a question wants
+    // the answer, and a timer mentioned in the same breath is rare enough to make them say it again.
+    const lookup = actions.find((a) => a.name === "look_up");
+    if (lookup) {
+      const query = typeof lookup.args.query === "string" && lookup.args.query.trim().length > 0 ? lookup.args.query.trim() : text;
+      const reply = await lookUp(key, text, query, messages.slice(1, -1));
+      const elapsedMs = Date.now() - startedAt;
+      if (reply.length === 0) {
+        console.log("TALK LOOKUP EMPTY " + JSON.stringify({ text, query }));
+        response.status(502).json({ error: "The search found nothing to say." });
+        return;
+      }
+      console.log("TALK LOOKUP " + JSON.stringify({ at: new Date().toISOString(), elapsedMs, text, query, reply }));
+      response.status(200).json({ reply, elapsedMs, model: SEARCH_MODEL, lookedUp: true });
+      return;
+    }
+
+    // Any other tool call means the device has work to do and will say what happened itself.
     if (actions.length > 0) {
+      const elapsedMs = Date.now() - startedAt;
       console.log("TALK ACTIONS " + JSON.stringify({ at: new Date().toISOString(), elapsedMs, text, actions }));
       response.status(200).json({ actions, elapsedMs, model });
       return;
     }
 
-    // gpt-oss models return their working in `reasoning` and the answer in `content`. Only the
-    // answer is ever spoken.
-    const reply = typeof message.content === "string" ? message.content.trim() : "";
+    // Some models return their working in `reasoning` and the answer in `content`. Only the answer
+    // is ever spoken.
+    const reply = cleanSpoken(typeof message.content === "string" ? message.content : "");
+    const elapsedMs = Date.now() - startedAt;
     if (reply.length === 0) {
       console.log("TALK EMPTY REPLY " + JSON.stringify(body).slice(0, 400));
       response.status(502).json({ error: "The model returned nothing to say." });
@@ -212,7 +320,14 @@ export default async function handler(request, response) {
     console.log("TALK " + JSON.stringify({ at: new Date().toISOString(), elapsedMs, model, text, reply }));
     response.status(200).json({ reply, elapsedMs, model });
   } catch (error) {
-    console.log("TALK ERROR " + String(error));
-    response.status(502).json({ error: "The model could not be reached." });
+    const status = typeof error?.status === "number" ? error.status : 0;
+    console.log("TALK ERROR " + status + " " + String(error) + " " + (error?.detail ?? ""));
+    if (status === 429) {
+      // The Groq free tier is 8,000 tokens a minute, and a turn costs several hundred. Say so,
+      // because "could not be reached" sends someone to check the network when the fix is a tier.
+      response.status(502).json({ error: "The model is rate limited right now. Try again in a moment." });
+      return;
+    }
+    response.status(502).json({ error: status > 0 ? error.message : "The model could not be reached." });
   }
 }

--- a/apps/cc-assistant/vite.config.ts
+++ b/apps/cc-assistant/vite.config.ts
@@ -11,6 +11,20 @@ import { VitePWA } from "vite-plugin-pwa";
 // where it lives. Set APP_BASE at build time to move it.
 const appBase = process.env.APP_BASE ?? "/cc-assistant/";
 
+// WHERE THE BRAIN IS WHEN RUNNING LOCALLY. The functions under api/ are Vercel serverless functions
+// and hold the model key; neither vite dev nor vite preview runs them. So a local server forwards
+// every /api call to the deployed copy. changeOrigin rewrites the Host header to the target, which
+// Vercel needs to find the deployment - a proxy that keeps the original Host gets DEPLOYMENT_NOT_FOUND.
+// Set ASSISTANT_API_ORIGIN to point the proxy somewhere else, such as a `vercel dev` on another port.
+const apiOrigin = process.env.ASSISTANT_API_ORIGIN ?? "https://cc-assistant-bice.vercel.app";
+const apiProxy = {
+  [`${appBase}api`]: {
+    target: apiOrigin,
+    changeOrigin: true,
+    rewrite: (path: string) => path.slice(appBase.length - 1),
+  },
+};
+
 export default defineConfig({
   base: appBase,
   server: {
@@ -18,6 +32,12 @@ export default defineConfig({
     // Listen on the network as well as loopback, so a phone can reach it. See the README: the phone
     // ALSO needs the page served over a secure connection or the browser refuses the microphone.
     host: true,
+    proxy: apiProxy,
+  },
+  preview: {
+    port: 5183,
+    host: true,
+    proxy: apiProxy,
   },
   worker: {
     // The speech worker is an ES module because it imports the transformers library.


### PR DESCRIPTION
Wilson: a faster brain, and a way to look things up

The fast model is now qwen3.6-27b with reasoning off. Measured on 29 August it
answers a kitchen question in about two hundred milliseconds and gets the
arithmetic right; gpt-oss-120b on low reasoning was slower and, given a question
that needed a moment's thought, spent its whole token budget thinking and
returned an empty answer, which the kitchen heard as "nothing to say".

Choosing it found a trap worth keeping: qwen3.8-27b, newer and just as fast,
answered "I'm setting a timer called barbecue" in words on every try and set
nothing. qwen3.6 did the same one time in three until the prompt said outright
that words are not a timer; with that line it called the tool eleven times out
of eleven. Any future model change has to re-run that check.

A look_up tool closes the biggest gap. The fast model calls it for anything
live, recent, or that it is not sure of, and the server answers with a second
call to gpt-oss-120b using Groq's built-in web search, so no search key was
needed. Two to fifteen seconds instead of two hundred milliseconds, but right
instead of invented: without search a model stated a gold price two thousand
dollars off as plain fact. There is deliberately no classifier in front, since
that would add a round trip to every turn to save it on the few. The reply comes
back as ordinary words, so the page needed no change.

Citation markers are stripped before anything is spoken. Rate limits now say so
rather than "could not be reached", because the Groq account is on the free
tier and that, not the model, was behind several failures during testing.

Locally, vite proxies /api to the deployed functions so a phone over Tailscale
gets the real brain; Tailscale cannot proxy to Vercel directly because it keeps
the tailnet name as the Host header.

