### PR TITLE
Wilson: cloud ears

### DIFF
--- a/apps/cc-assistant/HANDOVER.md
+++ b/apps/cc-assistant/HANDOVER.md
@@ -15,8 +15,11 @@ runs there, a memory: people with profiles and remembered facts, a per-household
 resolved place names, and a turn log, all as plain files under `%LOCALAPPDATA%\wilson`. It speaks
 with Orpheus streamed from Groq, ticks while it thinks, and has a kitchen screen (one circle) and a
 debug screen. Voice identification is built (WavLM x-vector in the browser, matching on the
-service) and NOT yet proven: it needs two real voices enrolled in a real browser. Issues #2612 to
-#2622 on the repo are the map. The Vercel deployment has none of the memory: its functions run
+service) and NOT yet proven: it needs two real voices enrolled in a real browser. Cloud ears (#2620) are in: after the wake word Wilson records the command itself, ends it on
+silence, and Whisper on Groq writes it down with the household's spellings as hints; the browser
+recogniser is left with the wake word only. The endpointing numbers live in `cloudEars.ts` and are
+the first thing to tune if clips end early or late. A local wake-word model for the Pi is the one
+remaining piece of hearing. Issues #2612 to #2622 on the repo are the map. The Vercel deployment has none of the memory: its functions run
 without the service and say so.
 
 Everything below is either a decision that has already been made and should not be relitigated

--- a/apps/cc-assistant/README.md
+++ b/apps/cc-assistant/README.md
@@ -43,6 +43,18 @@ The fast model routes by itself: when it decides a question needs looking up it 
 tool, and the server answers that with a second, slower model that has Groq's built-in web search.
 There is no separate classifier in front, because that would add a round trip to every turn.
 
+## Ears
+
+Two ways to hear a command, chosen in Settings:
+
+- **cloud** (default): the browser's recogniser hears only the wake word. From there Wilson records
+  from its own microphone until you go quiet (a quarter second of loudness at a time; three quiet
+  quarters end it), sends the clip to Whisper on Groq with the household's names and places as
+  spelling hints, and the words that come back are the command. About 300 ms, four cents an hour of
+  speech. This is the path the kitchen box will use, since a Raspberry Pi has no platform recogniser.
+- **browser**: the platform recogniser's own transcript, as before. Free, instant, and only exists
+  where the OS ships one.
+
 ## The rules, and the bugs that produced them
 
 Every one of these came from something that actually went wrong, and every one is kept as a test so
@@ -133,6 +145,8 @@ proxy straight to Vercel, because it keeps the tailnet name as the Host header a
 | `src/wakeWord/wakeWordMatcher.ts` | Finding the chosen word in a transcript |
 | `api/talk.js` | The brain: soul + rules + memory in, a sentence or a tool call out; `look_up` runs here |
 | `api/speak.js` | The voice: Orpheus on Groq, streamed |
+| `api/hear.js` | The ears: a clip in, Whisper on Groq writes it down, with the household's spellings as hints |
+| `src/assistant/cloudEars.ts` | Recording a command until the person goes quiet, and sending it to be heard |
 | `api/weather.js` | Open-Meteo, with misheard names corrected and remembered |
 | `api/turn.js` `api/people.js` `api/soul.js` `api/voice.js` | The log, the people and their memory, the soul document, voice enrolment and matching |
 | `api/result.js` | Where diagnostics reports go |

--- a/apps/cc-assistant/api/hear.js
+++ b/apps/cc-assistant/api/hear.js
@@ -1,0 +1,96 @@
+// Wilson's own hearing. A short clip of speech in, its words out.
+//
+// The browser's recogniser only exists where the platform ships one (Google's on Android,
+// Microsoft's on Windows); a Raspberry Pi has none. So the device records what was said after the
+// wake word and this sends the clip to Groq's Whisper on the same key as the brain and the voice.
+// whisper-large-v3-turbo runs at about 216 times real time and costs four cents an hour of audio.
+//
+// The clip comes as a WAV body (16 kHz, 16-bit mono from the page). Whisper takes a prompt of
+// known spellings, which is how "Perry Sound" becomes "Parry Sound" at the source: the household's
+// names and places, plus whatever the page passes (the wake word), go in.
+//
+// Web Request/Response signature: the body is raw audio, and this signature reads it as bytes
+// without anything trying to parse it as JSON.
+
+const GROQ_STT_URL = "https://api.groq.com/openai/v1/audio/transcriptions";
+const MODEL = "whisper-large-v3-turbo";
+/** Whisper's prompt is capped at 224 tokens; a comma list of names stays well inside at this length. */
+const MAX_PROMPT_CHARS = 600;
+const MIN_BYTES = 44 + 16000 * 2 * 0.3; // less than 0.3 s of audio is a click, not speech
+
+/** The spelling hints for this household, as one Whisper prompt. */
+export function hintsFor(words) {
+  const seen = new Set();
+  const list = [];
+  for (const w of words) {
+    const clean = String(w || "").trim();
+    if (clean.length === 0 || seen.has(clean.toLowerCase())) {
+      continue;
+    }
+    seen.add(clean.toLowerCase());
+    list.push(clean);
+  }
+  let prompt = list.join(", ");
+  if (prompt.length > MAX_PROMPT_CHARS) {
+    prompt = prompt.slice(0, MAX_PROMPT_CHARS).replace(/,[^,]*$/, "");
+  }
+  return prompt;
+}
+
+export default async function handler(request, wilson) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Send the audio with POST." }, { status: 405 });
+  }
+  const key = process.env.GROQ_API_KEY;
+  if (!key) {
+    return Response.json({ error: "The assistant has no model key configured on the server." }, { status: 500 });
+  }
+
+  const audio = new Uint8Array(await request.arrayBuffer());
+  if (audio.length < MIN_BYTES) {
+    return Response.json({ error: "The clip was too short to hold speech." }, { status: 400 });
+  }
+
+  const url = new URL(request.url, "http://localhost");
+  const fromPage = (url.searchParams.get("hints") || "").split(",");
+  const fromStore = wilson
+    ? [...wilson.store.people().map((p) => p.name), ...wilson.store.knownPlaceNames(), ...wilson.store.people().flatMap((p) => [p.profile.home, p.profile.currentLocation])]
+    : [];
+  const prompt = hintsFor([...fromPage, ...fromStore]);
+
+  const form = new FormData();
+  form.append("file", new Blob([audio], { type: "audio/wav" }), "clip.wav");
+  form.append("model", MODEL);
+  form.append("language", "en");
+  form.append("response_format", "json");
+  form.append("temperature", "0");
+  if (prompt.length > 0) {
+    form.append("prompt", prompt);
+  }
+
+  const startedAt = Date.now();
+  let upstream;
+  try {
+    upstream = await fetch(GROQ_STT_URL, { method: "POST", headers: { Authorization: `Bearer ${key}` }, body: form });
+  } catch (error) {
+    console.log("HEAR UNREACHABLE " + String(error));
+    return Response.json({ error: "The hearing service could not be reached." }, { status: 502 });
+  }
+  if (!upstream.ok) {
+    const detail = (await upstream.text()).slice(0, 300);
+    console.log("HEAR UPSTREAM FAILED " + upstream.status + " " + detail);
+    if (wilson) {
+      wilson.store.log({ kind: "hear", error: `whisper ${upstream.status}`, detail, bytes: audio.length });
+    }
+    return Response.json({ error: `The hearing service refused the clip (${upstream.status}).` }, { status: 502 });
+  }
+  const body = await upstream.json();
+  const text = typeof body.text === "string" ? body.text.trim() : "";
+  const elapsedMs = Date.now() - startedAt;
+  const seconds = Number(((audio.length - 44) / (16000 * 2)).toFixed(2));
+  console.log("HEAR " + JSON.stringify({ at: new Date().toISOString(), elapsedMs, seconds, text }));
+  if (wilson) {
+    wilson.store.log({ kind: "hear", text, seconds, elapsedMs, hints: prompt.length > 0 ? prompt : null });
+  }
+  return Response.json({ text, elapsedMs, seconds, model: MODEL });
+}

--- a/apps/cc-assistant/server/wilson.mjs
+++ b/apps/cc-assistant/server/wilson.mjs
@@ -50,6 +50,15 @@ for (const name of ["talk", "weather", "result", "turn", "soul", "people", "voic
   api[name] = (await import(`file:///${APP.replace(/\\/g, "/")}/api/${name}.js`)).default;
 }
 const speak = (await import(`file:///${APP.replace(/\\/g, "/")}/api/speak.js`)).default;
+const hear = (await import(`file:///${APP.replace(/\\/g, "/")}/api/hear.js`)).default;
+
+function readBytes(req) {
+  return new Promise((resolve) => {
+    const parts = [];
+    req.on("data", (c) => parts.push(c));
+    req.on("end", () => resolve(Buffer.concat(parts)));
+  });
+}
 
 const MIME = {
   ".html": "text/html", ".js": "text/javascript", ".css": "text/css", ".json": "application/json", ".wav": "audio/wav",
@@ -93,6 +102,17 @@ http
         }
         res.end();
         console.log(`${new Date().toISOString()} speak ${response.status} first-bytes ${first}ms total ${Date.now() - started}ms ${bytes} bytes`);
+        return;
+      }
+
+      if (url.pathname === `${BASE}/api/hear`) {
+        const bytes = await readBytes(req);
+        const started = Date.now();
+        const response = await hear(new Request("http://localhost" + req.url, { method: req.method, headers: { "content-type": "audio/wav" }, body: bytes }), wilson);
+        const text = await response.text();
+        res.writeHead(response.status, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+        res.end(text);
+        console.log(`${new Date().toISOString()} hear ${response.status} ${Date.now() - started}ms ${bytes.length} bytes`);
         return;
       }
 

--- a/apps/cc-assistant/src/assistant/AssistantScreen.tsx
+++ b/apps/cc-assistant/src/assistant/AssistantScreen.tsx
@@ -4,6 +4,7 @@ import { chirp, createListener, cue, localRecognitionReady, startThinkingTicks, 
 import { DEFAULT_VOICE, VOICES, speakStreamed, stopVoice, unlockVoice, type VoiceName } from "./voice";
 import { DebugPanel } from "./DebugPanel";
 import { VoiceRing, embedClip, enrolVoice, identifyVoice, loadSpeakerModel, watchSpeakerModel } from "./speakerId";
+import { captureUtterance, transcribeClip, type Captured } from "./cloudEars";
 import { watchMicLevel, type MicLevel } from "./micLevel";
 import { judgeEcho, similarity, ECHO_SIMILARITY } from "./echoGuard";
 import { clockFace as clockFaceOf } from "../skills/timerParse";
@@ -33,6 +34,13 @@ const HOME_KEY = "cc-assistant.home";
 const VOICE_KEY = "cc-assistant.voice";
 const OWNER_KEY = "cc-assistant.owner";
 const MODE_KEY = "cc-assistant.mode";
+const EARS_KEY = "cc-assistant.ears";
+
+// How the command is heard. "browser": the platform recogniser's transcript, as before. "cloud":
+// Wilson records the command itself and Whisper on Groq writes it down (the path the kitchen box
+// will use, since a Pi has no platform recogniser). The wake word is heard by the recogniser either
+// way, for now.
+type Ears = "browser" | "cloud";
 const WORKLET_URL = `${import.meta.env.BASE_URL}pcm-worklet.js`;
 /** How much of the last few seconds is the command, for identifying the voice. */
 const IDENTIFY_SECONDS = 3.5;
@@ -104,6 +112,18 @@ export function AssistantScreen() {
   });
   const ownerRef = useRef(owner);
   ownerRef.current = owner;
+  const [ears, setEars] = useState<Ears>(() => {
+    try {
+      return window.localStorage.getItem(EARS_KEY) === "browser" ? "browser" : "cloud";
+    } catch {
+      return "cloud";
+    }
+  });
+  const earsRef = useRef<Ears>(ears);
+  earsRef.current = ears;
+  // What the cloud ears last did: clip length, how it ended, Whisper's time and words.
+  const [earsInfo, setEarsInfo] = useState("");
+  const captureRef = useRef<{ stop(): void } | null>(null);
   const [speakerStatus, setSpeakerStatus] = useState("not loaded");
   const [identified, setIdentified] = useState("nobody yet");
   const identifiedRef = useRef<{ name: string | null; confidence: number } | null>(null);
@@ -169,10 +189,11 @@ export function AssistantScreen() {
     try {
       window.localStorage.setItem(OWNER_KEY, owner);
       window.localStorage.setItem(MODE_KEY, mode);
+      window.localStorage.setItem(EARS_KEY, ears);
     } catch {
       // Same.
     }
-  }, [owner, mode]);
+  }, [owner, mode, ears]);
 
   useEffect(() => watchSpeakerModel((s) => setSpeakerStatus(s.detail)), []);
 
@@ -461,10 +482,10 @@ export function AssistantScreen() {
    * "unknown" costs a little personalisation, a wrong name costs trust.
    */
   const identifyThenAsk = useCallback(
-    async (command: string) => {
+    async (command: string, audio: Float32Array | null = null) => {
       identifiedRef.current = null;
       const ring = ringRef.current;
-      const clip = ring !== null && ring.running ? ring.recent(IDENTIFY_SECONDS) : null;
+      const clip = audio ?? (ring !== null && ring.running ? ring.recent(IDENTIFY_SECONDS) : null);
       if (clip !== null) {
         try {
           const result = await identifyVoice(await embedClip(clip));
@@ -483,6 +504,83 @@ export function AssistantScreen() {
       await ask(command);
     },
     [ask],
+  );
+
+  /**
+   * Cloud ears: record what follows the wake word until the person goes quiet, have Whisper write
+   * it down, take the wake word off the front, and ask. `afterWake` means the clip may hold only the
+   * wake word; then Wilson waits for one more utterance before giving up.
+   */
+  const hearCommand = useCallback(
+    async (afterWake: boolean) => {
+      const ring = ringRef.current;
+      if (ring === null || !ring.running || captureRef.current !== null) {
+        return;
+      }
+      const capture = captureUtterance(ring);
+      captureRef.current = capture;
+      let captured: Captured;
+      try {
+        captured = await capture.done;
+      } finally {
+        captureRef.current = null;
+      }
+      if (stateRef.current !== "listening") {
+        // Stopped, or it fell asleep while we recorded. Nothing to do with the clip.
+        return;
+      }
+      if (!captured.heardSpeech || captured.endedBy === "stopped") {
+        setEarsInfo(`cloud: nothing heard (${captured.endedBy})`);
+        chirp("sleep");
+        setStateBoth("asleep");
+        setLive("");
+        return;
+      }
+      setStateBoth("thinking");
+      let heard;
+      try {
+        heard = await transcribeClip(captured.samples, [wakeWordRef.current, ownerRef.current]);
+      } catch (error) {
+        cue("fail");
+        setProblem(`Hearing failed: ${error instanceof Error ? error.message : String(error)}`);
+        setStateBoth("asleep");
+        setLive("");
+        return;
+      }
+      setEarsInfo(`cloud: ${captured.seconds.toFixed(1)} s clip, ended by ${captured.endedBy}, Whisper ${heard.elapsedMs} ms: "${heard.text}"`);
+      setLive(heard.text);
+      setLastHeardAt(Date.now());
+      const match = matchWakeWord(heard.text, wakeWordRef.current);
+      const command = (match !== null ? match.command : heard.text).trim();
+      if (command.length === 0) {
+        if (afterWake) {
+          // Just the name. Wait for the actual request, once.
+          setStateBoth("listening");
+          followUpUntilRef.current = Date.now() + FOLLOW_UP_MS;
+          void hearCommand(false);
+          return;
+        }
+        chirp("sleep");
+        setStateBoth("asleep");
+        setLive("");
+        return;
+      }
+      // Whisper's own words, and the very clip it heard them in, for identifying the voice.
+      const guard = judgeEcho(command, {
+        speaking: speakingRef.current,
+        lastSpokeEndedAt: lastSpokeEndedAtRef.current,
+        recentlySpoken: recentlySpokenRef.current,
+        now: Date.now(),
+      });
+      if (guard.isEcho) {
+        setSuppressed(`Ignored "${command}" - ${guard.reason}`);
+        setStateBoth("asleep");
+        return;
+      }
+      setSuppressed(null);
+      await identifyThenAsk(command, captured.samples);
+    },
+    [identifyThenAsk, setStateBoth],
   );
 
   const onHeard = useCallback(
@@ -506,6 +604,11 @@ export function AssistantScreen() {
           chirp("wake");
           setStateBoth("listening");
           followUpUntilRef.current = Date.now() + FOLLOW_UP_MS;
+          // With cloud ears, the command is recorded from here and written down by Whisper; the
+          // recogniser's own transcript of it is not used.
+          if (earsRef.current === "cloud" && ringRef.current !== null && ringRef.current.running) {
+            void hearCommand(true);
+          }
         }
         // Interrupting while it talks: saying the word again cuts it off.
         if (stateRef.current === "speaking" && matchWakeWord(text, wakeWordRef.current) !== null) {
@@ -520,6 +623,13 @@ export function AssistantScreen() {
           setStateBoth("listening");
           followUpUntilRef.current = Date.now() + FOLLOW_UP_MS;
         }
+        return;
+      }
+
+      // Cloud ears: final transcripts from the recogniser are not commands. Everything after the wake
+      // is heard by Wilson's own microphone and Whisper (hearCommand). Only the wake word above and
+      // the alarm silencer further up use the recogniser's words.
+      if (earsRef.current === "cloud" && ringRef.current !== null && ringRef.current.running) {
         return;
       }
 
@@ -560,7 +670,7 @@ export function AssistantScreen() {
         void identifyThenAsk(text);
       }
     },
-    [identifyThenAsk, setStateBoth],
+    [hearCommand, identifyThenAsk, setStateBoth],
   );
 
   const start = useCallback(async () => {
@@ -633,6 +743,7 @@ export function AssistantScreen() {
     listenerRef.current = null;
     micRef.current?.stop();
     micRef.current = null;
+    captureRef.current?.stop();
     void ringRef.current?.stop();
     ringRef.current = null;
     stopVoice();
@@ -716,7 +827,9 @@ export function AssistantScreen() {
             {resultCount} results
             {lastHeardAt === null ? " · nothing heard yet" : ` · last heard ${Math.round((Date.now() - lastHeardAt) / 1000)}s ago`}
             {voiceInfo !== null ? ` · voice ${voice}, first sound ${voiceInfo.firstSoundMs} ms` : ` · voice ${voice}`}
+            {` · ears ${ears}`}
           </p>
+          {earsInfo.length > 0 ? <p className="micNotice">{earsInfo}</p> : null}
           {notice !== null ? <p className="micNotice">{notice}</p> : null}
           {suppressed !== null ? <p className="micNotice">{suppressed}</p> : null}
         </div>
@@ -762,6 +875,14 @@ export function AssistantScreen() {
               ))}
             </select>
           </label>
+          <label>
+            Ears
+            <select value={ears} onChange={(e) => setEars(e.target.value as Ears)}>
+              <option value="cloud">cloud: Wilson records, Whisper on Groq writes it down (the kitchen box path)</option>
+              <option value="browser">browser: the platform recogniser's transcript</option>
+            </select>
+          </label>
+          {earsInfo.length > 0 ? <p className="status">{earsInfo}</p> : null}
           <p className="status">
             Wilson speaks with Orpheus on Groq, voice {voice}, streamed as it is made.
             {voiceInfo !== null ? ` Last reply: first sound after ${voiceInfo.firstSoundMs} ms, ${voiceInfo.seconds.toFixed(1)} s of speech.` : null}

--- a/apps/cc-assistant/src/assistant/cloudEars.ts
+++ b/apps/cc-assistant/src/assistant/cloudEars.ts
@@ -1,0 +1,138 @@
+// Hearing a command with Wilson's own microphone, and having it written down in the cloud.
+//
+// The browser's recogniser still hears the wake word (it is free, it is already running, and the
+// Pi will get a local wake-word model of its own later). From the wake on, THIS takes over:
+//
+//   1. start collecting from the voice ring, including the second before the wake fired, because
+//      the wake is detected from an interim transcript and the command has usually already begun;
+//   2. keep collecting until the person has spoken and then gone quiet for a while, or a ceiling
+//      is hit; a person who says the wake word and nothing else gets a short clip and a follow-up;
+//   3. send the clip to api/hear (Whisper on Groq) with the household's spellings as hints;
+//   4. the wake word is cut off the front of what comes back, and the rest is the command.
+//
+// Endpointing is done on loudness per quarter-second chunk. It is crude and it is honest: the
+// numbers are on the debug screen, and a clip that was cut early or late can be seen and heard
+// about. The Pi will do exactly this, which is the point of doing it here first.
+
+import { MODEL_SAMPLE_RATE } from "../audio/pcmCapture";
+import type { VoiceRing } from "./speakerId";
+
+/** Audio kept from before the wake fired. */
+export const PRE_ROLL_SECONDS = 1.0;
+/** A chunk louder than this is speech. Below it, for long enough, the person has stopped. */
+export const SPEECH_PEAK = 0.03;
+/** Quiet chunks in a row that end the utterance, once speech has been heard. 3 x 0.25 s. */
+export const END_SILENCE_CHUNKS = 3;
+/** Chunks to wait for speech to begin after the wake before giving up. 12 x 0.25 s. */
+export const START_TIMEOUT_CHUNKS = 12;
+/** The longest a command may be, in chunks. 48 x 0.25 s. */
+export const MAX_CHUNKS = 48;
+
+export interface Captured {
+  readonly samples: Float32Array;
+  readonly seconds: number;
+  /** Why the capture ended: what the debug screen shows. */
+  readonly endedBy: "silence" | "ceiling" | "no-speech" | "stopped";
+  readonly heardSpeech: boolean;
+}
+
+/**
+ * Collect one utterance from the ring, starting now (plus pre-roll), ending on silence.
+ * `stop` can be called to end it early (the assistant was stopped). Never throws for a quiet room:
+ * a clip that holds no speech comes back marked "no-speech" and the caller decides.
+ */
+export function captureUtterance(ring: VoiceRing): { done: Promise<Captured>; stop(): void } {
+  const parts: Float32Array[] = [];
+  const preRoll = ring.recent(PRE_ROLL_SECONDS);
+  if (preRoll !== null) {
+    parts.push(preRoll);
+  }
+  let chunks = 0;
+  let quiet = 0;
+  let heardSpeech = false;
+  let unsubscribe = () => undefined as void;
+  let finish: (why: Captured["endedBy"]) => void = () => undefined;
+
+  const done = new Promise<Captured>((resolve) => {
+    finish = (why) => {
+      unsubscribe();
+      const total = parts.reduce((n, p) => n + p.length, 0);
+      const samples = new Float32Array(total);
+      let at = 0;
+      for (const p of parts) {
+        samples.set(p, at);
+        at += p.length;
+      }
+      resolve({ samples, seconds: total / MODEL_SAMPLE_RATE, endedBy: why, heardSpeech });
+    };
+    unsubscribe = ring.subscribe((chunk) => {
+      parts.push(chunk.samples.slice());
+      chunks += 1;
+      if (chunk.peak >= SPEECH_PEAK) {
+        heardSpeech = true;
+        quiet = 0;
+      } else {
+        quiet += 1;
+      }
+      if (heardSpeech && quiet >= END_SILENCE_CHUNKS) {
+        finish("silence");
+      } else if (!heardSpeech && chunks >= START_TIMEOUT_CHUNKS) {
+        finish("no-speech");
+      } else if (chunks >= MAX_CHUNKS) {
+        finish("ceiling");
+      }
+    });
+  });
+
+  return { done, stop: () => finish("stopped") };
+}
+
+/** 16-bit mono WAV bytes from float samples, for the hearing service. */
+export function toWav(samples: Float32Array, sampleRate = MODEL_SAMPLE_RATE): Uint8Array {
+  const bytes = new Uint8Array(44 + samples.length * 2);
+  const view = new DataView(bytes.buffer);
+  const ascii = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i += 1) {
+      view.setUint8(offset + i, text.charCodeAt(i));
+    }
+  };
+  ascii(0, "RIFF");
+  view.setUint32(4, 36 + samples.length * 2, true);
+  ascii(8, "WAVE");
+  ascii(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  ascii(36, "data");
+  view.setUint32(40, samples.length * 2, true);
+  for (let i = 0; i < samples.length; i += 1) {
+    const s = Math.max(-1, Math.min(1, samples[i]));
+    view.setInt16(44 + i * 2, s < 0 ? s * 32768 : s * 32767, true);
+  }
+  return bytes;
+}
+
+export interface Heard {
+  readonly text: string;
+  readonly elapsedMs: number;
+  readonly seconds: number;
+}
+
+/** Send a clip to be written down. Rejects with a plain message when the service cannot. */
+export async function transcribeClip(samples: Float32Array, hints: string[]): Promise<Heard> {
+  const query = hints.length > 0 ? `?hints=${encodeURIComponent(hints.join(","))}` : "";
+  const response = await fetch(`${import.meta.env.BASE_URL}api/hear${query}`, {
+    method: "POST",
+    headers: { "Content-Type": "audio/wav" },
+    body: toWav(samples),
+  });
+  const body = (await response.json()) as Heard & { error?: string };
+  if (!response.ok) {
+    throw new Error(body.error ?? `Hearing failed (${response.status}).`);
+  }
+  return body;
+}

--- a/apps/cc-assistant/src/assistant/speakerId.ts
+++ b/apps/cc-assistant/src/assistant/speakerId.ts
@@ -15,7 +15,7 @@
 // afterwards). Until it has loaded, identification reports "not ready" and the turn proceeds without
 // a name, which is the correct answer rather than a guess.
 
-import { startPcmCapture, type PcmCapture, MODEL_SAMPLE_RATE } from "../audio/pcmCapture";
+import { startPcmCapture, type PcmCapture, type PcmChunk, MODEL_SAMPLE_RATE } from "../audio/pcmCapture";
 
 const MODEL_ID = "Xenova/wavlm-base-plus-sv";
 const RING_SECONDS = 8;
@@ -95,6 +95,7 @@ export class VoiceRing {
   private ring = new Float32Array(RING_SECONDS * MODEL_SAMPLE_RATE);
   private filled = 0;
   private lastPeak = 0;
+  private listeners = new Set<(chunk: PcmChunk) => void>();
 
   async start(workletUrl: string): Promise<void> {
     if (this.capture !== null) {
@@ -110,7 +111,18 @@ export class VoiceRing {
       }
       this.filled = Math.min(this.ring.length, this.filled + n);
       this.lastPeak = chunk.peak;
+      for (const listener of this.listeners) {
+        listener(chunk);
+      }
     });
+  }
+
+  /** Hear every chunk as it arrives (the command capture uses this). Returns the unsubscribe. */
+  subscribe(listener: (chunk: PcmChunk) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
Wilson: cloud ears

Wilson hears the command with its own microphone now, and Whisper on Groq writes it
down. The browser's recogniser is left with one job, the wake word, because it only
exists where the platform ships one and the kitchen box will be a Raspberry Pi, which
has none.

From the wake on: record from the voice ring, including the second before the wake
fired, since the wake is detected from an interim transcript and the command has
usually begun; keep going until the person has spoken and then been quiet for three
quarter-seconds, or the ceiling; send the clip to api/hear, which hands it to
whisper-large-v3-turbo with the household's names and places as spelling hints; cut
the wake word off the front of what comes back and the rest is the command. The same
clip identifies the voice, so hearing and identification agree on what was said.

Measured: a real clip written down correctly in 351 ms, hints applied. Four cents an
hour of speech. Ears are a setting, cloud or browser, so both paths stay testable and
comparable on the same device.

Endpointing is done on loudness and its numbers are named constants at the top of
cloudEars.ts, on purpose: they will need tuning, and the debug screen shows how every
clip ended so the tuning is done from evidence.

Issue thefrederiksen/devthrottle_internal#1871, minus the local wake-word model for the Pi, which is the one piece of
hearing still to come.
