### PR TITLE
feat(gateway): dictation transcripts kept 90 days, matching session history

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/TranscriptStoreTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TranscriptStoreTests.cs
@@ -18,6 +18,23 @@ public sealed class TranscriptStoreTests
     private static readonly DateTime Base = new(2026, 7, 24, 12, 0, 0, DateTimeKind.Utc);
 
     [Fact]
+    public void ProductionRetention_MatchesSessionHistory_AndTheCapDoesNotUndercutIt()
+    {
+        // Owner decision, 2026-09-01: every per-tenant record the Gateway keeps ages out on the SAME
+        // 90-day clock. Pinning the transcript window TO the history window means neither can be
+        // changed alone without this test naming the drift.
+        Assert.Equal(CcDirector.Gateway.History.SessionHistorySweep.Retention, TranscriptStore.RetentionWindow);
+        Assert.Equal(TimeSpan.FromDays(90), TranscriptStore.RetentionWindow);
+
+        // The cap must not silently undercut the window: the heaviest real tenant measured
+        // (2026-09-01) writes ~133 transcripts a day, so 90 days needs ~12,000 rows of headroom.
+        // A 10,000 cap would quietly turn "90 days" into ~75 for exactly the tenant the window
+        // is most about.
+        Assert.True(TranscriptStore.MaxTranscriptsPerTenant >= 133 * 90 * 2,
+            $"MaxTranscriptsPerTenant ({TranscriptStore.MaxTranscriptsPerTenant}) leaves less than 2x headroom over the measured heaviest tenant across the retention window");
+    }
+
+    [Fact]
     public void Append_PersistsRawAndCleanedAndMetadata()
     {
         using var h = new GatewayDbTestHarness();

--- a/src/CcDirector.Gateway/Prompts/PromptLogRetentionSweep.cs
+++ b/src/CcDirector.Gateway/Prompts/PromptLogRetentionSweep.cs
@@ -6,7 +6,7 @@ namespace CcDirector.Gateway.Prompts;
 /// The prompt log's retention window and its enforcement (CR-3b, devthrottle_internal issue #1180).
 /// Before this sweep existed the log said "retention is unbounded" out loud, which for a store of
 /// customer prompt text was the finding, not a feature. Now the log sits on the same footing as the
-/// other bounded stores (turn-review 7 days, session history 90 days, dictation transcripts 30 days,
+/// other bounded stores (turn-review 7 days, session history 90 days, dictation transcripts 90 days,
 /// voice-turn archives 24 hours): a window, and a sweep that makes the window true.
 ///
 /// This sweep does NOT ride the <see cref="Tenancy.TenantScopedSweep"/> seam, on purpose: that seam

--- a/src/CcDirector.Gateway/Transcription/DictionarySuggestionService.cs
+++ b/src/CcDirector.Gateway/Transcription/DictionarySuggestionService.cs
@@ -32,8 +32,8 @@ namespace CcDirector.Gateway.Transcription;
 /// </summary>
 public sealed class DictionarySuggestionService
 {
-    /// <summary>The most-recent transcripts mined per scan. Bounds the mining cost; the store's own 30-day /
-    /// 10,000-row retention (issue #509) already bounds what exists, and the newest slice is the relevant one
+    /// <summary>The most-recent transcripts mined per scan. Bounds the mining cost; the store's own 90-day /
+    /// 30,000-row retention already bounds what exists, and the newest slice is the relevant one
     /// for "what is the model getting wrong lately".</summary>
     public const int MaxTranscriptsMined = 5_000;
 

--- a/src/CcDirector.Gateway/Transcription/MicrophoneQualityLog.cs
+++ b/src/CcDirector.Gateway/Transcription/MicrophoneQualityLog.cs
@@ -21,8 +21,10 @@ namespace CcDirector.Gateway.Transcription;
 /// microphone's name. It exists to answer "which of my microphones is bad", which needs no recording
 /// of what was said.
 ///
-/// RETENTION: 30 days, matching the transcript-text window and the Transcription Health history, so
-/// the product keeps ONE answer to how long it holds on to anything derived from a user's voice.
+/// RETENTION: 30 days, matching the Transcription Health history. (It no longer matches the
+/// transcript-text window: the owner moved dictation transcripts to 90 days on 2026-09-01 to sit on
+/// the same clock as session history. These quality MEASUREMENTS carry no text of what was said, and
+/// nothing argued for holding them longer, so they keep the shorter window.)
 /// </summary>
 public sealed class MicrophoneQualityLog
 {

--- a/src/CcDirector.Gateway/Transcription/TranscriptStore.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscriptStore.cs
@@ -27,11 +27,15 @@ namespace CcDirector.Gateway.Transcription;
 /// <see cref="GatewayDatabase.CreateContext()"/>. A <see cref="TenantId"/> cannot be blank by construction, so
 /// a row can never be attributed to the wrong tenant.
 ///
-/// RETENTION, per tenant: a transcript is kept until it is either older than <see cref="RetentionWindow"/> (30
-/// days) or pushed past the newest <see cref="MaxTranscriptsPerTenant"/> (10,000) for that tenant, whichever
-/// bites first - about 10 MB of text per tenant maximum. Retention is THROTTLED so it does not run on every
-/// write (it runs on the first append per tenant per process and then every <see cref="RetentionCheckEvery"/>
-/// appends), which bounds the overshoot to the cap plus at most one check interval.
+/// RETENTION, per tenant: a transcript is kept until it is either older than <see cref="RetentionWindow"/> (90
+/// days, matching session_history's <c>SessionHistorySweep.Retention</c> so every per-tenant record the
+/// Gateway keeps ages out on the same clock) or pushed past the newest <see cref="MaxTranscriptsPerTenant"/>
+/// (30,000) for that tenant, whichever bites first - about 30 MB of text per tenant maximum. The cap is sized
+/// so the WINDOW is what normally bites: the heaviest real tenant measured (2026-09-01) writes ~133 transcripts
+/// a day, ~12,000 in 90 days - a 10,000 cap would silently cut their "90 days" to ~75. Retention is THROTTLED
+/// so it does not run on every write (it runs on the first append per tenant per process and then every
+/// <see cref="RetentionCheckEvery"/> appends), which bounds the overshoot to the cap plus at most one check
+/// interval.
 ///
 /// Threading: the Gateway is a single writer; every operation runs under this store's write lock over a fresh
 /// pooled context. A write failure is SWALLOWED-AND-LOGGED by the caller (the transcription-service hook), so
@@ -40,12 +44,14 @@ namespace CcDirector.Gateway.Transcription;
 /// </summary>
 public sealed class TranscriptStore
 {
-    /// <summary>How long a transcript is kept before age-trim removes it. Tunable constant (issue #509).</summary>
-    public static readonly TimeSpan RetentionWindow = TimeSpan.FromDays(30);
+    /// <summary>How long a transcript is kept before age-trim removes it. 90 days, the same clock as
+    /// session_history (owner decision, 2026-09-01; was 30 days from issue #509).</summary>
+    public static readonly TimeSpan RetentionWindow = TimeSpan.FromDays(90);
 
     /// <summary>The maximum transcripts kept per tenant; older rows beyond this are count-trimmed. About 1 KB
-    /// of text per utterance, so the cap is roughly 10 MB per tenant. Tunable constant (issue #509).</summary>
-    public const int MaxTranscriptsPerTenant = 10_000;
+    /// of text per utterance, so the cap is roughly 30 MB per tenant - sized so the 90-day window, not the
+    /// cap, is what normally bites (see the class doc for the measurement).</summary>
+    public const int MaxTranscriptsPerTenant = 30_000;
 
     /// <summary>Retention runs every this-many appends per tenant (plus the first append per tenant per
     /// process), so it does not run on every write. Bounds the overshoot to the cap plus one interval.</summary>


### PR DESCRIPTION
Owner decision, 2026-09-01: every per-tenant record the Gateway keeps ages out on the same 90-day clock. Dictation transcripts were on their own 30-day window (issue #509) - a session's counted history outlived the words that drove it by two months.

- `TranscriptStore.RetentionWindow`: 30 -> 90 days.
- `MaxTranscriptsPerTenant`: 10,000 -> 30,000. The cap is sized so the WINDOW is what normally bites: the heaviest real tenant measured (2026-09-01) writes ~133 transcripts/day, ~12,000 in 90 days - the old cap would have silently cut their "90 days" to ~75.
- New test pins `TranscriptStore.RetentionWindow` TO `SessionHistorySweep.Retention` so neither window can drift alone, and asserts the cap keeps 2x headroom over the measured rate.
- Comments stating the old window updated; the microphone-quality log KEEPS 30 days (no text of what was said) and its comment stops claiming it matches.

No schema change, no migration. Rows already pruned under 30 days are gone; the longer window accumulates from deploy.

Tests: TranscriptStore suite 19/19; full CcDirector.Gateway.UnitTests 3,132 passed, 2 skipped (the 8 Postgres-rig tests pass with cc-pg-test running - the standing container had been stopped for 6 days and was restarted).