### PR TITLE
Wilson: a launcher for starting at logon

### DIFF
--- a/apps/cc-assistant/server/start-wilson.cmd
+++ b/apps/cc-assistant/server/start-wilson.cmd
@@ -1,0 +1,15 @@
+@echo off
+rem Starts Wilson's service. Used by the "Wilson" scheduled task at logon, and fine by hand.
+rem
+rem The Groq key is read from the credentials file below unless GROQ_API_KEY is already set.
+rem Output goes to %LOCALAPPDATA%\wilson\service.log next to Wilson's data, so a silent failure
+rem at logon can be read about afterwards.
+
+setlocal
+cd /d "%~dp0.."
+if "%WILSON_CREDENTIALS_FILE%"=="" set "WILSON_CREDENTIALS_FILE=%LOCALAPPDATA%\cc-director\config\credentials.env"
+if not exist "%LOCALAPPDATA%\wilson" mkdir "%LOCALAPPDATA%\wilson"
+echo %date% %time% starting Wilson from %cd% >> "%LOCALAPPDATA%\wilson\service.log"
+node server\wilson.mjs >> "%LOCALAPPDATA%\wilson\service.log" 2>&1
+echo %date% %time% Wilson exited with %errorlevel% >> "%LOCALAPPDATA%\wilson\service.log"
+endlocal


### PR DESCRIPTION
Wilson: a launcher for starting at logon

A one-file launcher for Wilson's service, so a scheduled task can start it at logon
without anyone typing the environment in. It reads the Groq key from the credentials
file unless GROQ_API_KEY is already set, and writes everything the service prints to
service.log next to Wilson's data, so a start that failed while nobody was looking can
be read about afterwards.

The scheduled task itself is machine configuration, registered by hand on the machine
Wilson runs on; the launcher is the part worth keeping with the code.
