### PR TITLE
fix(director): find a Claude transcript that moved with the agent into a worktree

### DIFF
--- a/src/CcDirector.Core.UnitTests/Claude/ClaudeSessionReaderRelocatedTranscriptTests.cs
+++ b/src/CcDirector.Core.UnitTests/Claude/ClaudeSessionReaderRelocatedTranscriptTests.cs
@@ -1,0 +1,124 @@
+using CcDirector.Core.Claude;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Claude;
+
+/// <summary>
+/// A Claude Code transcript follows the agent's WORKING DIRECTORY, not the folder the session started in.
+/// When the agent enters a Claude Code worktree, Claude Code moves the transcript into that worktree's own
+/// project folder, and every Director reader that rebuilt the path from the repository folder went on
+/// answering "transcript not found" for the rest of the session (session 111, 1 September 2026: hours of
+/// <c>no_jsonl</c> from a Director looking one folder away from the live file). The lookup is now by the
+/// transcript's identity - its GUID file name - across the projects root.
+/// </summary>
+public sealed class ClaudeSessionReaderRelocatedTranscriptTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "csr-reloc-" + Guid.NewGuid().ToString("N"));
+
+    public ClaudeSessionReaderRelocatedTranscriptTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+    }
+
+    private string Folder(string name)
+    {
+        var dir = Path.Combine(_root, name);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string Transcript(string folder, string id)
+    {
+        var path = Path.Combine(folder, id + ".jsonl");
+        File.WriteAllText(path, "{}\n");
+        return path;
+    }
+
+    [Fact]
+    public void InTheStartFolder_IsFoundThere_WithoutLookingAnywhereElse()
+    {
+        var id = Guid.NewGuid().ToString();
+        var start = Folder("D--Repos-app");
+        var expected = Transcript(start, id);
+        // A decoy elsewhere with the same name must not win over the start folder.
+        Transcript(Folder("D--Repos-app--claude-worktrees-x"), id);
+
+        Assert.Equal(expected, ClaudeSessionReader.LocateJsonl(_root, id, "D--Repos-app"));
+    }
+
+    [Fact]
+    public void MovedIntoAWorktreeFolder_IsFoundThere()
+    {
+        // The session 111 shape: started in the repository, entered a worktree, and the transcript now lives
+        // ONLY under the worktree's project folder. The start folder exists and is empty of it.
+        var id = Guid.NewGuid().ToString();
+        Folder("D--ReposMindzie-mindzieWeb");
+        var moved = Transcript(Folder("D--ReposMindzie-mindzieWeb--claude-worktrees-ns-8922-load-upload"), id);
+
+        Assert.Equal(moved, ClaudeSessionReader.LocateJsonl(_root, id, "D--ReposMindzie-mindzieWeb"));
+    }
+
+    [Fact]
+    public void MovedAgain_IsFollowedAgain_NotPinnedToTheFirstRelocation()
+    {
+        // The remembered relocation is a shortcut, not a fact: if the file is no longer where it was last
+        // seen, the scan runs again and finds its new home.
+        var id = Guid.NewGuid().ToString();
+        Folder("D--Repos-app");
+        var first = Transcript(Folder("D--Repos-app--claude-worktrees-one"), id);
+        Assert.Equal(first, ClaudeSessionReader.LocateJsonl(_root, id, "D--Repos-app"));
+
+        File.Delete(first);
+        var second = Transcript(Folder("D--Repos-app--claude-worktrees-two"), id);
+
+        Assert.Equal(second, ClaudeSessionReader.LocateJsonl(_root, id, "D--Repos-app"));
+    }
+
+    [Fact]
+    public void Nowhere_AnswersTheStartFolderPath_SoNotFoundMessagesNameTheExpectedPlace()
+    {
+        var id = Guid.NewGuid().ToString();
+        Folder("D--Repos-app");
+        Folder("D--Repos-other");
+
+        var answer = ClaudeSessionReader.LocateJsonl(_root, id, "D--Repos-app");
+
+        Assert.Equal(Path.Combine(_root, "D--Repos-app", id + ".jsonl"), answer);
+        Assert.False(File.Exists(answer));
+    }
+
+    [Fact]
+    public void AfterAMiss_TheStartFolderIsStillCheckedEveryTime_SoANewTranscriptIsSeenAtOnce()
+    {
+        // The ordinary new-session case: the first read happens before Claude Code has written the file. The
+        // miss is remembered so the root is not re-scanned every read - but the START folder is checked on
+        // every call regardless, so the transcript is seen the moment it appears where it belongs.
+        var id = Guid.NewGuid().ToString();
+        var start = Folder("D--Repos-app");
+        Folder("D--Repos-other");
+        Assert.False(File.Exists(ClaudeSessionReader.LocateJsonl(_root, id, "D--Repos-app")));
+
+        var written = Transcript(start, id);
+
+        Assert.Equal(written, ClaudeSessionReader.LocateJsonl(_root, id, "D--Repos-app"));
+    }
+
+    [Fact]
+    public void AMissingProjectsRoot_AnswersTheStartFolderPath_AndDoesNotThrow()
+    {
+        var answer = ClaudeSessionReader.LocateJsonl(Path.Combine(_root, "does-not-exist"), Guid.NewGuid().ToString(), "D--Repos-app");
+        Assert.False(File.Exists(answer));
+    }
+
+    [Fact]
+    public void AnEmptySessionId_DoesNotScan()
+    {
+        // With no name to look for there is nothing to find; the caller gets the (nonsense) start path back
+        // exactly as before and reports it, rather than this helper matching some unrelated file.
+        Transcript(Folder("D--Repos-app--claude-worktrees-x"), "");
+        var answer = ClaudeSessionReader.LocateJsonl(_root, "", "D--Repos-app");
+        Assert.Equal(Path.Combine(_root, "D--Repos-app", ".jsonl"), answer);
+    }
+}

--- a/src/CcDirector.Core/Claude/ClaudeSessionReader.cs
+++ b/src/CcDirector.Core/Claude/ClaudeSessionReader.cs
@@ -220,11 +220,112 @@ public static class ClaudeSessionReader
 
     /// <summary>
     /// Get the path to the .jsonl file for a Claude session.
+    ///
+    /// THE TRANSCRIPT FOLLOWS THE AGENT'S WORKING DIRECTORY, NOT THE SESSION'S START FOLDER. Claude Code files
+    /// a transcript under the project folder named for the directory the agent is working in - and that
+    /// directory can change mid-session. When the agent enters a Claude Code worktree (the EnterWorktree
+    /// tool, which makes <c>.claude\worktrees\&lt;name&gt;</c> its new working directory), Claude Code MOVES the
+    /// whole transcript into the worktree's own project folder. The file keeps its name - the Claude session
+    /// id, a GUID - but it is no longer where this Director first found it.
+    ///
+    /// Before this, the path was computed from the repository path alone, so every reader in the Director
+    /// (turns, chat, history, the compaction marker, resume checks) went on opening the start folder and
+    /// answered "transcript not found" for the rest of the session's life. Observed 1 September 2026 on
+    /// session 111: the agent entered a worktree at 15:13 UTC, and from then on the hosted Gateway's every
+    /// narration attempt - one per 45-second sweep, for hours - came back <c>no_jsonl</c> from a Director
+    /// that was looking in the wrong folder while the live transcript sat one folder over. The phone read
+    /// "Voice did not arrive after 19m". The Director's own session record even held the correct path,
+    /// reported by the hook; this helper never consulted it, and neither did its ten callers.
+    ///
+    /// So the lookup is now BY IDENTITY: the start folder is checked first because it is right for every
+    /// session that has not moved, and when the file is not there, the projects root is scanned for the one
+    /// folder that holds <c>&lt;id&gt;.jsonl</c>. A GUID is unique, so a hit is that session's transcript, not
+    /// a guess. A relocation is remembered per session id so the scan happens once, not on every read. When
+    /// no folder holds the file, the start-folder path is returned unchanged, so every "not found at ..."
+    /// message still names the place the caller expected.
     /// </summary>
     public static string GetJsonlPath(string claudeSessionId, string repoPath)
+        => LocateJsonl(ClaudeProjectsPath, claudeSessionId, GetProjectFolder(repoPath));
+
+    /// <summary>(projects root, Claude session id) -> the folder-relocated transcript path already found for
+    /// it, so a session that moved once is not re-scanned for on every read. Keyed by root as well as id so a
+    /// test tree and the real tree can never answer for each other.</summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> RelocatedTranscripts =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>(projects root, Claude session id) -> when a scan last found NOTHING, so a transcript that is
+    /// genuinely absent (most often a brand-new session Claude Code has not written to yet) does not cost a
+    /// full scan on every 45-second read. The start folder is still checked first on every call, so a file
+    /// that appears where it is expected is seen at once; only the discovery of a RELOCATION waits out this
+    /// window.</summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTime> TranscriptScanMissedAt =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>How long a scan that found nothing is trusted before the projects root is scanned again.</summary>
+    internal static readonly TimeSpan RescanAfterMiss = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The lookup behind <see cref="GetJsonlPath"/>, with the projects root injected so it is tested against
+    /// a temporary tree rather than this machine's real <c>~/.claude/projects</c>.
+    /// </summary>
+    /// <param name="projectsRoot">The <c>~/.claude/projects</c> directory.</param>
+    /// <param name="claudeSessionId">The transcript's file name without the extension (a GUID).</param>
+    /// <param name="startFolderName">The project folder named for the directory the session STARTED in.</param>
+    internal static string LocateJsonl(string projectsRoot, string claudeSessionId, string startFolderName)
     {
-        var projectFolder = GetProjectFolderPath(repoPath);
-        return Path.Combine(projectFolder, $"{claudeSessionId}.jsonl");
+        var fileName = $"{claudeSessionId}.jsonl";
+        var expected = Path.Combine(projectsRoot, startFolderName, fileName);
+        if (File.Exists(expected)) return expected;
+        if (string.IsNullOrWhiteSpace(claudeSessionId)) return expected;   // nothing to look for by name
+
+        var key = projectsRoot + "|" + claudeSessionId;
+        if (RelocatedTranscripts.TryGetValue(key, out var remembered) && File.Exists(remembered))
+            return remembered;
+        if (TranscriptScanMissedAt.TryGetValue(key, out var missedAt) && DateTime.UtcNow - missedAt < RescanAfterMiss)
+            return expected;
+
+        // Every project folder that holds a transcript of this name. Ordinarily zero or one; more than one
+        // would mean the same GUID was written under two folders, which Claude Code does not do - if it ever
+        // happens the newest write is the live transcript and the fact is logged so it is not silent.
+        //
+        // The enumeration is guarded because it races the file system: a folder can vanish between being
+        // listed and being probed, and the root itself can be removed or become unreadable under us. Such
+        // a failure is logged and answered exactly as "not found" is - the start-folder path - so a caller
+        // that has always received a path keeps receiving one instead of an exception it never handled.
+        List<string> found;
+        try
+        {
+            found = Directory.Exists(projectsRoot)
+                ? Directory.EnumerateDirectories(projectsRoot)
+                    .Select(dir => Path.Combine(dir, fileName))
+                    .Where(File.Exists)
+                    .OrderByDescending(File.GetLastWriteTimeUtc)
+                    .ToList()
+                : new List<string>();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            FileLog.Write($"[ClaudeSessionReader] GetJsonlPath: scanning {projectsRoot} for {fileName} FAILED: {ex.Message} - answering the start-folder path {expected}");
+            TranscriptScanMissedAt[key] = DateTime.UtcNow;
+            return expected;
+        }
+        if (found.Count == 0)
+        {
+            TranscriptScanMissedAt[key] = DateTime.UtcNow;
+            return expected;
+        }
+        TranscriptScanMissedAt.TryRemove(key, out _);
+
+        var located = found[0];
+        if (found.Count > 1)
+            FileLog.Write($"[ClaudeSessionReader] GetJsonlPath: {found.Count} folders hold {fileName}; using the newest write {located}");
+        if (RelocatedTranscripts.TryAdd(key, located))
+            FileLog.Write($"[ClaudeSessionReader] GetJsonlPath: transcript {fileName} is not in its start folder "
+                        + $"{Path.GetDirectoryName(expected)}; the agent's working directory moved (a Claude Code worktree, most likely) "
+                        + $"and the transcript moved with it. Reading it from {located}");
+        else
+            RelocatedTranscripts[key] = located;
+        return located;
     }
 
     /// <summary>


### PR DESCRIPTION
## Why

Session 111's voice never arrived. The hosted Gateway retried every 45 seconds for hours and every attempt failed at the same step: the Director answered `no_jsonl` to the turns read. The transcript was not missing - Claude Code had moved it. The agent entered a Claude Code worktree at 15:13 UTC, and Claude Code files a transcript under the project folder for the agent's current working directory, so the whole file moved to `D--ReposMindzie-mindzieWeb--claude-worktrees-ns-8922-load-upload`. The Director kept computing the path from the repository folder and kept opening the empty spot. Ten readers share that helper, so chat and history reads failed for the session the same way.

## What

`ClaudeSessionReader.GetJsonlPath` checks the start folder first and, when the file is not there, locates `<id>.jsonl` across the projects root. The id is a GUID, so a hit is that session's transcript. A relocation is remembered per root and id and re-scanned if the remembered file is gone; a scan that finds nothing is not repeated for 30 seconds, and the start folder is still checked on every call so a brand-new transcript is seen the moment it appears. Nothing found still returns the start-folder path, so every "not found at" message names the expected place. A scan that fails on the file system is logged and answered the same way rather than thrown into callers.

## Proof

- Local gate green, nine suites. Parked `Core.Tests` reader, history and verification tests run green (51).
- Seven new tests in `Core.UnitTests`: found in the start folder (a decoy elsewhere does not win), found after moving to a worktree folder, followed when it moves again, the start-folder path when nowhere, a new transcript seen at once after a miss, a missing root, an empty id.
- Reviewed by Codex; the scan-can-throw and repeated-scan findings are fixed here, and the cache is keyed by root as well as id.

## After merging

The fix lives in the Director, so it reaches session 111's machine with the next Director build or release. The hosted Gateway needs nothing.
