### PR TITLE
Wilson: its own service, a memory, a soul, a voice, and two screens

### DIFF
--- a/apps/cc-assistant/HANDOVER.md
+++ b/apps/cc-assistant/HANDOVER.md
@@ -10,6 +10,15 @@ why, and what the next person has to decide before they can go further. Read the
 It works. It is deployed, it deploys itself on merge, and it does four things: answers questions,
 keeps timers, tells you the weather, and shuts up when told to.
 
+**Update, 29 August, evening.** Wilson now has its own service (`server/wilson.mjs`) and, when it
+runs there, a memory: people with profiles and remembered facts, a per-household soul document,
+resolved place names, and a turn log, all as plain files under `%LOCALAPPDATA%\wilson`. It speaks
+with Orpheus streamed from Groq, ticks while it thinks, and has a kitchen screen (one circle) and a
+debug screen. Voice identification is built (WavLM x-vector in the browser, matching on the
+service) and NOT yet proven: it needs two real voices enrolled in a real browser. Issues #2612 to
+#2622 on the repo are the map. The Vercel deployment has none of the memory: its functions run
+without the service and say so.
+
 Everything below is either a decision that has already been made and should not be relitigated
 without a reason, or a decision nobody has made yet.
 

--- a/apps/cc-assistant/README.md
+++ b/apps/cc-assistant/README.md
@@ -84,24 +84,30 @@ Suppressed speech, recogniser notices and the microphone level are all on screen
 
 ## Running it
 
+The real thing is Wilson's own service, which serves the page, runs the functions, and keeps the
+memory. It wants a Groq key, from `GROQ_API_KEY` or a `.env`-style file named by
+`WILSON_CREDENTIALS_FILE`:
+
 ```
 npm install
-npm run dev
+npm run build
+set WILSON_CREDENTIALS_FILE=C:\path\to\credentials.env
+npm run serve
 ```
 
-Then <http://localhost:5183/cc-assistant/>.
+Then <http://localhost:5183/cc-assistant/>. Everything Wilson keeps lands in `%LOCALAPPDATA%\wilson`
+(`WILSON_DATA_DIR` to move it): `household.json`, `soul.md`, `turns.jsonl`, all readable, all
+deletable. Add `?debug=1` to the address for the debug screen or `?debug=0` for the kitchen screen;
+a PC defaults to debug and a phone to the circle, and the choice is remembered.
 
-The functions under `api/` do not run locally; `vite.config.ts` proxies every `/api` call to the
-deployed copy on Vercel, so the local page has the real brain and the real keys. Set
-`ASSISTANT_API_ORIGIN` to send them somewhere else.
+For front-end work without the service, `npm run dev` runs Vite with `/api` proxied to the deployed
+copy on Vercel (set `ASSISTANT_API_ORIGIN` to point it elsewhere). That copy has no memory.
 
 **On a phone the microphone will not work over plain HTTP.** Browsers allow it only on a secure
 connection, and `localhost` is the sole exception, so a LAN address loads the page and then refuses
-the microphone. Put Tailscale in front of a built copy:
+the microphone. Put Tailscale in front of the service:
 
 ```
-npm run build
-npx vite preview --port 5183 --host
 tailscale serve --bg --https 8443 http://127.0.0.1:5183
 ```
 
@@ -113,8 +119,11 @@ proxy straight to Vercel, because it keeps the tailnet name as the Host header a
 
 | File | What it does |
 | --- | --- |
-| `src/assistant/AssistantScreen.tsx` | The app: the loop, the states, the screen |
-| `src/assistant/speech.ts` | Listening and speaking, using what the browser already has |
+| `src/assistant/AssistantScreen.tsx` | The app: the loop, the states, the two screens |
+| `src/assistant/DebugPanel.tsx` | The debug screen: turn log, people and memory, places, soul editor, voice enrolment |
+| `src/assistant/speech.ts` | Listening with the browser's recogniser; chirps, thinking ticks and cues |
+| `src/assistant/voice.ts` | Wilson's voice: the Orpheus stream played as it arrives |
+| `src/assistant/speakerId.ts` | Who is speaking: a voice embedding from the last few seconds of audio |
 | `src/assistant/echoGuard.ts` | Stops it answering its own voice |
 | `src/assistant/micLevel.ts` | Proof the microphone is open, in pixels |
 | `src/skills/timerParse.ts` | Reading durations out of a sentence |
@@ -122,9 +131,14 @@ proxy straight to Vercel, because it keeps the tailnet name as the Host header a
 | `src/skills/useTimers.ts` | The timers themselves, and the alarm |
 | `src/skills/weather.ts` | Turning a reading into words |
 | `src/wakeWord/wakeWordMatcher.ts` | Finding the chosen word in a transcript |
-| `api/talk.js` | The brain, and the tools it can call |
-| `api/weather.js` | Open-Meteo |
+| `api/talk.js` | The brain: soul + rules + memory in, a sentence or a tool call out; `look_up` runs here |
+| `api/speak.js` | The voice: Orpheus on Groq, streamed |
+| `api/weather.js` | Open-Meteo, with misheard names corrected and remembered |
+| `api/turn.js` `api/people.js` `api/soul.js` `api/voice.js` | The log, the people and their memory, the soul document, voice enrolment and matching |
 | `api/result.js` | Where diagnostics reports go |
+| `server/wilson.mjs` | Wilson's own service: serves the page, runs the functions, owns the data |
+| `server/store.mjs` | What Wilson keeps: `household.json`, `soul.md`, `turns.jsonl` |
+| `server/memory.mjs` | What a turn brings in from memory, and what it leaves behind |
 
 Behind the **Diagnostics** link at the bottom of the app are the measurement screens that settled
 which speech model a device should run. They are not the product but they answered real questions.

--- a/apps/cc-assistant/api/people.js
+++ b/apps/cc-assistant/api/people.js
@@ -1,0 +1,61 @@
+// The people Wilson knows, and what it knows about each. Read and edited from the settings screen,
+// because a memory a person cannot see and correct is not one they will trust.
+//
+//   GET                       everyone, with profiles and facts
+//   POST { name }             make sure a person exists (the device owner, on first run)
+//   POST { name, profile }    change profile fields ("" clears one)
+//   POST { name, forget }     drop one remembered fact by its exact text
+
+export default async function handler(request, response, wilson) {
+  if (!wilson) {
+    response.status(200).json({ people: [], editable: false, reason: "This deployment keeps no memory." });
+    return;
+  }
+  const store = wilson.store;
+  if (request.method === "GET") {
+    response.status(200).json({ people: store.people().map(publicView), places: store.places(), editable: true });
+    return;
+  }
+  if (request.method !== "POST") {
+    response.status(405).json({ error: "Read people with GET, change them with POST." });
+    return;
+  }
+  let payload = request.body;
+  if (typeof payload === "string") {
+    try {
+      payload = JSON.parse(payload);
+    } catch {
+      response.status(400).json({ error: "The body was not JSON." });
+      return;
+    }
+  }
+  payload = payload || {};
+  if (typeof payload.forgetPlace === "string") {
+    const existed = store.forgetPlace(payload.forgetPlace);
+    store.log({ kind: "place-forgotten", heard: payload.forgetPlace, existed });
+    response.status(200).json({ forgotten: existed, places: store.places() });
+    return;
+  }
+  const name = typeof payload.name === "string" ? payload.name.trim() : "";
+  if (name.length === 0) {
+    response.status(400).json({ error: "A person needs a name." });
+    return;
+  }
+  let person = store.person(name);
+  if (payload.profile && typeof payload.profile === "object") {
+    person = store.updateProfile(name, payload.profile);
+    store.log({ kind: "profile-edited", person: person.key, fields: Object.keys(payload.profile) });
+  }
+  if (typeof payload.forget === "string") {
+    store.forgetFact(name, payload.forget);
+    store.log({ kind: "fact-forgotten", person: person.key });
+    person = store.person(name);
+  }
+  response.status(200).json({ person: publicView(person), editable: true });
+}
+
+/** Voice embeddings are numbers nobody needs to see; the count is enough. */
+function publicView(person) {
+  const { voice, ...rest } = person;
+  return { ...rest, voiceSamples: voice && Array.isArray(voice.samples) ? voice.samples.length : 0 };
+}

--- a/apps/cc-assistant/api/soul.js
+++ b/apps/cc-assistant/api/soul.js
@@ -1,0 +1,35 @@
+// The soul document: who Wilson is, in the household's own words. Read on every turn by talk.js,
+// edited from the settings screen. Every previous version is kept on disk by the store.
+
+export default async function handler(request, response, wilson) {
+  if (!wilson) {
+    response.status(200).json({ soul: null, editable: false, reason: "This deployment has no soul document; the built-in prompt is used." });
+    return;
+  }
+  const store = wilson.store;
+  if (request.method === "GET") {
+    response.status(200).json({ soul: store.soul(), editable: true });
+    return;
+  }
+  if (request.method !== "PUT" && request.method !== "POST") {
+    response.status(405).json({ error: "Read the soul with GET, write it with PUT." });
+    return;
+  }
+  let payload = request.body;
+  if (typeof payload === "string") {
+    try {
+      payload = JSON.parse(payload);
+    } catch {
+      response.status(400).json({ error: "The body was not JSON." });
+      return;
+    }
+  }
+  const soul = payload && typeof payload.soul === "string" ? payload.soul : null;
+  if (soul === null || soul.trim().length === 0) {
+    response.status(400).json({ error: "A soul document cannot be empty." });
+    return;
+  }
+  store.writeSoul(soul);
+  store.log({ kind: "soul-edited", chars: soul.length });
+  response.status(200).json({ soul: store.soul(), editable: true });
+}

--- a/apps/cc-assistant/api/speak.js
+++ b/apps/cc-assistant/api/speak.js
@@ -1,0 +1,199 @@
+// The voice. Text in, a stream of spoken audio out, starting within about a quarter of a second.
+//
+// Groq's Orpheus model, on the same key as the brain. Measured on 29 August: first audio bytes in
+// 195-247 ms, a full sentence in about 700 ms, delivered as chunked WAV at 24 kHz, 16-bit mono.
+// The page starts playing the first chunk while the rest is still being made, which is the whole
+// point: what a reply feels like is set by the time to the first sound, not the time to the last.
+//
+// It runs here rather than in the page so the key never reaches a browser, same as talk.js.
+//
+// Orpheus takes at most 200 characters per request. Longer replies are cut at sentence ends and
+// requested in parallel; the pieces are joined into ONE continuous stream in the right order, so the
+// page sees a single WAV whatever the length. The header's data length is left as "unknown"
+// (0xFFFFFFFF), which is what Groq itself sends and what a streaming reader expects.
+//
+// Written against the Web Request/Response signature so the audio streams through Vercel instead of
+// being buffered to the end, which would throw away the latency the model is paid for.
+
+const GROQ_TTS_URL = "https://api.groq.com/openai/v1/audio/speech";
+const MODEL = "canopylabs/orpheus-v1-english";
+const VOICES = ["autumn", "diana", "hannah", "austin", "daniel", "troy"];
+const DEFAULT_VOICE = "austin";
+const MAX_PIECE = 200;
+
+const SAMPLE_RATE = 24000;
+const CHANNELS = 1;
+const BITS = 16;
+
+/** A 44-byte WAV header for a stream of unknown length. */
+function wavHeader() {
+  const header = new ArrayBuffer(44);
+  const view = new DataView(header);
+  const ascii = (offset, text) => {
+    for (let i = 0; i < text.length; i += 1) {
+      view.setUint8(offset + i, text.charCodeAt(i));
+    }
+  };
+  ascii(0, "RIFF");
+  view.setUint32(4, 0xffffffff, true);
+  ascii(8, "WAVE");
+  ascii(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, CHANNELS, true);
+  view.setUint32(24, SAMPLE_RATE, true);
+  view.setUint32(28, (SAMPLE_RATE * CHANNELS * BITS) / 8, true);
+  view.setUint16(32, (CHANNELS * BITS) / 8, true);
+  view.setUint16(34, BITS, true);
+  ascii(36, "data");
+  view.setUint32(40, 0xffffffff, true);
+  return new Uint8Array(header);
+}
+
+/**
+ * Cut text into pieces Orpheus will accept, at sentence ends where possible, then at commas, then at
+ * spaces. Never inside a word.
+ */
+export function splitForSpeech(text, max = MAX_PIECE) {
+  const pieces = [];
+  let rest = text.replace(/\s+/g, " ").trim();
+  while (rest.length > max) {
+    let cut = -1;
+    for (const pattern of [/[.!?]["')]?\s/g, /[,;:]\s/g, /\s/g]) {
+      let match;
+      while ((match = pattern.exec(rest)) !== null && match.index < max) {
+        cut = match.index + match[0].length;
+      }
+      if (cut > 0) {
+        break;
+      }
+    }
+    if (cut <= 0) {
+      cut = max;
+    }
+    pieces.push(rest.slice(0, cut).trim());
+    rest = rest.slice(cut).trim();
+  }
+  if (rest.length > 0) {
+    pieces.push(rest);
+  }
+  return pieces;
+}
+
+/** Strips the WAV header from Groq's stream, yielding only PCM bytes. */
+function pcmOnly(stream) {
+  let headerDone = false;
+  let held = new Uint8Array(0);
+  return new TransformStream({
+    transform(chunk, controller) {
+      if (headerDone) {
+        controller.enqueue(chunk);
+        return;
+      }
+      const joined = new Uint8Array(held.length + chunk.length);
+      joined.set(held);
+      joined.set(chunk, held.length);
+      held = joined;
+      const dataAt = findAscii(held, "data");
+      if (dataAt < 0) {
+        return;
+      }
+      const start = dataAt + 8;
+      if (held.length < start) {
+        return;
+      }
+      headerDone = true;
+      controller.enqueue(held.slice(start));
+      held = new Uint8Array(0);
+    },
+  });
+}
+
+function findAscii(bytes, text) {
+  outer: for (let i = 0; i + text.length <= bytes.length; i += 1) {
+    for (let j = 0; j < text.length; j += 1) {
+      if (bytes[i + j] !== text.charCodeAt(j)) {
+        continue outer;
+      }
+    }
+    return i;
+  }
+  return -1;
+}
+
+async function requestPiece(key, text, voice) {
+  const upstream = await fetch(GROQ_TTS_URL, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ model: MODEL, input: text, voice, response_format: "wav" }),
+  });
+  if (!upstream.ok || upstream.body === null) {
+    const detail = (await upstream.text()).slice(0, 300);
+    console.log("SPEAK UPSTREAM FAILED " + upstream.status + " " + detail);
+    throw new Error(`The voice refused the request (${upstream.status}).`);
+  }
+  return upstream.body.pipeThrough(pcmOnly());
+}
+
+export default async function handler(request) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Send the text to speak with POST." }, { status: 405 });
+  }
+  const key = process.env.GROQ_API_KEY;
+  if (!key) {
+    return Response.json({ error: "The assistant has no model key configured on the server." }, { status: 500 });
+  }
+
+  let payload;
+  try {
+    payload = await request.json();
+  } catch {
+    return Response.json({ error: "The body was not JSON." }, { status: 400 });
+  }
+  const text = payload && typeof payload.text === "string" ? payload.text.trim() : "";
+  if (text.length === 0) {
+    return Response.json({ error: "There was nothing to say." }, { status: 400 });
+  }
+  const voice = VOICES.includes(payload.voice) ? payload.voice : DEFAULT_VOICE;
+  const pieces = splitForSpeech(text);
+  const startedAt = Date.now();
+
+  // All pieces are requested at once so the second is ready by the time the first has played.
+  // They are drained in order, so the listener hears one uninterrupted sentence.
+  let pieceStreams;
+  try {
+    pieceStreams = await Promise.all(pieces.map((piece) => requestPiece(key, piece, voice)));
+  } catch (error) {
+    return Response.json({ error: error instanceof Error ? error.message : "The voice could not be reached." }, { status: 502 });
+  }
+
+  const out = new ReadableStream({
+    async start(controller) {
+      controller.enqueue(wavHeader());
+      let bytes = 0;
+      try {
+        for (const stream of pieceStreams) {
+          const reader = stream.getReader();
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) {
+              break;
+            }
+            bytes += value.length;
+            controller.enqueue(value);
+          }
+        }
+        console.log("SPEAK " + JSON.stringify({ at: new Date().toISOString(), voice, chars: text.length, pieces: pieces.length, bytes, elapsedMs: Date.now() - startedAt }));
+        controller.close();
+      } catch (error) {
+        console.log("SPEAK STREAM ERROR " + String(error));
+        controller.error(error);
+      }
+    },
+  });
+
+  return new Response(out, {
+    status: 200,
+    headers: { "Content-Type": "audio/wav", "Cache-Control": "no-store", "X-Voice": voice, "X-Pieces": String(pieces.length) },
+  });
+}

--- a/apps/cc-assistant/api/talk.js
+++ b/apps/cc-assistant/api/talk.js
@@ -23,6 +23,8 @@
 // There is deliberately no separate "router" call in front. A classifier hop would add a round trip
 // to EVERY turn to save it on the few; the fast model routing by tool call costs nothing extra.
 
+import { contextFor, extractAfterTurn, INTERVIEW_PROMPT } from "../server/memory.mjs";
+
 const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
 const FAST_MODEL = "qwen/qwen3.6-27b";
 const SEARCH_MODEL = "openai/gpt-oss-120b";
@@ -110,8 +112,23 @@ const OPEN_BRACKET = String.fromCharCode(0x3010);
 const CLOSE_BRACKET = String.fromCharCode(0x3011);
 const CITATION_MARKER = new RegExp(OPEN_BRACKET + "[^" + CLOSE_BRACKET + "]*" + CLOSE_BRACKET, "g");
 
+// Wilson has no screen. A web address read aloud is noise ("h t t p s colon slash slash"), and a
+// person who asked for an Amazon link got exactly that on 29 August. The prompt forbids it; this is
+// the guard for when the model does it anyway. Markdown links keep their words and lose the address,
+// bare addresses become "a web address", and stray markdown marks are dropped.
+const MARKDOWN_LINK = /\[([^\]]+)\]\((?:https?:\/\/|www\.)[^)]*\)/gi;
+const BARE_URL = /(?:https?:\/\/|www\.)[^\s)]+/gi;
+const MARKDOWN_MARKS = /[*_`#>]+/g;
+
 function cleanSpoken(text) {
-  return text.replace(CITATION_MARKER, "").replace(/\s+([.,;:!?])/g, "$1").replace(/\s+/g, " ").trim();
+  return text
+    .replace(CITATION_MARKER, "")
+    .replace(MARKDOWN_LINK, "$1")
+    .replace(BARE_URL, "a web address")
+    .replace(MARKDOWN_MARKS, "")
+    .replace(/\s+([.,;:!?])/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 // "none" is a Qwen setting; the gpt-oss family rejects it with a 400 and wants "low" at the least.
@@ -143,11 +160,11 @@ async function complete(key, body) {
  * The search model is told the original question AND the fast model's query, and is held to the same
  * one-sentence spoken rule. Reasoning is low because the search itself is where the time goes.
  */
-async function lookUp(key, question, query, history) {
+async function lookUp(key, question, query, systemPrompt, history) {
   const body = await complete(key, {
     model: process.env.ASSISTANT_SEARCH_MODEL || SEARCH_MODEL,
     messages: [
-      { role: "system", content: SYSTEM_PROMPT + " You have web search. Use it, then answer from what you found, in one spoken sentence. Say when the information is from, if it matters." },
+      { role: "system", content: systemPrompt + "\n\nYou have web search. Use it, then answer from what you found, in one spoken sentence. Say when the information is from, if it matters." },
       ...history,
       { role: "user", content: `${question}\n\n(Search for: ${query})` },
     ],
@@ -184,16 +201,18 @@ const CANNOT_DO = [
   "play music or control speakers",
   "control lights, heating or any other device",
   "read or change a calendar, list, message or email",
-  "remember anything after this conversation ends",
 ];
+// Only true on a deployment with no store (Vercel). With the Wilson service, it remembers.
+const CANNOT_REMEMBER = "remember anything after this conversation ends";
 
-const SYSTEM_PROMPT = [
+const RULES = [
   "You are a voice assistant in someone's kitchen. Everything you say is spoken out loud.",
   "ANSWER IN ONE SENTENCE, under twenty-five words. Use more only if asked to explain something.",
   "Give the answer and stop. Never restate the question, never explain how you worked it out,",
   "never say what you are about to do, and never offer further help or ask if there is anything else.",
   "Never use lists, headings, markdown or emoji. Say numbers the way a person says them aloud.",
-  "YOU CANNOT DO ANY OF THE FOLLOWING: " + CANNOT_DO.join("; ") + ".",
+  "You are VOICE ONLY: there is no screen. Never give a link, web address, email address, code, or anything that would have to be read. If asked for a link, say what to search for or where to find it instead, in words.",
+  "YOU CANNOT DO ANY OF THE FOLLOWING: " + CANNOT_DO.join("; ") + "{CANNOT_REMEMBER}.",
   "For anything about timers, or about the weather, CALL A TOOL. Do not answer in words and never invent a temperature.",
   "You have no way to start, stop or read a timer except by calling the tool. Words like 'I'll set a timer' or 'timer set' do nothing and are a lie. Call the tool instead, every time, even for a bare 'ten minute timer'.",
   "For anything live, recent, or that you are not certain of, call look_up rather than guessing. A confident wrong answer is worse than a short wait.",
@@ -203,7 +222,30 @@ const SYSTEM_PROMPT = [
   "worst mistake you can make.",
 ].join(" ");
 
-export default async function handler(request, response) {
+/**
+ * The whole system prompt for one turn: the soul (who Wilson is), the rules (what keeps it honest),
+ * what it knows about the person, and the timers. The soul comes from the household when there is a
+ * store, else the one line of default character below.
+ */
+function systemPromptFor({ soul, person, knownPlaces, hasMemory, timerState }) {
+  const character = soul && soul.trim().length > 0 ? soul.trim() : "You are a voice assistant in someone's kitchen.";
+  const rules = RULES.replace("{CANNOT_REMEMBER}", hasMemory ? "" : "; " + CANNOT_REMEMBER);
+  const parts = [character, rules];
+  if (hasMemory) {
+    parts.push(contextFor(person, knownPlaces));
+    parts.push(INTERVIEW_PROMPT);
+  }
+  parts.push(timerState);
+  return parts.filter((p) => p && p.length > 0).join("\n\n");
+}
+
+let turnCounter = 0;
+function newTurnId() {
+  turnCounter += 1;
+  return `${Date.now().toString(36)}-${turnCounter.toString(36)}`;
+}
+
+export default async function handler(request, response, wilson) {
   if (request.method !== "POST") {
     response.status(405).json({ error: "Send the turn with POST." });
     return;
@@ -236,19 +278,54 @@ export default async function handler(request, response) {
   // A short rolling history so "what about tomorrow" means something. Capped because a kitchen
   // conversation does not need a transcript of the whole week, and every turn pays for the tokens.
   const history = Array.isArray(payload.history) ? payload.history.slice(-8) : [];
+
+  // Who is talking. Until speaker identification lands, the page says who owns the device; when it
+  // does, the page says who it heard. Either way the name arrives here and memory attaches to it.
+  const store = wilson ? wilson.store : null;
+  const speaker = typeof payload.speaker === "string" && payload.speaker.trim().length > 0 ? payload.speaker.trim() : null;
+  const person = store && speaker ? store.person(speaker) : null;
+  const systemPrompt = systemPromptFor({
+    soul: store ? store.soul() : null,
+    person,
+    knownPlaces: store ? store.knownPlaceNames() : [],
+    hasMemory: store !== null,
+    timerState: describeTimers(payload.timers),
+  });
+
   const messages = [
-    { role: "system", content: SYSTEM_PROMPT },
+    { role: "system", content: systemPrompt },
     ...history
       .filter((m) => m && (m.role === "user" || m.role === "assistant") && typeof m.content === "string")
       .map((m) => ({ role: m.role, content: m.content })),
     { role: "user", content: text },
   ];
 
-  const timerState = describeTimers(payload.timers);
-  messages[0] = { role: "system", content: SYSTEM_PROMPT + " " + timerState };
-
   const model = process.env.ASSISTANT_MODEL || FAST_MODEL;
   const startedAt = Date.now();
+  const turnId = newTurnId();
+  const log = (record) => {
+    if (store) {
+      store.log({ kind: "turn", id: turnId, speaker: person ? person.key : null, heard: text, ...record });
+    }
+  };
+
+  // After the reply has gone out: is there anything here worth keeping about this person? Runs in
+  // the background, costs the person nothing to wait for, and is logged either way.
+  const rememberLater = (reply) => {
+    if (!store || !person) {
+      return;
+    }
+    extractAfterTurn(key, person, text, reply)
+      .then((found) => {
+        if (!found) {
+          return;
+        }
+        const added = store.addFacts(person.name, found.facts);
+        const profile = Object.keys(found.profile).length > 0 ? store.updateProfile(person.name, found.profile).profile : null;
+        store.log({ kind: "remembered", id: turnId, speaker: person.key, facts: added.map((f) => f.text), profile: found.profile, profileNow: profile });
+      })
+      .catch((error) => store.log({ kind: "remember-failed", id: turnId, speaker: person.key, error: String(error) }));
+  };
 
   try {
     // Reasoning is OFF for the fast model. This is a kitchen: a model that thinks for four seconds
@@ -287,15 +364,19 @@ export default async function handler(request, response) {
     const lookup = actions.find((a) => a.name === "look_up");
     if (lookup) {
       const query = typeof lookup.args.query === "string" && lookup.args.query.trim().length > 0 ? lookup.args.query.trim() : text;
-      const reply = await lookUp(key, text, query, messages.slice(1, -1));
+      const decidedMs = Date.now() - startedAt;
+      const reply = await lookUp(key, text, query, systemPrompt, messages.slice(1, -1));
       const elapsedMs = Date.now() - startedAt;
       if (reply.length === 0) {
         console.log("TALK LOOKUP EMPTY " + JSON.stringify({ text, query }));
-        response.status(502).json({ error: "The search found nothing to say." });
+        log({ route: "look_up", model: SEARCH_MODEL, query, decidedMs, elapsedMs, error: "The search found nothing to say." });
+        response.status(502).json({ error: "The search found nothing to say.", turnId });
         return;
       }
       console.log("TALK LOOKUP " + JSON.stringify({ at: new Date().toISOString(), elapsedMs, text, query, reply }));
-      response.status(200).json({ reply, elapsedMs, model: SEARCH_MODEL, lookedUp: true });
+      log({ route: "look_up", model: SEARCH_MODEL, query, decidedMs, elapsedMs, reply });
+      response.status(200).json({ reply, elapsedMs, model: SEARCH_MODEL, lookedUp: true, turnId });
+      rememberLater(reply);
       return;
     }
 
@@ -303,7 +384,9 @@ export default async function handler(request, response) {
     if (actions.length > 0) {
       const elapsedMs = Date.now() - startedAt;
       console.log("TALK ACTIONS " + JSON.stringify({ at: new Date().toISOString(), elapsedMs, text, actions }));
-      response.status(200).json({ actions, elapsedMs, model });
+      log({ route: "tool", model, elapsedMs, actions });
+      response.status(200).json({ actions, elapsedMs, model, turnId });
+      rememberLater("(the device carried out: " + actions.map((a) => a.name + " " + JSON.stringify(a.args)).join(", ") + ")");
       return;
     }
 
@@ -313,21 +396,25 @@ export default async function handler(request, response) {
     const elapsedMs = Date.now() - startedAt;
     if (reply.length === 0) {
       console.log("TALK EMPTY REPLY " + JSON.stringify(body).slice(0, 400));
-      response.status(502).json({ error: "The model returned nothing to say." });
+      log({ route: "plain", model, elapsedMs, error: "The model returned nothing to say." });
+      response.status(502).json({ error: "The model returned nothing to say.", turnId });
       return;
     }
 
     console.log("TALK " + JSON.stringify({ at: new Date().toISOString(), elapsedMs, model, text, reply }));
-    response.status(200).json({ reply, elapsedMs, model });
+    log({ route: "plain", model, elapsedMs, reply });
+    response.status(200).json({ reply, elapsedMs, model, turnId });
+    rememberLater(reply);
   } catch (error) {
     const status = typeof error?.status === "number" ? error.status : 0;
     console.log("TALK ERROR " + status + " " + String(error) + " " + (error?.detail ?? ""));
+    log({ route: "error", model, elapsedMs: Date.now() - startedAt, status, error: String(error), detail: error?.detail ?? null });
     if (status === 429) {
-      // The Groq free tier is 8,000 tokens a minute, and a turn costs several hundred. Say so,
-      // because "could not be reached" sends someone to check the network when the fix is a tier.
-      response.status(502).json({ error: "The model is rate limited right now. Try again in a moment." });
+      // A turn costs several hundred tokens against a per-minute allowance. Say so, because
+      // "could not be reached" sends someone to check the network when the fix is a tier.
+      response.status(502).json({ error: "The model is rate limited right now. Try again in a moment.", turnId });
       return;
     }
-    response.status(502).json({ error: status > 0 ? error.message : "The model could not be reached." });
+    response.status(502).json({ error: status > 0 ? error.message : "The model could not be reached.", turnId });
   }
 }

--- a/apps/cc-assistant/api/turn.js
+++ b/apps/cc-assistant/api/turn.js
@@ -1,0 +1,47 @@
+// The page's half of the turn log.
+//
+// The server knows what was heard and what the model decided (talk.js logs that). Only the page
+// knows what was actually said aloud, how long the voice took to make a sound, what the wake word
+// matched, and what was thrown away as echo. It reports those here, tagged with the turn id talk.js
+// handed out, and a reader joins the two by id.
+//
+// GET returns the recent log for the debug screen. DELETE clears it: the household owns its log.
+
+export default async function handler(request, response, wilson) {
+  if (!wilson) {
+    response.status(200).json({ logged: false, reason: "This deployment keeps no log." });
+    return;
+  }
+  const store = wilson.store;
+
+  if (request.method === "GET") {
+    const limit = Math.min(500, Math.max(1, Number(request.query?.limit) || 100));
+    response.status(200).json({ turns: store.recentTurns(limit), directory: store.directory });
+    return;
+  }
+  if (request.method === "DELETE") {
+    store.clearTurns();
+    response.status(200).json({ cleared: true });
+    return;
+  }
+  if (request.method !== "POST") {
+    response.status(405).json({ error: "Report a turn with POST." });
+    return;
+  }
+
+  let payload = request.body;
+  if (typeof payload === "string") {
+    try {
+      payload = JSON.parse(payload);
+    } catch {
+      response.status(400).json({ error: "The body was not JSON." });
+      return;
+    }
+  }
+  payload = payload || {};
+  const kind = typeof payload.kind === "string" ? payload.kind : "spoken";
+  const record = { kind, ...payload };
+  delete record.at;
+  store.log(record);
+  response.status(200).json({ logged: true });
+}

--- a/apps/cc-assistant/api/voice.js
+++ b/apps/cc-assistant/api/voice.js
@@ -1,0 +1,114 @@
+// Who is speaking. The page computes a voice embedding (a few hundred numbers that describe how a
+// voice sounds, not what it said) and this decides whose it is, by comparing it with the samples
+// each person recorded when they enrolled.
+//
+//   POST { action: "enrol", name, embedding, label }   store one sample for a person
+//   POST { action: "identify", embedding }              -> { name, confidence } or { name: null }
+//   POST { action: "clear", name }                      forget a person's voice
+//
+// Matching is cosine similarity against every stored sample, best sample wins; a person needs the
+// best match to clear THRESHOLD and to beat the runner-up by MARGIN, or the answer is "unknown".
+// Unknown is a fine answer: it just means no personalisation on this turn. A wrong name is worse.
+//
+// The embedding model lives in the page (src/assistant/speakerId.ts) because raw audio never
+// leaves the device; only the embedding does, and only to this local service.
+
+export const THRESHOLD = 0.62;
+export const MARGIN = 0.05;
+
+export function cosine(a, b) {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length && i < b.length; i += 1) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  if (na === 0 || nb === 0) {
+    return 0;
+  }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+/** Pure: given people with voice samples and one embedding, who is it? */
+export function identify(people, embedding, threshold = THRESHOLD, margin = MARGIN) {
+  const scores = people
+    .map((person) => {
+      const samples = person.voice && Array.isArray(person.voice.samples) ? person.voice.samples : [];
+      const best = samples.reduce((top, s) => Math.max(top, cosine(s.embedding, embedding)), -1);
+      return { name: person.name, key: person.key, best, samples: samples.length };
+    })
+    .filter((s) => s.samples > 0)
+    .sort((x, y) => y.best - x.best);
+  if (scores.length === 0) {
+    return { name: null, confidence: 0, reason: "nobody has enrolled", scores };
+  }
+  const [top, second] = scores;
+  if (top.best < threshold) {
+    return { name: null, confidence: top.best, reason: `best match ${top.name} at ${top.best.toFixed(2)}, below ${threshold}`, scores };
+  }
+  if (second && top.best - second.best < margin) {
+    return { name: null, confidence: top.best, reason: `${top.name} and ${second.name} too close (${top.best.toFixed(2)} vs ${second.best.toFixed(2)})`, scores };
+  }
+  return { name: top.name, key: top.key, confidence: top.best, reason: null, scores };
+}
+
+function validEmbedding(e) {
+  return Array.isArray(e) && e.length >= 32 && e.length <= 4096 && e.every((n) => typeof n === "number" && Number.isFinite(n));
+}
+
+export default async function handler(request, response, wilson) {
+  if (!wilson) {
+    response.status(200).json({ name: null, reason: "This deployment keeps no voices." });
+    return;
+  }
+  const store = wilson.store;
+  if (request.method !== "POST") {
+    response.status(405).json({ error: "POST an action." });
+    return;
+  }
+  let payload = request.body;
+  if (typeof payload === "string") {
+    try {
+      payload = JSON.parse(payload);
+    } catch {
+      response.status(400).json({ error: "The body was not JSON." });
+      return;
+    }
+  }
+  payload = payload || {};
+  const name = typeof payload.name === "string" ? payload.name.trim() : "";
+
+  if (payload.action === "clear") {
+    if (name.length === 0) {
+      response.status(400).json({ error: "Whose voice?" });
+      return;
+    }
+    store.clearVoice(name);
+    store.log({ kind: "voice-cleared", person: name });
+    response.status(200).json({ cleared: true });
+    return;
+  }
+  if (!validEmbedding(payload.embedding)) {
+    response.status(400).json({ error: "The embedding was missing or malformed." });
+    return;
+  }
+  if (payload.action === "enrol") {
+    if (name.length === 0) {
+      response.status(400).json({ error: "Whose voice?" });
+      return;
+    }
+    store.person(name);
+    const count = store.addVoiceSample(name, payload.embedding, typeof payload.label === "string" ? payload.label : "");
+    store.log({ kind: "voice-enrolled", person: name, samples: count });
+    response.status(200).json({ samples: count });
+    return;
+  }
+  if (payload.action === "identify") {
+    const result = identify(store.people(), payload.embedding);
+    response.status(200).json({ name: result.name, confidence: result.confidence, reason: result.reason, scores: result.scores.map((s) => ({ name: s.name, score: Number(s.best.toFixed(3)) })) });
+    return;
+  }
+  response.status(400).json({ error: "Unknown action." });
+}

--- a/apps/cc-assistant/api/weather.js
+++ b/apps/cc-assistant/api/weather.js
@@ -9,22 +9,188 @@
 const FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
 const GEOCODE_URL = "https://geocoding-api.open-meteo.com/v1/search";
 
-/** Turn a place name into coordinates. Returns null when there is no such place. */
-async function findPlace(name) {
-  const url = `${GEOCODE_URL}?name=${encodeURIComponent(name)}&count=1&language=en&format=json`;
+const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
+const SPELLING_MODEL = "qwen/qwen3.6-27b";
+
+/** Every candidate the geocoder has for a name, with region and country so a choice can be made. */
+async function geocode(name, count = 5) {
+  const url = `${GEOCODE_URL}?name=${encodeURIComponent(name)}&count=${count}&language=en&format=json`;
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`The place lookup failed (${response.status}).`);
   }
   const body = await response.json();
-  const first = Array.isArray(body.results) ? body.results[0] : null;
-  if (!first) {
-    return null;
-  }
-  return { latitude: first.latitude, longitude: first.longitude, place: first.name };
+  return (Array.isArray(body.results) ? body.results : []).map((r) => ({
+    latitude: r.latitude,
+    longitude: r.longitude,
+    name: r.name,
+    admin1: r.admin1 || "",
+    country: r.country || "",
+    // GeoNames feature codes: PPL* is a populated place; AIRP an airport, and so on.
+    populated: typeof r.feature_code === "string" && r.feature_code.startsWith("PPL"),
+  }));
 }
 
-export default async function handler(request, response) {
+/**
+ * The town, not its airport. Asking for Parry Sound and being told the weather at Parry Sound Area
+ * Municipal Airport is technically right and obviously wrong. Populated places come first; among
+ * those, or failing those, the one nearest home.
+ */
+function pickPlace(candidates, homePoint) {
+  if (candidates.length === 0) {
+    return null;
+  }
+  const towns = candidates.filter((c) => c.populated);
+  const pool = towns.length > 0 ? towns : candidates;
+  if (!homePoint) {
+    return pool[0];
+  }
+  return pool.slice().sort((a, b) => distanceKm(a, homePoint) - distanceKm(b, homePoint))[0];
+}
+
+function distanceKm(a, b) {
+  const rad = Math.PI / 180;
+  const dLat = (b.latitude - a.latitude) * rad;
+  const dLon = (b.longitude - a.longitude) * rad;
+  const s = Math.sin(dLat / 2) ** 2 + Math.cos(a.latitude * rad) * Math.cos(b.latitude * rad) * Math.sin(dLon / 2) ** 2;
+  return 6371 * 2 * Math.asin(Math.sqrt(s));
+}
+
+/**
+ * The recogniser wrote "Perry Sound"; the person said Parry Sound. The geocoder cannot bridge that,
+ * a language model can. Given the misspelling and where the household lives, it returns the most
+ * likely real place name, or null when it has no idea.
+ */
+/** Edit distance between two strings, lower-cased, letters only. */
+export function editDistance(a, b) {
+  const x = a.toLowerCase().replace(/[^a-z]/g, "");
+  const y = b.toLowerCase().replace(/[^a-z]/g, "");
+  const prev = new Array(y.length + 1);
+  for (let j = 0; j <= y.length; j += 1) {
+    prev[j] = j;
+  }
+  for (let i = 1; i <= x.length; i += 1) {
+    let diagonal = prev[0];
+    prev[0] = i;
+    for (let j = 1; j <= y.length; j += 1) {
+      const temp = prev[j];
+      prev[j] = Math.min(prev[j] + 1, prev[j - 1] + 1, diagonal + (x[i - 1] === y[j - 1] ? 0 : 1));
+      diagonal = temp;
+    }
+  }
+  return prev[y.length];
+}
+
+/**
+ * Of several possible real names for a misheard one, the one spelled most like what was heard.
+ * "Perry Sound" is one letter from "Parry Sound" and eight from "Port Perry"; a language model
+ * asked to choose picked Port Perry anyway, twice, because it was nearer the hint. Letters do not
+ * have opinions. Ties go to the earlier candidate, which is the model's own first choice.
+ */
+export function closestSpelling(heard, names) {
+  let best = null;
+  let bestDistance = Infinity;
+  for (const name of names) {
+    const d = editDistance(heard, name.split(",")[0]);
+    if (d < bestDistance) {
+      best = name;
+      bestDistance = d;
+    }
+  }
+  return best;
+}
+
+async function correctSpelling(key, heard, nearHint, candidates) {
+  if (!key) {
+    return null;
+  }
+  const upstream = await fetch(GROQ_URL, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: SPELLING_MODEL,
+      messages: [
+        {
+          role: "system",
+          content:
+            "A speech recogniser wrote down a place name and a map lookup found nothing by that spelling. List up to three real places it could have been, each as \"Name, Region, Country\", " +
+            "most likely first. The recogniser hears SOUNDS, so list places that sound like what was heard (same syllables, same rhythm), including any from the household's own list that fit. " +
+            "Return ONLY JSON: {\"places\": [\"...\", \"...\"]} or {\"places\": []} if you cannot tell.",
+        },
+        {
+          role: "user",
+          content:
+            `Heard: "${heard}". Hint: the household is near ${nearHint || "unknown"}.` +
+            (candidates.length > 0 ? ` Places this household talks about: ${candidates.join(", ")}.` : ""),
+        },
+      ],
+      reasoning_effort: "none",
+      response_format: { type: "json_object" },
+      max_tokens: 120,
+      temperature: 0,
+    }),
+  });
+  if (!upstream.ok) {
+    throw new Error(`The spelling check refused (${upstream.status}).`);
+  }
+  const body = await upstream.json();
+  let names = [];
+  try {
+    const parsed = JSON.parse(body?.choices?.[0]?.message?.content ?? "{}");
+    names = Array.isArray(parsed.places) ? parsed.places.filter((p) => typeof p === "string" && p.trim().length > 0).map((p) => p.trim()) : [];
+  } catch {
+    return null;
+  }
+  // The household's own places are always in the running, whatever the model listed.
+  for (const c of candidates) {
+    if (!names.some((n) => n.split(",")[0].trim().toLowerCase() === c.toLowerCase())) {
+      names.push(c);
+    }
+  }
+  return closestSpelling(heard, names);
+}
+
+/**
+ * Turn a place name into coordinates. Returns null when there is no such place.
+ *
+ * Four steps, each only when the previous found nothing: a name this household has resolved before;
+ * the geocoder as heard (picking the candidate nearest home when there are several); the geocoder
+ * with the model's corrected spelling; nothing. What resolves is remembered, so the same misspelling
+ * never fails twice.
+ */
+async function findPlace(name, { key, store, home, candidates = [] }) {
+  const remembered = store ? store.knownPlace(name) : null;
+  if (remembered) {
+    return { latitude: remembered.latitude, longitude: remembered.longitude, place: remembered.name, via: "remembered" };
+  }
+
+  const homePoint = home ? pickPlace(await geocode(home), null) : null;
+  const nearest = (candidates) => pickPlace(candidates, homePoint);
+
+  let found = nearest(await geocode(name));
+  let via = "geocoder";
+  if (!found) {
+    const homeLabel = homePoint ? [homePoint.name, homePoint.admin1, homePoint.country].filter(Boolean).join(", ") : home;
+    const corrected = await correctSpelling(key, name, homeLabel, candidates);
+    if (corrected && corrected.toLowerCase() !== name.toLowerCase()) {
+      // "Parry Sound, Ontario, Canada": the geocoder wants just the name, the rest disambiguates.
+      const justName = corrected.split(",")[0].trim();
+      const candidates = await geocode(justName);
+      const wanted = corrected.toLowerCase();
+      found = candidates.find((c) => wanted.includes(c.admin1.toLowerCase()) && c.admin1.length > 0) || nearest(candidates);
+      via = found ? `corrected from "${name}" to "${corrected}"` : "geocoder";
+    }
+  }
+  if (!found) {
+    return null;
+  }
+  if (store) {
+    store.rememberPlace(name, { name: found.name, admin1: found.admin1, country: found.country, latitude: found.latitude, longitude: found.longitude });
+  }
+  return { latitude: found.latitude, longitude: found.longitude, place: found.name, via };
+}
+
+export default async function handler(request, response, wilson) {
   if (request.method !== "POST") {
     response.status(405).json({ error: "Ask for the weather with POST." });
     return;
@@ -45,19 +211,46 @@ export default async function handler(request, response) {
   let latitude = Number(payload.latitude);
   let longitude = Number(payload.longitude);
   let place = typeof payload.place === "string" ? payload.place.trim() : "";
+  const home = typeof payload.home === "string" ? payload.home.trim() : "";
+
+  // With a store and a known person, where they ARE beats where they live, and both beat the page's
+  // saved home town: "I'm in Parry Sound this week" said once is enough.
+  const store = wilson ? wilson.store : null;
+  const speaker = typeof payload.speaker === "string" && payload.speaker.trim().length > 0 ? payload.speaker.trim() : null;
+  const person = store && speaker ? store.person(speaker) : null;
+  const named = payload.named === true;
+  let resolvedVia = null;
+  if (!named && person) {
+    const known = person.profile.currentLocation || person.profile.home;
+    if (typeof known === "string" && known.trim().length > 0) {
+      place = known.trim();
+      resolvedVia = person.profile.currentLocation ? "current location from memory" : "home from memory";
+    }
+  }
+  const homeHint = (person && person.profile.home) || home;
+  // The household's own places are the likeliest answers to a misheard name.
+  const candidates = [
+    ...(store ? store.knownPlaceNames() : []),
+    ...(person ? [person.profile.home, person.profile.currentLocation] : []),
+    home,
+  ].filter((p) => typeof p === "string" && p.trim().length > 0);
 
   try {
     // A named place wins over coordinates: asking for the weather in London while standing in Toronto
     // means London.
     if (place.length > 0) {
-      const found = await findPlace(place);
+      const found = await findPlace(place, { key: process.env.GROQ_API_KEY, store, home: homeHint, candidates: [...new Set(candidates)] });
       if (found === null) {
+        if (store) {
+          store.log({ kind: "weather", place, notFound: true });
+        }
         response.status(200).json({ notFound: true, place });
         return;
       }
       latitude = found.latitude;
       longitude = found.longitude;
       place = found.place;
+      resolvedVia = resolvedVia ? `${resolvedVia}; ${found.via}` : found.via;
     }
 
     if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
@@ -99,8 +292,11 @@ export default async function handler(request, response) {
       throw new Error("The forecast came back without a temperature in it.");
     }
 
-    console.log("WEATHER " + JSON.stringify({ at: new Date().toISOString(), place: reading.place, code: reading.code }));
-    response.status(200).json({ reading });
+    console.log("WEATHER " + JSON.stringify({ at: new Date().toISOString(), place: reading.place, code: reading.code, via: resolvedVia }));
+    if (store) {
+      store.log({ kind: "weather", asked: typeof payload.place === "string" ? payload.place : null, place: reading.place, via: resolvedVia, temperature: reading.temperature });
+    }
+    response.status(200).json({ reading, via: resolvedVia });
   } catch (error) {
     console.log("WEATHER ERROR " + String(error));
     response.status(502).json({ error: "I could not reach the weather service." });

--- a/apps/cc-assistant/package.json
+++ b/apps/cc-assistant/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
+    "serve": "node server/wilson.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/apps/cc-assistant/server/memory.mjs
+++ b/apps/cc-assistant/server/memory.mjs
@@ -1,0 +1,109 @@
+// What Wilson brings to a turn, and what it takes away from one.
+//
+// BEFORE a turn: the person's profile and their remembered facts become a short block in the system
+// prompt, so "what's the weather" knows they are in Parry Sound this week without being told again.
+//
+// AFTER a turn: the fast model reads what was said and answers one question - is there anything here
+// worth keeping about this person? - and returns it as data. It runs after the reply has gone out,
+// so it costs the person nothing to wait for. It is given what is already known, so it does not
+// return the same fact every day.
+//
+// The model only ever proposes; the store decides (dedupes, caps). Nothing here composes speech.
+
+const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
+const EXTRACT_MODEL = "qwen/qwen3.6-27b";
+
+/** Profile fields Wilson understands. Anything else the model returns is kept too, but these have meaning. */
+export const PROFILE_FIELDS = {
+  callMe: "what to call them",
+  home: "home town or city",
+  currentLocation: "where they are right now, if away from home",
+  units: "celsius or fahrenheit",
+  household: "who else lives in the house",
+  language: "language they prefer",
+};
+
+/** The block that goes into the system prompt. Empty when nothing is known. */
+export function contextFor(person, knownPlaces = []) {
+  if (!person) {
+    return "";
+  }
+  const lines = [];
+  lines.push(`You are talking to ${person.profile.callMe || person.name}.`);
+  const profileLines = Object.entries(person.profile)
+    .filter(([field, value]) => field !== "callMe" && value !== "" && value !== null && value !== undefined)
+    .map(([field, value]) => `${PROFILE_FIELDS[field] || field}: ${value}`);
+  if (profileLines.length > 0) {
+    lines.push("About them: " + profileLines.join("; ") + ".");
+  }
+  const facts = (person.facts || []).slice(-40);
+  if (facts.length > 0) {
+    lines.push("Things they have told you before, oldest first: " + facts.map((f) => f.text).join(" | "));
+  }
+  if (knownPlaces.length > 0) {
+    lines.push("Place names this household uses, spelled correctly: " + knownPlaces.join(", ") + ".");
+  }
+  lines.push("Use what you know without announcing that you remember it. If they tell you something new about themselves, just take it in; do not say you will remember it.");
+  return lines.join(" ");
+}
+
+/** The interview, for when a person asks Wilson to get to know them. One question at a time. */
+export const INTERVIEW_PROMPT =
+  "If they ask you to get to know them, interview them, or set up, ask these ONE AT A TIME, waiting for each answer, skipping any you already know: " +
+  "what to call them; where home is; whether they are somewhere else right now; Celsius or Fahrenheit; who else lives in the house; anything they want you to know. " +
+  "Then say in one sentence what you have got. Never ask two questions in one breath.";
+
+/**
+ * After the reply is out: anything worth keeping?
+ * Returns { facts: string[], profile: object } or null when there was nothing.
+ */
+export async function extractAfterTurn(key, person, heard, reply) {
+  const known = {
+    profile: person.profile,
+    recentFacts: (person.facts || []).slice(-20).map((f) => f.text),
+  };
+  const body = {
+    model: EXTRACT_MODEL,
+    messages: [
+      {
+        role: "system",
+        content:
+          "You maintain a house assistant's memory about one person. You are given what is already known, then one exchange. " +
+          "Return ONLY JSON: {\"facts\": [..], \"profile\": {..}}. " +
+          "facts: new, durable, specific things about the person worth knowing next month, as short third-person sentences (\"Her mother's birthday is March 3rd\"). Not questions, not weather, not timers, not things already known, not the assistant's own words. Usually empty. " +
+          `profile: only fields that changed, from: ${Object.keys(PROFILE_FIELDS).join(", ")}. currentLocation is where they say they ARE (a trip, a cottage); home is where they LIVE. Both hold a PLACE NAME ONLY, as on a map: from \"I am up at the cottage in Parry Sound until Friday\" the currentLocation is \"Parry Sound\" and the fact is \"At the cottage until Friday\". Use an empty string to clear currentLocation when they say they are home. ` +
+          "If nothing is worth keeping, return {\"facts\": [], \"profile\": {}}.",
+      },
+      { role: "user", content: `Known: ${JSON.stringify(known)}\n\nPerson said: ${heard}\nAssistant replied: ${reply}` },
+    ],
+    reasoning_effort: "none",
+    response_format: { type: "json_object" },
+    max_tokens: 300,
+    temperature: 0,
+  };
+  const upstream = await fetch(GROQ_URL, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!upstream.ok) {
+    throw new Error(`Memory extraction refused (${upstream.status}).`);
+  }
+  const result = await upstream.json();
+  const content = result?.choices?.[0]?.message?.content;
+  if (typeof content !== "string") {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error("Memory extraction returned something that was not JSON: " + content.slice(0, 120));
+  }
+  const facts = Array.isArray(parsed.facts) ? parsed.facts.filter((f) => typeof f === "string") : [];
+  const profile = parsed.profile && typeof parsed.profile === "object" ? parsed.profile : {};
+  if (facts.length === 0 && Object.keys(profile).length === 0) {
+    return null;
+  }
+  return { facts, profile };
+}

--- a/apps/cc-assistant/server/store.mjs
+++ b/apps/cc-assistant/server/store.mjs
@@ -1,0 +1,256 @@
+// What Wilson keeps. The household, its people, what it has learned, its soul, and every turn.
+//
+// Plain files in one directory, so a person can open them and see exactly what Wilson knows and
+// delete any of it. That is the privacy model for the local version: nothing is hidden and nothing
+// leaves the machine. When Wilson becomes a hosted service this becomes a database behind the same
+// functions; the shapes below are the contract.
+//
+//   household.json   people, their profiles and remembered facts, resolved place names
+//   soul.md          who Wilson is, in the household's own words
+//   turns.jsonl      one line per event, appended, never rewritten
+//
+// The directory is WILSON_DATA_DIR, or %LOCALAPPDATA%\wilson on Windows and ~/.wilson elsewhere.
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const DEFAULT_SOUL = `# Wilson
+
+You are Wilson, the assistant in this house. You are calm, quick and plain-spoken. You answer in one
+short sentence unless asked to explain. You are voice only: there is no screen, so you never give a
+link or anything that has to be read; you say what to search for instead. You use the name a person
+asked to be called. You do not perform enthusiasm and you never apologise twice.
+`;
+
+const MAX_FACTS_PER_PERSON = 200;
+
+export function dataDirectory() {
+  if (process.env.WILSON_DATA_DIR) {
+    return process.env.WILSON_DATA_DIR;
+  }
+  if (process.platform === "win32" && process.env.LOCALAPPDATA) {
+    return path.join(process.env.LOCALAPPDATA, "wilson");
+  }
+  return path.join(os.homedir(), ".wilson");
+}
+
+function personKey(name) {
+  return String(name || "").trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export class Store {
+  constructor(directory = dataDirectory()) {
+    this.directory = directory;
+    fs.mkdirSync(directory, { recursive: true });
+    this.householdPath = path.join(directory, "household.json");
+    this.soulPath = path.join(directory, "soul.md");
+    this.turnsPath = path.join(directory, "turns.jsonl");
+    if (!fs.existsSync(this.householdPath)) {
+      this.writeHousehold({ people: {}, places: {} });
+    }
+    if (!fs.existsSync(this.soulPath)) {
+      fs.writeFileSync(this.soulPath, DEFAULT_SOUL, "utf8");
+    }
+  }
+
+  readHousehold() {
+    return JSON.parse(fs.readFileSync(this.householdPath, "utf8"));
+  }
+
+  writeHousehold(household) {
+    // Written whole and atomically, so a crash mid-write cannot leave half a household.
+    const tmp = this.householdPath + ".tmp";
+    fs.writeFileSync(tmp, JSON.stringify(household, null, 2), "utf8");
+    fs.renameSync(tmp, this.householdPath);
+  }
+
+  // ---- people --------------------------------------------------------------------------------
+
+  /** The person record, created on first sight. `name` is how they asked to be known. */
+  person(name) {
+    const key = personKey(name);
+    if (key.length === 0) {
+      return null;
+    }
+    const household = this.readHousehold();
+    if (!household.people[key]) {
+      household.people[key] = { name: String(name).trim(), profile: {}, facts: [], voice: { samples: [] }, createdAt: new Date().toISOString() };
+      this.writeHousehold(household);
+    }
+    return { key, ...household.people[key] };
+  }
+
+  people() {
+    const household = this.readHousehold();
+    return Object.entries(household.people).map(([key, p]) => ({ key, ...p }));
+  }
+
+  /** Merge profile fields. Empty strings delete a field; everything else replaces. */
+  updateProfile(name, fields) {
+    const key = personKey(name);
+    const household = this.readHousehold();
+    const person = household.people[key];
+    if (!person) {
+      return null;
+    }
+    for (const [field, value] of Object.entries(fields || {})) {
+      if (value === "" || value === null || value === undefined) {
+        delete person.profile[field];
+      } else {
+        person.profile[field] = value;
+      }
+    }
+    person.updatedAt = new Date().toISOString();
+    this.writeHousehold(household);
+    return { key, ...person };
+  }
+
+  /** Remember a fact about a person. Repeats are ignored; the list is capped at the newest 200. */
+  addFacts(name, facts, source = "said") {
+    const key = personKey(name);
+    const household = this.readHousehold();
+    const person = household.people[key];
+    if (!person) {
+      return [];
+    }
+    const known = new Set(person.facts.map((f) => f.text.toLowerCase()));
+    const added = [];
+    for (const text of facts) {
+      const clean = String(text).trim();
+      if (clean.length === 0 || known.has(clean.toLowerCase())) {
+        continue;
+      }
+      known.add(clean.toLowerCase());
+      const fact = { text: clean, at: new Date().toISOString(), source };
+      person.facts.push(fact);
+      added.push(fact);
+    }
+    if (person.facts.length > MAX_FACTS_PER_PERSON) {
+      person.facts = person.facts.slice(-MAX_FACTS_PER_PERSON);
+    }
+    if (added.length > 0) {
+      this.writeHousehold(household);
+    }
+    return added;
+  }
+
+  forgetFact(name, text) {
+    const key = personKey(name);
+    const household = this.readHousehold();
+    const person = household.people[key];
+    if (!person) {
+      return false;
+    }
+    const before = person.facts.length;
+    person.facts = person.facts.filter((f) => f.text !== text);
+    this.writeHousehold(household);
+    return person.facts.length < before;
+  }
+
+  /** Voice samples for speaker identification: embeddings stored as plain number arrays. */
+  addVoiceSample(name, embedding, label) {
+    const key = personKey(name);
+    const household = this.readHousehold();
+    const person = household.people[key];
+    if (!person) {
+      return null;
+    }
+    person.voice = person.voice || { samples: [] };
+    person.voice.samples.push({ embedding, label, at: new Date().toISOString() });
+    this.writeHousehold(household);
+    return person.voice.samples.length;
+  }
+
+  clearVoice(name) {
+    const key = personKey(name);
+    const household = this.readHousehold();
+    const person = household.people[key];
+    if (!person) {
+      return;
+    }
+    person.voice = { samples: [] };
+    this.writeHousehold(household);
+  }
+
+  // ---- places --------------------------------------------------------------------------------
+
+  /** A place name as it was heard, mapped to what it resolved to. "perry sound" -> Parry Sound. */
+  rememberPlace(heard, resolved) {
+    const household = this.readHousehold();
+    household.places[personKey(heard)] = { ...resolved, heard, at: new Date().toISOString() };
+    this.writeHousehold(household);
+  }
+
+  knownPlace(heard) {
+    const household = this.readHousehold();
+    return household.places[personKey(heard)] || null;
+  }
+
+  knownPlaceNames() {
+    const household = this.readHousehold();
+    return [...new Set(Object.values(household.places).map((p) => p.name))];
+  }
+
+  places() {
+    const household = this.readHousehold();
+    return Object.entries(household.places).map(([heard, p]) => ({ heard: p.heard || heard, ...p }));
+  }
+
+  /** A wrong mapping must not stick: "perry sound" resolved to the wrong town once is forgotten here. */
+  forgetPlace(heard) {
+    const household = this.readHousehold();
+    const key = personKey(heard);
+    const existed = key in household.places;
+    delete household.places[key];
+    this.writeHousehold(household);
+    return existed;
+  }
+
+  // ---- soul ----------------------------------------------------------------------------------
+
+  soul() {
+    return fs.readFileSync(this.soulPath, "utf8");
+  }
+
+  writeSoul(text) {
+    // Every previous version is kept, so a bad edit is a file away from undone.
+    if (fs.existsSync(this.soulPath)) {
+      const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+      fs.copyFileSync(this.soulPath, path.join(this.directory, `soul.${stamp}.md`));
+    }
+    fs.writeFileSync(this.soulPath, String(text), "utf8");
+  }
+
+  // ---- turns ---------------------------------------------------------------------------------
+
+  /** Append one event. Never throws on a bad line: the log must not take the assistant down. */
+  log(record) {
+    try {
+      fs.appendFileSync(this.turnsPath, JSON.stringify({ at: new Date().toISOString(), ...record }) + "\n", "utf8");
+    } catch (error) {
+      console.log("STORE LOG FAILED " + String(error));
+    }
+  }
+
+  /** The most recent events, newest last. */
+  recentTurns(limit = 50) {
+    if (!fs.existsSync(this.turnsPath)) {
+      return [];
+    }
+    const lines = fs.readFileSync(this.turnsPath, "utf8").trim().split("\n").filter((l) => l.length > 0);
+    return lines.slice(-limit).map((l) => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return { kind: "unreadable", line: l };
+      }
+    });
+  }
+
+  clearTurns() {
+    if (fs.existsSync(this.turnsPath)) {
+      fs.unlinkSync(this.turnsPath);
+    }
+  }
+}

--- a/apps/cc-assistant/server/wilson.mjs
+++ b/apps/cc-assistant/server/wilson.mjs
@@ -1,0 +1,146 @@
+// Wilson's own service. Serves the built page, runs the api/ functions in-process, and gives them
+// the one thing Vercel cannot: a place to keep things (server/store.mjs).
+//
+//   node server/wilson.mjs            after `npm run build`
+//   http://localhost:5183/cc-assistant/
+//
+// The api/ handlers keep the Vercel signature (request, response) and take an OPTIONAL third
+// argument, the Wilson context, which only this server passes. On Vercel they run without it and
+// Wilson has no memory there; that is a stated property of that deployment, not a fallback.
+//
+// The key comes from GROQ_API_KEY, or from the credentials file named by WILSON_CREDENTIALS_FILE
+// (a .env file with a GROQ_API_KEY= line), read at start.
+
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Store } from "./store.mjs";
+
+const APP = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DIST = path.join(APP, "dist");
+const BASE = "/cc-assistant";
+const PORT = Number(process.env.WILSON_PORT || 5183);
+
+function loadKey() {
+  if (process.env.GROQ_API_KEY) {
+    return;
+  }
+  const file = process.env.WILSON_CREDENTIALS_FILE;
+  if (!file) {
+    throw new Error("Set GROQ_API_KEY, or WILSON_CREDENTIALS_FILE to a .env file that has a GROQ_API_KEY line.");
+  }
+  const line = fs.readFileSync(file, "utf8").split(/\r?\n/).find((l) => l.startsWith("GROQ_API_KEY="));
+  if (!line) {
+    throw new Error(`No GROQ_API_KEY line in ${file}.`);
+  }
+  process.env.GROQ_API_KEY = line.slice("GROQ_API_KEY=".length).trim().replace(/^"|"$/g, "");
+}
+loadKey();
+
+if (!fs.existsSync(path.join(DIST, "index.html"))) {
+  throw new Error(`No build at ${DIST}. Run: npm run build`);
+}
+
+const store = new Store();
+const wilson = { store };
+
+const api = {};
+for (const name of ["talk", "weather", "result", "turn", "soul", "people", "voice"]) {
+  api[name] = (await import(`file:///${APP.replace(/\\/g, "/")}/api/${name}.js`)).default;
+}
+const speak = (await import(`file:///${APP.replace(/\\/g, "/")}/api/speak.js`)).default;
+
+const MIME = {
+  ".html": "text/html", ".js": "text/javascript", ".css": "text/css", ".json": "application/json", ".wav": "audio/wav",
+  ".svg": "image/svg+xml", ".png": "image/png", ".webmanifest": "application/manifest+json", ".ico": "image/x-icon", ".onnx": "application/octet-stream",
+};
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    let data = "";
+    req.on("data", (c) => (data += c));
+    req.on("end", () => resolve(data));
+  });
+}
+
+http
+  .createServer(async (req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    try {
+      if (url.pathname === `${BASE}/api/speak`) {
+        const raw = await readBody(req);
+        const started = Date.now();
+        const response = await speak(new Request("http://localhost" + req.url, { method: req.method, headers: { "content-type": "application/json" }, body: raw }));
+        res.writeHead(response.status, Object.fromEntries(response.headers));
+        if (response.body === null) {
+          res.end();
+          return;
+        }
+        const reader = response.body.getReader();
+        let first = null;
+        let bytes = 0;
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          if (first === null) {
+            first = Date.now() - started;
+          }
+          bytes += value.length;
+          res.write(Buffer.from(value));
+        }
+        res.end();
+        console.log(`${new Date().toISOString()} speak ${response.status} first-bytes ${first}ms total ${Date.now() - started}ms ${bytes} bytes`);
+        return;
+      }
+
+      const match = url.pathname.match(new RegExp(`^${BASE}/api/([a-z]+)$`));
+      if (match && api[match[1]]) {
+        const raw = await readBody(req);
+        let body = raw;
+        try {
+          body = JSON.parse(raw);
+        } catch {
+          // Handlers cope with strings and empty bodies.
+        }
+        const response = {
+          code: 200,
+          status(c) {
+            this.code = c;
+            return this;
+          },
+          json(obj) {
+            res.writeHead(this.code, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+            res.end(JSON.stringify(obj));
+          },
+        };
+        const started = Date.now();
+        await api[match[1]]({ method: req.method, body, query: Object.fromEntries(url.searchParams) }, response, wilson);
+        console.log(`${new Date().toISOString()} ${match[1]} ${response.code} ${Date.now() - started}ms`);
+        return;
+      }
+
+      let rel = url.pathname.startsWith(BASE) ? url.pathname.slice(BASE.length) : url.pathname;
+      if (rel === "" || rel === "/") {
+        rel = "/index.html";
+      }
+      let file = path.join(DIST, rel);
+      if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) {
+        file = path.join(DIST, "index.html");
+      }
+      res.writeHead(200, { "Content-Type": MIME[path.extname(file)] || "application/octet-stream", "Cache-Control": "no-cache" });
+      fs.createReadStream(file).pipe(res);
+    } catch (error) {
+      console.log(`${new Date().toISOString()} ERROR ${req.url} ${String(error)}`);
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+      }
+      res.end(JSON.stringify({ error: String(error) }));
+    }
+  })
+  .listen(PORT, "0.0.0.0", () => {
+    console.log(`Wilson on http://localhost:${PORT}${BASE}/`);
+    console.log(`Data in ${store.directory}`);
+  });

--- a/apps/cc-assistant/src/assistant/AssistantScreen.tsx
+++ b/apps/cc-assistant/src/assistant/AssistantScreen.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { matchWakeWord, describeWakeWordWeakness } from "../wakeWord/wakeWordMatcher";
-import { chirp, createListener, localRecognitionReady, speak, stopSpeaking, type Listener } from "./speech";
+import { chirp, createListener, cue, localRecognitionReady, startThinkingTicks, type Listener } from "./speech";
+import { DEFAULT_VOICE, VOICES, speakStreamed, stopVoice, unlockVoice, type VoiceName } from "./voice";
+import { DebugPanel } from "./DebugPanel";
+import { VoiceRing, embedClip, enrolVoice, identifyVoice, loadSpeakerModel, watchSpeakerModel } from "./speakerId";
 import { watchMicLevel, type MicLevel } from "./micLevel";
 import { judgeEcho, similarity, ECHO_SIMILARITY } from "./echoGuard";
 import { clockFace as clockFaceOf } from "../skills/timerParse";
@@ -27,6 +30,35 @@ interface Turn {
 const FOLLOW_UP_MS = 5000;
 const WAKE_WORD_KEY = "cc-assistant.wakeWord";
 const HOME_KEY = "cc-assistant.home";
+const VOICE_KEY = "cc-assistant.voice";
+const OWNER_KEY = "cc-assistant.owner";
+const MODE_KEY = "cc-assistant.mode";
+const WORKLET_URL = `${import.meta.env.BASE_URL}pcm-worklet.js`;
+/** How much of the last few seconds is the command, for identifying the voice. */
+const IDENTIFY_SECONDS = 3.5;
+
+type Mode = "production" | "debug";
+
+// Which screen. ?debug=1 or ?debug=0 wins, then what was chosen last time, then: a PC gets the debug
+// screen and a phone gets the circle, because that is where each is looked at.
+function initialMode(): Mode {
+  try {
+    const wanted = new URLSearchParams(window.location.search).get("debug");
+    if (wanted === "1") {
+      return "debug";
+    }
+    if (wanted === "0") {
+      return "production";
+    }
+    const saved = window.localStorage.getItem(MODE_KEY);
+    if (saved === "debug" || saved === "production") {
+      return saved;
+    }
+    return /Android|iPhone|iPad/i.test(navigator.userAgent) ? "production" : "debug";
+  } catch {
+    return "debug";
+  }
+}
 
 export function AssistantScreen() {
   const [wakeWord, setWakeWord] = useState(() => {
@@ -49,6 +81,35 @@ export function AssistantScreen() {
       return "";
     }
   });
+  const [voice, setVoice] = useState<VoiceName>(() => {
+    try {
+      const saved = window.localStorage.getItem(VOICE_KEY);
+      return (VOICES as readonly string[]).includes(saved ?? "") ? (saved as VoiceName) : DEFAULT_VOICE;
+    } catch {
+      return DEFAULT_VOICE;
+    }
+  });
+  const voiceRef = useRef<VoiceName>(voice);
+  voiceRef.current = voice;
+  // How long the last reply took to make a sound. The number the voice is judged by.
+  const [voiceInfo, setVoiceInfo] = useState<{ firstSoundMs: number; seconds: number } | null>(null);
+  const [mode, setMode] = useState<Mode>(initialMode);
+  // Who this device belongs to: who Wilson assumes is talking until the voice says otherwise.
+  const [owner, setOwner] = useState(() => {
+    try {
+      return window.localStorage.getItem(OWNER_KEY) ?? "";
+    } catch {
+      return "";
+    }
+  });
+  const ownerRef = useRef(owner);
+  ownerRef.current = owner;
+  const [speakerStatus, setSpeakerStatus] = useState("not loaded");
+  const [identified, setIdentified] = useState("nobody yet");
+  const identifiedRef = useRef<{ name: string | null; confidence: number } | null>(null);
+  const ringRef = useRef<VoiceRing | null>(null);
+  // Bumped after every turn so the debug panel re-reads the log.
+  const [logVersion, setLogVersion] = useState(0);
   // The evidence that it is awake. Without these, a silent room and a dead microphone look identical.
   const [level, setLevel] = useState(0);
   const [micInfo, setMicInfo] = useState<{ label: string; echoCancellation: boolean } | null>(null);
@@ -97,6 +158,75 @@ export function AssistantScreen() {
   }, [wakeWord]);
 
   useEffect(() => {
+    try {
+      window.localStorage.setItem(VOICE_KEY, voice);
+    } catch {
+      // Same.
+    }
+  }, [voice]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(OWNER_KEY, owner);
+      window.localStorage.setItem(MODE_KEY, mode);
+    } catch {
+      // Same.
+    }
+  }, [owner, mode]);
+
+  useEffect(() => watchSpeakerModel((s) => setSpeakerStatus(s.detail)), []);
+
+  /** The name a turn is attributed to: the voice if it was recognised, else the device's owner. */
+  const speakerName = useCallback((): string | null => {
+    const heard = identifiedRef.current;
+    if (heard && heard.name !== null) {
+      return heard.name;
+    }
+    return ownerRef.current.trim().length > 0 ? ownerRef.current.trim() : null;
+  }, []);
+
+  /** The page's half of the turn log: what was actually said, and how fast. Fire and forget. */
+  const reportSpoken = useCallback((turnId: string | null, said: string, by: "model" | "device", spoken: { firstSoundMs: number; seconds: number } | null, extra: Record<string, unknown> = {}) => {
+    const heard = identifiedRef.current;
+    void fetch(`${import.meta.env.BASE_URL}api/turn`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        kind: "spoken",
+        id: turnId,
+        said,
+        by,
+        firstSoundMs: spoken ? spoken.firstSoundMs : null,
+        speechSeconds: spoken ? Number(spoken.seconds.toFixed(2)) : null,
+        identified: heard ? heard.name ?? "unknown" : "not attempted",
+        confidence: heard ? Number(heard.confidence.toFixed(3)) : null,
+        ...extra,
+      }),
+    })
+      .then(() => setLogVersion((v) => v + 1))
+      .catch(() => undefined);
+  }, []);
+
+  // Every spoken reply goes through here. The voice streams from the server and starts within a
+  // quarter of a second; a short rising note marks the instant it does. When it cannot be reached
+  // at all, the failure is shown on screen and sounded, because a silent assistant and a broken one
+  // look the same.
+  const speak = useCallback(async (text: string, onStart?: () => void): Promise<{ firstSoundMs: number; seconds: number } | null> => {
+    try {
+      const spoken = await speakStreamed(text, voiceRef.current, () => {
+        cue("speak");
+        onStart?.();
+      });
+      setVoiceInfo(spoken);
+      return spoken;
+    } catch (error) {
+      cue("fail");
+      setProblem(`The voice failed: ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
     void localRecognitionReady("en-US").then(setOnDevice);
   }, []);
 
@@ -119,14 +249,15 @@ export function AssistantScreen() {
       recentlySpokenRef.current = [...recentlySpokenRef.current, sentence].slice(-4);
       speakingRef.current = true;
       setStateBoth("speaking");
-      await speak(sentence);
+      const spoken = await speak(sentence);
       speakingRef.current = false;
       lastSpokeEndedAtRef.current = Date.now();
       followUpUntilRef.current = 0;
       setStateBoth("asleep");
       setLive("");
+      return spoken;
     },
-    [setStateBoth],
+    [setStateBoth, speak],
   );
 
   const timers = useTimers((finished) => {
@@ -165,10 +296,12 @@ export function AssistantScreen() {
       return sayNoLocation();
     }
     try {
+      // `named` tells the service whether a place was actually said. Without one, it may know
+      // better than the saved home town where this person is right now.
       const response = await fetch(`${import.meta.env.BASE_URL}api/weather`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ place: wanted }),
+        body: JSON.stringify({ place: wanted, named: place !== null, home: homeRef.current, speaker: speakerName() }),
       });
       const body = (await response.json()) as {
         reading?: Parameters<typeof sayWeather>[0];
@@ -189,7 +322,7 @@ export function AssistantScreen() {
     } catch {
       return "I could not reach the weather service.";
     }
-  }, []);
+  }, [speakerName]);
 
   /** Carry out one tool the model asked for, and return the sentence describing what happened. */
   const runAction = useCallback((action: { name: string; args: Record<string, unknown> }): string => {
@@ -229,18 +362,24 @@ export function AssistantScreen() {
     busyRef.current = true;
     setStateBoth("thinking");
     const startedAt = Date.now();
+    // Audible thinking, from now until the reply is in hand. A wait that can be heard is a wait;
+    // a silent one is a fault.
+    const stopTicks = startThinkingTicks();
+    let turnId: string | null = null;
 
     try {
       const response = await fetch(`${import.meta.env.BASE_URL}api/talk`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: question, history: historyRef.current, timers: timersRef.current.snapshot() }),
+        body: JSON.stringify({ text: question, history: historyRef.current, timers: timersRef.current.snapshot(), speaker: speakerName() }),
       });
       const body = (await response.json()) as {
         reply?: string;
         actions?: Array<{ name: string; args: Record<string, unknown> }>;
         error?: string;
+        turnId?: string;
       };
+      turnId = body.turnId ?? null;
       if (!response.ok) {
         throw new Error(body.error ?? `The assistant failed (${response.status}).`);
       }
@@ -266,7 +405,9 @@ export function AssistantScreen() {
           [{ id: turnIdRef.current, you: question, it: sentence, ms: Date.now() - startedAt }, ...previous].slice(0, 30),
         );
         busyRef.current = false;
-        await say(sentence);
+        stopTicks();
+        const spoken = await say(sentence);
+        reportSpoken(turnId, sentence, "device", spoken);
         return;
       }
 
@@ -286,11 +427,13 @@ export function AssistantScreen() {
       );
 
       busyRef.current = false;
+      stopTicks();
       recentlySpokenRef.current = [...recentlySpokenRef.current, body.reply].slice(-4);
       speakingRef.current = true;
-      await speak(body.reply, () => setStateBoth("speaking"));
+      const spoken = await speak(body.reply, () => setStateBoth("speaking"));
       speakingRef.current = false;
       lastSpokeEndedAtRef.current = Date.now();
+      reportSpoken(turnId, body.reply, "model", spoken);
       // STRAIGHT BACK TO SLEEP. It does not keep listening after it has answered. Say the wake word
       // again for the next thing.
       followUpUntilRef.current = 0;
@@ -299,15 +442,48 @@ export function AssistantScreen() {
       setLive("");
     } catch (error) {
       busyRef.current = false;
+      stopTicks();
+      cue("fail");
       const message = error instanceof Error ? error.message : String(error);
       setProblem(message);
+      reportSpoken(turnId, "", "device", null, { error: message });
       speakingRef.current = true;
       await speak("Something went wrong.");
       speakingRef.current = false;
       lastSpokeEndedAtRef.current = Date.now();
       setStateBoth("asleep");
     }
-  }, [answerWeather, runAction, setStateBoth]);
+  }, [answerWeather, reportSpoken, runAction, setStateBoth, speak, speakerName]);
+
+  /**
+   * Who just spoke, from the last few seconds of audio, before the command goes to the brain.
+   * Quick when the model is loaded (tens of milliseconds), and skipped honestly when it is not:
+   * "unknown" costs a little personalisation, a wrong name costs trust.
+   */
+  const identifyThenAsk = useCallback(
+    async (command: string) => {
+      identifiedRef.current = null;
+      const ring = ringRef.current;
+      const clip = ring !== null && ring.running ? ring.recent(IDENTIFY_SECONDS) : null;
+      if (clip !== null) {
+        try {
+          const result = await identifyVoice(await embedClip(clip));
+          identifiedRef.current = { name: result.name, confidence: result.confidence };
+          setIdentified(
+            result.name !== null
+              ? `${result.name} (${result.confidence.toFixed(2)})`
+              : `unknown: ${result.reason ?? "no match"}`,
+          );
+        } catch (error) {
+          setIdentified(`not identified: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      } else {
+        setIdentified("not identified: no audio captured");
+      }
+      await ask(command);
+    },
+    [ask],
+  );
 
   const onHeard = useCallback(
     (text: string, isFinal: boolean) => {
@@ -339,7 +515,7 @@ export function AssistantScreen() {
           }
           speakingRef.current = false;
           lastSpokeEndedAtRef.current = Date.now();
-          stopSpeaking();
+          stopVoice();
           chirp("wake");
           setStateBoth("listening");
           followUpUntilRef.current = Date.now() + FOLLOW_UP_MS;
@@ -363,7 +539,7 @@ export function AssistantScreen() {
             setSuppressed(`Ignored "${text}" - ${decision.reason}`);
             return;
           }
-          void ask(match.command);
+          void identifyThenAsk(match.command);
         } else {
           setStateBoth("listening");
           followUpUntilRef.current = Date.now() + FOLLOW_UP_MS;
@@ -381,10 +557,10 @@ export function AssistantScreen() {
           return;
         }
         setSuppressed(null);
-        void ask(text);
+        void identifyThenAsk(text);
       }
     },
-    [ask, setStateBoth],
+    [identifyThenAsk, setStateBoth],
   );
 
   const start = useCallback(async () => {
@@ -392,6 +568,10 @@ export function AssistantScreen() {
     setNotice(null);
     setResultCount(0);
     setLastHeardAt(null);
+
+    // From the press itself, while the browser still counts this as a user gesture: audio may only
+    // start from one, and the voice's AudioContext has to be made and resumed here or it stays mute.
+    await unlockVoice();
 
     // Open the microphone ourselves first. This is what makes "is it listening" answerable: the meter
     // moves or it does not. It also surfaces a refused permission here, plainly, instead of leaving
@@ -429,8 +609,18 @@ export function AssistantScreen() {
       listenerRef.current = listener;
       listener.start();
       setStateBoth("asleep");
-      // A first utterance primes the voice on some browsers, which otherwise swallow the first reply.
-      void speak(" ");
+
+      // The voice ring runs beside the recogniser so there is audio to identify a speaker from. It
+      // is not allowed to stop the assistant: a ring that will not open is reported, and Wilson
+      // still listens and answers, just without knowing who.
+      try {
+        const ring = new VoiceRing();
+        await ring.start(WORKLET_URL);
+        ringRef.current = ring;
+        void loadSpeakerModel();
+      } catch (error) {
+        setNotice(`No voice identification: ${error instanceof Error ? error.message : String(error)}`);
+      }
     } catch (error) {
       setProblem(error instanceof Error ? error.message : String(error));
       micRef.current?.stop();
@@ -443,7 +633,9 @@ export function AssistantScreen() {
     listenerRef.current = null;
     micRef.current?.stop();
     micRef.current = null;
-    stopSpeaking();
+    void ringRef.current?.stop();
+    ringRef.current = null;
+    stopVoice();
     setStateBoth("off");
     setLive("");
     setLevel(0);
@@ -453,27 +645,65 @@ export function AssistantScreen() {
   useEffect(() => () => {
     listenerRef.current?.stop();
     micRef.current?.stop();
+    void ringRef.current?.stop();
+  }, []);
+
+  /**
+   * Enrol a voice: wait while the person reads the line, take the seconds that just went by, embed
+   * them, and store the result for that name. Needs the assistant started, so the ring is open.
+   */
+  const enrol = useCallback(async (name: string, line: string): Promise<string> => {
+    const ring = ringRef.current;
+    if (ring === null || !ring.running) {
+      throw new Error("press Start first, so the microphone is open");
+    }
+    await loadSpeakerModel();
+    await new Promise((resolve) => window.setTimeout(resolve, 4500));
+    const clip = ring.recent(4);
+    if (clip === null) {
+      throw new Error("nothing but silence was heard; read the line out loud after pressing");
+    }
+    const samples = await enrolVoice(name, await embedClip(clip), line);
+    return `Enrolled for ${name}: ${samples} sample${samples === 1 ? "" : "s"} now.`;
   }, []);
 
   const weakness = describeWakeWordWeakness(wakeWord);
 
   return (
-    <div className="assistant" data-state={state}>
-      <div className="eyeWrap">
+    <div className="assistant" data-state={problem !== null && state === "asleep" ? "error" : state} data-mode={mode}>
+      {/* In the kitchen the circle is the whole interface: tap it to start, tap again to stop. */}
+      <div
+        className="eyeWrap"
+        role={mode === "production" ? "button" : undefined}
+        tabIndex={mode === "production" ? 0 : undefined}
+        aria-label={mode === "production" ? (state === "off" ? "Start Wilson" : "Stop Wilson") : undefined}
+        onClick={mode === "production" ? () => (state === "off" ? void start() : stop()) : undefined}
+        onKeyDown={mode === "production" ? (e) => (e.key === "Enter" || e.key === " " ? (state === "off" ? void start() : stop()) : undefined) : undefined}
+      >
         <div className="eye" />
       </div>
 
       <p className="stateLine">
-        {state === "off" ? "Not listening" : null}
+        {state === "off" ? (mode === "production" ? "Tap to start" : "Not listening") : null}
         {state === "asleep" ? `Say "${wakeWord}"` : null}
         {state === "listening" ? "Listening" : null}
         {state === "thinking" ? "Thinking" : null}
         {state === "speaking" ? "Talking" : null}
       </p>
 
-      <p className="liveLine">{state === "off" ? "" : live}</p>
+      {mode === "production" ? (
+        <p className="heardLine">{state === "listening" || state === "thinking" ? live : ""}</p>
+      ) : (
+        <p className="liveLine">{state === "off" ? "" : live}</p>
+      )}
 
-      {state !== "off" ? (
+      {mode === "production" ? (
+        <button className="cornerButton" onClick={() => setMode("debug")}>
+          debug
+        </button>
+      ) : null}
+
+      {state !== "off" && mode === "debug" ? (
         <div className="mic">
           <div className="meter" aria-label="Microphone level">
             <div className="meterFill" style={{ width: `${Math.min(100, Math.round(level * 220))}%` }} />
@@ -485,24 +715,28 @@ export function AssistantScreen() {
             {" · "}
             {resultCount} results
             {lastHeardAt === null ? " · nothing heard yet" : ` · last heard ${Math.round((Date.now() - lastHeardAt) / 1000)}s ago`}
+            {voiceInfo !== null ? ` · voice ${voice}, first sound ${voiceInfo.firstSoundMs} ms` : ` · voice ${voice}`}
           </p>
           {notice !== null ? <p className="micNotice">{notice}</p> : null}
           {suppressed !== null ? <p className="micNotice">{suppressed}</p> : null}
         </div>
       ) : null}
 
-      <div className="assistantButtons">
-        {state === "off" ? (
-          <button className="big go" onClick={() => void start()}>Start</button>
-        ) : (
-          <button className="big stop" onClick={stop}>Stop</button>
-        )}
-        <button onClick={() => setSettingsOpen((o) => !o)}>{settingsOpen ? "Hide" : "Settings"}</button>
-      </div>
+      {mode === "debug" ? (
+        <div className="assistantButtons">
+          {state === "off" ? (
+            <button className="big go" onClick={() => void start()}>Start</button>
+          ) : (
+            <button className="big stop" onClick={stop}>Stop</button>
+          )}
+          <button onClick={() => setSettingsOpen((o) => !o)}>{settingsOpen ? "Hide" : "Settings"}</button>
+          <button onClick={() => setMode("production")}>Kitchen screen</button>
+        </div>
+      ) : null}
 
       {problem !== null ? <p className="verdict bad">{problem}</p> : null}
 
-      {settingsOpen ? (
+      {settingsOpen && mode === "debug" ? (
         <div className="settings">
           <label>
             Wake word
@@ -518,6 +752,20 @@ export function AssistantScreen() {
               spellCheck={false}
             />
           </label>
+          <label>
+            Voice
+            <select value={voice} onChange={(e) => setVoice(e.target.value as VoiceName)}>
+              {VOICES.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+          </label>
+          <p className="status">
+            Wilson speaks with Orpheus on Groq, voice {voice}, streamed as it is made.
+            {voiceInfo !== null ? ` Last reply: first sound after ${voiceInfo.firstSoundMs} ms, ${voiceInfo.seconds.toFixed(1)} s of speech.` : null}
+          </p>
           <p className="status">
             Listening runs on this device with {engine || "the speech model"}, and the audio never leaves it.
             {onDevice === false ? " The browser's own recogniser is not usable here." : null}
@@ -544,7 +792,7 @@ export function AssistantScreen() {
         </ul>
       ) : null}
 
-      {turns.length > 0 ? (
+      {turns.length > 0 && mode === "debug" ? (
         <ul className="turns">
           {turns.map((t) => (
             <li key={t.id}>
@@ -554,6 +802,17 @@ export function AssistantScreen() {
             </li>
           ))}
         </ul>
+      ) : null}
+
+      {mode === "debug" ? (
+        <DebugPanel
+          owner={owner}
+          onOwnerChange={setOwner}
+          enrol={enrol}
+          speakerStatus={speakerStatus}
+          lastIdentified={identified}
+          version={logVersion}
+        />
       ) : null}
     </div>
   );

--- a/apps/cc-assistant/src/assistant/DebugPanel.tsx
+++ b/apps/cc-assistant/src/assistant/DebugPanel.tsx
@@ -1,0 +1,292 @@
+// Everything Wilson knows and did, on one screen, clearly marked as the debug view.
+//
+// The production screen is one circle. This is the other screen: the turn log as the service kept
+// it, the people and what is remembered about each (editable, because a memory you cannot correct is
+// one you will not trust), the soul document (editable, versioned by the store), and voice enrolment.
+
+import { useCallback, useEffect, useState } from "react";
+import { ENROLMENT_LINES } from "./speakerId";
+
+const BASE = import.meta.env.BASE_URL;
+
+interface Person {
+  readonly key: string;
+  readonly name: string;
+  readonly profile: Record<string, string>;
+  readonly facts: ReadonlyArray<{ text: string; at: string; source: string }>;
+  readonly voiceSamples: number;
+}
+
+interface TurnRecord {
+  readonly at: string;
+  readonly kind: string;
+  readonly [field: string]: unknown;
+}
+
+export interface DebugPanelProps {
+  /** Who this device says is talking, until the voice says otherwise. */
+  readonly owner: string;
+  readonly onOwnerChange: (name: string) => void;
+  /** Record a few seconds and enrol it for a person. Provided by the screen, which owns the mic. */
+  readonly enrol: (name: string, line: string) => Promise<string>;
+  readonly speakerStatus: string;
+  readonly lastIdentified: string;
+  /** A counter the screen bumps after each turn so the log refreshes. */
+  readonly version: number;
+}
+
+export function DebugPanel({ owner, onOwnerChange, enrol, speakerStatus, lastIdentified, version }: DebugPanelProps) {
+  const [turns, setTurns] = useState<TurnRecord[]>([]);
+  const [directory, setDirectory] = useState("");
+  const [people, setPeople] = useState<Person[]>([]);
+  const [places, setPlaces] = useState<Array<{ heard: string; name: string; admin1: string; country: string }>>([]);
+  const [memoryNote, setMemoryNote] = useState("");
+  const [soul, setSoul] = useState("");
+  const [soulDraft, setSoulDraft] = useState("");
+  const [soulNote, setSoulNote] = useState("");
+  const [enrolNote, setEnrolNote] = useState("");
+  const [enrolling, setEnrolling] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const t = (await (await fetch(`${BASE}api/turn?limit=60`)).json()) as { turns?: TurnRecord[]; directory?: string; reason?: string };
+      setTurns((t.turns ?? []).slice().reverse());
+      setDirectory(t.directory ?? t.reason ?? "");
+      const p = (await (await fetch(`${BASE}api/people`)).json()) as { people?: Person[]; places?: Array<{ heard: string; name: string; admin1: string; country: string }>; reason?: string };
+      setPeople(p.people ?? []);
+      setPlaces(p.places ?? []);
+      if (p.reason) {
+        setMemoryNote(p.reason);
+      }
+    } catch (error) {
+      setMemoryNote(`Could not read the service: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh, version]);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const s = (await (await fetch(`${BASE}api/soul`)).json()) as { soul?: string | null; reason?: string };
+        setSoul(s.soul ?? "");
+        setSoulDraft(s.soul ?? "");
+        if (s.reason) {
+          setSoulNote(s.reason);
+        }
+      } catch {
+        setSoulNote("Could not read the soul document.");
+      }
+    })();
+  }, []);
+
+  const saveSoul = async () => {
+    try {
+      const response = await fetch(`${BASE}api/soul`, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ soul: soulDraft }) });
+      const body = (await response.json()) as { soul?: string; error?: string };
+      if (!response.ok) {
+        setSoulNote(body.error ?? "Saving failed.");
+        return;
+      }
+      setSoul(body.soul ?? soulDraft);
+      setSoulNote("Saved. The next turn uses it.");
+    } catch (error) {
+      setSoulNote(`Saving failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  const editProfile = async (name: string, field: string, value: string) => {
+    await fetch(`${BASE}api/people`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name, profile: { [field]: value } }) });
+    await refresh();
+  };
+
+  const forget = async (name: string, text: string) => {
+    await fetch(`${BASE}api/people`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name, forget: text }) });
+    await refresh();
+  };
+
+  const forgetPlace = async (heard: string) => {
+    await fetch(`${BASE}api/people`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ forgetPlace: heard }) });
+    await refresh();
+  };
+
+  const clearLog = async () => {
+    await fetch(`${BASE}api/turn`, { method: "DELETE" });
+    await refresh();
+  };
+
+  const doEnrol = async (line: string) => {
+    if (owner.trim().length === 0) {
+      setEnrolNote("Say who you are first (the name box above).");
+      return;
+    }
+    setEnrolling(true);
+    setEnrolNote(`Read this out loud now: "${line}"`);
+    try {
+      setEnrolNote(await enrol(owner.trim(), line));
+      await refresh();
+    } catch (error) {
+      setEnrolNote(`Enrolment failed: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      setEnrolling(false);
+    }
+  };
+
+  return (
+    <div className="debug">
+      <div className="debugBanner">DEBUG VIEW. Nothing below is shown in the kitchen.</div>
+
+      <section className="debugBlock">
+        <h3>Who is talking</h3>
+        <label>
+          This device belongs to
+          <input value={owner} onChange={(e) => onOwnerChange(e.target.value)} placeholder="Soren" spellCheck={false} />
+        </label>
+        <p className="debugLine">Voice model: {speakerStatus}. Last turn identified as: {lastIdentified}.</p>
+        <p className="debugLine">Enrol your voice: press a line, then read it aloud. Three lines is enough. Do it once per person, with the name box set to that person.</p>
+        <div className="debugRow">
+          {ENROLMENT_LINES.map((line, i) => (
+            <button key={line} disabled={enrolling} onClick={() => void doEnrol(line)}>
+              Enrol line {i + 1}
+            </button>
+          ))}
+        </div>
+        {enrolNote.length > 0 ? <p className="debugLine strong">{enrolNote}</p> : null}
+      </section>
+
+      <section className="debugBlock">
+        <h3>People and memory</h3>
+        {memoryNote.length > 0 ? <p className="debugLine">{memoryNote}</p> : null}
+        {people.length === 0 ? <p className="debugLine">Nobody yet. Wilson adds a person the first time a name talks to it.</p> : null}
+        {people.map((p) => (
+          <div key={p.key} className="person">
+            <h4>
+              {p.name} <span className="dim">({p.voiceSamples} voice samples)</span>
+            </h4>
+            <div className="profileGrid">
+              {["callMe", "home", "currentLocation", "units", "household", "language"].map((field) => (
+                <label key={field}>
+                  {field}
+                  <input
+                    defaultValue={p.profile[field] ?? ""}
+                    spellCheck={false}
+                    onBlur={(e) => {
+                      if ((p.profile[field] ?? "") !== e.target.value) {
+                        void editProfile(p.name, field, e.target.value);
+                      }
+                    }}
+                  />
+                </label>
+              ))}
+            </div>
+            {p.facts.length === 0 ? (
+              <p className="debugLine">Nothing remembered yet.</p>
+            ) : (
+              <ul className="facts">
+                {p.facts
+                  .slice()
+                  .reverse()
+                  .map((f) => (
+                    <li key={f.at + f.text}>
+                      <span>{f.text}</span>
+                      <span className="dim">{f.at.slice(0, 16).replace("T", " ")}</span>
+                      <button onClick={() => void forget(p.name, f.text)}>forget</button>
+                    </li>
+                  ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </section>
+
+      <section className="debugBlock">
+        <h3>Places, as heard and as resolved</h3>
+        <p className="debugLine">A misheard name is corrected once and then remembered. If a correction is wrong, forget it here and it will be looked up fresh next time.</p>
+        {places.length === 0 ? (
+          <p className="debugLine">No places resolved yet.</p>
+        ) : (
+          <ul className="facts">
+            {places.map((pl) => (
+              <li key={pl.heard}>
+                <span>
+                  "{pl.heard}" is {pl.name}
+                  {pl.admin1 ? `, ${pl.admin1}` : ""}
+                  {pl.country ? `, ${pl.country}` : ""}
+                </span>
+                <button onClick={() => void forgetPlace(pl.heard)}>forget</button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="debugBlock">
+        <h3>Soul document</h3>
+        <p className="debugLine">Who Wilson is, in your words. Loaded into every turn. Previous versions are kept on disk.</p>
+        <textarea value={soulDraft} onChange={(e) => setSoulDraft(e.target.value)} rows={10} spellCheck={false} />
+        <div className="debugRow">
+          <button onClick={() => void saveSoul()} disabled={soulDraft === soul}>
+            Save soul
+          </button>
+          <button onClick={() => setSoulDraft(soul)} disabled={soulDraft === soul}>
+            Revert
+          </button>
+          {soulNote.length > 0 ? <span className="debugLine">{soulNote}</span> : null}
+        </div>
+      </section>
+
+      <section className="debugBlock">
+        <h3>Turn log</h3>
+        <p className="debugLine">
+          {directory.length > 0 ? `Kept at ${directory}` : ""} Newest first. Server lines are what was heard and decided; "spoken" lines are what the page actually said.
+        </p>
+        <div className="debugRow">
+          <button onClick={() => void refresh()}>Refresh</button>
+          <button onClick={() => void clearLog()}>Clear log</button>
+        </div>
+        <ul className="log">
+          {turns.map((t, i) => (
+            <li key={i}>
+              <span className="dim">{String(t.at).slice(11, 19)}</span>
+              <span className={`kind kind-${t.kind}`}>{t.kind}</span>
+              <span className="body">{describe(t)}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+/** One line per record, the fields that matter for that kind. */
+function describe(t: TurnRecord): string {
+  const parts: string[] = [];
+  const pick = (...fields: string[]) => {
+    for (const f of fields) {
+      const v = t[f];
+      if (v === undefined || v === null || v === "") {
+        continue;
+      }
+      parts.push(`${f}=${typeof v === "string" ? v : JSON.stringify(v)}`);
+    }
+  };
+  switch (t.kind) {
+    case "turn":
+      pick("speaker", "heard", "route", "actions", "query", "reply", "elapsedMs", "error");
+      break;
+    case "spoken":
+      pick("said", "by", "firstSoundMs", "speechSeconds", "identified", "confidence", "suppressed");
+      break;
+    case "remembered":
+      pick("speaker", "facts", "profile");
+      break;
+    case "weather":
+      pick("asked", "place", "via", "notFound");
+      break;
+    default:
+      pick(...Object.keys(t).filter((k) => k !== "at" && k !== "kind"));
+  }
+  return parts.join("  ");
+}

--- a/apps/cc-assistant/src/assistant/assistant.css
+++ b/apps/cc-assistant/src/assistant/assistant.css
@@ -103,3 +103,51 @@
 @media (prefers-reduced-motion: reduce) { .timers li.ringing .face { animation: none; } }
 .timerWarning { font-size: 11.5px; color: #5a626e; text-align: center; display: block; }
 .timers .tname { color: #ffb44d; font-weight: 700; text-transform: capitalize; }
+
+/* Two screens. Production is the eye and nothing else; debug is everything, and says so. */
+.assistant[data-mode="production"] { gap: 22px; justify-content: center; }
+.assistant[data-mode="production"] .eyeWrap { width: min(62vw, 360px); height: min(62vw, 360px); cursor: pointer; }
+.assistant[data-mode="production"] .stateLine { font-size: 18px; }
+.assistant[data-mode="production"] .cornerButton {
+  position: fixed; right: 14px; bottom: 14px; font-size: 11px; padding: 6px 10px; opacity: .35;
+}
+.assistant[data-mode="production"] .cornerButton:hover, .assistant[data-mode="production"] .cornerButton:focus-visible { opacity: 1; }
+[data-state="error"] .eye { --gain: .9; --bloom: 60px; --bloomA: .35; filter: hue-rotate(-20deg) brightness(.9); }
+.heardLine { margin: 0; color: #cdd3dc; font-size: 16px; max-width: 34ch; text-align: center; min-height: 24px; }
+
+.debug {
+  width: 100%; max-width: 760px; display: flex; flex-direction: column; gap: 14px; margin-top: 16px;
+  border-top: 2px dashed #3a2a12; padding-top: 14px;
+}
+.debugBanner {
+  font-size: 12px; letter-spacing: .14em; text-transform: uppercase; color: #ffb44d;
+  border: 1px solid #5a4110; background: #1c1508; border-radius: 6px; padding: 8px 12px; text-align: center;
+}
+.debugBlock { border: 1px solid #1c222b; border-radius: 8px; padding: 14px 16px; background: #0b0e13; display: flex; flex-direction: column; gap: 8px; }
+.debugBlock h3 { margin: 0; font-size: 12px; letter-spacing: .12em; text-transform: uppercase; color: #7a828e; }
+.debugBlock h4 { margin: 6px 0 0; font-size: 15px; color: #e4e7ec; }
+.debugBlock label { display: flex; flex-direction: column; gap: 4px; font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: #7a828e; }
+.debugBlock input, .debugBlock textarea, .settings select {
+  font: inherit; font-size: 14px; padding: 8px 10px; border-radius: 6px; border: 1px solid #262d38; background: #06070a; color: #e4e7ec;
+}
+.debugBlock textarea { font-family: "Cascadia Mono", Consolas, ui-monospace, monospace; font-size: 13px; line-height: 1.5; resize: vertical; }
+.debugLine { margin: 0; font-size: 13px; color: #7a828e; }
+.debugLine.strong { color: #ffb44d; }
+.debugRow { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.debugBlock button { font-size: 12.5px; padding: 7px 12px; }
+.debugBlock button:disabled { opacity: .4; cursor: default; }
+.dim { color: #4a5260; font-size: 11.5px; }
+.person { border-top: 1px solid #1c222b; padding-top: 8px; display: flex; flex-direction: column; gap: 8px; }
+.profileGrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 8px; }
+.facts { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.facts li { display: flex; gap: 10px; align-items: baseline; font-size: 13.5px; color: #cdd3dc; }
+.facts li span:first-child { flex: 1; }
+.facts button { font-size: 11px; padding: 3px 8px; }
+.log { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 3px; max-height: 420px; overflow: auto;
+  font-family: "Cascadia Mono", Consolas, ui-monospace, monospace; font-size: 12px; }
+.log li { display: grid; grid-template-columns: 62px 92px 1fr; gap: 8px; align-items: baseline; }
+.log .kind { color: #7a828e; }
+.log .kind-turn { color: #4fbf8b; }
+.log .kind-spoken { color: #ffb44d; }
+.log .kind-remembered { color: #9085e9; }
+.log .body { color: #cdd3dc; white-space: pre-wrap; word-break: break-word; }

--- a/apps/cc-assistant/src/assistant/speakerId.ts
+++ b/apps/cc-assistant/src/assistant/speakerId.ts
@@ -1,0 +1,211 @@
+// Who is speaking, from how the voice sounds.
+//
+// A speaker-verification model (WavLM base plus SV, via transformers.js) turns a few seconds of
+// audio into a vector of 512 numbers that describes the voice, not the words. Two clips of the same
+// person land close together; two people land apart. Enrolment stores a few of those vectors per
+// person on the Wilson service; every command is then matched against them (api/voice.js).
+//
+// Raw audio never leaves the device. Only the vector does, and only to the local service.
+//
+// The platform recogniser gives us text and swallows the audio, so this keeps its own microphone
+// open in parallel and remembers the last few seconds. When a command is heard, the seconds that
+// just went by are the utterance.
+//
+// The model is fetched from the Hugging Face hub on first use (about 90 MB, cached by the browser
+// afterwards). Until it has loaded, identification reports "not ready" and the turn proceeds without
+// a name, which is the correct answer rather than a guess.
+
+import { startPcmCapture, type PcmCapture, MODEL_SAMPLE_RATE } from "../audio/pcmCapture";
+
+const MODEL_ID = "Xenova/wavlm-base-plus-sv";
+const RING_SECONDS = 8;
+const CHUNK_SECONDS = 0.25;
+/** Below this peak the clip is silence, and a silence embedding matches nobody, so do not try. */
+const MIN_PEAK = 0.02;
+
+export interface SpeakerModelStatus {
+  readonly state: "idle" | "loading" | "ready" | "failed";
+  readonly detail: string;
+}
+
+type Embedder = (samples: Float32Array) => Promise<number[]>;
+
+let embedder: Embedder | null = null;
+let loading: Promise<Embedder> | null = null;
+let status: SpeakerModelStatus = { state: "idle", detail: "not loaded" };
+const watchers = new Set<(s: SpeakerModelStatus) => void>();
+
+function setStatus(next: SpeakerModelStatus): void {
+  status = next;
+  for (const w of watchers) {
+    w(next);
+  }
+}
+
+export function speakerModelStatus(): SpeakerModelStatus {
+  return status;
+}
+
+export function watchSpeakerModel(watcher: (s: SpeakerModelStatus) => void): () => void {
+  watchers.add(watcher);
+  watcher(status);
+  return () => watchers.delete(watcher);
+}
+
+/** Load the model once. Safe to call repeatedly; later calls share the first load. */
+export function loadSpeakerModel(): Promise<Embedder> {
+  if (embedder !== null) {
+    return Promise.resolve(embedder);
+  }
+  if (loading !== null) {
+    return loading;
+  }
+  setStatus({ state: "loading", detail: "fetching the voice model" });
+  loading = (async () => {
+    const startedAt = performance.now();
+    const transformers = await import("@huggingface/transformers");
+    const { AutoProcessor, WavLMForXVector } = transformers as unknown as {
+      AutoProcessor: { from_pretrained(id: string): Promise<(audio: Float32Array) => Promise<Record<string, unknown>>> };
+      WavLMForXVector: { from_pretrained(id: string, options?: Record<string, unknown>): Promise<(inputs: Record<string, unknown>) => Promise<{ embeddings: { data: Float32Array } }>> };
+    };
+    const processor = await AutoProcessor.from_pretrained(MODEL_ID);
+    const model = await WavLMForXVector.from_pretrained(MODEL_ID);
+    const made: Embedder = async (samples) => {
+      const inputs = await processor(samples);
+      const { embeddings } = await model(inputs);
+      const out = Array.from(embeddings.data);
+      // Unit length, so cosine similarity on the server is a plain dot product of comparable vectors.
+      const norm = Math.sqrt(out.reduce((s, v) => s + v * v, 0)) || 1;
+      return out.map((v) => v / norm);
+    };
+    embedder = made;
+    setStatus({ state: "ready", detail: `voice model ready in ${Math.round(performance.now() - startedAt)} ms` });
+    return made;
+  })();
+  loading.catch((error: unknown) => {
+    loading = null;
+    setStatus({ state: "failed", detail: `voice model failed to load: ${error instanceof Error ? error.message : String(error)}` });
+  });
+  return loading;
+}
+
+/** A rolling window of the last few seconds from the microphone, at the model's sample rate. */
+export class VoiceRing {
+  private capture: PcmCapture | null = null;
+  private ring = new Float32Array(RING_SECONDS * MODEL_SAMPLE_RATE);
+  private filled = 0;
+  private lastPeak = 0;
+
+  async start(workletUrl: string): Promise<void> {
+    if (this.capture !== null) {
+      return;
+    }
+    this.capture = await startPcmCapture(CHUNK_SECONDS, workletUrl, (chunk) => {
+      const n = chunk.samples.length;
+      if (n >= this.ring.length) {
+        this.ring.set(chunk.samples.subarray(n - this.ring.length));
+      } else {
+        this.ring.copyWithin(0, n);
+        this.ring.set(chunk.samples, this.ring.length - n);
+      }
+      this.filled = Math.min(this.ring.length, this.filled + n);
+      this.lastPeak = chunk.peak;
+    });
+  }
+
+  async stop(): Promise<void> {
+    const c = this.capture;
+    this.capture = null;
+    this.filled = 0;
+    if (c !== null) {
+      await c.stop();
+    }
+  }
+
+  get running(): boolean {
+    return this.capture !== null;
+  }
+
+  /** The most recent `seconds` of audio, or null when there is not enough yet or it is silence. */
+  recent(seconds: number): Float32Array | null {
+    const wanted = Math.min(this.ring.length, Math.round(seconds * MODEL_SAMPLE_RATE));
+    if (this.filled < wanted) {
+      return null;
+    }
+    const clip = this.ring.slice(this.ring.length - wanted);
+    let peak = 0;
+    for (let i = 0; i < clip.length; i += 1) {
+      const a = Math.abs(clip[i]);
+      if (a > peak) {
+        peak = a;
+      }
+    }
+    return peak < MIN_PEAK ? null : clip;
+  }
+
+  get peak(): number {
+    return this.lastPeak;
+  }
+}
+
+/** Embed a clip. Rejects when the model is not loaded yet, rather than blocking a turn on a download. */
+export async function embedClip(samples: Float32Array): Promise<number[]> {
+  if (embedder === null) {
+    void loadSpeakerModel();
+    throw new Error(status.state === "loading" ? "the voice model is still loading" : "the voice model is not loaded");
+  }
+  return embedder(samples);
+}
+
+export interface Identified {
+  readonly name: string | null;
+  readonly confidence: number;
+  readonly reason: string | null;
+  readonly scores: ReadonlyArray<{ name: string; score: number }>;
+}
+
+/** Ask the service whose voice this is. */
+export async function identifyVoice(embedding: number[]): Promise<Identified> {
+  const response = await fetch(`${import.meta.env.BASE_URL}api/voice`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "identify", embedding }),
+  });
+  const body = (await response.json()) as Identified & { error?: string };
+  if (!response.ok) {
+    throw new Error(body.error ?? `Identification failed (${response.status}).`);
+  }
+  return body;
+}
+
+/** Store one enrolment sample for a person. Returns how many they now have. */
+export async function enrolVoice(name: string, embedding: number[], label: string): Promise<number> {
+  const response = await fetch(`${import.meta.env.BASE_URL}api/voice`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "enrol", name, embedding, label }),
+  });
+  const body = (await response.json()) as { samples?: number; error?: string };
+  if (!response.ok || typeof body.samples !== "number") {
+    throw new Error(body.error ?? `Enrolment failed (${response.status}).`);
+  }
+  return body.samples;
+}
+
+export async function clearVoice(name: string): Promise<void> {
+  const response = await fetch(`${import.meta.env.BASE_URL}api/voice`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "clear", name }),
+  });
+  if (!response.ok) {
+    throw new Error(`Clearing the voice failed (${response.status}).`);
+  }
+}
+
+/** The sentences a person reads when enrolling. Varied sounds, short enough to say in four seconds. */
+export const ENROLMENT_LINES = [
+  "Wilson, set a timer for ten minutes and tell me the weather.",
+  "The quick brown fox jumps over the lazy dog every single morning.",
+  "I would like a cup of coffee, two eggs, and the news from Toronto.",
+];

--- a/apps/cc-assistant/src/assistant/speech.ts
+++ b/apps/cc-assistant/src/assistant/speech.ts
@@ -186,8 +186,11 @@ export function createListener(language: string, preferLocal: boolean, events: L
   };
 }
 
-/** Say something out loud. Resolves when it has finished, or when it is cut off. */
-export function speak(text: string, onStart?: () => void): Promise<void> {
+/**
+ * The browser's own voice. No longer Wilson's voice (that is voice.ts, streamed from the server);
+ * kept for the diagnostics screens, which compare engines.
+ */
+export function speakWithBrowserVoice(text: string, onStart?: () => void): Promise<void> {
   return new Promise((resolve) => {
     if (typeof speechSynthesis === "undefined") {
       resolve();
@@ -203,11 +206,82 @@ export function speak(text: string, onStart?: () => void): Promise<void> {
   });
 }
 
-/** Stop talking immediately, for when somebody interrupts. */
-export function stopSpeaking(): void {
+/** Stop the browser's voice immediately. */
+export function stopBrowserVoice(): void {
   if (typeof speechSynthesis !== "undefined") {
     speechSynthesis.cancel();
   }
+}
+
+/**
+ * A short sound for a moment that needs marking: the instant speech begins, or a failure.
+ *
+ * "speak" is one quick rising note, a touch lower than the wake chirp so the two are not confused.
+ * "fail" is a low, slightly longer tone. Both local, instant, and quiet.
+ */
+export function cue(kind: "speak" | "fail"): void {
+  try {
+    const context = new AudioContext();
+    const now = context.currentTime;
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    oscillator.type = "sine";
+    if (kind === "speak") {
+      oscillator.frequency.setValueAtTime(520, now);
+      oscillator.frequency.exponentialRampToValueAtTime(780, now + 0.07);
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(0.14, now + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.09);
+      oscillator.start(now);
+      oscillator.stop(now + 0.1);
+    } else {
+      oscillator.frequency.setValueAtTime(220, now);
+      oscillator.frequency.exponentialRampToValueAtTime(160, now + 0.25);
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(0.2, now + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+      oscillator.start(now);
+      oscillator.stop(now + 0.32);
+    }
+    oscillator.connect(gain).connect(context.destination);
+    window.setTimeout(() => void context.close(), 600);
+  } catch {
+    // A missing sound is a cosmetic loss, not a reason to fail a turn.
+  }
+}
+
+/**
+ * The sound of thinking: a soft tick every 700 ms for as long as it runs, so a wait is audibly a
+ * wait and silence never means dead. Returns the function that stops it. On the search path the
+ * wait can be fifteen seconds; without this, that is fifteen seconds of wondering.
+ */
+export function startThinkingTicks(): () => void {
+  let context: AudioContext | null = null;
+  try {
+    context = new AudioContext();
+  } catch {
+    return () => undefined;
+  }
+  const ctx = context;
+  const tick = () => {
+    const now = ctx.currentTime;
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+    oscillator.type = "triangle";
+    oscillator.frequency.value = 1320;
+    gain.gain.setValueAtTime(0, now);
+    gain.gain.linearRampToValueAtTime(0.05, now + 0.005);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.04);
+    oscillator.connect(gain).connect(ctx.destination);
+    oscillator.start(now);
+    oscillator.stop(now + 0.05);
+  };
+  // The first tick waits: a reply that arrives in 200 ms should never tick at all.
+  const interval = window.setInterval(tick, 700);
+  return () => {
+    window.clearInterval(interval);
+    void ctx.close();
+  };
 }
 
 /**

--- a/apps/cc-assistant/src/assistant/voice.ts
+++ b/apps/cc-assistant/src/assistant/voice.ts
@@ -1,0 +1,218 @@
+// Wilson's voice: a WAV stream from the server, played as it arrives.
+//
+// The server (api/speak.js) starts sending audio about a quarter of a second after being asked, and
+// keeps sending while the rest of the sentence is still being made. Waiting for the whole file
+// before playing would add the entire generation time, most of a second for one sentence, on top.
+// So this reads the stream, turns each arriving block of 16-bit samples into an AudioBuffer, and
+// schedules it to play exactly where the previous block ends. The ear hears one continuous voice.
+//
+// One AudioContext for the life of the page, created on the Start press: browsers only allow audio
+// to start from a user gesture, and a context made later would begin suspended and play nothing.
+
+const BASE = import.meta.env.BASE_URL;
+
+/** Samples per scheduled block. 2400 at 24 kHz is 100 ms: small enough to start fast, large enough to be cheap. */
+const BLOCK_SAMPLES = 2400;
+/** How far ahead of "now" the first block is placed, to cover scheduling jitter. */
+const LEAD_SECONDS = 0.04;
+
+export const VOICES = ["austin", "daniel", "troy", "hannah", "diana", "autumn"] as const;
+export type VoiceName = (typeof VOICES)[number];
+export const DEFAULT_VOICE: VoiceName = "austin";
+
+let context: AudioContext | null = null;
+let current: { abort: AbortController; sources: AudioBufferSourceNode[] } | null = null;
+
+/** Call from a user gesture, once. Makes and resumes the context so later speech is allowed to play. */
+export async function unlockVoice(): Promise<void> {
+  if (context === null) {
+    context = new AudioContext();
+  }
+  if (context.state !== "running") {
+    await context.resume();
+  }
+}
+
+export interface Spoken {
+  /** Milliseconds from asking to the first sound. The number that matters; shown in diagnostics. */
+  readonly firstSoundMs: number;
+  /** Seconds of audio played. */
+  readonly seconds: number;
+}
+
+/**
+ * Speak a sentence in Wilson's voice. Resolves when the last sample has played, or when cut off.
+ * Rejects with a plain message when the voice cannot be reached, so the caller can show it.
+ */
+export function speakStreamed(text: string, voice: VoiceName, onStart?: () => void): Promise<Spoken> {
+  return new Promise<Spoken>((resolve, reject) => {
+    if (context === null) {
+      reject(new Error("The voice was not unlocked. Press Start first."));
+      return;
+    }
+    const ctx = context;
+    stopVoice();
+    const abort = new AbortController();
+    const mine = { abort, sources: [] as AudioBufferSourceNode[] };
+    current = mine;
+
+    const askedAt = performance.now();
+    let firstSoundMs = -1;
+    let nextStart = 0;
+    let totalSeconds = 0;
+    let sampleRate = 24000;
+    let headerDone = false;
+    let held = new Uint8Array(0);
+    let finishedReading = false;
+    let scheduled = 0;
+    let ended = 0;
+
+    const maybeResolve = () => {
+      if (finishedReading && ended >= scheduled) {
+        if (current === mine) {
+          current = null;
+        }
+        resolve({ firstSoundMs: firstSoundMs < 0 ? 0 : firstSoundMs, seconds: totalSeconds });
+      }
+    };
+
+    const schedule = (pcm: Int16Array) => {
+      const buffer = ctx.createBuffer(1, pcm.length, sampleRate);
+      const channel = buffer.getChannelData(0);
+      for (let i = 0; i < pcm.length; i += 1) {
+        channel[i] = pcm[i] / 32768;
+      }
+      const source = ctx.createBufferSource();
+      source.buffer = buffer;
+      source.connect(ctx.destination);
+      if (nextStart < ctx.currentTime + LEAD_SECONDS) {
+        nextStart = ctx.currentTime + LEAD_SECONDS;
+      }
+      if (firstSoundMs < 0) {
+        firstSoundMs = Math.round(performance.now() - askedAt + LEAD_SECONDS * 1000);
+        onStart?.();
+      }
+      source.onended = () => {
+        ended += 1;
+        maybeResolve();
+      };
+      source.start(nextStart);
+      nextStart += buffer.duration;
+      totalSeconds += buffer.duration;
+      scheduled += 1;
+      mine.sources.push(source);
+    };
+
+    // Whole samples only: a chunk can end halfway through a 16-bit sample, and the odd byte is
+    // carried to the next chunk rather than played as noise.
+    let carry = new Uint8Array(0);
+    const feed = (bytes: Uint8Array) => {
+      const joined = new Uint8Array(carry.length + bytes.length);
+      joined.set(carry);
+      joined.set(bytes, carry.length);
+      const usable = joined.length - (joined.length % 2);
+      const samples = new Int16Array(joined.buffer.slice(0, usable));
+      carry = joined.slice(usable);
+      for (let at = 0; at < samples.length; at += BLOCK_SAMPLES) {
+        schedule(samples.subarray(at, Math.min(at + BLOCK_SAMPLES, samples.length)));
+      }
+    };
+
+    const parseHeader = (bytes: Uint8Array): Uint8Array | null => {
+      const joined = new Uint8Array(held.length + bytes.length);
+      joined.set(held);
+      joined.set(bytes, held.length);
+      held = joined;
+      const dataAt = findAscii(held, "data");
+      if (dataAt < 0 || held.length < dataAt + 8) {
+        return null;
+      }
+      const fmtAt = findAscii(held, "fmt ");
+      if (fmtAt >= 0) {
+        const view = new DataView(held.buffer, held.byteOffset, held.byteLength);
+        sampleRate = view.getUint32(fmtAt + 12, true);
+      }
+      headerDone = true;
+      const rest = held.slice(dataAt + 8);
+      held = new Uint8Array(0);
+      return rest;
+    };
+
+    (async () => {
+      const response = await fetch(`${BASE}api/speak`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text, voice }),
+        signal: abort.signal,
+      });
+      if (!response.ok || response.body === null) {
+        let message = `The voice failed (${response.status}).`;
+        try {
+          const body = (await response.json()) as { error?: string };
+          if (body.error) {
+            message = body.error;
+          }
+        } catch {
+          // The status is the message.
+        }
+        throw new Error(message);
+      }
+      const reader = response.body.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        if (!headerDone) {
+          const pcm = parseHeader(value);
+          if (pcm !== null && pcm.length > 0) {
+            feed(pcm);
+          }
+        } else {
+          feed(value);
+        }
+      }
+      finishedReading = true;
+      maybeResolve();
+    })().catch((error: unknown) => {
+      if (current === mine) {
+        current = null;
+      }
+      if (abort.signal.aborted) {
+        resolve({ firstSoundMs: firstSoundMs < 0 ? 0 : firstSoundMs, seconds: totalSeconds });
+        return;
+      }
+      reject(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
+}
+
+/** Cut the voice off now, for when somebody interrupts. */
+export function stopVoice(): void {
+  if (current === null) {
+    return;
+  }
+  const stopping = current;
+  current = null;
+  stopping.abort.abort();
+  for (const source of stopping.sources) {
+    try {
+      source.onended = null;
+      source.stop();
+    } catch {
+      // Already finished.
+    }
+  }
+}
+
+function findAscii(bytes: Uint8Array, text: string): number {
+  outer: for (let i = 0; i + text.length <= bytes.length; i += 1) {
+    for (let j = 0; j < text.length; j += 1) {
+      if (bytes[i + j] !== text.charCodeAt(j)) {
+        continue outer;
+      }
+    }
+    return i;
+  }
+  return -1;
+}


### PR DESCRIPTION
Wilson: its own service, a memory, a soul, a voice, and two screens

Wilson stops being a static page with three stateless functions. server/wilson.mjs is
Wilson's own service: it serves the built page, runs the api/ functions in-process, and
gives them a place to keep things, which Vercel could not. The functions keep their
Vercel signature and take an optional third argument, the Wilson context; on Vercel they
run without it and Wilson has no memory there, stated plainly rather than papered over.

What it keeps, as plain files under %LOCALAPPDATA%\wilson so a person can read and delete
every line: household.json (people, profiles, remembered facts, resolved place names),
soul.md (who Wilson is, in the household's words, previous versions kept), and
turns.jsonl (one line per event, appended, never rewritten). Text only, never audio.

The voice is Orpheus on Groq, streamed. First audio in about a quarter of a second,
played as it arrives through Web Audio, replies over two hundred characters cut at
sentence ends and joined into one stream. The browser's voice is no longer Wilson's.

Memory works in two directions. Before a turn the person's profile, their remembered
facts and the household's place names go into the prompt. After the reply is out, the
fast model is asked whether anything worth keeping was said and the store decides
(dedupe, cap). Say "I'm up at the cottage in Parry Sound until Friday" once and a plain
"what's the weather" the next day answers for Parry Sound. "Get to know me" runs an
interview one question at a time. Until the voice says otherwise, the person is whoever
the device says it belongs to.

A misheard place name is now corrected. "Perry Sound" found nothing on the map; the
model is asked for sound-alike candidates and the one SPELLED closest to what was heard
wins, because the model on its own chose Port Perry twice for being nearer the hint.
Towns beat their airports. The resolved mapping is remembered and can be forgotten.

Two screens: the kitchen screen is one circle you tap, and the debug screen is
everything, under a banner that says so. A tick every 700 ms while thinking, a rising
note the instant speech starts, a low tone on failure.

Voice identification is built and not proven: WavLM x-vector embeddings in the browser,
enrolment from three read lines, cosine matching on the service with a threshold and a
margin so the answer is "unknown" before it is ever wrong. Proving it takes two real
voices in a real browser, which no test here can supply.

Issues thefrederiksen/devthrottle_internal#1863 thefrederiksen/devthrottle_internal#1864 thefrederiksen/devthrottle_internal#1865 thefrederiksen/devthrottle_internal#1866 thefrederiksen/devthrottle_internal#1868 thefrederiksen/devthrottle_internal#1869 and the local half of thefrederiksen/devthrottle_internal#1870; thefrederiksen/devthrottle_internal#1867 built,
awaiting a second voice.
