### PR TITLE
Spawning into a mission failed through one of the two spawn doors

### DIFF
--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -127,12 +127,6 @@ public sealed class ControlApiHost : IAsyncDisposable
         => _gatewayClient?.ListFleetSessionsWithReachabilityAsync(ct);
 
     private TurnSummaryCache? _turnSummaryCache;
-    // Mission records (mission-as-first-class-unit-of-work): a durable, file-backed store with no runtime
-    // dependencies, so it is ready from construction (unlike the caches wired up in StartAsync).
-    // A Director runs on one person's machine and serves one owner, so its store is single-tenant: every
-    // record is Local's, including any written before missions carried an owner (#1039).
-    private readonly Core.Sessions.MissionStore _missionStore =
-        new(filePath: null, adoptUnattributedAs: Core.Tenancy.TenantId.Local);
     private SessionStatusWingman? _statusWingman;
     private ProactiveExplainService? _proactiveExplain;
     private TerminalStateDetector? _terminalStateDetector;
@@ -888,7 +882,7 @@ public sealed class ControlApiHost : IAsyncDisposable
         }
 
         return SessionCommandExecutor.DispatchAsync(_sessionManager, DirectorId, cmd,
-            new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, MissionStore = _missionStore, DirectorVersion = _version, Repositories = _repositoryRegistry, ReapplyGatewayAsync = ReapplyGatewayAsync });
+            new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, DirectorVersion = _version, Repositories = _repositoryRegistry, ReapplyGatewayAsync = ReapplyGatewayAsync });
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -265,8 +265,9 @@ internal static class ControlEndpoints
             Name = s.CustomName,
             Number = s.Number,
             // Mission attachment (mission-as-first-class-unit-of-work): the link + cached display name flow
-            // straight through the Gateway aggregation on the SessionDto; the RESOLVED Mission record lives
-            // in the Director's MissionStore.
+            // straight through the Gateway aggregation on the SessionDto. Both values were STAMPED by what
+            // the create or attach verb carried - the Mission record itself lives at the Gateway, and this
+            // Director holds no mission store to resolve one from (issue #2629).
             MissionId = s.MissionId,
             MissionName = s.MissionName,
             // Workflow seat (Workflows mission, phase 5b): the run this session executes, with its

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -26,9 +26,11 @@ internal sealed class SessionCommandServices
     /// <summary>The turn-summary + goal-assessment cache (setting a wingman goal kicks an assessment).</summary>
     public TurnSummaryCache? TurnSummaryCache { get; init; }
 
-    /// <summary>The Mission record store (attaching a session to a Mission, and honoring a create-time
-    /// MissionId, resolve the Mission's display name through it). Null skips Mission resolution.</summary>
-    public MissionStore? MissionStore { get; init; }
+    // There is deliberately NO mission store here. Missions are a fleet-level record owned by the Gateway,
+    // which resolves one in the caller's own tenant and sends the create/attach verb its NAME alongside its
+    // id; the Director stamps what it was handed. The Director-local store this field used to point at was
+    // a different, per-machine set that nothing wrote any more, and consulting it made a real mission look
+    // unknown (issue #2629). Do not reintroduce it.
 
     /// <summary>
     /// Gateway Cleanup mission, Phase 0 (wave 3): this Director's build version string, so a director-level
@@ -480,40 +482,39 @@ internal static class SessionCommandExecutor
                     $"invalid workflow seat: version {badVersion} is not a published version number.");
         }
 
-        // Mission attach at spawn. Missions are a FLEET-level concept and now live at the Gateway (source of
-        // truth), so the mission name that binds the session into a pod arrives ON the create request:
-        //   * GATEWAY path (MissionId AND MissionName both set): the Gateway already resolved+validated the
-        //     mission against its OWN store, so the Director stamps the attachment DIRECTLY - no local-store
-        //     lookup, no local validation. This is the end state.
-        //   * TRANSITIONAL BRIDGE (MissionId set, MissionName blank): an old caller hitting the Director's
-        //     POST /sessions directly for a Director-store mission. The Director resolves the name from its
-        //     own MissionStore exactly as before, rejecting an unknown mission. This local-lookup bridge is
-        //     TEMPORARY: it is REMOVED when the Gateway Cleanup Phase 1 drops the Director MissionStore, after
-        //     which the Director never resolves a mission name locally and only stamps what create carries.
-        //   * No MissionId: no attach.
-        // Resolved BEFORE creating the session (mirroring the explicit-role check) so an unknown mission never
-        // silently drops. attachMissionId / attachMissionName below carry the values stamped after creation.
+        // Mission attach at spawn. Missions are a FLEET-level concept and live at the Gateway (the source of
+        // truth), so the mission that binds the session into a pod arrives ON the create request, ID AND
+        // NAME TOGETHER: the Gateway resolved and validated it against its own tenant-scoped store before
+        // dispatching, and that resolution IS the authorization. The Director stamps what it was handed -
+        // no local store, no lookup, no second opinion. No MissionId means no attach.
+        //
+        // AN ID WITH NO NAME IS REFUSED, and the message says why (issue #2629). The Director used to
+        // resolve a bare id against its OWN missions.json - a different, per-machine, single-tenant set
+        // that nothing writes any more. So a caller that skipped the Gateway's resolution got a mission
+        // that was real, active and listed by `cc-devthrottle mission list` reported as UNKNOWN, with
+        // advice to create something that already existed. That bridge was documented as temporary from
+        // the day it was written and is now gone: a bare id means the caller bypassed the one place that
+        // can answer, and saying so plainly beats consulting a stale store and guessing.
+        //
+        // Resolved BEFORE creating the session (mirroring the explicit-role check) so a refused mission
+        // never leaves a started session attached to nothing. attachMissionId / attachMissionName below
+        // carry the values stamped after creation.
         Guid? attachMissionId = null;
         string? attachMissionName = null;
         if (req.MissionId is Guid createMissionId)
         {
-            if (!string.IsNullOrWhiteSpace(req.MissionName))
+            if (string.IsNullOrWhiteSpace(req.MissionName))
             {
-                // Gateway path: trust the Gateway's already-validated mission id + name; stamp directly.
-                attachMissionId = createMissionId;
-                attachMissionName = req.MissionName;
+                FileLog.Write($"[SessionCommandExecutor] create REFUSED: mission {createMissionId} arrived " +
+                              "with no name, so it was never resolved by the Gateway");
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
+                    $"mission '{createMissionId}' arrived without its name, so it was not resolved by the " +
+                    "Gateway. Missions live at the Gateway, not on this machine - spawn through the Gateway " +
+                    "(cc-devthrottle session spawn), which resolves the mission and sends its name.");
             }
-            else
-            {
-                // Transitional bridge: resolve the name from the local Director MissionStore. Removed with
-                // the Director MissionStore in Phase 1.
-                var mission = services?.MissionStore?.Get(Core.Tenancy.TenantId.Local, createMissionId);
-                if (mission is null)
-                    return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
-                        $"unknown mission '{createMissionId}'. Create it first with POST /missions.");
-                attachMissionId = mission.MissionId;
-                attachMissionName = mission.MissionName;
-            }
+            // The Gateway resolved this mission inside the caller's own tenant; stamp it.
+            attachMissionId = createMissionId;
+            attachMissionName = req.MissionName;
         }
 
         // RawCli requires a Command; validate before constructing the agent.
@@ -765,20 +766,18 @@ internal static class SessionCommandExecutor
     /// BadRequest. Returns the updated session mapped through the SAME <see cref="ControlEndpoints.Map"/> the
     /// stream snapshot uses. Mirrors <see cref="SetRole"/>.
     ///
-    /// The Mission NAME arrives one of two ways, exactly as it does on the create path (see the mission block
-    /// in <see cref="Create"/>), because a Mission is a FLEET-level record whose source of truth is the
-    /// Gateway and not this machine:
-    ///  * GATEWAY path (MissionId AND MissionName both set): the Gateway resolved the mission against its own
-    ///    TENANT-SCOPED store before sending the verb, and that resolution is the authorization. The Director
-    ///    stamps the attachment directly - no local lookup, no second opinion. This is the end state.
-    ///  * TRANSITIONAL BRIDGE (MissionId set, MissionName blank): an old caller naming a mission in the
-    ///    Director's OWN store. The Director resolves it locally exactly as before. Removed with the Director
-    ///    MissionStore in Gateway Cleanup Phase 1.
+    /// The Mission ID and NAME arrive TOGETHER, exactly as they do on the create path (see the mission
+    /// block in <see cref="Create"/>), because a Mission is a FLEET-level record whose source of truth is
+    /// the Gateway and not this machine. The Gateway resolved the mission against its own TENANT-SCOPED
+    /// store before sending the verb, and that resolution is the authorization; the Director stamps the
+    /// attachment directly - no local lookup, no second opinion. An id with no name is refused, because it
+    /// was never resolved by the only store that can answer.
     ///
-    /// The Director deliberately does NOT re-validate a Gateway-supplied mission against its local store. It
-    /// could not: the local store is a different (single-tenant, per-machine) set, so a mission that is real
-    /// and owned would be rejected here for being absent from the wrong store - which is exactly the failure
-    /// issue #1548 fixed on the spawn path.
+    /// The Director deliberately does NOT re-validate a Gateway-supplied mission locally, and no longer has
+    /// anything to re-validate it against. It could not: the old local store was a different (single-tenant,
+    /// per-machine) set, so a mission that is real and owned was rejected for being absent from the wrong
+    /// store - the failure issue #1548 fixed on the spawn path and issue #2629 hit again through a second
+    /// spawn door.
     /// </summary>
     internal static DirectorCommandResult AttachMission(SessionManager sessionManager, string directorId, DirectorCommand command, SessionCommandServices? services)
     {
@@ -818,24 +817,20 @@ internal static class SessionCommandExecutor
             return DirectorCommandResult.Success(Serialize(ControlEndpoints.Map(session, directorId)));
         }
 
-        if (!string.IsNullOrWhiteSpace(request.MissionName))
+        if (string.IsNullOrWhiteSpace(request.MissionName))
         {
-            // Gateway path: the mission was resolved inside the caller's own tenant; stamp it.
-            session.AttachToMission(missionId, request.MissionName);
-            ApplySeat();
-            FileLog.Write($"[SessionCommandExecutor] attach-mission: session={guid} mission={missionId} (resolved by the Gateway)");
-            return DirectorCommandResult.Success(Serialize(ControlEndpoints.Map(session, directorId)));
+            FileLog.Write($"[SessionCommandExecutor] attach-mission REFUSED: session={guid} mission={missionId} " +
+                          "arrived with no name, so it was never resolved by the Gateway");
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
+                $"mission '{missionId}' arrived without its name, so it was not resolved by the Gateway. " +
+                "Missions live at the Gateway, not on this machine - attach through the Gateway " +
+                "(cc-devthrottle mission attach), which resolves the mission and sends its name.");
         }
 
-        // Transitional bridge. The Director's store is single-tenant - one machine, one owner - so Local is
-        // its whole world.
-        var mission = services?.MissionStore?.Get(Core.Tenancy.TenantId.Local, missionId);
-        if (mission is null)
-            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
-                $"unknown mission '{missionId}'. Create it first with POST /missions.");
-
-        session.AttachToMission(mission.MissionId, mission.MissionName);
-        FileLog.Write($"[SessionCommandExecutor] attach-mission: session={guid} mission={mission.MissionId}");
+        // The Gateway resolved this mission inside the caller's own tenant; stamp it.
+        session.AttachToMission(missionId, request.MissionName);
+        ApplySeat();
+        FileLog.Write($"[SessionCommandExecutor] attach-mission: session={guid} mission={missionId} (resolved by the Gateway)");
         return DirectorCommandResult.Success(Serialize(ControlEndpoints.Map(session, directorId)));
     }
 

--- a/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
@@ -154,17 +154,20 @@ public sealed class NewSessionRequest
     /// session's <see cref="SessionDto.MissionId"/> and caches the resolved
     /// <see cref="SessionDto.MissionName"/> at birth - the attachment that binds this session into a pod.
     /// The Mission must already exist (create it with POST /missions); an unknown Mission is REJECTED as a
-    /// bad request. Null leaves the session attached to no Mission.
+    /// bad request BY THE GATEWAY, which is the only place that holds missions. Null leaves the session
+    /// attached to no Mission.
     /// </summary>
     public Guid? MissionId { get; set; }
 
     /// <summary>
-    /// Optional resolved display name of the Mission named by <see cref="MissionId"/>. Set by the Gateway
-    /// when it spawns a session into a GATEWAY-NATIVE mission: the Gateway validates the mission against its
-    /// OWN store, then forwards BOTH <see cref="MissionId"/> and this name so the Director stamps the
-    /// attachment directly WITHOUT any local mission-store lookup (the Gateway is the source of truth). Left
-    /// null by a caller hitting a Director's POST /sessions directly for an old Director-store mission, in
-    /// which case the Director resolves the name locally (the transitional bridge in SessionCommandExecutor).
+    /// The resolved display name of the Mission named by <see cref="MissionId"/>, and it travels WITH the
+    /// id rather than instead of it. Set by the Gateway on every spawn into a mission: the Gateway resolves
+    /// and validates the mission against its OWN store inside the caller's tenant - it is the source of
+    /// truth - and forwards BOTH values, so the Director stamps the attachment directly with no lookup of
+    /// its own. The Director holds no mission store, so an id arriving here with a blank name was resolved
+    /// by nobody and the create is REFUSED (issue #2629; there is no local fallback and there must not be
+    /// one - the transitional bridge that used to sit in SessionCommandExecutor consulted a stale
+    /// per-machine file and reported live missions as unknown).
     /// </summary>
     public string? MissionName { get; set; }
 

--- a/src/CcDirector.Gateway.Tests/DirectorSpawnMissionAndSeatTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorSpawnMissionAndSeatTests.cs
@@ -1,0 +1,285 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Running;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.Workflows;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// ISSUE #2629: BOTH SPAWN DOORS MUST HAND THE DIRECTOR A FINISHED ANSWER.
+///
+/// A session can be started two ways - POST /machines/{machine}/sessions ("some Director on that computer")
+/// and POST /directors/{id}/sessions ("this exact Director", the door an unqualified
+/// <c>cc-devthrottle session spawn</c> uses). The machine door resolved a mission-scoped spawn against the
+/// Gateway's mission store and stamped the resolved NAME onto the create request. The Director door
+/// forwarded the request verbatim. So a create reached the Director carrying an id and no name, the
+/// Director read that as an old caller naming a mission in its own local store, and answered
+/// <c>unknown mission '&lt;id&gt;'. Create it first with POST /missions.</c> for a mission that was real,
+/// active, and listed by <c>cc-devthrottle mission list</c> - blocking every new mission-scoped session on
+/// the machine. The workflow SEAT was missing from that door too, and silently: a session inside a mission
+/// with none of the conduct the mission pins and no membership row for governance to read.
+///
+/// WHY THE EXISTING TESTS DID NOT CATCH IT, which is the part worth keeping. FleetSpawnMissionAttachTests
+/// pinned the DIRECTOR's contract and stayed green throughout - it was right about what the Director does
+/// with a name, and blind to whether the caller sent one. MachineSpawnWorkflowScopeTests pinned the machine
+/// door. Nobody asserted the property that actually matters: that EVERY door does this, not just the one
+/// somebody thought of. So these tests drive BOTH doors through the same body and compare their output.
+///
+/// Be precise about the limit of that, because the obvious stronger claim is false: these tests name the two
+/// routes that exist, so they cannot fail for a THIRD door somebody adds later. What guards that case is the
+/// shared resolver being the only implementation - there is no second copy to reach for - not this file.
+/// If a third spawn door is added, add it here.
+///
+/// The Director is a capture here, not a real one: what is under test is what LEAVES the Gateway.
+/// </summary>
+public sealed class DirectorSpawnMissionAndSeatTests : IDisposable
+{
+    private const string DirectorId = "dir-spawn-2629";
+    private const string Machine = "SPAWN-PC";
+
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+    private readonly GatewayDbTestHarness _db = new();
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-spawn-2629-" + Guid.NewGuid().ToString("N"));
+
+    private WebApplication? _app;
+    private HttpClient? _http;
+    private DirectorRegistry? _registry;
+
+    /// <summary>The create request each door dispatched, or null when nothing was dispatched at all.</summary>
+    private NewSessionRequest? _directorDoorSaw;
+    private NewSessionRequest? _machineDoorSaw;
+
+    /// <summary>What the captured Director answers with - a real Director echoes the seat it stamped.</summary>
+    private SessionDto _reply = new() { SessionId = Guid.NewGuid().ToString() };
+
+    public void Dispose()
+    {
+        _http?.Dispose();
+        if (_app is not null) _app.StopAsync().GetAwaiter().GetResult();
+        _registry?.Dispose();
+        _db.Dispose();
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch (Exception) { /* best effort */ }
+    }
+
+    /// <summary>A resolver that always finds the same Director, so the machine door reaches its create.</summary>
+    private sealed class AlwaysFound : IDirectorTargetResolver
+    {
+        public Task<DirectorTargetResult> ResolveAsync(string machine, string? director, CancellationToken ct)
+            => Task.FromResult(new DirectorTargetResult(DirectorId, null));
+    }
+
+    private async Task<(MissionStore missions, WorkflowRunStore runs)> StartAsync()
+    {
+        Directory.CreateDirectory(_dir);
+        var missions = new MissionStore(Path.Combine(_dir, "missions.json"), adoptUnattributedAs: TenantId.Local);
+        var db = _db.Open();
+        _ = new WorkflowStore(db);   // seeds the built-in workflows, so "mission" has a published version
+        var runs = new WorkflowRunStore(db);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls($"http://127.0.0.1:{GatewayHost.OperatingSystemAssignedPort}");
+        var app = builder.Build();
+
+        _registry = new DirectorRegistry(Path.Combine(_dir, "instances"));
+        _registry.RegisterFromStream(DirectorId, Machine, "test", "0.0.0-test", pid: 1,
+            startedAt: DateTime.UtcNow, tenant: TenantId.Local);
+
+        // The Director door: create rides the tunnel, so the capture IS the sendCommand hook.
+        DirectorCommandRouter.SendDirectorCommandAsync send = (directorId, command, ct) =>
+        {
+            if (command.Verb == "create")
+            {
+                _directorDoorSaw = JsonSerializer.Deserialize<NewSessionRequest>(command.PayloadJson ?? "{}", Web);
+                return Task.FromResult<DirectorCommandResult?>(
+                    DirectorCommandResult.Success(JsonSerializer.Serialize(_reply, Web)));
+            }
+            return Task.FromResult<DirectorCommandResult?>(null);
+        };
+
+        // The machine door: create goes through the spawner, so the capture is its create hook.
+        var spawner = new MachineSessionSpawner(new AlwaysFound(), (directorId, req, ct) =>
+        {
+            _machineDoorSaw = req;
+            return Task.FromResult<(bool, SessionDto?, string?)>((true, _reply, null));
+        });
+
+        // Self-host boundary: one tenant, resolved as Local, so both doors read the same mission store.
+        var boundary = new HostedTenantBoundary(new SingleTenantContext(), new Pairing.DeviceRegistry());
+
+        GatewayEndpoints.Map(app, _registry, version: "test", token: "test-token",
+            tenantBoundary: boundary, sendCommand: send, missions: missions, workflowRuns: runs);
+        MachineEndpoints.Map(app, new LauncherRegistry(), spawner, boundary: boundary,
+            missions: missions, workflowRuns: runs);
+
+        await app.StartAsync();
+        _app = app;
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{BoundPort.Of(app)}/") };
+        return (missions, runs);
+    }
+
+    private Task<HttpResponseMessage> ThroughTheDirectorDoor(object body) =>
+        _http!.PostAsJsonAsync($"directors/{DirectorId}/sessions", body);
+
+    private Task<HttpResponseMessage> ThroughTheMachineDoor(object body) =>
+        _http!.PostAsJsonAsync($"machines/{Machine}/sessions", body);
+
+    /// <summary>
+    /// THE REGRESSION. The Director door must stamp the mission's resolved NAME onto the create it
+    /// dispatches. Without the name the Director cannot tell a Gateway-resolved mission from an
+    /// unresolved one, and refuses the spawn.
+    /// </summary>
+    [Fact]
+    public async Task The_director_door_stamps_the_resolved_mission_name_on_the_create()
+    {
+        var (missions, _) = await StartAsync();
+        var mission = missions.Create(TenantId.Local, "OneAdvanced product enhancements");
+
+        var response = await ThroughTheDirectorDoor(new
+        {
+            repoPath = @"C:\repo",
+            agent = "ClaudeCode",
+            missionId = mission.MissionId,   // the id ALONE, exactly as the command line sends it
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(_directorDoorSaw);
+        Assert.Equal(mission.MissionId, _directorDoorSaw!.MissionId);
+        // The whole defect in one assertion: this was null, and the Director refused the spawn.
+        Assert.Equal("OneAdvanced product enhancements", _directorDoorSaw.MissionName);
+    }
+
+    /// <summary>
+    /// The anti-drift assertion. Both doors are given the same body and must produce the same stamped
+    /// create - the property that was false for four weeks while each door was individually "correct".
+    /// </summary>
+    [Fact]
+    public async Task Both_doors_stamp_the_same_mission_name_for_the_same_request()
+    {
+        var (missions, _) = await StartAsync();
+        var mission = missions.Create(TenantId.Local, "Same Mission Either Way");
+        var body = new { repoPath = @"C:\repo", agent = "ClaudeCode", missionId = mission.MissionId };
+
+        Assert.Equal(HttpStatusCode.Created, (await ThroughTheDirectorDoor(body)).StatusCode);
+        Assert.Equal(HttpStatusCode.Created, (await ThroughTheMachineDoor(body)).StatusCode);
+
+        Assert.NotNull(_directorDoorSaw);
+        Assert.NotNull(_machineDoorSaw);
+        Assert.Equal(_machineDoorSaw!.MissionName, _directorDoorSaw!.MissionName);
+        Assert.Equal("Same Mission Either Way", _directorDoorSaw.MissionName);
+    }
+
+    /// <summary>
+    /// An unknown mission is refused BY THE GATEWAY, which is the only place that can know, and the create
+    /// never leaves. Before this, the refusal came from the Director against a store that could not answer,
+    /// and reached the caller as a 502 wrapping a message that told them to create a mission they already had.
+    /// </summary>
+    [Fact]
+    public async Task An_unknown_mission_is_refused_at_the_gateway_and_no_create_is_dispatched()
+    {
+        await StartAsync();
+
+        var response = await ThroughTheDirectorDoor(new
+        {
+            repoPath = @"C:\repo",
+            agent = "ClaudeCode",
+            missionId = Guid.NewGuid(),
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);   // not a 502 from downstream
+        Assert.Contains("unknown mission", await response.Content.ReadAsStringAsync());
+        Assert.Null(_directorDoorSaw);                                   // nothing was dispatched
+    }
+
+    /// <summary>
+    /// The quiet half of the same defect: a mission-scoped spawn through the Director door is SEATED on the
+    /// mission's run, so the agent is pinned to the conduct its mission runs on. This door seated nothing.
+    /// </summary>
+    [Fact]
+    public async Task The_director_door_seats_a_mission_spawn_on_the_missions_run()
+    {
+        var (missions, runs) = await StartAsync();
+        var mission = missions.Create(TenantId.Local, "Seated Mission");
+        var run = runs.Create("mission", "Seated Mission", missionId: mission.MissionId);
+        // A real Director echoes the seat it stamped; the participant record depends on that proof.
+        _reply = new SessionDto { SessionId = Guid.NewGuid().ToString(), WorkflowRunId = run.Id };
+
+        var response = await ThroughTheDirectorDoor(new
+        {
+            repoPath = @"C:\repo",
+            agent = "ClaudeCode",
+            missionId = mission.MissionId,
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(_directorDoorSaw);
+        Assert.Equal(run.Id, _directorDoorSaw!.WorkflowRunId);
+        Assert.Equal("mission", _directorDoorSaw.WorkflowId);
+        Assert.Equal(run.WorkflowVersion, _directorDoorSaw.WorkflowVersion);
+
+        // And the membership row governance reads, which this door never wrote. Asserted FIELD BY FIELD,
+        // not just "a row exists for this session": the machine on this door comes from the registered
+        // Director rather than from a path segment, so a blank or a director id in that column would
+        // otherwise pass unnoticed and governance would join effort to the wrong computer.
+        var stored = runs.Get(run.Id);
+        Assert.NotNull(stored);
+        var participant = Assert.Single(stored!.Participants, p => p.SessionId == _reply.SessionId);
+        Assert.Equal(Machine, participant.Machine);
+        Assert.Equal("ClaudeCode", participant.AgentKind);
+        Assert.Equal("", participant.Role);
+    }
+
+    /// <summary>
+    /// An unknown workflow run is refused the same way through this door as through the other one - the
+    /// resolver is shared, so the refusal is too.
+    /// </summary>
+    [Fact]
+    public async Task An_unknown_workflow_run_is_refused_at_the_gateway_through_the_director_door()
+    {
+        await StartAsync();
+
+        var response = await ThroughTheDirectorDoor(new
+        {
+            repoPath = @"C:\repo",
+            agent = "ClaudeCode",
+            workflowRunId = Guid.NewGuid(),
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains("unknown workflow run", await response.Content.ReadAsStringAsync());
+        Assert.Null(_directorDoorSaw);
+    }
+
+    /// <summary>
+    /// The negative control: a spawn that names no mission and no run is untouched by any of this and still
+    /// reaches the Director. Otherwise a "fix" that refused everything would look like a pass.
+    /// </summary>
+    [Fact]
+    public async Task A_plain_spawn_is_unaffected_and_still_reaches_the_director()
+    {
+        await StartAsync();
+
+        var response = await ThroughTheDirectorDoor(new { repoPath = @"C:\repo", agent = "ClaudeCode" });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(_directorDoorSaw);
+        Assert.Null(_directorDoorSaw!.MissionId);
+        Assert.Null(_directorDoorSaw.MissionName);
+        Assert.Null(_directorDoorSaw.WorkflowRunId);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/FleetSpawnMissionAttachTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetSpawnMissionAttachTests.cs
@@ -21,9 +21,12 @@ namespace CcDirector.Gateway.Tests;
 /// real verb core:
 ///
 ///   * MissionId + MissionName both present (the Gateway path): stamp DIRECTLY, no local lookup -
-///     the local store knowing nothing about the mission must not matter.
-///   * MissionId alone (an old caller): the TEMPORARY local-store bridge resolves it, and an id the
-///     local store does not know is REFUSED loudly rather than silently dropped.
+///     the Director having no mission store of its own must not matter.
+///   * MissionId alone: REFUSED loudly rather than silently dropped, and rather than resolved against
+///     a store that cannot answer. Issue #2629: the temporary local-store bridge that used to sit here
+///     is GONE. It resolved a bare id against a stale per-machine missions.json, so the second spawn
+///     door - POST /directors/{id}/sessions, which forwarded the create verbatim and never stamped the
+///     name - produced "unknown mission" for a mission that was real, active and listed.
 ///   * No mission: no attach, no lookup.
 /// </summary>
 [Collection("DirectorRoot")]
@@ -68,18 +71,18 @@ public sealed class FleetSpawnMissionAttachTests : IDisposable
         CommandArgs = "/k",
     };
 
-    private DirectorCommandResult Spawn(NewSessionRequest body, MissionStore? localStore = null)
+    private DirectorCommandResult Spawn(NewSessionRequest body)
         => SessionCommandExecutor.Create(_sm, "dir-spawn-mission", new DirectorCommand
         {
             CommandId = "cmd-spawn-mission",
             Verb = "create",
             SessionId = "",
             PayloadJson = JsonSerializer.Serialize(body, Json),
-        }, localStore is null ? null : new SessionCommandServices { MissionStore = localStore });
+        }, null);
 
-    private async Task<SessionDto> SpawnOkAndCleanUpAsync(NewSessionRequest body, MissionStore? localStore = null)
+    private async Task<SessionDto> SpawnOkAndCleanUpAsync(NewSessionRequest body)
     {
-        var result = Spawn(body, localStore);
+        var result = Spawn(body);
         Assert.Equal(DirectorCommandStatus.Ok, result.Status);
         var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "{}", Json)!;
         if (dto.SessionId is not null && Guid.TryParse(dto.SessionId, out var id))
@@ -93,8 +96,8 @@ public sealed class FleetSpawnMissionAttachTests : IDisposable
     public async Task Gateway_resolved_mission_attaches_directly_without_any_local_lookup()
     {
         // The Gateway path: id AND name arrive together because the Gateway already resolved the mission
-        // against ITS store. The Director's own store knows nothing about this mission, and that must not
-        // matter - re-resolving locally is the wrong-store defect #1548 was about.
+        // against ITS store. The Director holds no mission store at all, and that must not matter -
+        // re-resolving locally is the wrong-store defect #1548 and #2629 were both about.
         var body = SpawnBody();
         body.MissionId = KnownMissionId;
         body.MissionName = KnownMissionName;
@@ -106,19 +109,22 @@ public sealed class FleetSpawnMissionAttachTests : IDisposable
     }
 
     [Fact]
-    public void Old_caller_with_id_only_and_a_local_store_miss_is_refused_loudly()
+    public void An_id_with_no_name_is_refused_loudly_and_names_the_real_problem()
     {
-        // The transitional bridge: an id-only create resolves against the LOCAL store, and an unknown id
-        // must be refused rather than silently dropping the attach - an unattached session in a pod that
-        // expected it is the quiet version of the same defect.
+        // A create carrying a mission id and no name never passed through the Gateway's resolution, so
+        // nothing on this machine can say what that mission is. Refusing is right - silently dropping the
+        // attach would leave a session outside the pod that expected it, which is the quiet version of the
+        // same defect. What must NOT happen is the old answer: consulting a stale per-machine store and
+        // calling a real mission unknown, then advising the caller to create one that already exists.
         var body = SpawnBody();
         body.MissionId = Guid.NewGuid();
 
-        var result = Spawn(body, new MissionStore(
-            Path.Combine(_root, "missions-empty.json"), adoptUnattributedAs: Core.Tenancy.TenantId.Local));
+        var result = Spawn(body);
 
         Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
-        Assert.Contains("unknown mission", result.Error);
+        Assert.Contains("without its name", result.Error);
+        Assert.Contains("Gateway", result.Error);
+        Assert.DoesNotContain("Create it first", result.Error);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.UnitTests/MissionCommandTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/MissionCommandTests.cs
@@ -11,6 +11,13 @@ namespace CcDirector.Gateway.Tests;
 /// <see cref="SessionCommandExecutor"/>: the <c>attach-mission</c> verb stamps a session's MissionId +
 /// cached MissionName (and detaches on a blank id), and a create-time <see cref="NewSessionRequest.MissionId"/>
 /// attaches the new session at spawn. Mirrors the set-role tests in <see cref="SessionCommandExecutorTests"/>.
+///
+/// THE CONTRACT THESE PIN (issue #2629): the mission's ID AND NAME arrive together, because the Gateway -
+/// the only store that holds missions - resolved the mission in the caller's own tenant before sending the
+/// verb. The Director stamps what it was handed and owns no mission store of its own. An id with no name
+/// was never resolved by anybody, and is REFUSED rather than looked up locally: the Director-local store
+/// this code used to consult was a different, per-machine set that nothing writes any more, so consulting
+/// it reported a real, active, listed mission as unknown and took mission-scoped spawning down.
 /// </summary>
 [Collection("DirectorRoot")]
 public sealed class MissionCommandTests
@@ -31,10 +38,8 @@ public sealed class MissionCommandTests
         return (sm, session);
     }
 
-    // The Director's store is single-tenant - one machine, one owner - so every record is Local's (#1039).
-    private static MissionStore NewMissionStore() =>
-        new(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"),
-            adoptUnattributedAs: Core.Tenancy.TenantId.Local);
+    // No mission store: the Director has none, and these tests would be lying if they handed it one.
+    private static SessionCommandServices Services() => new();
 
     private static DirectorCommand AttachCommand(string sid, Guid? missionId, string? missionName = null) => new()
     {
@@ -78,35 +83,39 @@ public sealed class MissionCommandTests
         var (sm, session) = NewSession();
         try
         {
-            var store = NewMissionStore();
-            var mission = store.Create(Core.Tenancy.TenantId.Local, "Session Lifecycle");
-            var services = new SessionCommandServices { MissionStore = store };
+            var missionId = Guid.NewGuid();
 
-            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), mission.MissionId), services);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand(session.Id.ToString(), missionId, "Session Lifecycle"), Services());
 
             Assert.Equal(DirectorCommandStatus.Ok, result.Status);
-            Assert.Equal(mission.MissionId, session.MissionId);
-            Assert.Equal("Session Lifecycle", session.MissionName); // resolved + cached from the store
+            Assert.Equal(missionId, session.MissionId);
+            Assert.Equal("Session Lifecycle", session.MissionName); // cached from what the Gateway sent
 
             var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "", Json);
             Assert.NotNull(dto);
-            Assert.Equal(mission.MissionId, dto.MissionId);
+            Assert.Equal(missionId, dto.MissionId);
             Assert.Equal("Session Lifecycle", dto.MissionName);
         }
         finally { sm.Dispose(); }
     }
 
+    // Issue #2629: an id with NO name was never resolved by the Gateway, so there is nobody who can say
+    // what it is. Refused, loudly, and with a message that names the real problem - the old behaviour was
+    // to look it up in a stale per-machine store and report a real mission as "unknown".
     [Fact]
-    public async Task AttachMission_UnknownMission_ReturnsBadRequest_Unchanged()
+    public async Task AttachMission_IdWithNoName_IsRefused_AndSaysWhy()
     {
         var (sm, session) = NewSession();
         try
         {
-            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
-
-            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), Guid.NewGuid()), services);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand(session.Id.ToString(), Guid.NewGuid()), Services());
 
             Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.Contains("without its name", result.Error);
+            Assert.Contains("Gateway", result.Error);
+            Assert.DoesNotContain("Create it first", result.Error); // the old lie: it already exists
             Assert.Null(session.MissionId);
             Assert.Null(session.MissionName);
         }
@@ -119,14 +128,13 @@ public sealed class MissionCommandTests
         var (sm, session) = NewSession();
         try
         {
-            var store = NewMissionStore();
-            var mission = store.Create(Core.Tenancy.TenantId.Local, "Session Lifecycle");
-            var services = new SessionCommandServices { MissionStore = store };
+            var missionId = Guid.NewGuid();
 
-            await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), mission.MissionId), services);
-            Assert.Equal(mission.MissionId, session.MissionId);
+            await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand(session.Id.ToString(), missionId, "Session Lifecycle"), Services());
+            Assert.Equal(missionId, session.MissionId);
 
-            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), null), services);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), null), Services());
 
             Assert.Equal(DirectorCommandStatus.Ok, result.Status);
             Assert.Null(session.MissionId); // cleared -> detached
@@ -141,11 +149,8 @@ public sealed class MissionCommandTests
         var sm = new SessionManager(new Core.Configuration.AgentOptions());
         try
         {
-            var store = NewMissionStore();
-            var mission = store.Create(Core.Tenancy.TenantId.Local, "Session Lifecycle");
-            var services = new SessionCommandServices { MissionStore = store };
-
-            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(Guid.NewGuid().ToString(), mission.MissionId), services);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand(Guid.NewGuid().ToString(), Guid.NewGuid(), "Session Lifecycle"), Services());
 
             Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
         }
@@ -158,9 +163,8 @@ public sealed class MissionCommandTests
         var sm = new SessionManager(new Core.Configuration.AgentOptions());
         try
         {
-            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
-
-            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand("not-a-guid", Guid.NewGuid()), services);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                AttachCommand("not-a-guid", Guid.NewGuid(), "Session Lifecycle"), Services());
 
             Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
         }
@@ -170,22 +174,21 @@ public sealed class MissionCommandTests
     // Issue #2387: the GATEWAY path on the attach verb, matching what create already does. A mission is a
     // FLEET record whose source of truth is the Gateway; when the Gateway has resolved it inside the caller's
     // own tenant and sends the NAME with the id, the Director stamps it directly. Proof of "no local lookup":
-    // the id is not in the Director's store - the store is EMPTY - and the attach still succeeds with the
-    // carried name. A local lookup would reject a mission that is real and owned, which is precisely the
-    // failure #1548 fixed on the spawn path.
+    // the Director is given NO mission store at all here, and the attach still succeeds with the carried
+    // name. A local lookup would reject a mission that is real and owned, which is precisely the failure
+    // #1548 fixed on one spawn door and #2629 hit again through the other.
     [Fact]
     public async Task AttachMission_WithMissionNamePresent_StampsDirectly_WithoutStoreLookup()
     {
         var (sm, session) = NewSession();
         try
         {
-            var services = new SessionCommandServices { MissionStore = NewMissionStore() }; // empty store
-            var carriedId = Guid.NewGuid(); // never created in this store
+            var carriedId = Guid.NewGuid();
 
             var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
-                AttachCommand(session.Id.ToString(), carriedId, "Gateway Native Mission"), services);
+                AttachCommand(session.Id.ToString(), carriedId, "Gateway Native Mission"), Services());
 
-            Assert.Equal(DirectorCommandStatus.Ok, result.Status); // NOT rejected despite the empty store
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status); // NOT rejected: nothing local was consulted
             Assert.Equal(carriedId, session.MissionId);
             Assert.Equal("Gateway Native Mission", session.MissionName);
         }
@@ -202,46 +205,42 @@ public sealed class MissionCommandTests
         var (sm, session) = NewSession();
         try
         {
-            var store = NewMissionStore();
-            var first = store.Create(Core.Tenancy.TenantId.Local, "First Mission");
-            var second = store.Create(Core.Tenancy.TenantId.Local, "Second Mission");
-            var services = new SessionCommandServices { MissionStore = store };
+            var first = Guid.NewGuid();
+            var second = Guid.NewGuid();
 
             await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
-                AttachCommand(session.Id.ToString(), first.MissionId), services);
-            Assert.Equal(first.MissionId, session.MissionId);   // the control: it really was on the first
+                AttachCommand(session.Id.ToString(), first, "First Mission"), Services());
+            Assert.Equal(first, session.MissionId);   // the control: it really was on the first
 
             var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
-                AttachCommand(session.Id.ToString(), second.MissionId), services);
+                AttachCommand(session.Id.ToString(), second, "Second Mission"), Services());
 
             Assert.Equal(DirectorCommandStatus.Ok, result.Status);
-            Assert.Equal(second.MissionId, session.MissionId);
+            Assert.Equal(second, session.MissionId);
             Assert.Equal("Second Mission", session.MissionName);  // the cached name moved with the id
         }
         finally { sm.Dispose(); }
     }
 
     // Issue #2387: a REFUSED attach leaves the session on the mission it already had. Without this, a
-    // mistyped mission id would silently detach a correctly-attached session - a failure that looks like
-    // nothing happened until somebody goes looking for the pod.
+    // refusal would silently detach a correctly-attached session - a failure that looks like nothing
+    // happened until somebody goes looking for the pod.
     [Fact]
-    public async Task AttachMission_UnknownMission_LeavesAnExistingAttachmentIntact()
+    public async Task AttachMission_ARefusedAttach_LeavesAnExistingAttachmentIntact()
     {
         var (sm, session) = NewSession();
         try
         {
-            var store = NewMissionStore();
-            var mission = store.Create(Core.Tenancy.TenantId.Local, "Real Mission");
-            var services = new SessionCommandServices { MissionStore = store };
+            var mission = Guid.NewGuid();
 
             await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
-                AttachCommand(session.Id.ToString(), mission.MissionId), services);
+                AttachCommand(session.Id.ToString(), mission, "Real Mission"), Services());
 
             var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
-                AttachCommand(session.Id.ToString(), Guid.NewGuid()), services);
+                AttachCommand(session.Id.ToString(), Guid.NewGuid()), Services()); // no name -> refused
 
             Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
-            Assert.Equal(mission.MissionId, session.MissionId);
+            Assert.Equal(mission, session.MissionId);
             Assert.Equal("Real Mission", session.MissionName);
         }
         finally { sm.Dispose(); }
@@ -261,7 +260,7 @@ public sealed class MissionCommandTests
         var (sm, session) = NewSession();
         try
         {
-            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+            var services = Services();
             var missionA = Guid.NewGuid();
             var runA = Guid.NewGuid();
             var missionB = Guid.NewGuid();
@@ -300,7 +299,7 @@ public sealed class MissionCommandTests
         var (sm, session) = NewSession();
         try
         {
-            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+            var services = Services();
             var chosenRun = Guid.NewGuid();
             var missionA = Guid.NewGuid();
             var missionB = Guid.NewGuid();
@@ -330,7 +329,7 @@ public sealed class MissionCommandTests
         var (sm, session) = NewSession();
         try
         {
-            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+            var services = Services();
             var mission = Guid.NewGuid();
             var run = Guid.NewGuid();
 
@@ -359,7 +358,7 @@ public sealed class MissionCommandTests
         var (sm, session) = NewSession();
         try
         {
-            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+            var services = Services();
             var chosenRun = Guid.NewGuid();
 
             await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
@@ -378,7 +377,7 @@ public sealed class MissionCommandTests
     }
 
     [Fact]
-    public async Task AttachMission_WithoutASeatDecision_TouchesTheSeatAtAll()
+    public async Task AttachMission_WithoutASeatDecision_NeverTouchesTheSeatAtAll()
     {
         // The compatibility case, and the one that keeps the two decisions separable: a payload that says
         // nothing about the seat must not clear it. Otherwise every caller that has not been taught about
@@ -386,9 +385,8 @@ public sealed class MissionCommandTests
         var (sm, session) = NewSession();
         try
         {
-            var store = NewMissionStore();
-            var mission = store.Create(Core.Tenancy.TenantId.Local, "Local mission");
-            var services = new SessionCommandServices { MissionStore = store };
+            var services = Services();
+            var mission = Guid.NewGuid();
             var run = Guid.NewGuid();
 
             await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
@@ -396,64 +394,26 @@ public sealed class MissionCommandTests
                 services);
 
             var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
-                AttachCommand(session.Id.ToString(), mission.MissionId), services);
+                AttachCommand(session.Id.ToString(), mission, "Mission B"), services);
 
             Assert.Equal(DirectorCommandStatus.Ok, result.Status);
-            Assert.Equal(mission.MissionId, session.MissionId);
+            Assert.Equal(mission, session.MissionId);
             Assert.Equal(run, session.WorkflowRunId);   // untouched, because nothing asked for it to move
         }
         finally { sm.Dispose(); }
     }
 
-    [Fact]
-    public async Task Create_WithMissionId_AttachesNewSessionAtSpawn()
-    {
-        var sm = new SessionManager(new Core.Configuration.AgentOptions());
-        try
-        {
-            var store = NewMissionStore();
-            var mission = store.Create(Core.Tenancy.TenantId.Local, "Session Lifecycle");
-            var services = new SessionCommandServices { MissionStore = store };
-
-            var command = CreateCommand(new NewSessionRequest
-            {
-                RepoPath = Path.GetTempPath(),
-                Agent = "RawCli",
-                Command = TestShellPath,
-                Name = "mission-create-test",
-                MissionId = mission.MissionId,
-            });
-
-            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command, services);
-
-            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
-            var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "", Json);
-            Assert.NotNull(dto);
-            Assert.Equal(mission.MissionId, dto.MissionId);
-            Assert.Equal("Session Lifecycle", dto.MissionName);
-
-            Assert.True(Guid.TryParse(dto.SessionId, out var sid));
-            var session = sm.GetSession(sid);
-            Assert.NotNull(session);
-            Assert.Equal(mission.MissionId, session.MissionId);
-            Assert.Equal("Session Lifecycle", session.MissionName);
-        }
-        finally { sm.Dispose(); }
-    }
-
-    // Gateway Cleanup mission (Wave 4b): when the create request carries BOTH a MissionId and a MissionName
-    // (the GATEWAY path - the Gateway already validated the mission against its own store), the Director
-    // stamps the attachment DIRECTLY with no local-store lookup. Proof of "no lookup": the id is NOT in the
-    // store here (in fact the store is EMPTY), yet the create succeeds and stamps the carried name - a local
-    // lookup would have rejected it as unknown.
+    // The create path's GATEWAY contract: the request carries the mission id AND the name the Gateway
+    // resolved, and the Director stamps the attachment directly. Proof that nothing local is consulted:
+    // the Director is given no mission store at all, and the create still succeeds with the carried name.
+    // A local lookup would have rejected a mission that is real, active and owned - the #2629 failure.
     [Fact]
     public async Task Create_WithMissionNamePresent_StampsDirectly_WithoutStoreLookup()
     {
         var sm = new SessionManager(new Core.Configuration.AgentOptions());
         try
         {
-            var services = new SessionCommandServices { MissionStore = NewMissionStore() }; // empty store
-            var carriedId = Guid.NewGuid(); // never created in the store
+            var carriedId = Guid.NewGuid();
 
             var command = CreateCommand(new NewSessionRequest
             {
@@ -465,13 +425,13 @@ public sealed class MissionCommandTests
                 MissionName = "Gateway Native Mission", // resolved+validated by the Gateway already
             });
 
-            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command, services);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command, Services());
 
-            Assert.Equal(DirectorCommandStatus.Ok, result.Status); // NOT rejected despite the empty store
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status); // NOT rejected: nothing local was consulted
             var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "", Json);
             Assert.NotNull(dto);
             Assert.Equal(carriedId, dto.MissionId);
-            Assert.Equal("Gateway Native Mission", dto.MissionName); // stamped from the request, not the store
+            Assert.Equal("Gateway Native Mission", dto.MissionName); // stamped from the request
 
             Assert.True(Guid.TryParse(dto.SessionId, out var sid));
             var session = sm.GetSession(sid);
@@ -482,48 +442,15 @@ public sealed class MissionCommandTests
         finally { sm.Dispose(); }
     }
 
-    // Gateway Cleanup mission (Wave 4b): the TRANSITIONAL BRIDGE. When the create request carries a MissionId
-    // but a BLANK MissionName (an old caller hitting the Director's POST /sessions directly for a
-    // Director-store mission), the Director resolves the name from its OWN store - so the stamped name comes
-    // from the store, not the request. Proof: the store name differs from anything on the request.
+    // Issue #2629, at the create verb: a mission id with no name reached this Director because some caller
+    // skipped the Gateway's resolution. It is REFUSED, before the session is created, and the message says
+    // where missions actually live instead of telling the caller to create one that already exists.
     [Fact]
-    public async Task Create_WithMissionNameAbsent_ResolvesNameFromLocalStore()
+    public async Task Create_WithMissionIdButNoName_IsRefused_AndNoSessionIsCreated()
     {
         var sm = new SessionManager(new Core.Configuration.AgentOptions());
         try
         {
-            var store = NewMissionStore();
-            var mission = store.Create(Core.Tenancy.TenantId.Local, "Name From Director Store");
-            var services = new SessionCommandServices { MissionStore = store };
-
-            var command = CreateCommand(new NewSessionRequest
-            {
-                RepoPath = Path.GetTempPath(),
-                Agent = "RawCli",
-                Command = TestShellPath,
-                Name = "bridge-mission-create",
-                MissionId = mission.MissionId,
-                MissionName = null, // blank -> the transitional local-store lookup resolves the name
-            });
-
-            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command, services);
-
-            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
-            var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "", Json);
-            Assert.NotNull(dto);
-            Assert.Equal(mission.MissionId, dto.MissionId);
-            Assert.Equal("Name From Director Store", dto.MissionName); // resolved from the store
-        }
-        finally { sm.Dispose(); }
-    }
-
-    [Fact]
-    public async Task Create_WithUnknownMissionId_ReturnsBadRequest_NoSessionCreated()
-    {
-        var sm = new SessionManager(new Core.Configuration.AgentOptions());
-        try
-        {
-            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
             var before = sm.ListSessions().Count;
 
             var command = CreateCommand(new NewSessionRequest
@@ -531,13 +458,17 @@ public sealed class MissionCommandTests
                 RepoPath = Path.GetTempPath(),
                 Agent = "RawCli",
                 Command = TestShellPath,
-                Name = "bad-mission",
-                MissionId = Guid.NewGuid(), // never created in the store
+                Name = "unresolved-mission",
+                MissionId = Guid.NewGuid(),
+                MissionName = null, // never resolved by the Gateway
             });
 
-            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command, services);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command, Services());
 
             Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.Contains("without its name", result.Error);
+            Assert.Contains("Gateway", result.Error);
+            Assert.DoesNotContain("Create it first", result.Error); // the old lie: it already exists
             Assert.Equal(before, sm.ListSessions().Count); // rejected before creation - no orphan
         }
         finally { sm.Dispose(); }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -3106,6 +3106,23 @@ internal static class GatewayEndpoints
 
             FileLog.Write($"[GatewayEndpoints] POST /directors/{id}/sessions: repo={req.RepoPath}, agent={req.Agent}");
 
+            // THE MISSION NAME AND THE WORKFLOW SEAT, resolved here exactly as the machine door resolves
+            // them (issue #2629). This is the door an unqualified `cc-devthrottle session spawn` uses, and
+            // it used to forward the create VERBATIM - so a mission-scoped spawn reached the Director
+            // carrying an id and no name, the Director read that as an old caller naming a mission in its
+            // own stale local store, and refused a mission that was real, active and listed. The seat was
+            // missing too, silently: a session in a mission with none of the conduct the mission pins.
+            //
+            // Both doors now call the SAME resolver, so neither can drift from the other again.
+            var spawnTenant = ResolveReadTenant(ctx, tenantBoundary);
+            if (spawnTenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" },
+                    statusCode: StatusCodes.Status403Forbidden);
+            var spawnRoute = $"POST /directors/{id}/sessions";
+            if (!SpawnMissionAndSeat.TryResolve(req, spawnTenant.Value, missions, workflowRuns, spawnRoute,
+                    out var seatRun, out var resolveError))
+                return resolveError!;
+
             // Issue #1177 (Phase 1): create rides the target Director's stream. Tunnel-only: a null return
             // means the Director is not connected, and a non-Ok stream result (validation/creation failure)
             // collapses to 502 - both surface as the error below.
@@ -3124,6 +3141,12 @@ internal static class GatewayEndpoints
             }
             if (body is null)
                 return Results.Problem(err ?? "failed", statusCode: StatusCodes.Status502BadGateway);
+
+            // The membership row governance reads, on the same terms as the machine door: recorded only
+            // when the Director's reply proves the seat landed, and never turned into an HTTP failure the
+            // caller would retry into a second session.
+            SpawnMissionAndSeat.RecordParticipant(seatRun, workflowRuns, req, body, d.MachineName ?? "", spawnRoute);
+
             return Results.Json(body, statusCode: 201);
         });
 

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -327,62 +327,12 @@ internal static class MachineEndpoints
 
             StampOriginFromDeviceKey(req, ctx);
 
-            // Gateway Cleanup mission (Wave 4b): a mission-scoped spawn is validated against the Gateway's OWN
-            // mission store (the source of truth) and the resolved NAME is stamped onto the create request, so
-            // the Director stamps the attachment directly with no local-store lookup. Reject an unknown mission
-            // here rather than forwarding it to a Director that no longer owns mission validation.
-            if (req.MissionId is Guid spawnMissionId && missions is not null)
-            {
-                // #1039: resolve the mission in the CALLING tenant. This lookup was by bare id, so naming
-                // another account's mission id here stamped that account's mission NAME - free text a person
-                // typed - onto the caller's own session. It is the same disclosure GET /missions/{mid} was,
-                // reached through the spawn route instead, and the issue does not name it.
-                var mission = missions.Get(tenant, spawnMissionId);
-                if (mission is null)
-                {
-                    FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: unknown mission {spawnMissionId}");
-                    return Results.BadRequest(new { error = $"unknown mission '{spawnMissionId}'. Create it first with POST /missions." });
-                }
-                req.MissionName = mission.MissionName;
-            }
-
-            // Workflows mission (phase 5b): resolve the seat. An EXPLICIT run id must exist; a
-            // mission-scoped spawn with no explicit run auto-seats onto the mission's newest run (the
-            // one POST /missions opened). The run's workflow id + pinned version ride the create
-            // request so the Director stamps the seat with no lookup of its own - and the seated
-            // session's conduct is pinned to the run's version, never a moving head.
-            Contracts.WorkflowRunDto? seatRun = null;
-            if (workflowRuns is not null)
-            {
-                if (req.WorkflowRunId is Guid explicitRunId)
-                {
-                    seatRun = workflowRuns.Get(explicitRunId);
-                    if (seatRun is null)
-                    {
-                        FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: unknown workflow run {explicitRunId}");
-                        return Results.BadRequest(new { error = $"unknown workflow run '{explicitRunId}'." });
-                    }
-                }
-                else if (req.MissionId is Guid seatMissionId)
-                {
-                    seatRun = workflowRuns.List(missionId: seatMissionId, limit: 1).FirstOrDefault();
-                }
-
-                if (seatRun is not null && !seatRun.WorkflowEnabled)
-                {
-                    // The owner turned this workflow OFF: no new seats. The spawn proceeds
-                    // unseated - the owner's switch, honestly applied and loudly logged.
-                    FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: workflow " +
-                                  $"'{seatRun.WorkflowId}' is OFF - spawning UNSEATED");
-                    seatRun = null;
-                }
-                if (seatRun is not null)
-                {
-                    req.WorkflowRunId = seatRun.Id;
-                    req.WorkflowId = seatRun.WorkflowId;
-                    req.WorkflowVersion = seatRun.WorkflowVersion;
-                }
-            }
+            // The mission NAME and the workflow SEAT, resolved in the ONE place both spawn doors share
+            // (issue #2629 - this route and POST /directors/{id}/sessions had drifted, and the Director
+            // door's missing name took mission-scoped spawning down completely).
+            var route = $"POST /machines/{machine}/sessions";
+            if (!SpawnMissionAndSeat.TryResolve(req, tenant, missions, workflowRuns, route, out var seatRun, out var resolveError))
+                return resolveError!;
 
             var (ok, dto, error, _) = await spawner.SpawnOnMachineAsync(machine, req, ct);
             if (!ok || dto is null)
@@ -391,50 +341,8 @@ internal static class MachineEndpoints
                 return Results.Json(new { error = error ?? $"could not start a session on '{machine}'", machine }, statusCode: 502);
             }
 
-            // Record the new session as a run participant - the persisted run-to-session membership
-            // (#1771). The session id is the canonical fleet GUID governance joins effort on. Two
-            // guards, both from inspection findings:
-            //  - Record ONLY when the Director's reply proves the seat actually landed. An older
-            //    Director (rolling upgrade) ignores the seat fields and returns a DTO without them;
-            //    recording membership for a session whose agent never received its conduct would be
-            //    a governance lie.
-            //  - The spawn has already SUCCEEDED; a participant-write failure is reported loudly in
-            //    the log, never converted into an HTTP failure the caller would retry into a second
-            //    session.
-            if (seatRun is not null && workflowRuns is not null && !string.IsNullOrWhiteSpace(dto.SessionId))
-            {
-                if (dto.WorkflowRunId != seatRun.Id)
-                {
-                    FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: Director did NOT " +
-                                  $"stamp the seat (returned run={dto.WorkflowRunId?.ToString() ?? "none"}; it " +
-                                  "likely predates seated sessions). Session started UNSEATED; no participant recorded.");
-                }
-                else
-                {
-                    try
-                    {
-                        workflowRuns.Patch(seatRun.Id, new Contracts.PatchWorkflowRunRequest
-                        {
-                            AddParticipants = new List<Contracts.WorkflowRunParticipantDto>
-                            {
-                                new()
-                                {
-                                    SessionId = dto.SessionId,
-                                    AgentKind = req.Agent,
-                                    Role = req.Role ?? "",
-                                    Machine = machine,
-                                },
-                            },
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: run-participant " +
-                                      $"record FAILED for session {dto.SessionId} on run {seatRun.Id}: {ex.Message}. " +
-                                      "The session is seated and running; governance is missing this membership row.");
-                    }
-                }
-            }
+            // The run-participant record, in the same shared place the resolution lives.
+            SpawnMissionAndSeat.RecordParticipant(seatRun, workflowRuns, req, dto, machine, route);
 
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: started sid={dto.SessionId}" +
                           (seatRun is null ? "" : $", seated on run {seatRun.Id} ({seatRun.WorkflowId} v{seatRun.WorkflowVersion})"));

--- a/src/CcDirector.Gateway/Api/SpawnMissionAndSeat.cs
+++ b/src/CcDirector.Gateway/Api/SpawnMissionAndSeat.cs
@@ -1,0 +1,173 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Http;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The one place a spawn's MISSION and WORKFLOW SEAT are resolved before the create leaves the Gateway.
+///
+/// A session can be started through two doors - POST /machines/{machine}/sessions ("some Director on that
+/// computer") and POST /directors/{id}/sessions ("this exact Director", which is what an unqualified
+/// <c>cc-devthrottle session spawn</c> uses) - and BOTH must hand the Director a finished answer, because
+/// the Director no longer holds missions or runs and cannot resolve either one itself.
+///
+/// THIS EXISTS BECAUSE THE TWO DOORS DRIFTED, and the drift was a total outage of mission-scoped spawning
+/// (issue #2629). The machine door resolved the mission name; the Director door forwarded the request
+/// verbatim. So a create arrived carrying a mission id and no NAME, which the Director read as "an old
+/// caller naming a mission in my own local store", looked the id up in a stale per-machine missions.json,
+/// and refused a mission that was real, active and listed - advising the caller to create something that
+/// already existed. The seat drifted the same way and more quietly: the Director door seated nothing, so a
+/// mission-scoped session started there would have run without the conduct its mission pins, and with no
+/// membership row for governance to read.
+///
+/// Two copies of a rule drift apart by default; one cannot. Anything a spawn door must do to a create
+/// request before dispatching it belongs HERE, and a door that skips this helper is the same defect again.
+/// </summary>
+internal static class SpawnMissionAndSeat
+{
+    /// <summary>
+    /// Resolve the mission NAME and the workflow SEAT onto <paramref name="req"/>, in the caller's own
+    /// tenant. Returns false when the request must be refused, with <paramref name="error"/> holding the
+    /// answer to return; true otherwise, with <paramref name="seatRun"/> naming the run the session was
+    /// seated on (null = unseated, which is a normal outcome and not a failure).
+    ///
+    /// <paramref name="route"/> names the calling door in the log, so a rejection says which one it came
+    /// through.
+    /// </summary>
+    internal static bool TryResolve(
+        NewSessionRequest req,
+        TenantId tenant,
+        Core.Sessions.MissionStore? missions,
+        Workflows.WorkflowRunStore? workflowRuns,
+        string route,
+        out WorkflowRunDto? seatRun,
+        out IResult? error)
+    {
+        seatRun = null;
+        error = null;
+
+        // Gateway Cleanup mission (Wave 4b): a mission-scoped spawn is validated against the Gateway's OWN
+        // mission store (the source of truth) and the resolved NAME is stamped onto the create request, so
+        // the Director stamps the attachment directly with no local-store lookup. Reject an unknown mission
+        // here rather than forwarding it to a Director that no longer owns mission validation.
+        if (req.MissionId is Guid spawnMissionId && missions is not null)
+        {
+            // #1039: resolve the mission in the CALLING tenant. This lookup was by bare id, so naming
+            // another account's mission id here stamped that account's mission NAME - free text a person
+            // typed - onto the caller's own session. It is the same disclosure GET /missions/{mid} was,
+            // reached through the spawn route instead, and the issue does not name it.
+            var mission = missions.Get(tenant, spawnMissionId);
+            if (mission is null)
+            {
+                FileLog.Write($"[SpawnMissionAndSeat] {route}: unknown mission {spawnMissionId}");
+                error = Results.BadRequest(new { error = $"unknown mission '{spawnMissionId}'. Create it first with POST /missions." });
+                return false;
+            }
+            req.MissionName = mission.MissionName;
+        }
+
+        // Workflows mission (phase 5b): resolve the seat. An EXPLICIT run id must exist; a mission-scoped
+        // spawn with no explicit run auto-seats onto the mission's newest run (the one POST /missions
+        // opened). The run's workflow id + pinned version ride the create request so the Director stamps
+        // the seat with no lookup of its own - and the seated session's conduct is pinned to the run's
+        // version, never a moving head.
+        // ON THE RUN LOOKUP AND TENANCY, because it reads like a hole and is not - a reviewer raised it as
+        // one. The run id here IS caller-supplied, unlike the mission id above it is not resolved against a
+        // tenant argument, and a caller owning the target Director does not by itself prove they own the
+        // run. What closes it is the store, not this code: WorkflowRunEntity is a tenant-scoped entity
+        // (GatewayDbContext.ApplyTenantScope) carrying a global query filter TenantId == ActiveTenant, and
+        // WorkflowRunStore.Get opens its context from the AMBIENT tenant - the caller's own on hosted, set
+        // by the request middleware. Another account's run id therefore reads back as nothing and is
+        // refused below as unknown, which is also how an id that never existed is answered, so the two
+        // cannot be told apart. Do not "fix" this by passing the tenant in: that would imply the store is
+        // unfiltered, which is the belief worth not planting.
+        if (workflowRuns is not null)
+        {
+            if (req.WorkflowRunId is Guid explicitRunId)
+            {
+                seatRun = workflowRuns.Get(explicitRunId);
+                if (seatRun is null)
+                {
+                    FileLog.Write($"[SpawnMissionAndSeat] {route}: unknown workflow run {explicitRunId}");
+                    error = Results.BadRequest(new { error = $"unknown workflow run '{explicitRunId}'." });
+                    return false;
+                }
+            }
+            else if (req.MissionId is Guid seatMissionId)
+            {
+                seatRun = workflowRuns.List(missionId: seatMissionId, limit: 1).FirstOrDefault();
+            }
+
+            if (seatRun is not null && !seatRun.WorkflowEnabled)
+            {
+                // The owner turned this workflow OFF: no new seats. The spawn proceeds unseated - the
+                // owner's switch, honestly applied and loudly logged.
+                FileLog.Write($"[SpawnMissionAndSeat] {route}: workflow '{seatRun.WorkflowId}' is OFF - spawning UNSEATED");
+                seatRun = null;
+            }
+            if (seatRun is not null)
+            {
+                req.WorkflowRunId = seatRun.Id;
+                req.WorkflowId = seatRun.WorkflowId;
+                req.WorkflowVersion = seatRun.WorkflowVersion;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Record the new session as a participant of the run it was seated on - the persisted
+    /// run-to-session membership (#1771). The session id is the canonical fleet GUID governance joins
+    /// effort on. Two guards, both from inspection findings:
+    ///  - Record ONLY when the Director's reply proves the seat actually landed. An older Director
+    ///    (rolling upgrade) ignores the seat fields and returns a DTO without them; recording membership
+    ///    for a session whose agent never received its conduct would be a governance lie.
+    ///  - The spawn has already SUCCEEDED; a participant-write failure is reported loudly in the log,
+    ///    never converted into an HTTP failure the caller would retry into a second session.
+    /// </summary>
+    internal static void RecordParticipant(
+        WorkflowRunDto? seatRun,
+        Workflows.WorkflowRunStore? workflowRuns,
+        NewSessionRequest req,
+        SessionDto dto,
+        string machine,
+        string route)
+    {
+        if (seatRun is null || workflowRuns is null || string.IsNullOrWhiteSpace(dto.SessionId))
+            return;
+
+        if (dto.WorkflowRunId != seatRun.Id)
+        {
+            FileLog.Write($"[SpawnMissionAndSeat] {route}: Director did NOT stamp the seat (returned " +
+                          $"run={dto.WorkflowRunId?.ToString() ?? "none"}; it likely predates seated " +
+                          "sessions). Session started UNSEATED; no participant recorded.");
+            return;
+        }
+
+        try
+        {
+            workflowRuns.Patch(seatRun.Id, new PatchWorkflowRunRequest
+            {
+                AddParticipants = new List<WorkflowRunParticipantDto>
+                {
+                    new()
+                    {
+                        SessionId = dto.SessionId,
+                        AgentKind = req.Agent,
+                        Role = req.Role ?? "",
+                        Machine = machine,
+                    },
+                },
+            });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SpawnMissionAndSeat] {route}: run-participant record FAILED for session " +
+                          $"{dto.SessionId} on run {seatRun.Id}: {ex.Message}. The session is seated and " +
+                          "running; governance is missing this membership row.");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -98,13 +98,16 @@ public sealed class GatewayHost : IAsyncDisposable
     public Streaming.RepoHistoryStore RepoHistory { get; }
 
     /// <summary>
-    /// Gateway Cleanup mission (Wave 4b): the Gateway's OWN store of Missions. Missions are a fleet-level
-    /// concept (they span Directors and machines and nest), so the source of truth lives at the Gateway,
-    /// like fleet messaging and scheduling - not on any one Director. Reuses the same JSON-file-backed
-    /// <see cref="Core.Sessions.MissionStore"/> the Director uses, pointed at a Gateway-side file. The
-    /// mission REST endpoints (POST/GET /missions) read and write this, and a mission-scoped spawn
-    /// validates against it before forwarding the create to a Director. The Director's own /missions
-    /// routes stay until a later phase; this is the additive Gateway-native equivalent.
+    /// Gateway Cleanup mission (Wave 4b): the ONLY store of Missions. Missions are a fleet-level concept
+    /// (they span Directors and machines and nest), so the source of truth lives at the Gateway, like fleet
+    /// messaging and scheduling - not on any one Director. It is the JSON-file-backed
+    /// <see cref="Core.Sessions.MissionStore"/>, pointed at a Gateway-side file. The mission REST endpoints
+    /// (POST/GET /missions) read and write this, and every spawn door validates against it and stamps the
+    /// resolved NAME onto the create before forwarding it to a Director.
+    ///
+    /// A Director no longer keeps one at all: the local store, and the create-time bridge that consulted
+    /// it, were removed with issue #2629 after a spawn door that forwarded the id WITHOUT the name sent the
+    /// Director to that stale per-machine file, which reported a live mission as unknown.
     /// </summary>
     public Core.Sessions.MissionStore Missions { get; }
 

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -782,7 +782,12 @@ def spawn_session(
     # against Standalone/Manager/Worker/Architect and rejects an unknown value (never a silent drop).
     if role:
         body["role"] = role
-    # Mission attach at spawn: forward the Mission id; the Director resolves+validates it (unknown -> 400).
+    # Mission attach at spawn: forward the Mission id ALONE. The GATEWAY resolves and validates it against
+    # its own store - the only one that holds missions - and sends the Director the resolved name alongside
+    # the id; an unknown mission is a 400 from the Gateway. This tool deliberately does not look a mission
+    # up itself: a second copy of that rule here would be a second thing to get wrong (issue #2629, where
+    # one of the two Gateway spawn routes forwarded the id without the name and the Director, asked to
+    # resolve something it does not hold, called a live mission unknown).
     #
     # INHERITANCE (issue #2387). With no --mission, a session that has a CONTROLLER inherits that
     # controller's mission. Default ON, because the fleet already records the relationship and the case


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle_internal#1876.

## What was broken

A session spawn reaches the Gateway two ways:

- `POST /machines/{machine}/sessions` - "some Director on that computer"
- `POST /directors/{id}/sessions` - "this exact Director", which is what an unqualified `cc-devthrottle session spawn` uses

Only the machine door resolved a mission-scoped spawn against the Gateway's mission store, the source of truth, and stamped the resolved mission NAME onto the create request. The Director door forwarded the request verbatim.

So a create arrived at the Director carrying a mission id and no name. The Director read that as an old caller naming a mission in its own local store, looked the id up in a per-machine `missions.json` that nothing has written since July, and answered:

```
unknown mission '2d549e83-...'. Create it first with POST /missions.
```

for a mission that was real, active, and listed by `cc-devthrottle mission list`. Every new mission-scoped session on the machine was blocked, and the error told the caller to create something they already had.

The workflow SEAT was missing from that door too, and silently: a session inside a mission with none of the conduct its mission pins, and no membership row for governance to read.

Proved live against the hosted Gateway before any code was written, with three requests that stopped short of creating anything:

| Request | Result |
|---|---|
| `/directors/{id}/sessions` + mission id only | `director returned BadRequest: unknown mission '2d549e83-...'` |
| `/directors/{id}/sessions` + mission id **and** name | passes the mission block |
| `/machines/SOREN_NORTH/sessions` + mission id only | passes - the Gateway stamped the name |

## What changed

**One resolver, both doors.** `SpawnMissionAndSeat` stamps the mission name, resolves the workflow seat, and records the run participant. `MachineEndpoints` now calls it instead of holding its own copy; `GatewayEndpoints` calls it where it previously did nothing. Two copies of a rule drift apart by default; one cannot.

**The Director's local mission bridge is gone**, from both the create and the attach-mission verbs, along with its store in `ControlApiHost`. That bridge was documented as temporary the day it was written, and consulting a store that cannot answer is exactly what turned a live mission into an unknown one. A mission id arriving without its name is now refused with the reason - it was never resolved by the Gateway - and a log line, where before it failed with no log line at all.

**Four stale claims corrected.** `NewSessionRequest`, `ControlEndpoints`, `GatewayHost` and the command line's `session_ops.py` all still told the reader that the Director resolves mission ids locally. Anyone following that documentation would now get a bad request and no idea why.

## Proof

The five new tests fail against the unfixed route and pass against the fixed one. The sixth - a plain spawn naming no mission - passes either way, as the negative control.

The whole suite is green, including both parked suites: `Gateway.Tests` 2321 and `Core.Tests` 4380, plus the nine default suites. Run with the Postgres proof rig up, so the eight `HostedSchemaRefusesAnUnownedRowTests` failures this machine shows by default were absent rather than excused. The parked suites exceed a single run's window, so they were run in class-partitioned chunks whose executed counts sum back to the full suite totals.

Reviewed independently by a different agent family, which cut its own worktree, reverted the fix there, and reproduced the reversion proof rather than taking mine. No functional or security defect found. Three findings, all applied: the stale claims above, an overclaim in a test comment (these tests name the two doors that exist, so they cannot fail for a third one somebody adds later - what guards that is there being only one implementation), and a pre-existing test name asserting the opposite of what it said.

One earlier review claimed the explicit workflow-run lookup is not tenant-scoped. It is: `WorkflowRunEntity` is tenant-scoped with a global query filter on the active tenant, and `WorkflowRunStore.Get` opens its context from the ambient tenant, so a foreign run id reads back as nothing and is refused as unknown. That reasoning is now recorded at the lookup so it is not raised a third time.

## Deploying

Gateway first, which is also the natural order. An old Gateway paired with a new Director still fails a mission spawn through the Director door - but that is what happens today, so it is the same failure with an honest message, not a regression.

## Noticed, not fixed

Two asymmetries of the same kind, outside this issue and worth their own work: the cross-Director handover route builds its own spawn request and never carries the mission across, so a handed-over session silently leaves its mission; and the Director door does not stamp the origin from the device key the way the machine door does, so a spawn through it records whatever the body claimed.
