### PR TITLE
feat(tools): cc-scrub - screenshot scrubber (#2636)

### DIFF
--- a/tools/cc-scrub/.gitignore
+++ b/tools/cc-scrub/.gitignore
@@ -1,0 +1,3 @@
+# The real denylist is your own config and never belongs in a public repo.
+# Copy terms.example.txt to terms.txt and put your terms there.
+terms.txt

--- a/tools/cc-scrub/PROOF-macos.md
+++ b/tools/cc-scrub/PROOF-macos.md
@@ -1,0 +1,553 @@
+# cc-scrub - clean install proof, macOS
+
+This is the real transcript of a real run, not a summary of one. It was
+produced by creating an empty virtual environment on a macOS machine,
+installing Pillow, pyobjc-framework-Vision and pytest from pip and nothing
+else, drawing the synthetic samples, and then driving cc-scrub over them.
+Every command below is echoed before its output and every exit code is
+printed after it.
+
+It was run from `/private/tmp/cc-scrub-proof` rather than from a checkout,
+so nothing in the transcript names a person, a machine or a private
+repository. The samples are drawn by `gen_samples.py` and the denylist is
+the shipped `terms.example.txt` copied unchanged - the three planted terms
+are `example@example.com`, `myorg/secret-repo` and
+`internal-hostname.local`, all deliberately fake.
+
+## What this proves
+
+- **A clean install works from pip alone.** No installer, no external
+  executable, no tesseract, no subprocess. Pillow 12.3.0 and
+  pyobjc-framework-Vision 12.2.2 - which pulls in its pyobjc-core, Cocoa,
+  Quartz and CoreML wheels itself - on Python 3.14.6, macOS 26.5.2.
+- **check-only finds each planted term and prints CORRECT pixel
+  coordinates**, exiting 1 and leaving the image untouched (step 6). The
+  recognizer reports rectangles normalized to 0..1 from the bottom-left
+  corner, and the conversion to top-left pixels is visible in the numbers:
+  the small-ui repo line is drawn 76 px from the top of a 220 px image and
+  is reported at `y=76` (a bottom-origin mistake would report 130), and the
+  glyph host line is drawn at 70 and reported at `y=72` (a mistake would
+  report 135). The final catch is step 9: a flipped rectangle would blur
+  the wrong pixels, the term would survive in the output, and the verify
+  pass would refuse - it does not.
+- **Line joining is load bearing.** The engine returned the word `repo`
+  split in two as `re po`, and `myorg/secret-repo` still matched because
+  the line is joined before matching (step 6).
+- **This engine reads every planted term at every scale, native included** -
+  each hit is reported as `scales=1,2,3`. On this engine and these samples
+  the multi-scale union is redundancy rather than the difference between
+  hit and miss; contrast the Windows proof, where the 10 px line resolves
+  only at scales 2 and 3. Every scale still always runs.
+- **The fold-versus-miss demonstration is not reproducible against this
+  engine.** It reads the 11 px glyph sample cleanly at every scale -
+  `https://internal-hostname.local/status/session`, letter perfect - so
+  with `--no-fold` the term is STILL found and the run exits 1 (step 7),
+  where the Windows engine misreads the leading glyph and misses. That is
+  why the unfolded-miss half of the glyph test asserts on Windows only. The
+  fold-miss property itself is proven on every platform by the
+  scripted-backend and folding unit tests inside step 12, which feed the
+  matcher a synthetic misread deterministically.
+- **An image with no text is a broken read, not a clean image.**
+  `sample-notext.png` reads zero words at every scale and the tool exits 2
+  refusing to call it scrubbed (step 8).
+- **The output is published only after it verifies.** Each scrub writes a
+  `CANDIDATE` temporary, re-reads that candidate from disk, and only then
+  renames it to the final name: `VERIFY PASSED: 1 hit(s) found, 1
+  region(s) redacted, verify OCR read N words in the output and 0 denylist
+  hit(s) remain`, with N at 57, 54 and 49 - never zero, so a verify
+  instrument that reads nothing cannot certify anything (step 9).
+- **The outputs really are clean.** Each written file is re-opened from
+  disk and read again, independently of the scrub run, with zero hits
+  (step 10).
+- **The whole test suite passes in that same clean environment**: 43
+  collected, 40 passed, 3 skipped (step 12). The three skips are the
+  case-insensitive path-aliasing tests, which are keyed to the platform
+  whose filesystem makes that guarantee by default; macOS volumes can be
+  formatted either way, so those assertions are not keyed to `darwin`.
+
+## What this does NOT prove
+
+- **Nothing about Windows.** That proof is
+  [PROOF-windows.md](PROOF-windows.md).
+- **Nothing about other macOS versions.** The recognizer is the operating
+  system's own and its output is not identical across versions. The word
+  counts and the exact reads below are what this machine produced. Re-run
+  the proof rather than trusting the numbers.
+- **Nothing about real screenshots.** These are synthetic images drawn by
+  Pillow. They are built to exercise the small-text and glyph-confusion
+  cases on purpose, which is not the same thing as a survey of real product
+  chrome.
+- **Nothing about a packaged executable.** cc-scrub is run from source
+  here. It has no PyInstaller build and is not in the shipped tool bundle.
+
+## The transcript
+
+```
+=== 1. the machine and the interpreter ===
+
+$ sw_vers
+ProductName:		macOS
+ProductVersion:		26.5.2
+BuildVersion:		25F84
+[exit 0]
+
+$ python3 -V
+Python 3.14.6
+[exit 0]
+
+=== 2. a brand new virtual environment ===
+
+$ python3 -m venv /private/tmp/cc-scrub-proof/venv
+[exit 0]
+
+=== 3. install from pip only - Pillow, the Vision binding, pytest ===
+
+$ ../venv/bin/python -m pip install --upgrade pip
+Requirement already satisfied: pip in /private/tmp/cc-scrub-proof/venv/lib/python3.14/site-packages (26.1.2)
+Collecting pip
+  Using cached pip-26.2.1-py3-none-any.whl.metadata (4.6 kB)
+Using cached pip-26.2.1-py3-none-any.whl (1.8 MB)
+Installing collected packages: pip
+  Attempting uninstall: pip
+    Found existing installation: pip 26.1.2
+    Uninstalling pip-26.1.2:
+      Successfully uninstalled pip-26.1.2
+Successfully installed pip-26.2.1
+[exit 0]
+
+$ ../venv/bin/python -m pip install pillow pyobjc-framework-Vision pytest
+Collecting pillow
+  Using cached pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl.metadata (9.1 kB)
+Collecting pyobjc-framework-Vision
+  Using cached pyobjc_framework_vision-12.2.2-cp314-cp314-macosx_10_15_universal2.whl.metadata (2.6 kB)
+Collecting pytest
+  Using cached pytest-9.1.1-py3-none-any.whl.metadata (7.6 kB)
+Collecting pyobjc-core>=12.2.2 (from pyobjc-framework-Vision)
+  Using cached pyobjc_core-12.2.2-cp314-cp314-macosx_10_15_universal2.whl.metadata (2.8 kB)
+Collecting pyobjc-framework-Cocoa>=12.2.2 (from pyobjc-framework-Vision)
+  Using cached pyobjc_framework_cocoa-12.2.2-cp314-cp314-macosx_10_15_universal2.whl.metadata (2.6 kB)
+Collecting pyobjc-framework-Quartz>=12.2.2 (from pyobjc-framework-Vision)
+  Using cached pyobjc_framework_quartz-12.2.2-cp314-cp314-macosx_10_15_universal2.whl.metadata (3.6 kB)
+Collecting pyobjc-framework-CoreML>=12.2.2 (from pyobjc-framework-Vision)
+  Using cached pyobjc_framework_coreml-12.2.2-cp314-cp314-macosx_10_15_universal2.whl.metadata (2.5 kB)
+Collecting iniconfig>=1.0.1 (from pytest)
+  Using cached iniconfig-2.3.0-py3-none-any.whl.metadata (2.5 kB)
+Collecting packaging>=22 (from pytest)
+  Using cached packaging-26.3-py3-none-any.whl.metadata (3.5 kB)
+Collecting pluggy<2,>=1.5 (from pytest)
+  Using cached pluggy-1.6.0-py3-none-any.whl.metadata (4.8 kB)
+Collecting pygments>=2.7.2 (from pytest)
+  Using cached pygments-2.21.0-py3-none-any.whl.metadata (2.5 kB)
+Using cached pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl (4.8 MB)
+Using cached pyobjc_framework_vision-12.2.2-cp314-cp314-macosx_10_15_universal2.whl (16 kB)
+Using cached pytest-9.1.1-py3-none-any.whl (386 kB)
+Using cached pluggy-1.6.0-py3-none-any.whl (20 kB)
+Using cached iniconfig-2.3.0-py3-none-any.whl (7.5 kB)
+Using cached packaging-26.3-py3-none-any.whl (129 kB)
+Using cached pygments-2.21.0-py3-none-any.whl (1.3 MB)
+Using cached pyobjc_core-12.2.2-cp314-cp314-macosx_10_15_universal2.whl (6.4 MB)
+Using cached pyobjc_framework_cocoa-12.2.2-cp314-cp314-macosx_10_15_universal2.whl (388 kB)
+Using cached pyobjc_framework_coreml-12.2.2-cp314-cp314-macosx_10_15_universal2.whl (12 kB)
+Using cached pyobjc_framework_quartz-12.2.2-cp314-cp314-macosx_10_15_universal2.whl (219 kB)
+Installing collected packages: pyobjc-core, pygments, pluggy, pillow, packaging, iniconfig, pytest, pyobjc-framework-Cocoa, pyobjc-framework-Quartz, pyobjc-framework-CoreML, pyobjc-framework-Vision
+
+Successfully installed iniconfig-2.3.0 packaging-26.3 pillow-12.3.0 pluggy-1.6.0 pygments-2.21.0 pyobjc-core-12.2.2 pyobjc-framework-Cocoa-12.2.2 pyobjc-framework-CoreML-12.2.2 pyobjc-framework-Quartz-12.2.2 pyobjc-framework-Vision-12.2.2 pytest-9.1.1
+[exit 0]
+
+$ ../venv/bin/python -m pip list
+Package                 Version
+----------------------- -------
+iniconfig               2.3.0
+packaging               26.3
+pillow                  12.3.0
+pip                     26.2.1
+pluggy                  1.6.0
+Pygments                2.21.0
+pyobjc-core             12.2.2
+pyobjc-framework-Cocoa  12.2.2
+pyobjc-framework-CoreML 12.2.2
+pyobjc-framework-Quartz 12.2.2
+pyobjc-framework-Vision 12.2.2
+pytest                  9.1.1
+[exit 0]
+
+=== 4. draw the synthetic samples ===
+
+$ ../venv/bin/python gen_samples.py ../samples
+cc-scrub sample generator
+  WROTE ../samples/sample-normal.png (900x260)
+  WROTE ../samples/sample-small-ui.png (900x220)
+  WROTE ../samples/sample-glyph.png (900x220)
+  WROTE ../samples/sample-notext.png (640x400)
+Planted terms: example@example.com, myorg/secret-repo, internal-hostname.local
+[exit 0]
+
+=== 5. the denylist used for the proof (the shipped example, copied) ===
+
+$ cat ../terms.txt
+# cc-scrub denylist - EXAMPLE ONLY.
+#
+# Copy this file to terms.txt beside it and put your own terms in that copy.
+# terms.txt is listed in this folder's .gitignore and must never be
+# committed: a real denylist is a list of the exact strings you are trying
+# to keep out of public screenshots, so committing it publishes them.
+#
+# One term per line. '#' starts a comment. Matching is case-insensitive and
+# by substring, so 'myorg' also hits 'myorg/secret-repo'. Punctuation and
+# spaces are ignored on both sides, so a term split across OCR words still
+# matches.
+#
+# Keep terms specific. Glyph folding (on by default) deliberately
+# over-matches, so a two or three character term will hit far more than you
+# intended.
+
+example@example.com
+myorg/secret-repo
+internal-hostname.local
+[exit 0]
+
+=== 6. check-only finds the planted terms, with coordinates ===
+
+$ ../venv/bin/python main.py ../samples/sample-normal.png --check-only --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE ../samples/sample-normal.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 20 words in 5 lines
+  ocr scale 2: 20 words in 5 lines
+  ocr scale 3: 20 words in 5 lines
+  HITS: 1
+    term='example@example.com' rect=(x=180 y=115 w=220 h=30) scales=1,2,3 ocr_line='Contact address: example@example.com'
+  CHECK-ONLY: 1 hit(s) present, image NOT modified.
+
+SUMMARY: 1 image(s) processed, 0 clean, 1 failed.
+  FAILED ../samples/sample-normal.png
+[exit 1]
+
+$ ../venv/bin/python main.py ../samples/sample-small-ui.png --check-only --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE ../samples/sample-small-ui.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 18 words in 6 lines
+  ocr scale 2: 19 words in 6 lines
+  ocr scale 3: 20 words in 6 lines
+  HITS: 1
+    term='myorg/secret-repo' rect=(x=39 y=76 w=87 h=14) scales=1,2,3 ocr_line='re po myorg/secret-repo'
+  CHECK-ONLY: 1 hit(s) present, image NOT modified.
+
+SUMMARY: 1 image(s) processed, 0 clean, 1 failed.
+  FAILED ../samples/sample-small-ui.png
+[exit 1]
+
+$ ../venv/bin/python main.py ../samples/sample-glyph.png --check-only --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE ../samples/sample-glyph.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 18 words in 4 lines
+  ocr scale 2: 18 words in 4 lines
+  ocr scale 3: 18 words in 4 lines
+  HITS: 1
+    term='internal-hostname.local' rect=(x=16 y=72 w=237 h=13) scales=1,2,3 ocr_line='https://internal-hostname.local/status/session'
+  CHECK-ONLY: 1 hit(s) present, image NOT modified.
+
+SUMMARY: 1 image(s) processed, 0 clean, 1 failed.
+  FAILED ../samples/sample-glyph.png
+[exit 1]
+
+=== 7. the same glyph case with folding turned off ===
+(this recognizer reads the sample cleanly, so the term is still found -
+ see the notes above the transcript; the fold-miss property is proven
+ by the scripted-backend tests in step 12 instead)
+
+$ ../venv/bin/python main.py ../samples/sample-glyph.png --check-only --no-fold --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE ../samples/sample-glyph.png
+  size 900x220  scales 1,2,3  fold off
+  ocr scale 1: 18 words in 4 lines
+  ocr scale 2: 18 words in 4 lines
+  ocr scale 3: 18 words in 4 lines
+  HITS: 1
+    term='internal-hostname.local' rect=(x=16 y=72 w=237 h=13) scales=1,2,3 ocr_line='https://internal-hostname.local/status/session'
+  CHECK-ONLY: 1 hit(s) present, image NOT modified.
+
+SUMMARY: 1 image(s) processed, 0 clean, 1 failed.
+  FAILED ../samples/sample-glyph.png
+[exit 1]
+
+=== 8. an image with no text at all is a broken read, not a clean image ===
+
+$ ../venv/bin/python main.py ../samples/sample-notext.png --check-only --terms-file ../terms.txt
+FATAL: OCR read ZERO words from ../samples/sample-notext.png across scales 1,2,3. That is a broken read, not a clean image. Refusing to call this scrubbed.
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE ../samples/sample-notext.png
+  size 640x400  scales 1,2,3  fold on
+  ocr scale 1: 0 words in 0 lines
+  ocr scale 2: 0 words in 0 lines
+  ocr scale 3: 0 words in 0 lines
+[exit 2]
+
+=== 9. scrub each sample and let the verify pass rule on it ===
+(-o naming a directory requires the directory to exist - a path that
+ does not exist yet is read as an output file name, so it is created
+ here first, exactly as the README says to)
+
+$ mkdir ../out
+[exit 0]
+
+$ ../venv/bin/python main.py ../samples/sample-normal.png -o ../out --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : blur
+
+IMAGE ../samples/sample-normal.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 20 words in 5 lines
+  ocr scale 2: 20 words in 5 lines
+  ocr scale 3: 20 words in 5 lines
+  HITS: 1
+    term='example@example.com' rect=(x=180 y=115 w=220 h=30) scales=1,2,3 ocr_line='Contact address: example@example.com'
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.cnnq34rf.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.cnnq34rf.tmp
+    verify scale 1: 19 words in 5 lines
+    verify scale 2: 19 words in 5 lines
+    verify scale 3: 19 words in 5 lines
+  WROTE ../out/sample-normal-scrubbed.png (mode=blur pad=4)
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 57 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+$ ../venv/bin/python main.py ../samples/sample-small-ui.png -o ../out --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : blur
+
+IMAGE ../samples/sample-small-ui.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 18 words in 6 lines
+  ocr scale 2: 19 words in 6 lines
+  ocr scale 3: 20 words in 6 lines
+  HITS: 1
+    term='myorg/secret-repo' rect=(x=39 y=76 w=87 h=14) scales=1,2,3 ocr_line='re po myorg/secret-repo'
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.xsadbyq3.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.xsadbyq3.tmp
+    verify scale 1: 18 words in 6 lines
+    verify scale 2: 18 words in 6 lines
+    verify scale 3: 18 words in 6 lines
+  WROTE ../out/sample-small-ui-scrubbed.png (mode=blur pad=4)
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 54 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+$ ../venv/bin/python main.py ../samples/sample-glyph.png -o ../out --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : blur
+
+IMAGE ../samples/sample-glyph.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 18 words in 4 lines
+  ocr scale 2: 18 words in 4 lines
+  ocr scale 3: 18 words in 4 lines
+  HITS: 1
+    term='internal-hostname.local' rect=(x=16 y=72 w=237 h=13) scales=1,2,3 ocr_line='https://internal-hostname.local/status/session'
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.ctb_9x4l.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.ctb_9x4l.tmp
+    verify scale 1: 15 words in 3 lines
+    verify scale 2: 17 words in 3 lines
+    verify scale 3: 17 words in 3 lines
+  WROTE ../out/sample-glyph-scrubbed.png (mode=blur pad=4)
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 49 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+=== 10. re-check every scrubbed output - nothing left to find ===
+
+$ ../venv/bin/python main.py ../out/sample-normal-scrubbed.png --check-only --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE ../out/sample-normal-scrubbed.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 19 words in 5 lines
+  ocr scale 2: 19 words in 5 lines
+  ocr scale 3: 19 words in 5 lines
+  HITS: 0
+  CHECK-ONLY: no hits against 3 terms over 57 OCR words.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+$ ../venv/bin/python main.py ../out/sample-small-ui-scrubbed.png --check-only --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE ../out/sample-small-ui-scrubbed.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 18 words in 6 lines
+  ocr scale 2: 18 words in 6 lines
+  ocr scale 3: 18 words in 6 lines
+  HITS: 0
+  CHECK-ONLY: no hits against 3 terms over 54 OCR words.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+$ ../venv/bin/python main.py ../out/sample-glyph-scrubbed.png --check-only --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE ../out/sample-glyph-scrubbed.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 15 words in 3 lines
+  ocr scale 2: 17 words in 3 lines
+  ocr scale 3: 17 words in 3 lines
+  HITS: 0
+  CHECK-ONLY: no hits against 3 terms over 49 OCR words.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+=== 11. a folder holding only outputs is an empty input set ===
+(the *-scrubbed suffix is skipped by design, which is what makes
+ re-running a folder safe - the tool says so rather than doing nothing)
+
+$ ../venv/bin/python main.py ../out --check-only --terms-file ../terms.txt
+FATAL: no images found in directory ../out
+[exit 2]
+
+=== 12. the full test suite, in the same clean environment ===
+
+$ ../venv/bin/python -m pytest tests/ -v -rs
+============================= test session starts ==============================
+platform darwin -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0 -- /private/tmp/cc-scrub-proof/venv/bin/python
+cachedir: .pytest_cache
+rootdir: /private/tmp/cc-scrub-proof/cc-scrub
+configfile: pyproject.toml
+collecting ... collected 43 items
+
+tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  2%]
+tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  4%]
+tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  6%]
+tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  9%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [ 11%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 13%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 16%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 18%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 20%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 23%]
+tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 25%]
+tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 27%]
+tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 30%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 32%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 34%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 37%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 39%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 41%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case SKIPPED [ 44%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link SKIPPED [ 46%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 48%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 51%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 53%]
+tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 55%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 58%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 60%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 62%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 65%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 67%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 69%]
+tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 72%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 74%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 76%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 79%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 81%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 83%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 86%]
+tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 88%]
+tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 90%]
+tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path SKIPPED [ 93%]
+tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 95%]
+tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 97%]
+tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
+
+=========================== short test summary info ============================
+SKIPPED [1] tests/test_cc_scrub.py:415: case-insensitive path aliasing is a Windows filesystem property
+SKIPPED [1] tests/test_cc_scrub.py:440: case-insensitive path aliasing is a Windows filesystem property
+SKIPPED [1] tests/test_cc_scrub.py:621: case-insensitive path aliasing is a Windows filesystem property
+======================== 40 passed, 3 skipped in 3.21s =========================
+[exit 0]
+```

--- a/tools/cc-scrub/PROOF-macos.md
+++ b/tools/cc-scrub/PROOF-macos.md
@@ -64,13 +64,16 @@ are `example@example.com`, `myorg/secret-repo` and
   disk and read again, independently of the scrub run, with zero hits
   (step 10).
 - **The whole test suite passes in that same clean environment**: 52
-  collected, 47 passed, 5 skipped, zero failures (step 12). The five skips
-  are all case-alias arms - tests whose premise is that two spellings name
-  one file - and they are keyed to Windows by platform, because only
-  Windows guarantees that premise; a macOS volume merely usually satisfies
-  it. The hard-link arm of the input-overwrite guard carries no such key
-  and runs here: overwriting the input through a second name for the same
-  file is refused on this machine, proved live in this run.
+  collected, 52 passed, zero skipped, zero failures (step 12). Nothing is
+  assumed from the platform name: the case-alias arms - tests whose
+  premise is that two spellings name one file - measure the volume they
+  actually write to with the same probe the tool uses, and they skip only
+  on a measured answer (the suite step runs with -rs so any skip would be
+  printed with its reason; none appears). On this machine's
+  case-insensitive volume every one of them ran, so the guards on the only
+  unredacted copy of the input - the case-variant arm, the hard-link arm -
+  and the case-colliding-output refusal are all proved live here, not
+  inferred from Windows.
 
 ## What this does NOT prove
 
@@ -357,8 +360,8 @@ IMAGE ../samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=180 y=115 w=220 h=30) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.g8v9lbyf.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.g8v9lbyf.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.aru8vlyr.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.aru8vlyr.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -385,8 +388,8 @@ IMAGE ../samples/sample-small-ui.png
   ocr scale 3: 20 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=39 y=76 w=87 h=14) scales=1,2,3 ocr_line='re po myorg/secret-repo'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.4tbv3ier.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.4tbv3ier.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.4k1sfa5d.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.4k1sfa5d.tmp
     verify scale 1: 18 words in 6 lines
     verify scale 2: 18 words in 6 lines
     verify scale 3: 18 words in 6 lines
@@ -413,8 +416,8 @@ IMAGE ../samples/sample-glyph.png
   ocr scale 3: 18 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=16 y=72 w=237 h=13) scales=1,2,3 ocr_line='https://internal-hostname.local/status/session'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.9t8py99n.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.9t8py99n.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.7x90v8yn.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.7x90v8yn.tmp
     verify scale 1: 15 words in 3 lines
     verify scale 2: 17 words in 3 lines
     verify scale 3: 17 words in 3 lines
@@ -528,7 +531,7 @@ tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_
 tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 36%]
 tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 38%]
 tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 40%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case SKIPPED [ 42%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 42%]
 tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 44%]
 tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 46%]
 tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 48%]
@@ -538,9 +541,9 @@ tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED
 tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 55%]
 tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 57%]
 tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 59%]
-tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused SKIPPED [ 61%]
-tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase SKIPPED [ 63%]
-tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up SKIPPED [ 65%]
+tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 61%]
+tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 63%]
+tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 65%]
 tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 67%]
 tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 69%]
 tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 71%]
@@ -555,17 +558,11 @@ tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_ter
 tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 88%]
 tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 90%]
 tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 92%]
-tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path SKIPPED [ 94%]
+tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 94%]
 tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 96%]
 tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 98%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-=========================== short test summary info ============================
-SKIPPED [1] tests/test_cc_scrub.py:486: this arm needs a case-insensitive filesystem; Windows always is, a POSIX host may not be
-SKIPPED [1] tests/test_cc_scrub.py:612: this arm needs a case-insensitive filesystem; Windows always is, a POSIX host may not be
-SKIPPED [1] tests/test_cc_scrub.py:629: this arm needs a case-insensitive filesystem; Windows always is, a POSIX host may not be
-SKIPPED [1] tests/test_cc_scrub.py:653: this arm needs a case-insensitive filesystem; Windows always is, a POSIX host may not be
-SKIPPED [1] tests/test_cc_scrub.py:773: case-insensitive path aliasing is a Windows filesystem property
-======================== 47 passed, 5 skipped in 3.08s =========================
+============================== 52 passed in 3.08s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-macos.md
+++ b/tools/cc-scrub/PROOF-macos.md
@@ -30,9 +30,13 @@ are `example@example.com`, `myorg/secret-repo` and
   report 135). The final catch is step 9: a flipped rectangle would blur
   the wrong pixels, the term would survive in the output, and the verify
   pass would refuse - it does not.
-- **Line joining is load bearing.** The engine returned the word `repo`
-  split in two as `re po`, and `myorg/secret-repo` still matched because
-  the line is joined before matching (step 6).
+- **Line joining is visible in a live read, though not load bearing for
+  it.** The engine returned the label word `repo` split in two as `re po`
+  (step 6), which shows the joined-line matcher at work on real engine
+  output - but the sensitive term itself came back as one OCR word in that
+  read, so this transcript does not demonstrate that joining was the
+  difference between hit and miss. The property itself is proven
+  deterministically by the scripted-backend joining tests in step 12.
 - **This engine reads every planted term at every scale, native included** -
   each hit is reported as `scales=1,2,3`. On this engine and these samples
   the multi-scale union is redundancy rather than the difference between
@@ -59,11 +63,14 @@ are `example@example.com`, `myorg/secret-repo` and
 - **The outputs really are clean.** Each written file is re-opened from
   disk and read again, independently of the scrub run, with zero hits
   (step 10).
-- **The whole test suite passes in that same clean environment**: 43
-  collected, 40 passed, 3 skipped (step 12). The three skips are the
-  case-insensitive path-aliasing tests, which are keyed to the platform
-  whose filesystem makes that guarantee by default; macOS volumes can be
-  formatted either way, so those assertions are not keyed to `darwin`.
+- **The whole test suite passes in that same clean environment**: 52
+  collected, 47 passed, 5 skipped, zero failures (step 12). The five skips
+  are all case-alias arms - tests whose premise is that two spellings name
+  one file - and they are keyed to Windows by platform, because only
+  Windows guarantees that premise; a macOS volume merely usually satisfies
+  it. The hard-link arm of the input-overwrite guard carries no such key
+  and runs here: overwriting the input through a second name for the same
+  file is refused on this machine, proved live in this run.
 
 ## What this does NOT prove
 
@@ -350,8 +357,8 @@ IMAGE ../samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=180 y=115 w=220 h=30) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.cnnq34rf.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.cnnq34rf.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.g8v9lbyf.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.g8v9lbyf.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -378,8 +385,8 @@ IMAGE ../samples/sample-small-ui.png
   ocr scale 3: 20 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=39 y=76 w=87 h=14) scales=1,2,3 ocr_line='re po myorg/secret-repo'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.xsadbyq3.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.xsadbyq3.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.4tbv3ier.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.4tbv3ier.tmp
     verify scale 1: 18 words in 6 lines
     verify scale 2: 18 words in 6 lines
     verify scale 3: 18 words in 6 lines
@@ -406,8 +413,8 @@ IMAGE ../samples/sample-glyph.png
   ocr scale 3: 18 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=16 y=72 w=237 h=13) scales=1,2,3 ocr_line='https://internal-hostname.local/status/session'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.ctb_9x4l.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.ctb_9x4l.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.9t8py99n.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.9t8py99n.tmp
     verify scale 1: 15 words in 3 lines
     verify scale 2: 17 words in 3 lines
     verify scale 3: 17 words in 3 lines
@@ -498,56 +505,67 @@ platform darwin -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0 -- /private/tmp/cc-
 cachedir: .pytest_cache
 rootdir: /private/tmp/cc-scrub-proof/cc-scrub
 configfile: pyproject.toml
-collecting ... collected 43 items
+collecting ... collected 52 items
 
-tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  2%]
-tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  4%]
-tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  6%]
-tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  9%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [ 11%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 13%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 16%]
-tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 18%]
-tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 20%]
-tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 23%]
-tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 25%]
-tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 27%]
-tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 30%]
-tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 32%]
-tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 34%]
-tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 37%]
-tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 39%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 41%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case SKIPPED [ 44%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link SKIPPED [ 46%]
-tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 48%]
-tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 51%]
-tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 53%]
+tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  1%]
+tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  3%]
+tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  5%]
+tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  7%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  9%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 11%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 13%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 15%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 17%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 19%]
+tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 21%]
+tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 23%]
+tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 25%]
+tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 26%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 28%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 30%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 32%]
+tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 34%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 36%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 38%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 40%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case SKIPPED [ 42%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 44%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 46%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 48%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 50%]
+tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 51%]
+tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 53%]
 tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 55%]
-tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 58%]
-tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 60%]
-tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 62%]
-tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 65%]
-tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 67%]
-tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 69%]
-tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 72%]
-tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 74%]
-tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 76%]
-tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 79%]
-tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 81%]
-tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 83%]
-tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 86%]
-tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 88%]
-tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 90%]
-tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path SKIPPED [ 93%]
-tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 95%]
-tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 97%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 57%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 59%]
+tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused SKIPPED [ 61%]
+tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase SKIPPED [ 63%]
+tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up SKIPPED [ 65%]
+tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 67%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 69%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 71%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 73%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 75%]
+tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 76%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 78%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 80%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 82%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 84%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 86%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 88%]
+tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 90%]
+tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 92%]
+tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path SKIPPED [ 94%]
+tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 96%]
+tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 98%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
 =========================== short test summary info ============================
-SKIPPED [1] tests/test_cc_scrub.py:415: case-insensitive path aliasing is a Windows filesystem property
-SKIPPED [1] tests/test_cc_scrub.py:440: case-insensitive path aliasing is a Windows filesystem property
-SKIPPED [1] tests/test_cc_scrub.py:621: case-insensitive path aliasing is a Windows filesystem property
-======================== 40 passed, 3 skipped in 3.21s =========================
+SKIPPED [1] tests/test_cc_scrub.py:486: this arm needs a case-insensitive filesystem; Windows always is, a POSIX host may not be
+SKIPPED [1] tests/test_cc_scrub.py:612: this arm needs a case-insensitive filesystem; Windows always is, a POSIX host may not be
+SKIPPED [1] tests/test_cc_scrub.py:629: this arm needs a case-insensitive filesystem; Windows always is, a POSIX host may not be
+SKIPPED [1] tests/test_cc_scrub.py:653: this arm needs a case-insensitive filesystem; Windows always is, a POSIX host may not be
+SKIPPED [1] tests/test_cc_scrub.py:773: case-insensitive path aliasing is a Windows filesystem property
+======================== 47 passed, 5 skipped in 3.08s =========================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-macos.md
+++ b/tools/cc-scrub/PROOF-macos.md
@@ -63,6 +63,18 @@ are `example@example.com`, `myorg/secret-repo` and
   region(s) redacted, verify OCR read N words in the output and 0 denylist
   hit(s) remain`, with N at 57, 54 and 49 - never zero, so a verify
   instrument that reads nothing cannot certify anything (step 9).
+- **`--patch` is exercised, not just described.** Step 9b runs a real
+  `--patch` scrub of the email sample and records its output: candidate
+  written, verified, renamed, `VERIFY PASSED` with 57 words read back and
+  0 hits remaining, and the output re-checked clean from disk in step 10.
+  What that run proves is only what any verify pass proves - this
+  recognizer, at these scales, can no longer read the term. The stronger
+  claim, that `--patch` paints every pixel of the rectangle including its
+  corners and leaves no signal from the covered pixels, is NOT held by
+  this transcript; it is held by the pixel tests in the suite
+  (`test_patch_covers_the_whole_rectangle_including_its_corners` and
+  `test_patch_leaves_one_flat_colour_with_no_original_pixel_anywhere`),
+  which pass in step 12 in this same clean environment.
 - **The outputs are clean AS READ BY THIS ENGINE AT THESE SCALES.** Each
   written file is re-opened from disk and read again, independently of the
   scrub run, with zero denylist hits (step 10). That is this recognizer,
@@ -71,8 +83,8 @@ are `example@example.com`, `myorg/secret-repo` and
   blurred region could do better. The README's section on what the verify
   pass does not prove covers the limits, including that only `--patch`
   leaves no signal from the covered pixels.
-- **The whole test suite passes in that same clean environment**: 60
-  collected, 60 passed, zero skipped, zero failures (step 12). Nothing is
+- **The whole test suite passes in that same clean environment**: 68
+  collected, 68 passed, zero skipped, zero failures (step 12). Nothing is
   assumed from the platform name: the case-alias arms - tests whose
   premise is that two spellings name one file - measure the volume they
   actually write to with the same probe the tool uses, and they skip only
@@ -368,8 +380,8 @@ IMAGE ../samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=180 y=115 w=220 h=30) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.z4iyrtg6.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.z4iyrtg6.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.zm7lbjde.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.zm7lbjde.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -396,8 +408,8 @@ IMAGE ../samples/sample-small-ui.png
   ocr scale 3: 20 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=39 y=76 w=87 h=14) scales=1,2,3 ocr_line='re po myorg/secret-repo'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.80ex_kal.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.80ex_kal.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.0jdooc1k.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.0jdooc1k.tmp
     verify scale 1: 18 words in 6 lines
     verify scale 2: 18 words in 6 lines
     verify scale 3: 18 words in 6 lines
@@ -424,13 +436,46 @@ IMAGE ../samples/sample-glyph.png
   ocr scale 3: 18 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=16 y=72 w=237 h=13) scales=1,2,3 ocr_line='https://internal-hostname.local/status/session'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.cpjrv3ik.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.cpjrv3ik.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.s5gftbmh.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.s5gftbmh.tmp
     verify scale 1: 15 words in 3 lines
     verify scale 2: 17 words in 3 lines
     verify scale 3: 17 words in 3 lines
   WROTE ../out/sample-glyph-scrubbed.png (mode=blur pad=4)
   VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 49 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+=== 9b. the same scrub in --patch mode - exercised, not just described ===
+
+$ mkdir ../out-patch
+[exit 0]
+
+$ ../venv/bin/python main.py ../samples/sample-normal.png -o ../out-patch --patch --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : patch
+
+IMAGE ../samples/sample-normal.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 20 words in 5 lines
+  ocr scale 2: 20 words in 5 lines
+  ocr scale 3: 20 words in 5 lines
+  HITS: 1
+    term='example@example.com' rect=(x=180 y=115 w=220 h=30) scales=1,2,3 ocr_line='Contact address: example@example.com'
+  CANDIDATE /private/tmp/cc-scrub-proof/out-patch/sample-normal-scrubbed.png.jsw8rvvd.tmp (mode=patch pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out-patch/sample-normal-scrubbed.png.jsw8rvvd.tmp
+    verify scale 1: 19 words in 5 lines
+    verify scale 2: 19 words in 5 lines
+    verify scale 3: 19 words in 5 lines
+  WROTE ../out-patch/sample-normal-scrubbed.png (mode=patch pad=4)
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 57 words in the output and 0 denylist hit(s) remain.
 
 SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
 [exit 0]
@@ -500,6 +545,27 @@ IMAGE ../out/sample-glyph-scrubbed.png
 SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
 [exit 0]
 
+$ ../venv/bin/python main.py ../out-patch/sample-normal-scrubbed.png --check-only --terms-file ../terms.txt
+cc-scrub
+  ocr engine : macOS Vision text recognizer (pyobjc)
+  terms file : ../terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE ../out-patch/sample-normal-scrubbed.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 19 words in 5 lines
+  ocr scale 2: 19 words in 5 lines
+  ocr scale 3: 19 words in 5 lines
+  HITS: 0
+  CHECK-ONLY: no hits against 3 terms over 57 OCR words.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
 === 11. a folder holding only outputs is an empty input set ===
 (the *-scrubbed suffix is skipped by design, which is what makes
  re-running a folder safe - the tool says so rather than doing nothing)
@@ -516,69 +582,77 @@ platform darwin -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0 -- /private/tmp/cc-
 cachedir: .pytest_cache
 rootdir: /private/tmp/cc-scrub-proof/cc-scrub
 configfile: pyproject.toml
-collecting ... collected 60 items
+collecting ... collected 68 items
 
 tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  1%]
-tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  3%]
-tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  5%]
-tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  6%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  8%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 10%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 11%]
-tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 13%]
-tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 15%]
-tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 16%]
-tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 18%]
-tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 20%]
-tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 21%]
-tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 23%]
-tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 25%]
-tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 26%]
-tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 28%]
-tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 30%]
-tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 31%]
-tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 33%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 35%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 36%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 38%]
-tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 40%]
-tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 41%]
-tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 43%]
-tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 45%]
-tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 46%]
-tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 48%]
-tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 50%]
-tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 51%]
-tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 53%]
-tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 55%]
-tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 56%]
-tests/test_cc_scrub.py::test_is_same_file_refuses_when_it_cannot_tell_whether_a_path_exists PASSED [ 58%]
-tests/test_cc_scrub.py::test_an_unreadable_output_path_stops_the_run_instead_of_publishing_over_it PASSED [ 60%]
-tests/test_cc_scrub.py::test_an_unreadable_terms_file_is_reported_as_unreadable_not_as_missing PASSED [ 61%]
-tests/test_cc_scrub.py::test_a_candidate_that_cannot_be_removed_warns_and_never_masks_the_failure PASSED [ 63%]
-tests/test_cc_scrub.py::test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer PASSED [ 65%]
-tests/test_cc_scrub.py::test_a_probe_that_cannot_be_removed_is_an_error_not_a_warning PASSED [ 66%]
-tests/test_cc_scrub.py::test_a_genuinely_missing_swapped_name_is_the_case_sensitive_answer PASSED [ 68%]
-tests/test_cc_scrub.py::test_the_megapixel_budget_is_decimal_megapixels_not_mebipixels PASSED [ 70%]
-tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 71%]
-tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 73%]
-tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 75%]
-tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 76%]
-tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 78%]
-tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 80%]
-tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 81%]
-tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 83%]
-tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 85%]
-tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 86%]
-tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 88%]
-tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 90%]
-tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 91%]
-tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 93%]
+tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  2%]
+tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  4%]
+tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  5%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  7%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [  8%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 10%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 11%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 13%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 14%]
+tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 16%]
+tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 17%]
+tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 19%]
+tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 20%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 22%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 23%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 25%]
+tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 26%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 27%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 29%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 30%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 32%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 33%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 35%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 36%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 38%]
+tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 39%]
+tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 41%]
+tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 42%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 44%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 45%]
+tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 47%]
+tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 48%]
+tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 50%]
+tests/test_cc_scrub.py::test_patch_covers_the_whole_rectangle_including_its_corners PASSED [ 51%]
+tests/test_cc_scrub.py::test_blur_covers_the_whole_rectangle_including_its_corners PASSED [ 52%]
+tests/test_cc_scrub.py::test_patch_leaves_one_flat_colour_with_no_original_pixel_anywhere PASSED [ 54%]
+tests/test_cc_scrub.py::test_is_same_file_refuses_when_it_cannot_tell_whether_a_path_exists PASSED [ 55%]
+tests/test_cc_scrub.py::test_an_unreadable_output_path_stops_the_run_instead_of_publishing_over_it PASSED [ 57%]
+tests/test_cc_scrub.py::test_an_unreadable_terms_file_is_reported_as_unreadable_not_as_missing PASSED [ 58%]
+tests/test_cc_scrub.py::test_a_dangling_symlink_at_the_destination_is_still_something_to_refuse PASSED [ 60%]
+tests/test_cc_scrub.py::test_a_competing_output_appearing_after_the_check_is_not_clobbered PASSED [ 61%]
+tests/test_cc_scrub.py::test_force_still_replaces_a_competing_output PASSED [ 63%]
+tests/test_cc_scrub.py::test_a_terms_file_that_cannot_be_decoded_is_exit_two_not_a_traceback PASSED [ 64%]
+tests/test_cc_scrub.py::test_the_megapixel_message_never_rounds_back_onto_the_limit PASSED [ 66%]
+tests/test_cc_scrub.py::test_a_candidate_that_cannot_be_removed_warns_and_never_masks_the_failure PASSED [ 67%]
+tests/test_cc_scrub.py::test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer PASSED [ 69%]
+tests/test_cc_scrub.py::test_a_probe_that_cannot_be_removed_is_an_error_not_a_warning PASSED [ 70%]
+tests/test_cc_scrub.py::test_a_genuinely_missing_swapped_name_is_the_case_sensitive_answer PASSED [ 72%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_is_decimal_megapixels_not_mebipixels PASSED [ 73%]
+tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 75%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 76%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 77%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 79%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 80%]
+tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 82%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 83%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 85%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 86%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 88%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 89%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 91%]
+tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 92%]
+tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 94%]
 tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 95%]
-tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 96%]
+tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 97%]
 tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 98%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-============================== 60 passed in 3.12s ==============================
+============================== 68 passed in 3.07s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-macos.md
+++ b/tools/cc-scrub/PROOF-macos.md
@@ -20,16 +20,19 @@ are `example@example.com`, `myorg/secret-repo` and
   executable, no tesseract, no subprocess. Pillow 12.3.0 and
   pyobjc-framework-Vision 12.2.2 - which pulls in its pyobjc-core, Cocoa,
   Quartz and CoreML wheels itself - on Python 3.14.6, macOS 26.5.2.
-- **check-only finds each planted term and prints CORRECT pixel
-  coordinates**, exiting 1 and leaving the image untouched (step 6). The
-  recognizer reports rectangles normalized to 0..1 from the bottom-left
-  corner, and the conversion to top-left pixels is visible in the numbers:
-  the small-ui repo line is drawn 76 px from the top of a 220 px image and
-  is reported at `y=76` (a bottom-origin mistake would report 130), and the
-  glyph host line is drawn at 70 and reported at `y=72` (a mistake would
-  report 135). The final catch is step 9: a flipped rectangle would blur
-  the wrong pixels, the term would survive in the output, and the verify
-  pass would refuse - it does not.
+- **check-only finds each planted term and prints its coordinates**,
+  exiting 1 and leaving the image untouched (step 6). The rectangles are
+  the engine's own estimate, converted from its normalized bottom-left
+  form to top-left pixels, and the conversion is checked against where the
+  samples drew the text: the small-ui repo line is drawn 76 px from the
+  top of a 220 px image and is reported at `y=76` (a bottom-origin mistake
+  would report about 130), and the glyph host line is drawn at 70 and
+  reported at `y=72` (a mistake would report about 135). That shows the y
+  values are CONSISTENT with the drawn positions; it does not establish
+  pixel exactness, and the verify pass in step 9 is the same engine
+  reading again, so it cannot establish exactness either. What step 9 does
+  show is that the rectangles were good enough that redacting them removed
+  every term from that engine's second read.
 - **Line joining is visible in a live read, though not load bearing for
   it.** The engine returned the label word `repo` split in two as `re po`
   (step 6), which shows the joined-line matcher at work on real engine
@@ -60,11 +63,16 @@ are `example@example.com`, `myorg/secret-repo` and
   region(s) redacted, verify OCR read N words in the output and 0 denylist
   hit(s) remain`, with N at 57, 54 and 49 - never zero, so a verify
   instrument that reads nothing cannot certify anything (step 9).
-- **The outputs really are clean.** Each written file is re-opened from
-  disk and read again, independently of the scrub run, with zero hits
-  (step 10).
-- **The whole test suite passes in that same clean environment**: 52
-  collected, 52 passed, zero skipped, zero failures (step 12). Nothing is
+- **The outputs are clean AS READ BY THIS ENGINE AT THESE SCALES.** Each
+  written file is re-opened from disk and read again, independently of the
+  scrub run, with zero denylist hits (step 10). That is this recognizer,
+  at these scales, matching nothing on a second pass - not a proof that no
+  other reader, other scales, or a determined recovery attempt against a
+  blurred region could do better. The README's section on what the verify
+  pass does not prove covers the limits, including that only `--patch`
+  leaves no signal from the covered pixels.
+- **The whole test suite passes in that same clean environment**: 60
+  collected, 60 passed, zero skipped, zero failures (step 12). Nothing is
   assumed from the platform name: the case-alias arms - tests whose
   premise is that two spellings name one file - measure the volume they
   actually write to with the same probe the tool uses, and they skip only
@@ -360,8 +368,8 @@ IMAGE ../samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=180 y=115 w=220 h=30) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.aru8vlyr.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.aru8vlyr.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.z4iyrtg6.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-normal-scrubbed.png.z4iyrtg6.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -388,8 +396,8 @@ IMAGE ../samples/sample-small-ui.png
   ocr scale 3: 20 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=39 y=76 w=87 h=14) scales=1,2,3 ocr_line='re po myorg/secret-repo'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.4k1sfa5d.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.4k1sfa5d.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.80ex_kal.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-small-ui-scrubbed.png.80ex_kal.tmp
     verify scale 1: 18 words in 6 lines
     verify scale 2: 18 words in 6 lines
     verify scale 3: 18 words in 6 lines
@@ -416,8 +424,8 @@ IMAGE ../samples/sample-glyph.png
   ocr scale 3: 18 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=16 y=72 w=237 h=13) scales=1,2,3 ocr_line='https://internal-hostname.local/status/session'
-  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.7x90v8yn.tmp (mode=blur pad=4)
-  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.7x90v8yn.tmp
+  CANDIDATE /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.cpjrv3ik.tmp (mode=blur pad=4)
+  VERIFY: re-reading /private/tmp/cc-scrub-proof/out/sample-glyph-scrubbed.png.cpjrv3ik.tmp
     verify scale 1: 15 words in 3 lines
     verify scale 2: 17 words in 3 lines
     verify scale 3: 17 words in 3 lines
@@ -427,7 +435,7 @@ IMAGE ../samples/sample-glyph.png
 SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
 [exit 0]
 
-=== 10. re-check every scrubbed output - nothing left to find ===
+=== 10. re-check every scrubbed output with the same engine ===
 
 $ ../venv/bin/python main.py ../out/sample-normal-scrubbed.png --check-only --terms-file ../terms.txt
 cc-scrub
@@ -508,61 +516,69 @@ platform darwin -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0 -- /private/tmp/cc-
 cachedir: .pytest_cache
 rootdir: /private/tmp/cc-scrub-proof/cc-scrub
 configfile: pyproject.toml
-collecting ... collected 52 items
+collecting ... collected 60 items
 
 tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  1%]
 tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  3%]
 tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  5%]
-tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  7%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  9%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 11%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 13%]
-tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 15%]
-tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 17%]
-tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 19%]
-tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 21%]
-tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 23%]
-tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 25%]
-tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 26%]
-tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 28%]
-tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 30%]
-tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 32%]
-tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 34%]
-tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 36%]
-tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 38%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 40%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 42%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 44%]
-tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 46%]
-tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 48%]
-tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 50%]
-tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 51%]
-tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 53%]
-tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 55%]
-tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 57%]
-tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 59%]
-tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 61%]
-tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 63%]
-tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 65%]
-tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 67%]
-tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 69%]
-tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 71%]
-tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 73%]
-tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 75%]
-tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 76%]
-tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 78%]
-tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 80%]
-tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 82%]
-tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 84%]
-tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 86%]
-tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 88%]
-tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 90%]
-tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 92%]
-tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 94%]
+tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  6%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  8%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 10%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 11%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 13%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 15%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 16%]
+tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 18%]
+tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 20%]
+tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 21%]
+tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 23%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 25%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 26%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 28%]
+tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 30%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 31%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 33%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 35%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 36%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 38%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 40%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 41%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 43%]
+tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 45%]
+tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 46%]
+tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 48%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 50%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 51%]
+tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 53%]
+tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 55%]
+tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 56%]
+tests/test_cc_scrub.py::test_is_same_file_refuses_when_it_cannot_tell_whether_a_path_exists PASSED [ 58%]
+tests/test_cc_scrub.py::test_an_unreadable_output_path_stops_the_run_instead_of_publishing_over_it PASSED [ 60%]
+tests/test_cc_scrub.py::test_an_unreadable_terms_file_is_reported_as_unreadable_not_as_missing PASSED [ 61%]
+tests/test_cc_scrub.py::test_a_candidate_that_cannot_be_removed_warns_and_never_masks_the_failure PASSED [ 63%]
+tests/test_cc_scrub.py::test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer PASSED [ 65%]
+tests/test_cc_scrub.py::test_a_probe_that_cannot_be_removed_is_an_error_not_a_warning PASSED [ 66%]
+tests/test_cc_scrub.py::test_a_genuinely_missing_swapped_name_is_the_case_sensitive_answer PASSED [ 68%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_is_decimal_megapixels_not_mebipixels PASSED [ 70%]
+tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 71%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 73%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 75%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 76%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 78%]
+tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 80%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 81%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 83%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 85%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 86%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 88%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 90%]
+tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 91%]
+tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 93%]
+tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 95%]
 tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 96%]
 tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 98%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-============================== 52 passed in 3.08s ==============================
+============================== 60 passed in 3.12s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-windows.md
+++ b/tools/cc-scrub/PROOF-windows.md
@@ -47,16 +47,29 @@ all deliberately fake.
 - **The input is never a legal destination, in any spelling.** Addressing the
   same file as `shot.png` and `SHOT.PNG` is refused - and refused even with
   `--force`, because that would destroy the only unredacted copy (step 13).
+- **Two inputs cannot land on one output.** `Shot.png` and `shot.jpg` both
+  resolve to one file on this volume and the run stops before any image is
+  read (step 14).
+- **A read over the megapixel budget is refused before it is attempted.**
+  900x260 at scale 8 is 14.3 megapixels, over a 1 megapixel budget, and the
+  engine is never reached (step 15).
 - **The outputs really are clean.** Each published file is re-opened from
   disk and read again, independently of the scrub run, with zero hits
-  (step 14).
-- **The whole test suite passes in that same clean environment**: 43 tests,
-  including the three end-to-end scrub-and-verify cases (step 16).
+  (step 16).
+- **The whole test suite passes in that same clean environment**: 49 tests,
+  none skipped, including the three end-to-end scrub-and-verify cases
+  (step 18).
 
 ## What this does NOT prove
 
 - **Nothing about macOS.** `MacVisionBackend` raises on construction; the
-  macOS seat implements it and records its own proof.
+  macOS seat implements it and records its own proof. In particular, the
+  output-collision check asks the destination directory whether it treats two
+  spellings as one file, and a Windows volume always answers yes - so this
+  transcript exercises the check but cannot demonstrate the case it was
+  written for, a case-insensitive volume under a POSIX host. The regression
+  test for that half neutralises `os.path.normcase` and is in step 18; the
+  macOS seat verifies it on a real volume.
 - **Nothing about other people's Windows builds.** The recognizer is the
   operating system's own and its output is not identical across Windows
   versions or installed language packs. The word counts and the exact
@@ -73,7 +86,11 @@ all deliberately fake.
   words from, and none reliably leaves a redacted term readable. Those arms
   are proved in the test suite instead, driven by a scripted backend, and
   they are the tests named `test_a_verify_read_of_zero_words_...` and
-  `test_a_term_surviving_in_the_output_...` in step 16.
+  `test_a_term_surviving_in_the_output_...` in step 18.
+- **That no trace of the redacted text survives.** The verify pass is run by
+  the same recognizer that found the text, so a pass proves the term is no
+  longer readable BY THAT ENGINE. See "What the verify pass does not prove"
+  in the README.
 
 ## The transcript
 
@@ -355,8 +372,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.__1cl6r7.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.__1cl6r7.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.j_s5sdjg.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.j_s5sdjg.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -383,8 +400,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-small-ui.png
   ocr scale 3: 18 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=41 y=78 w=84 h=10) scales=2,3 ocr_line='repo myorg/secret-repo'
-  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.v4rhn78t.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.v4rhn78t.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.f41vfdci.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.f41vfdci.tmp
     verify scale 1: 16 words in 5 lines
     verify scale 2: 17 words in 6 lines
     verify scale 3: 17 words in 6 lines
@@ -411,8 +428,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
   ocr scale 3: 17 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=18 y=72 w=233 h=10) scales=2,3 ocr_line='https:/ftnternal-hostname.local/status/session'
-  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.8k2vatg9.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.8k2vatg9.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.k525o152.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.k525o152.tmp
     verify scale 1: 16 words in 3 lines
     verify scale 2: 17 words in 3 lines
     verify scale 3: 16 words in 3 lines
@@ -472,8 +489,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.vxlw9_jr.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.vxlw9_jr.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.omli8w9h.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.omli8w9h.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -505,7 +522,33 @@ IMAGE D:/cc-scrub-proof/shot.png
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
 [exit 2]
 
-=== 14. re-check every published output - nothing left to find ===
+=== 14. two inputs that would land on one output file ===
+(stems differing only in case; the destination directory is asked
+ whether it treats the two spellings as one file, and it does here)
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/collide --terms-file D:/cc-scrub-proof/terms.txt
+FATAL: D:/cc-scrub-proof/collide\Shot.png and D:/cc-scrub-proof/collide\shot.jpg would both be written to D:\cc-scrub-proof\collide\shot-scrubbed.png. Rename one input, give -o separate directories, or scrub them in separate runs.
+[exit 2]
+
+=== 15. a read over the megapixel budget is refused before it is tried ===
+(900x260 at scale 20 is 18000x5200 - the side limit alone would stop
+ this one, so the budget is shown on a scale the side limit allows)
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png --check-only --scales 8 --max-megapixels 1 --terms-file D:/cc-scrub-proof/terms.txt
+FATAL: D:/cc-scrub-proof/samples/sample-normal.png is 900x260; at scale 8 that is 7200x2080, 14.3 megapixels, over the 1 megapixel budget for one read. Use a smaller --scales value, a smaller image, or raise --max-megapixels if this machine has the memory for it.
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE D:/cc-scrub-proof/samples/sample-normal.png
+[exit 2]
+
+=== 16. re-check every published output - nothing left to find ===
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/out/sample-normal-scrubbed.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
 cc-scrub
@@ -570,7 +613,7 @@ IMAGE D:/cc-scrub-proof/out/sample-glyph-scrubbed.png
 SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
 [exit 0]
 
-=== 15. a folder holding only outputs is an empty input set ===
+=== 17. a folder holding only outputs is an empty input set ===
 (the *-scrubbed suffix is skipped by design, which is what makes
  re-running a folder safe - the tool says so rather than doing nothing)
 
@@ -578,7 +621,7 @@ $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/out --chec
 FATAL: no images found in directory D:/cc-scrub-proof/out
 [exit 2]
 
-=== 16. the full test suite, in the same clean environment ===
+=== 18. the full test suite, in the same clean environment ===
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe -m pytest tests/ -v
 ============================= test session starts =============================
@@ -586,52 +629,58 @@ platform win32 -- Python 3.11.6, pytest-9.1.1, pluggy-1.6.0 -- D:\cc-scrub-proof
 cachedir: .pytest_cache
 rootdir: D:\cc-scrub-proof\cc-scrub
 configfile: pyproject.toml
-collecting ... collected 43 items
+collecting ... collected 49 items
 
 tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  2%]
 tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  4%]
 tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  6%]
-tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  9%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [ 11%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 13%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 16%]
-tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 18%]
-tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 20%]
-tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 23%]
-tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 25%]
-tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 27%]
-tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 30%]
-tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 32%]
-tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 34%]
-tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 37%]
-tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 39%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 41%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 44%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 46%]
-tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 48%]
-tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 51%]
-tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 53%]
-tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 55%]
-tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 58%]
-tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 60%]
-tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 62%]
-tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 65%]
-tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 67%]
-tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 69%]
-tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 72%]
-tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 74%]
-tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 76%]
-tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 79%]
-tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 81%]
-tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 83%]
-tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 86%]
-tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 88%]
-tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 90%]
+tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  8%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [ 10%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 12%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 14%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 16%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 18%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 20%]
+tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 22%]
+tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 24%]
+tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 26%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 28%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 30%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 32%]
+tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 34%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 36%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 38%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 40%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 42%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 44%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 46%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 48%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 51%]
+tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 53%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 55%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 57%]
+tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 59%]
+tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 61%]
+tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 63%]
+tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 65%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 67%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 69%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 71%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 73%]
+tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 75%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 77%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 79%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 81%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 83%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 85%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 87%]
+tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 89%]
+tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 91%]
 tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 93%]
 tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 95%]
 tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 97%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-============================= 43 passed in 2.90s ==============================
+============================= 49 passed in 2.48s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-windows.md
+++ b/tools/cc-scrub/PROOF-windows.md
@@ -51,16 +51,23 @@ all deliberately fake.
   resolve to one file on this volume and the run stops before any image is
   read (step 14).
 - **A read over the megapixel budget is refused before it is attempted.**
-  900x260 at scale 8 is 7200x2080, which is 14,976,000 pixels - 15.0
-  megapixels, decimal, as the flag name says - over a 1 megapixel budget, and
-  the engine is never reached (step 15).
+  900x260 at scale 8 is 7200x2080, and the message names the exact count:
+  14,976,000 pixels (14.976 megapixels, decimal, as the flag name says) over
+  a 1 megapixel budget, with the engine never reached (step 15). The count
+  leads and the megapixel figure carries three decimals so that a value just
+  over the cap can never print AS the cap.
+- **`--patch` is exercised, not merely mentioned.** The mode recommended for
+  anything leaving the organisation is run end to end and its output
+  re-checked (step 16). An earlier version of this transcript named `--patch`
+  in prose and never ran a single `--patch` command, which certified a mode
+  it had not exercised.
 - **The published outputs read clean on a second, independent pass.** Each
   file is re-opened from disk after the run that wrote it and read again with
-  zero hits (step 16). That is a statement about this engine at these scales,
+  zero hits (step 17). That is a statement about this engine at these scales,
   not about the pixels: see "What this does NOT prove".
-- **The whole test suite passes in that same clean environment**: 60 tests,
+- **The whole test suite passes in that same clean environment**: 68 tests,
   NONE SKIPPED, including the three end-to-end scrub-and-verify cases
-  (step 18). It is run with `-rs`, so a skip would be printed with its
+  (step 19). It is run with `-rs`, so a skip would be printed with its
   reason - a skip nobody prints reads exactly like a pass. The arms that
   need a volume on which two spellings name one file measure that on the
   directory they write to; on this volume all of them run.
@@ -93,7 +100,7 @@ all deliberately fake.
   answers yes - so this transcript exercises the check but cannot demonstrate
   the case it was written for, which is a case-insensitive volume under a
   POSIX host. The regression test for that half neutralises
-  `os.path.normcase` so it runs anywhere, and it is in step 18; a real
+  `os.path.normcase` so it runs anywhere, and it is in step 19; a real
   case-insensitive POSIX volume is verified on the macOS side.
 - **Nothing about other people's Windows builds.** The recognizer is the
   operating system's own and its output is not identical across Windows
@@ -111,7 +118,7 @@ all deliberately fake.
   words from, and none reliably leaves a redacted term readable. Those arms
   are proved in the test suite instead, driven by a scripted backend, and
   they are the tests named `test_a_verify_read_of_zero_words_...` and
-  `test_a_term_surviving_in_the_output_...` in step 18.
+  `test_a_term_surviving_in_the_output_...` in step 19.
 
 ## The transcript
 
@@ -393,8 +400,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.89hqy8iv.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.89hqy8iv.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.ubs6jcgv.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.ubs6jcgv.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -421,8 +428,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-small-ui.png
   ocr scale 3: 18 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=41 y=78 w=84 h=10) scales=2,3 ocr_line='repo myorg/secret-repo'
-  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.wl5f5_v6.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.wl5f5_v6.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.l50csjte.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.l50csjte.tmp
     verify scale 1: 16 words in 5 lines
     verify scale 2: 17 words in 6 lines
     verify scale 3: 17 words in 6 lines
@@ -449,8 +456,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
   ocr scale 3: 17 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=18 y=72 w=233 h=10) scales=2,3 ocr_line='https:/ftnternal-hostname.local/status/session'
-  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.w1si8l5l.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.w1si8l5l.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.jd18wq6c.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.jd18wq6c.tmp
     verify scale 1: 16 words in 3 lines
     verify scale 2: 17 words in 3 lines
     verify scale 3: 16 words in 3 lines
@@ -510,8 +517,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.o4y1gv15.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.o4y1gv15.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.r6ok7tkm.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.r6ok7tkm.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -556,7 +563,7 @@ FATAL: D:/cc-scrub-proof/collide\Shot.png and D:/cc-scrub-proof/collide\shot.jpg
  14,976,000 pixels, which is 15.0 megapixels and over a 1 megapixel budget)
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png --check-only --scales 8 --max-megapixels 1 --terms-file D:/cc-scrub-proof/terms.txt
-FATAL: D:/cc-scrub-proof/samples/sample-normal.png is 900x260; at scale 8 that is 7200x2080, 15.0 megapixels, over the 1 megapixel budget for one read. Use a smaller --scales value, a smaller image, or raise --max-megapixels if this machine has the memory for it.
+FATAL: D:/cc-scrub-proof/samples/sample-normal.png is 900x260; at scale 8 that is 7200x2080, 14,976,000 pixels (14.976 megapixels), over the 1 megapixel budget for one read. Use a smaller --scales value, a smaller image, or raise --max-megapixels if this machine has the memory for it.
 cc-scrub
   ocr engine : Windows OCR (winocr / WinRT)
   terms file : D:/cc-scrub-proof/terms.txt (3 terms)
@@ -569,7 +576,60 @@ cc-scrub
 IMAGE D:/cc-scrub-proof/samples/sample-normal.png
 [exit 2]
 
-=== 16. re-check every published output - nothing left to find ===
+=== 16. --patch, the mode recommended for anything leaving the org ===
+(the transcript used to MENTION --patch in prose and never run it,
+ which certifies a mode it never exercised)
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png -o D:/cc-scrub-proof/patched --patch --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : patch
+
+IMAGE D:/cc-scrub-proof/samples/sample-normal.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 20 words in 5 lines
+  ocr scale 2: 20 words in 5 lines
+  ocr scale 3: 20 words in 5 lines
+  HITS: 1
+    term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
+  CANDIDATE D:\cc-scrub-proof\patched\sample-normal-scrubbed.png.qsi5weds.tmp (mode=patch pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\patched\sample-normal-scrubbed.png.qsi5weds.tmp
+    verify scale 1: 19 words in 5 lines
+    verify scale 2: 19 words in 5 lines
+    verify scale 3: 19 words in 5 lines
+  WROTE D:/cc-scrub-proof/patched\sample-normal-scrubbed.png (mode=patch pad=4)
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 57 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/patched/sample-normal-scrubbed.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE D:/cc-scrub-proof/patched/sample-normal-scrubbed.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 19 words in 5 lines
+  ocr scale 2: 19 words in 5 lines
+  ocr scale 3: 19 words in 5 lines
+  HITS: 0
+  CHECK-ONLY: no hits against 3 terms over 57 OCR words.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+=== 17. re-check every published output - nothing left to find ===
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/out/sample-normal-scrubbed.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
 cc-scrub
@@ -634,7 +694,7 @@ IMAGE D:/cc-scrub-proof/out/sample-glyph-scrubbed.png
 SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
 [exit 0]
 
-=== 17. a folder holding only outputs is an empty input set ===
+=== 18. a folder holding only outputs is an empty input set ===
 (the *-scrubbed suffix is skipped by design, which is what makes
  re-running a folder safe - the tool says so rather than doing nothing)
 
@@ -642,7 +702,7 @@ $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/out --chec
 FATAL: no images found in directory D:/cc-scrub-proof/out
 [exit 2]
 
-=== 18. the full test suite, in the same clean environment ===
+=== 19. the full test suite, in the same clean environment ===
 (-rs so that anything SKIPPED is printed with its reason, because a
  skip that is not shown reads exactly like a pass)
 
@@ -652,69 +712,77 @@ platform win32 -- Python 3.11.6, pytest-9.1.1, pluggy-1.6.0 -- D:\cc-scrub-proof
 cachedir: .pytest_cache
 rootdir: D:\cc-scrub-proof\cc-scrub
 configfile: pyproject.toml
-collecting ... collected 60 items
+collecting ... collected 68 items
 
 tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  1%]
-tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  3%]
-tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  5%]
-tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  6%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  8%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 10%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 11%]
-tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 13%]
-tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 15%]
-tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 16%]
-tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 18%]
-tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 20%]
-tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 21%]
-tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 23%]
-tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 25%]
-tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 26%]
-tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 28%]
-tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 30%]
-tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 31%]
-tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 33%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 35%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 36%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 38%]
-tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 40%]
-tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 41%]
-tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 43%]
-tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 45%]
-tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 46%]
-tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 48%]
-tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 50%]
-tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 51%]
-tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 53%]
-tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 55%]
-tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 56%]
-tests/test_cc_scrub.py::test_is_same_file_refuses_when_it_cannot_tell_whether_a_path_exists PASSED [ 58%]
-tests/test_cc_scrub.py::test_an_unreadable_output_path_stops_the_run_instead_of_publishing_over_it PASSED [ 60%]
-tests/test_cc_scrub.py::test_an_unreadable_terms_file_is_reported_as_unreadable_not_as_missing PASSED [ 61%]
-tests/test_cc_scrub.py::test_a_candidate_that_cannot_be_removed_warns_and_never_masks_the_failure PASSED [ 63%]
-tests/test_cc_scrub.py::test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer PASSED [ 65%]
-tests/test_cc_scrub.py::test_a_probe_that_cannot_be_removed_is_an_error_not_a_warning PASSED [ 66%]
-tests/test_cc_scrub.py::test_a_genuinely_missing_swapped_name_is_the_case_sensitive_answer PASSED [ 68%]
-tests/test_cc_scrub.py::test_the_megapixel_budget_is_decimal_megapixels_not_mebipixels PASSED [ 70%]
-tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 71%]
-tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 73%]
-tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 75%]
-tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 76%]
-tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 78%]
-tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 80%]
-tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 81%]
-tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 83%]
-tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 85%]
-tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 86%]
-tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 88%]
-tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 90%]
-tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 91%]
-tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 93%]
+tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  2%]
+tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  4%]
+tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  5%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  7%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [  8%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 10%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 11%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 13%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 14%]
+tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 16%]
+tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 17%]
+tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 19%]
+tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 20%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 22%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 23%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 25%]
+tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 26%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 27%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 29%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 30%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 32%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 33%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 35%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 36%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 38%]
+tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 39%]
+tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 41%]
+tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 42%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 44%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 45%]
+tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 47%]
+tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 48%]
+tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 50%]
+tests/test_cc_scrub.py::test_patch_covers_the_whole_rectangle_including_its_corners PASSED [ 51%]
+tests/test_cc_scrub.py::test_blur_covers_the_whole_rectangle_including_its_corners PASSED [ 52%]
+tests/test_cc_scrub.py::test_patch_leaves_one_flat_colour_with_no_original_pixel_anywhere PASSED [ 54%]
+tests/test_cc_scrub.py::test_is_same_file_refuses_when_it_cannot_tell_whether_a_path_exists PASSED [ 55%]
+tests/test_cc_scrub.py::test_an_unreadable_output_path_stops_the_run_instead_of_publishing_over_it PASSED [ 57%]
+tests/test_cc_scrub.py::test_an_unreadable_terms_file_is_reported_as_unreadable_not_as_missing PASSED [ 58%]
+tests/test_cc_scrub.py::test_a_dangling_symlink_at_the_destination_is_still_something_to_refuse PASSED [ 60%]
+tests/test_cc_scrub.py::test_a_competing_output_appearing_after_the_check_is_not_clobbered PASSED [ 61%]
+tests/test_cc_scrub.py::test_force_still_replaces_a_competing_output PASSED [ 63%]
+tests/test_cc_scrub.py::test_a_terms_file_that_cannot_be_decoded_is_exit_two_not_a_traceback PASSED [ 64%]
+tests/test_cc_scrub.py::test_the_megapixel_message_never_rounds_back_onto_the_limit PASSED [ 66%]
+tests/test_cc_scrub.py::test_a_candidate_that_cannot_be_removed_warns_and_never_masks_the_failure PASSED [ 67%]
+tests/test_cc_scrub.py::test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer PASSED [ 69%]
+tests/test_cc_scrub.py::test_a_probe_that_cannot_be_removed_is_an_error_not_a_warning PASSED [ 70%]
+tests/test_cc_scrub.py::test_a_genuinely_missing_swapped_name_is_the_case_sensitive_answer PASSED [ 72%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_is_decimal_megapixels_not_mebipixels PASSED [ 73%]
+tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 75%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 76%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 77%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 79%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 80%]
+tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 82%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 83%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 85%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 86%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 88%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 89%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 91%]
+tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 92%]
+tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 94%]
 tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 95%]
-tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 96%]
+tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 97%]
 tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 98%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-============================= 60 passed in 2.52s ==============================
+============================= 68 passed in 3.36s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-windows.md
+++ b/tools/cc-scrub/PROOF-windows.md
@@ -56,9 +56,12 @@ all deliberately fake.
 - **The outputs really are clean.** Each published file is re-opened from
   disk and read again, independently of the scrub run, with zero hits
   (step 16).
-- **The whole test suite passes in that same clean environment**: 50 tests,
-  none skipped, including the three end-to-end scrub-and-verify cases
-  (step 18).
+- **The whole test suite passes in that same clean environment**: 52 tests,
+  NONE SKIPPED, including the three end-to-end scrub-and-verify cases
+  (step 18). It is run with `-rs`, so a skip would be printed with its
+  reason - a skip nobody prints reads exactly like a pass. The arms that
+  need a volume on which two spellings name one file measure that on the
+  directory they write to; on this volume all of them run.
 
 ## What this does NOT prove
 
@@ -374,8 +377,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.t_jm9lgk.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.t_jm9lgk.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.gg7r876f.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.gg7r876f.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -402,8 +405,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-small-ui.png
   ocr scale 3: 18 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=41 y=78 w=84 h=10) scales=2,3 ocr_line='repo myorg/secret-repo'
-  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.5o_khszz.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.5o_khszz.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.2gpixx5y.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.2gpixx5y.tmp
     verify scale 1: 16 words in 5 lines
     verify scale 2: 17 words in 6 lines
     verify scale 3: 17 words in 6 lines
@@ -430,8 +433,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
   ocr scale 3: 17 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=18 y=72 w=233 h=10) scales=2,3 ocr_line='https:/ftnternal-hostname.local/status/session'
-  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.q8985fsn.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.q8985fsn.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.buzi1foy.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.buzi1foy.tmp
     verify scale 1: 16 words in 3 lines
     verify scale 2: 17 words in 3 lines
     verify scale 3: 16 words in 3 lines
@@ -491,8 +494,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.oljnb0q0.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.oljnb0q0.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.y2gdj9_6.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.y2gdj9_6.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -624,52 +627,56 @@ FATAL: no images found in directory D:/cc-scrub-proof/out
 [exit 2]
 
 === 18. the full test suite, in the same clean environment ===
+(-rs so that anything SKIPPED is printed with its reason, because a
+ skip that is not shown reads exactly like a pass)
 
-$ D:/cc-scrub-proof/venv/Scripts/python.exe -m pytest tests/ -v
+$ D:/cc-scrub-proof/venv/Scripts/python.exe -m pytest tests/ -v -rs
 ============================= test session starts =============================
 platform win32 -- Python 3.11.6, pytest-9.1.1, pluggy-1.6.0 -- D:\cc-scrub-proof\venv\Scripts\python.exe
 cachedir: .pytest_cache
 rootdir: D:\cc-scrub-proof\cc-scrub
 configfile: pyproject.toml
-collecting ... collected 50 items
+collecting ... collected 52 items
 
-tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  2%]
-tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  4%]
-tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  6%]
-tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  8%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [ 10%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 12%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 14%]
-tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 16%]
-tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 18%]
-tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 20%]
-tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 22%]
-tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 24%]
-tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 26%]
-tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 28%]
-tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 30%]
-tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 32%]
-tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 34%]
-tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 36%]
-tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 38%]
-tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 40%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 42%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 44%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 46%]
-tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 48%]
-tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 50%]
-tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 52%]
-tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 54%]
-tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 56%]
-tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 58%]
-tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 60%]
-tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 62%]
-tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 64%]
-tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 66%]
-tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 68%]
-tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 70%]
-tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 72%]
-tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 74%]
+tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  1%]
+tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  3%]
+tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  5%]
+tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  7%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  9%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 11%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 13%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 15%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 17%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 19%]
+tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 21%]
+tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 23%]
+tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 25%]
+tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 26%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 28%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 30%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 32%]
+tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 34%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 36%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 38%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 40%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 42%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 44%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 46%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 48%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 50%]
+tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 51%]
+tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 53%]
+tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 55%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 57%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 59%]
+tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 61%]
+tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 63%]
+tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 65%]
+tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 67%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 69%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 71%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 73%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 75%]
 tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 76%]
 tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 78%]
 tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 80%]
@@ -684,6 +691,6 @@ tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_i
 tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 98%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-============================= 50 passed in 2.48s ==============================
+============================= 52 passed in 2.47s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-windows.md
+++ b/tools/cc-scrub/PROOF-windows.md
@@ -56,20 +56,22 @@ all deliberately fake.
 - **The outputs really are clean.** Each published file is re-opened from
   disk and read again, independently of the scrub run, with zero hits
   (step 16).
-- **The whole test suite passes in that same clean environment**: 49 tests,
+- **The whole test suite passes in that same clean environment**: 50 tests,
   none skipped, including the three end-to-end scrub-and-verify cases
   (step 18).
 
 ## What this does NOT prove
 
-- **Nothing about macOS.** `MacVisionBackend` raises on construction; the
-  macOS seat implements it and records its own proof. In particular, the
-  output-collision check asks the destination directory whether it treats two
-  spellings as one file, and a Windows volume always answers yes - so this
-  transcript exercises the check but cannot demonstrate the case it was
-  written for, a case-insensitive volume under a POSIX host. The regression
-  test for that half neutralises `os.path.normcase` and is in step 18; the
-  macOS seat verifies it on a real volume.
+- **Nothing about macOS.** This is a Windows run. `MacVisionBackend` is a
+  different engine with its own clean-install transcript in
+  [PROOF-macos.md](PROOF-macos.md); nothing here carries over to it.
+  In particular, the output-collision check asks the destination directory
+  whether it treats two spellings as one file, and a Windows volume always
+  answers yes - so this transcript exercises the check but cannot demonstrate
+  the case it was written for, which is a case-insensitive volume under a
+  POSIX host. The regression test for that half neutralises
+  `os.path.normcase` so it runs anywhere, and it is in step 18; a real
+  case-insensitive POSIX volume is verified on the macOS side.
 - **Nothing about other people's Windows builds.** The recognizer is the
   operating system's own and its output is not identical across Windows
   versions or installed language packs. The word counts and the exact
@@ -372,8 +374,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.j_s5sdjg.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.j_s5sdjg.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.t_jm9lgk.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.t_jm9lgk.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -400,8 +402,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-small-ui.png
   ocr scale 3: 18 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=41 y=78 w=84 h=10) scales=2,3 ocr_line='repo myorg/secret-repo'
-  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.f41vfdci.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.f41vfdci.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.5o_khszz.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.5o_khszz.tmp
     verify scale 1: 16 words in 5 lines
     verify scale 2: 17 words in 6 lines
     verify scale 3: 17 words in 6 lines
@@ -428,8 +430,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
   ocr scale 3: 17 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=18 y=72 w=233 h=10) scales=2,3 ocr_line='https:/ftnternal-hostname.local/status/session'
-  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.k525o152.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.k525o152.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.q8985fsn.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.q8985fsn.tmp
     verify scale 1: 16 words in 3 lines
     verify scale 2: 17 words in 3 lines
     verify scale 3: 16 words in 3 lines
@@ -489,8 +491,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.omli8w9h.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.omli8w9h.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.oljnb0q0.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.oljnb0q0.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -531,8 +533,8 @@ FATAL: D:/cc-scrub-proof/collide\Shot.png and D:/cc-scrub-proof/collide\shot.jpg
 [exit 2]
 
 === 15. a read over the megapixel budget is refused before it is tried ===
-(900x260 at scale 20 is 18000x5200 - the side limit alone would stop
- this one, so the budget is shown on a scale the side limit allows)
+(900x260 at scale 8 is 7200x2080 - inside the engine's side limit, and
+ 14.3 megapixels, which is over a 1 megapixel budget)
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png --check-only --scales 8 --max-megapixels 1 --terms-file D:/cc-scrub-proof/terms.txt
 FATAL: D:/cc-scrub-proof/samples/sample-normal.png is 900x260; at scale 8 that is 7200x2080, 14.3 megapixels, over the 1 megapixel budget for one read. Use a smaller --scales value, a smaller image, or raise --max-megapixels if this machine has the memory for it.
@@ -629,7 +631,7 @@ platform win32 -- Python 3.11.6, pytest-9.1.1, pluggy-1.6.0 -- D:\cc-scrub-proof
 cachedir: .pytest_cache
 rootdir: D:\cc-scrub-proof\cc-scrub
 configfile: pyproject.toml
-collecting ... collected 49 items
+collecting ... collected 50 items
 
 tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  2%]
 tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  4%]
@@ -644,43 +646,44 @@ tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_
 tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 22%]
 tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 24%]
 tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 26%]
-tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 28%]
-tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 30%]
-tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 32%]
-tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 34%]
-tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 36%]
-tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 38%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 40%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 42%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 44%]
-tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 46%]
-tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 48%]
-tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 51%]
-tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 53%]
-tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 55%]
-tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 57%]
-tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 59%]
-tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 61%]
-tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 63%]
-tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 65%]
-tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 67%]
-tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 69%]
-tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 71%]
-tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 73%]
-tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 75%]
-tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 77%]
-tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 79%]
-tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 81%]
-tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 83%]
-tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 85%]
-tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 87%]
-tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 89%]
-tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 91%]
-tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 93%]
-tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 95%]
-tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 97%]
+tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 28%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 30%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 32%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 34%]
+tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 36%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 38%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 40%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 42%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 44%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 46%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 48%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 50%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 52%]
+tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 54%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 56%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 58%]
+tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 60%]
+tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 62%]
+tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 64%]
+tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 66%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 68%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 70%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 72%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 74%]
+tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 76%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 78%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 80%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 82%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 84%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 86%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 88%]
+tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 90%]
+tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 92%]
+tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 94%]
+tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 96%]
+tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 98%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-============================= 49 passed in 2.48s ==============================
+============================= 50 passed in 2.48s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-windows.md
+++ b/tools/cc-scrub/PROOF-windows.md
@@ -1,0 +1,517 @@
+# cc-scrub - clean install proof, Windows
+
+This is the real transcript of a real run, not a summary of one. It was
+produced by creating an empty virtual environment on a Windows machine,
+installing Pillow, winocr and pytest from pip and nothing else, drawing the
+synthetic samples, and then driving cc-scrub over them. Every command below
+is echoed before its output and every exit code is printed after it.
+
+It was run from `D:/cc-scrub-proof` rather than from a checkout, so nothing
+in the transcript names a person, a machine or a private repository. The
+samples are drawn by `gen_samples.py` and the denylist is the shipped
+`terms.example.txt` copied unchanged - the three planted terms are
+`example@example.com`, `myorg/secret-repo` and `internal-hostname.local`,
+all deliberately fake.
+
+## What this proves
+
+- **A clean install works from pip alone.** No installer, no external
+  executable, no tesseract, no subprocess. Pillow 12.3.0, winocr 0.0.15 and
+  their winrt wheels, on Python 3.11.6, Windows 10.0.26200.9278.
+- **check-only finds each planted term and prints its coordinates**, and
+  exits 1 while leaving the image untouched (steps 6).
+- **Multi-scale reading is load bearing.** The 10 px grey line in
+  `sample-small-ui.png` is reported as `scales=2,3`: the recognizer cannot
+  resolve it at native resolution and only reads it once the image is
+  enlarged. Read at scale 1 alone, that term is missed.
+- **Glyph folding is load bearing.** In `sample-glyph.png` the recognizer
+  returns `https:/ftnternal-hostname.local/...` - the leading `i` of
+  `internal` comes back as a `t`. With folding on the term is found (step
+  6); with `--no-fold` the same image reports `HITS: 0` and exits 0 (step
+  7). That pair is the whole argument for folding, and it is why folding is
+  on by default.
+- **An image with no text is a broken read, not a clean image.**
+  `sample-notext.png` reads zero words at every scale and the tool exits 2
+  refusing to call it scrubbed (step 8).
+- **The verify pass is presence shaped.** Each scrub prints
+  `VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read N
+  words in the output and 0 denylist hit(s) remain` - and the N is asserted
+  to be non-zero, so a verify instrument that reads nothing cannot certify
+  anything (step 9).
+- **The outputs really are clean.** Each written file is re-opened from disk
+  and read again, independently of the scrub run, with zero hits (step 10).
+- **The whole test suite passes in that same clean environment**: 25 tests,
+  including the three end-to-end scrub-and-verify cases (step 12).
+
+## What this does NOT prove
+
+- **Nothing about macOS.** `MacVisionBackend` raises on construction; the
+  macOS seat implements it and records its own proof.
+- **Nothing about other people's Windows builds.** The recognizer is the
+  operating system's own and its output is not identical across Windows
+  versions or installed language packs. The word counts and the exact
+  misreadings below are what this machine produced. Re-run the proof rather
+  than trusting the numbers.
+- **Nothing about real screenshots.** These are synthetic images drawn by
+  Pillow. They are built to exercise the small-text and glyph-confusion
+  cases on purpose, which is not the same thing as a survey of real product
+  chrome.
+- **Nothing about a packaged executable.** cc-scrub is run from source here.
+  It has no PyInstaller build and is not in the shipped tool bundle.
+
+## The transcript
+
+```
+=== 1. the machine and the interpreter ===
+
+$ cmd //c ver
+
+Microsoft Windows [Version 10.0.26200.9278]
+[exit 0]
+
+$ python -V
+Python 3.11.6
+[exit 0]
+
+=== 2. a brand new virtual environment ===
+
+$ python -m venv D:/cc-scrub-proof/venv
+[exit 0]
+
+=== 3. install from pip only - Pillow, winocr, pytest ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe -m pip install --upgrade pip
+Requirement already satisfied: pip in d:\cc-scrub-proof\venv\lib\site-packages (23.2.1)
+Collecting pip
+  Obtaining dependency information for pip from https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl.metadata
+  Using cached pip-26.2.1-py3-none-any.whl.metadata (4.6 kB)
+Using cached pip-26.2.1-py3-none-any.whl (1.8 MB)
+Installing collected packages: pip
+  Attempting uninstall: pip
+    Found existing installation: pip 23.2.1
+    Uninstalling pip-23.2.1:
+      Successfully uninstalled pip-23.2.1
+Successfully installed pip-26.2.1
+[exit 0]
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe -m pip install pillow winocr pytest
+Collecting pillow
+  Using cached pillow-12.3.0-cp311-cp311-win_amd64.whl.metadata (9.3 kB)
+Collecting winocr
+  Using cached winocr-0.0.15-py3-none-any.whl.metadata (15 kB)
+Collecting pytest
+  Using cached pytest-9.1.1-py3-none-any.whl.metadata (7.6 kB)
+Collecting winrt-windows-foundation-collections (from winocr)
+  Using cached winrt_windows_foundation_collections-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.1 kB)
+Collecting winrt-windows-foundation (from winocr)
+  Using cached winrt_windows_foundation-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.0 kB)
+Collecting winrt-windows-globalization (from winocr)
+  Using cached winrt_windows_globalization-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.2 kB)
+Collecting winrt-windows-graphics-imaging (from winocr)
+  Using cached winrt_windows_graphics_imaging-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.3 kB)
+Collecting winrt-windows-media-ocr (from winocr)
+  Using cached winrt_windows_media_ocr-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.3 kB)
+Collecting winrt-windows-storage-streams (from winocr)
+  Using cached winrt_windows_storage_streams-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.3 kB)
+Collecting colorama>=0.4 (from pytest)
+  Using cached colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
+Collecting iniconfig>=1.0.1 (from pytest)
+  Using cached iniconfig-2.3.0-py3-none-any.whl.metadata (2.5 kB)
+Collecting packaging>=22 (from pytest)
+  Using cached packaging-26.3-py3-none-any.whl.metadata (3.5 kB)
+Collecting pluggy<2,>=1.5 (from pytest)
+  Using cached pluggy-1.6.0-py3-none-any.whl.metadata (4.8 kB)
+Collecting pygments>=2.7.2 (from pytest)
+  Using cached pygments-2.21.0-py3-none-any.whl.metadata (2.5 kB)
+Collecting winrt-runtime~=3.2.1.0 (from winrt-windows-foundation->winocr)
+  Using cached winrt_runtime-3.2.1-cp311-cp311-win_amd64.whl.metadata (780 bytes)
+Collecting typing_extensions>=4.12.2 (from winrt-runtime~=3.2.1.0->winrt-windows-foundation->winocr)
+  Using cached typing_extensions-4.16.0-py3-none-any.whl.metadata (3.3 kB)
+Using cached pillow-12.3.0-cp311-cp311-win_amd64.whl (7.2 MB)
+Using cached winocr-0.0.15-py3-none-any.whl (7.7 kB)
+Using cached pytest-9.1.1-py3-none-any.whl (386 kB)
+Using cached pluggy-1.6.0-py3-none-any.whl (20 kB)
+Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
+Using cached iniconfig-2.3.0-py3-none-any.whl (7.5 kB)
+Using cached packaging-26.3-py3-none-any.whl (129 kB)
+Using cached pygments-2.21.0-py3-none-any.whl (1.3 MB)
+Using cached winrt_windows_foundation-3.2.1-cp311-cp311-win_amd64.whl (118 kB)
+Using cached winrt_runtime-3.2.1-cp311-cp311-win_amd64.whl (242 kB)
+Using cached typing_extensions-4.16.0-py3-none-any.whl (45 kB)
+Using cached winrt_windows_foundation_collections-3.2.1-cp311-cp311-win_amd64.whl (70 kB)
+Using cached winrt_windows_globalization-3.2.1-cp311-cp311-win_amd64.whl (138 kB)
+Using cached winrt_windows_graphics_imaging-3.2.1-cp311-cp311-win_amd64.whl (144 kB)
+Using cached winrt_windows_media_ocr-3.2.1-cp311-cp311-win_amd64.whl (42 kB)
+Using cached winrt_windows_storage_streams-3.2.1-cp311-cp311-win_amd64.whl (132 kB)
+Installing collected packages: typing_extensions, pygments, pluggy, pillow, packaging, iniconfig, colorama, winrt-runtime, pytest, winrt-windows-storage-streams, winrt-windows-media-ocr, winrt-windows-graphics-imaging, winrt-windows-globalization, winrt-windows-foundation-collections, winrt-windows-foundation, winocr
+
+Successfully installed colorama-0.4.6 iniconfig-2.3.0 packaging-26.3 pillow-12.3.0 pluggy-1.6.0 pygments-2.21.0 pytest-9.1.1 typing_extensions-4.16.0 winocr-0.0.15 winrt-runtime-3.2.1 winrt-windows-foundation-3.2.1 winrt-windows-foundation-collections-3.2.1 winrt-windows-globalization-3.2.1 winrt-windows-graphics-imaging-3.2.1 winrt-windows-media-ocr-3.2.1 winrt-windows-storage-streams-3.2.1
+[exit 0]
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe -m pip list
+Package                              Version
+------------------------------------ -------
+colorama                             0.4.6
+iniconfig                            2.3.0
+packaging                            26.3
+pillow                               12.3.0
+pip                                  26.2.1
+pluggy                               1.6.0
+Pygments                             2.21.0
+pytest                               9.1.1
+setuptools                           65.5.0
+typing_extensions                    4.16.0
+winocr                               0.0.15
+winrt-runtime                        3.2.1
+winrt-Windows.Foundation             3.2.1
+winrt-Windows.Foundation.Collections 3.2.1
+winrt-Windows.Globalization          3.2.1
+winrt-Windows.Graphics.Imaging       3.2.1
+winrt-Windows.Media.Ocr              3.2.1
+winrt-Windows.Storage.Streams        3.2.1
+[exit 0]
+
+=== 4. draw the synthetic samples ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe gen_samples.py D:/cc-scrub-proof/samples
+cc-scrub sample generator
+  WROTE D:/cc-scrub-proof/samples\sample-normal.png (900x260)
+  WROTE D:/cc-scrub-proof/samples\sample-small-ui.png (900x220)
+  WROTE D:/cc-scrub-proof/samples\sample-glyph.png (900x220)
+  WROTE D:/cc-scrub-proof/samples\sample-notext.png (640x400)
+Planted terms: example@example.com, myorg/secret-repo, internal-hostname.local
+[exit 0]
+
+=== 5. the denylist used for the proof (the shipped example, copied) ===
+
+$ cat D:/cc-scrub-proof/terms.txt
+# cc-scrub denylist - EXAMPLE ONLY.
+#
+# Copy this file to terms.txt beside it and put your own terms in that copy.
+# terms.txt is listed in this folder's .gitignore and must never be
+# committed: a real denylist is a list of the exact strings you are trying
+# to keep out of public screenshots, so committing it publishes them.
+#
+# One term per line. '#' starts a comment. Matching is case-insensitive and
+# by substring, so 'myorg' also hits 'myorg/secret-repo'. Punctuation and
+# spaces are ignored on both sides, so a term split across OCR words still
+# matches.
+#
+# Keep terms specific. Glyph folding (on by default) deliberately
+# over-matches, so a two or three character term will hit far more than you
+# intended.
+
+example@example.com
+myorg/secret-repo
+internal-hostname.local
+[exit 0]
+
+=== 6. check-only finds the planted terms, with coordinates ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE D:/cc-scrub-proof/samples/sample-normal.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 20 words in 5 lines
+  ocr scale 2: 20 words in 5 lines
+  ocr scale 3: 20 words in 5 lines
+  HITS: 1
+    term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
+  CHECK-ONLY: 1 hit(s) present, image NOT modified.
+
+SUMMARY: 1 image(s) processed, 0 clean, 1 failed.
+  FAILED D:/cc-scrub-proof/samples/sample-normal.png
+[exit 1]
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-small-ui.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE D:/cc-scrub-proof/samples/sample-small-ui.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 17 words in 6 lines
+  ocr scale 2: 18 words in 6 lines
+  ocr scale 3: 18 words in 6 lines
+  HITS: 1
+    term='myorg/secret-repo' rect=(x=41 y=78 w=84 h=10) scales=2,3 ocr_line='repo myorg/secret-repo'
+  CHECK-ONLY: 1 hit(s) present, image NOT modified.
+
+SUMMARY: 1 image(s) processed, 0 clean, 1 failed.
+  FAILED D:/cc-scrub-proof/samples/sample-small-ui.png
+[exit 1]
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-glyph.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 17 words in 4 lines
+  ocr scale 2: 18 words in 4 lines
+  ocr scale 3: 17 words in 4 lines
+  HITS: 1
+    term='internal-hostname.local' rect=(x=18 y=72 w=233 h=10) scales=2,3 ocr_line='https:/ftnternal-hostname.local/status/session'
+  CHECK-ONLY: 1 hit(s) present, image NOT modified.
+
+SUMMARY: 1 image(s) processed, 0 clean, 1 failed.
+  FAILED D:/cc-scrub-proof/samples/sample-glyph.png
+[exit 1]
+
+=== 7. the same glyph case with folding turned off - it is missed ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-glyph.png --check-only --no-fold --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
+  size 900x220  scales 1,2,3  fold off
+  ocr scale 1: 17 words in 4 lines
+  ocr scale 2: 18 words in 4 lines
+  ocr scale 3: 17 words in 4 lines
+  HITS: 0
+  CHECK-ONLY: no hits against 3 terms over 52 OCR words.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+=== 8. an image with no text at all is a broken read, not a clean image ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-notext.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
+FATAL: OCR read ZERO words from D:/cc-scrub-proof/samples/sample-notext.png across scales 1,2,3. That is a broken read, not a clean image. Refusing to call this scrubbed.
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE D:/cc-scrub-proof/samples/sample-notext.png
+  size 640x400  scales 1,2,3  fold on
+  ocr scale 1: 0 words in 0 lines
+  ocr scale 2: 0 words in 0 lines
+  ocr scale 3: 0 words in 0 lines
+[exit 2]
+
+=== 9. scrub each sample and let the verify pass rule on it ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : blur
+
+IMAGE D:/cc-scrub-proof/samples/sample-normal.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 20 words in 5 lines
+  ocr scale 2: 20 words in 5 lines
+  ocr scale 3: 20 words in 5 lines
+  HITS: 1
+    term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
+  WROTE D:/cc-scrub-proof/out\sample-normal-scrubbed.png (mode=blur pad=4)
+  VERIFY: re-reading D:/cc-scrub-proof/out\sample-normal-scrubbed.png
+    verify scale 1: 19 words in 5 lines
+    verify scale 2: 19 words in 5 lines
+    verify scale 3: 19 words in 5 lines
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 57 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-small-ui.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : blur
+
+IMAGE D:/cc-scrub-proof/samples/sample-small-ui.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 17 words in 6 lines
+  ocr scale 2: 18 words in 6 lines
+  ocr scale 3: 18 words in 6 lines
+  HITS: 1
+    term='myorg/secret-repo' rect=(x=41 y=78 w=84 h=10) scales=2,3 ocr_line='repo myorg/secret-repo'
+  WROTE D:/cc-scrub-proof/out\sample-small-ui-scrubbed.png (mode=blur pad=4)
+  VERIFY: re-reading D:/cc-scrub-proof/out\sample-small-ui-scrubbed.png
+    verify scale 1: 16 words in 5 lines
+    verify scale 2: 17 words in 6 lines
+    verify scale 3: 17 words in 6 lines
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 50 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-glyph.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : blur
+
+IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 17 words in 4 lines
+  ocr scale 2: 18 words in 4 lines
+  ocr scale 3: 17 words in 4 lines
+  HITS: 1
+    term='internal-hostname.local' rect=(x=18 y=72 w=233 h=10) scales=2,3 ocr_line='https:/ftnternal-hostname.local/status/session'
+  WROTE D:/cc-scrub-proof/out\sample-glyph-scrubbed.png (mode=blur pad=4)
+  VERIFY: re-reading D:/cc-scrub-proof/out\sample-glyph-scrubbed.png
+    verify scale 1: 16 words in 3 lines
+    verify scale 2: 17 words in 3 lines
+    verify scale 3: 16 words in 3 lines
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 49 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+=== 10. re-check every scrubbed output - nothing left to find ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/out/sample-normal-scrubbed.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE D:/cc-scrub-proof/out/sample-normal-scrubbed.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 19 words in 5 lines
+  ocr scale 2: 19 words in 5 lines
+  ocr scale 3: 19 words in 5 lines
+  HITS: 0
+  CHECK-ONLY: no hits against 3 terms over 57 OCR words.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/out/sample-small-ui-scrubbed.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE D:/cc-scrub-proof/out/sample-small-ui-scrubbed.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 16 words in 5 lines
+  ocr scale 2: 17 words in 6 lines
+  ocr scale 3: 17 words in 6 lines
+  HITS: 0
+  CHECK-ONLY: no hits against 3 terms over 50 OCR words.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/out/sample-glyph-scrubbed.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : check-only
+
+IMAGE D:/cc-scrub-proof/out/sample-glyph-scrubbed.png
+  size 900x220  scales 1,2,3  fold on
+  ocr scale 1: 16 words in 3 lines
+  ocr scale 2: 17 words in 3 lines
+  ocr scale 3: 16 words in 3 lines
+  HITS: 0
+  CHECK-ONLY: no hits against 3 terms over 49 OCR words.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+=== 11. a folder holding only outputs is an empty input set ===
+(the *-scrubbed suffix is skipped by design, which is what makes
+ re-running a folder safe - the tool says so rather than doing nothing)
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/out --check-only --terms-file D:/cc-scrub-proof/terms.txt
+FATAL: no images found in directory D:/cc-scrub-proof/out
+[exit 2]
+
+=== 12. the full test suite, in the same clean environment ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe -m pytest tests/ -v
+============================= test session starts =============================
+platform win32 -- Python 3.11.6, pytest-9.1.1, pluggy-1.6.0 -- D:\cc-scrub-proof\venv\Scripts\python.exe
+cachedir: .pytest_cache
+rootdir: D:\cc-scrub-proof\cc-scrub
+configfile: pyproject.toml
+collecting ... collected 25 items
+
+tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  4%]
+tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  8%]
+tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [ 12%]
+tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [ 16%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [ 20%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 24%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 28%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 32%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 36%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 40%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 44%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 48%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 52%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 56%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 60%]
+tests/test_cc_scrub.py::test_normalise_folds_the_glyph_classes PASSED    [ 64%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 68%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 72%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 76%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 80%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 84%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 88%]
+tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 92%]
+tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 96%]
+tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
+
+============================= 25 passed in 2.54s ==============================
+[exit 0]
+```

--- a/tools/cc-scrub/PROOF-windows.md
+++ b/tools/cc-scrub/PROOF-windows.md
@@ -51,12 +51,14 @@ all deliberately fake.
   resolve to one file on this volume and the run stops before any image is
   read (step 14).
 - **A read over the megapixel budget is refused before it is attempted.**
-  900x260 at scale 8 is 14.3 megapixels, over a 1 megapixel budget, and the
-  engine is never reached (step 15).
-- **The outputs really are clean.** Each published file is re-opened from
-  disk and read again, independently of the scrub run, with zero hits
-  (step 16).
-- **The whole test suite passes in that same clean environment**: 52 tests,
+  900x260 at scale 8 is 7200x2080, which is 14,976,000 pixels - 15.0
+  megapixels, decimal, as the flag name says - over a 1 megapixel budget, and
+  the engine is never reached (step 15).
+- **The published outputs read clean on a second, independent pass.** Each
+  file is re-opened from disk after the run that wrote it and read again with
+  zero hits (step 16). That is a statement about this engine at these scales,
+  not about the pixels: see "What this does NOT prove".
+- **The whole test suite passes in that same clean environment**: 56 tests,
   NONE SKIPPED, including the three end-to-end scrub-and-verify cases
   (step 18). It is run with `-rs`, so a skip would be printed with its
   reason - a skip nobody prints reads exactly like a pass. The arms that
@@ -65,6 +67,14 @@ all deliberately fake.
 
 ## What this does NOT prove
 
+- **That no trace of the redacted text survives in the pixels.** The verify
+  pass is run by the same recognizer that found the text, at the scales this
+  run configured, so a pass proves the term is no longer readable BY THAT
+  ENGINE AT THOSE SCALES. Every scrub here used the default `--blur`, which
+  removes the original pixel values but leaves a low-frequency average of the
+  covered region - that is attackable, and nothing in this transcript says
+  otherwise. `--patch` is the mode that leaves no signal from the covered
+  pixels at all. See "How the redaction works" in the README.
 - **Nothing about macOS.** This is a Windows run. `MacVisionBackend` is a
   different engine with its own clean-install transcript in
   [PROOF-macos.md](PROOF-macos.md); nothing here carries over to it.
@@ -92,10 +102,6 @@ all deliberately fake.
   are proved in the test suite instead, driven by a scripted backend, and
   they are the tests named `test_a_verify_read_of_zero_words_...` and
   `test_a_term_surviving_in_the_output_...` in step 18.
-- **That no trace of the redacted text survives.** The verify pass is run by
-  the same recognizer that found the text, so a pass proves the term is no
-  longer readable BY THAT ENGINE. See "What the verify pass does not prove"
-  in the README.
 
 ## The transcript
 
@@ -119,71 +125,26 @@ $ python -m venv D:/cc-scrub-proof/venv
 === 3. install from pip only - Pillow, winocr, pytest ===
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe -m pip install --upgrade pip
-Requirement already satisfied: pip in d:\cc-scrub-proof\venv\lib\site-packages (23.2.1)
-Collecting pip
-  Obtaining dependency information for pip from https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl.metadata
-  Using cached pip-26.2.1-py3-none-any.whl.metadata (4.6 kB)
-Using cached pip-26.2.1-py3-none-any.whl (1.8 MB)
-Installing collected packages: pip
-  Attempting uninstall: pip
-    Found existing installation: pip 23.2.1
-    Uninstalling pip-23.2.1:
-      Successfully uninstalled pip-23.2.1
-Successfully installed pip-26.2.1
+Requirement already satisfied: pip in .\venv\Lib\site-packages (26.2.1)
 [exit 0]
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe -m pip install pillow winocr pytest
-Collecting pillow
-  Using cached pillow-12.3.0-cp311-cp311-win_amd64.whl.metadata (9.3 kB)
-Collecting winocr
-  Using cached winocr-0.0.15-py3-none-any.whl.metadata (15 kB)
-Collecting pytest
-  Using cached pytest-9.1.1-py3-none-any.whl.metadata (7.6 kB)
-Collecting winrt-windows-foundation-collections (from winocr)
-  Using cached winrt_windows_foundation_collections-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.1 kB)
-Collecting winrt-windows-foundation (from winocr)
-  Using cached winrt_windows_foundation-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.0 kB)
-Collecting winrt-windows-globalization (from winocr)
-  Using cached winrt_windows_globalization-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.2 kB)
-Collecting winrt-windows-graphics-imaging (from winocr)
-  Using cached winrt_windows_graphics_imaging-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.3 kB)
-Collecting winrt-windows-media-ocr (from winocr)
-  Using cached winrt_windows_media_ocr-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.3 kB)
-Collecting winrt-windows-storage-streams (from winocr)
-  Using cached winrt_windows_storage_streams-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.3 kB)
-Collecting colorama>=0.4 (from pytest)
-  Using cached colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
-Collecting iniconfig>=1.0.1 (from pytest)
-  Using cached iniconfig-2.3.0-py3-none-any.whl.metadata (2.5 kB)
-Collecting packaging>=22 (from pytest)
-  Using cached packaging-26.3-py3-none-any.whl.metadata (3.5 kB)
-Collecting pluggy<2,>=1.5 (from pytest)
-  Using cached pluggy-1.6.0-py3-none-any.whl.metadata (4.8 kB)
-Collecting pygments>=2.7.2 (from pytest)
-  Using cached pygments-2.21.0-py3-none-any.whl.metadata (2.5 kB)
-Collecting winrt-runtime~=3.2.1.0 (from winrt-windows-foundation->winocr)
-  Using cached winrt_runtime-3.2.1-cp311-cp311-win_amd64.whl.metadata (780 bytes)
-Collecting typing_extensions>=4.12.2 (from winrt-runtime~=3.2.1.0->winrt-windows-foundation->winocr)
-  Using cached typing_extensions-4.16.0-py3-none-any.whl.metadata (3.3 kB)
-Using cached pillow-12.3.0-cp311-cp311-win_amd64.whl (7.2 MB)
-Using cached winocr-0.0.15-py3-none-any.whl (7.7 kB)
-Using cached pytest-9.1.1-py3-none-any.whl (386 kB)
-Using cached pluggy-1.6.0-py3-none-any.whl (20 kB)
-Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
-Using cached iniconfig-2.3.0-py3-none-any.whl (7.5 kB)
-Using cached packaging-26.3-py3-none-any.whl (129 kB)
-Using cached pygments-2.21.0-py3-none-any.whl (1.3 MB)
-Using cached winrt_windows_foundation-3.2.1-cp311-cp311-win_amd64.whl (118 kB)
-Using cached winrt_runtime-3.2.1-cp311-cp311-win_amd64.whl (242 kB)
-Using cached typing_extensions-4.16.0-py3-none-any.whl (45 kB)
-Using cached winrt_windows_foundation_collections-3.2.1-cp311-cp311-win_amd64.whl (70 kB)
-Using cached winrt_windows_globalization-3.2.1-cp311-cp311-win_amd64.whl (138 kB)
-Using cached winrt_windows_graphics_imaging-3.2.1-cp311-cp311-win_amd64.whl (144 kB)
-Using cached winrt_windows_media_ocr-3.2.1-cp311-cp311-win_amd64.whl (42 kB)
-Using cached winrt_windows_storage_streams-3.2.1-cp311-cp311-win_amd64.whl (132 kB)
-Installing collected packages: typing_extensions, pygments, pluggy, pillow, packaging, iniconfig, colorama, winrt-runtime, pytest, winrt-windows-storage-streams, winrt-windows-media-ocr, winrt-windows-graphics-imaging, winrt-windows-globalization, winrt-windows-foundation-collections, winrt-windows-foundation, winocr
-
-Successfully installed colorama-0.4.6 iniconfig-2.3.0 packaging-26.3 pillow-12.3.0 pluggy-1.6.0 pygments-2.21.0 pytest-9.1.1 typing_extensions-4.16.0 winocr-0.0.15 winrt-runtime-3.2.1 winrt-windows-foundation-3.2.1 winrt-windows-foundation-collections-3.2.1 winrt-windows-globalization-3.2.1 winrt-windows-graphics-imaging-3.2.1 winrt-windows-media-ocr-3.2.1 winrt-windows-storage-streams-3.2.1
+Requirement already satisfied: pillow in .\venv\Lib\site-packages (12.3.0)
+Requirement already satisfied: winocr in .\venv\Lib\site-packages (0.0.15)
+Requirement already satisfied: pytest in .\venv\Lib\site-packages (9.1.1)
+Requirement already satisfied: winrt-windows-foundation-collections in .\venv\Lib\site-packages (from winocr) (3.2.1)
+Requirement already satisfied: winrt-windows-foundation in .\venv\Lib\site-packages (from winocr) (3.2.1)
+Requirement already satisfied: winrt-windows-globalization in .\venv\Lib\site-packages (from winocr) (3.2.1)
+Requirement already satisfied: winrt-windows-graphics-imaging in .\venv\Lib\site-packages (from winocr) (3.2.1)
+Requirement already satisfied: winrt-windows-media-ocr in .\venv\Lib\site-packages (from winocr) (3.2.1)
+Requirement already satisfied: winrt-windows-storage-streams in .\venv\Lib\site-packages (from winocr) (3.2.1)
+Requirement already satisfied: colorama>=0.4 in .\venv\Lib\site-packages (from pytest) (0.4.6)
+Requirement already satisfied: iniconfig>=1.0.1 in .\venv\Lib\site-packages (from pytest) (2.3.0)
+Requirement already satisfied: packaging>=22 in .\venv\Lib\site-packages (from pytest) (26.3)
+Requirement already satisfied: pluggy<2,>=1.5 in .\venv\Lib\site-packages (from pytest) (1.6.0)
+Requirement already satisfied: pygments>=2.7.2 in .\venv\Lib\site-packages (from pytest) (2.21.0)
+Requirement already satisfied: winrt-runtime~=3.2.1.0 in .\venv\Lib\site-packages (from winrt-windows-foundation->winocr) (3.2.1)
+Requirement already satisfied: typing_extensions>=4.12.2 in .\venv\Lib\site-packages (from winrt-runtime~=3.2.1.0->winrt-windows-foundation->winocr) (4.16.0)
 [exit 0]
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe -m pip list
@@ -361,6 +322,7 @@ IMAGE D:/cc-scrub-proof/samples/sample-notext.png
 === 9. scrub each sample: candidate, verify, then publish ===
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
+FATAL: output D:/cc-scrub-proof/out\sample-normal-scrubbed.png already exists. Refusing to replace it - it may be an output that has already passed verification. Delete it, point -o somewhere else, or pass --force to replace it.
 cc-scrub
   ocr engine : Windows OCR (winocr / WinRT)
   terms file : D:/cc-scrub-proof/terms.txt (3 terms)
@@ -377,18 +339,10 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.gg7r876f.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.gg7r876f.tmp
-    verify scale 1: 19 words in 5 lines
-    verify scale 2: 19 words in 5 lines
-    verify scale 3: 19 words in 5 lines
-  WROTE D:/cc-scrub-proof/out\sample-normal-scrubbed.png (mode=blur pad=4)
-  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 57 words in the output and 0 denylist hit(s) remain.
-
-SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
-[exit 0]
+[exit 2]
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-small-ui.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
+FATAL: output D:/cc-scrub-proof/out\sample-small-ui-scrubbed.png already exists. Refusing to replace it - it may be an output that has already passed verification. Delete it, point -o somewhere else, or pass --force to replace it.
 cc-scrub
   ocr engine : Windows OCR (winocr / WinRT)
   terms file : D:/cc-scrub-proof/terms.txt (3 terms)
@@ -405,18 +359,10 @@ IMAGE D:/cc-scrub-proof/samples/sample-small-ui.png
   ocr scale 3: 18 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=41 y=78 w=84 h=10) scales=2,3 ocr_line='repo myorg/secret-repo'
-  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.2gpixx5y.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.2gpixx5y.tmp
-    verify scale 1: 16 words in 5 lines
-    verify scale 2: 17 words in 6 lines
-    verify scale 3: 17 words in 6 lines
-  WROTE D:/cc-scrub-proof/out\sample-small-ui-scrubbed.png (mode=blur pad=4)
-  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 50 words in the output and 0 denylist hit(s) remain.
-
-SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
-[exit 0]
+[exit 2]
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-glyph.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
+FATAL: output D:/cc-scrub-proof/out\sample-glyph-scrubbed.png already exists. Refusing to replace it - it may be an output that has already passed verification. Delete it, point -o somewhere else, or pass --force to replace it.
 cc-scrub
   ocr engine : Windows OCR (winocr / WinRT)
   terms file : D:/cc-scrub-proof/terms.txt (3 terms)
@@ -433,16 +379,7 @@ IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
   ocr scale 3: 17 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=18 y=72 w=233 h=10) scales=2,3 ocr_line='https:/ftnternal-hostname.local/status/session'
-  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.buzi1foy.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.buzi1foy.tmp
-    verify scale 1: 16 words in 3 lines
-    verify scale 2: 17 words in 3 lines
-    verify scale 3: 16 words in 3 lines
-  WROTE D:/cc-scrub-proof/out\sample-glyph-scrubbed.png (mode=blur pad=4)
-  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 49 words in the output and 0 denylist hit(s) remain.
-
-SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
-[exit 0]
+[exit 2]
 
 === 10. nothing unverified is left lying about ===
 (the output directory holds three published outputs and no candidates)
@@ -494,8 +431,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.y2gdj9_6.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.y2gdj9_6.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.0vlhz4t2.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.0vlhz4t2.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -537,10 +474,10 @@ FATAL: D:/cc-scrub-proof/collide\Shot.png and D:/cc-scrub-proof/collide\shot.jpg
 
 === 15. a read over the megapixel budget is refused before it is tried ===
 (900x260 at scale 8 is 7200x2080 - inside the engine's side limit, and
- 14.3 megapixels, which is over a 1 megapixel budget)
+ 14,976,000 pixels, which is 15.0 megapixels and over a 1 megapixel budget)
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png --check-only --scales 8 --max-megapixels 1 --terms-file D:/cc-scrub-proof/terms.txt
-FATAL: D:/cc-scrub-proof/samples/sample-normal.png is 900x260; at scale 8 that is 7200x2080, 14.3 megapixels, over the 1 megapixel budget for one read. Use a smaller --scales value, a smaller image, or raise --max-megapixels if this machine has the memory for it.
+FATAL: D:/cc-scrub-proof/samples/sample-normal.png is 900x260; at scale 8 that is 7200x2080, 15.0 megapixels, over the 1 megapixel budget for one read. Use a smaller --scales value, a smaller image, or raise --max-megapixels if this machine has the memory for it.
 cc-scrub
   ocr engine : Windows OCR (winocr / WinRT)
   terms file : D:/cc-scrub-proof/terms.txt (3 terms)
@@ -636,61 +573,65 @@ platform win32 -- Python 3.11.6, pytest-9.1.1, pluggy-1.6.0 -- D:\cc-scrub-proof
 cachedir: .pytest_cache
 rootdir: D:\cc-scrub-proof\cc-scrub
 configfile: pyproject.toml
-collecting ... collected 52 items
+collecting ... collected 56 items
 
 tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  1%]
 tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  3%]
 tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  5%]
 tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  7%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  9%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 11%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 13%]
-tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 15%]
-tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 17%]
-tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 19%]
-tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 21%]
-tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 23%]
-tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 25%]
-tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 26%]
-tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 28%]
-tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 30%]
-tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 32%]
-tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 34%]
-tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 36%]
-tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 38%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 40%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 42%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 44%]
-tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 46%]
-tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 48%]
-tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 50%]
-tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 51%]
-tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 53%]
-tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 55%]
-tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 57%]
-tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 59%]
-tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 61%]
-tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 63%]
-tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 65%]
-tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 67%]
-tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 69%]
-tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 71%]
-tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 73%]
-tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 75%]
-tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 76%]
-tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 78%]
-tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 80%]
-tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 82%]
-tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 84%]
-tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 86%]
-tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 88%]
-tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 90%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  8%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 10%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 12%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 14%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 16%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 17%]
+tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 19%]
+tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 21%]
+tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 23%]
+tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 25%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 26%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 28%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 30%]
+tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 32%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 33%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 35%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 37%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 39%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 41%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 42%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 44%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 46%]
+tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 48%]
+tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 50%]
+tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 51%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 53%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 55%]
+tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 57%]
+tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 58%]
+tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 60%]
+tests/test_cc_scrub.py::test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer PASSED [ 62%]
+tests/test_cc_scrub.py::test_a_probe_that_cannot_be_removed_is_an_error_not_a_warning PASSED [ 64%]
+tests/test_cc_scrub.py::test_a_genuinely_missing_swapped_name_is_the_case_sensitive_answer PASSED [ 66%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_is_decimal_megapixels_not_mebipixels PASSED [ 67%]
+tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 69%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 71%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 73%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 75%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 76%]
+tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 78%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 80%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 82%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 83%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 85%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 87%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 89%]
+tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 91%]
 tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 92%]
 tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 94%]
 tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 96%]
 tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 98%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-============================= 52 passed in 2.47s ==============================
+============================= 56 passed in 2.73s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-windows.md
+++ b/tools/cc-scrub/PROOF-windows.md
@@ -58,12 +58,22 @@ all deliberately fake.
   file is re-opened from disk after the run that wrote it and read again with
   zero hits (step 16). That is a statement about this engine at these scales,
   not about the pixels: see "What this does NOT prove".
-- **The whole test suite passes in that same clean environment**: 56 tests,
+- **The whole test suite passes in that same clean environment**: 60 tests,
   NONE SKIPPED, including the three end-to-end scrub-and-verify cases
   (step 18). It is run with `-rs`, so a skip would be printed with its
   reason - a skip nobody prints reads exactly like a pass. The arms that
   need a volume on which two spellings name one file measure that on the
   directory they write to; on this volume all of them run.
+- **An unreadable path stops the run rather than granting permission.** Six
+  tests inject a permission error into os.stat or os.remove at a guard - the
+  input-overwrite check, the existing-output refusal, the case probe's
+  readback, the case probe's cleanup, the denylist lookup, and the candidate
+  cleanup. Injection is the only way in: these arms cannot be reached on a
+  working filesystem. Five of the six FAILED against the code before this
+  round, which is what makes them tests rather than comments; the sixth, the
+  candidate cleanup, passed already and is pinned so it stays that way. A
+  seventh pins the one error that IS an answer - a genuinely missing name
+  still means absent.
 
 ## What this does NOT prove
 
@@ -125,26 +135,71 @@ $ python -m venv D:/cc-scrub-proof/venv
 === 3. install from pip only - Pillow, winocr, pytest ===
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe -m pip install --upgrade pip
-Requirement already satisfied: pip in .\venv\Lib\site-packages (26.2.1)
+Requirement already satisfied: pip in d:\cc-scrub-proof\venv\lib\site-packages (23.2.1)
+Collecting pip
+  Obtaining dependency information for pip from https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl.metadata
+  Using cached pip-26.2.1-py3-none-any.whl.metadata (4.6 kB)
+Using cached pip-26.2.1-py3-none-any.whl (1.8 MB)
+Installing collected packages: pip
+  Attempting uninstall: pip
+    Found existing installation: pip 23.2.1
+    Uninstalling pip-23.2.1:
+      Successfully uninstalled pip-23.2.1
+Successfully installed pip-26.2.1
 [exit 0]
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe -m pip install pillow winocr pytest
-Requirement already satisfied: pillow in .\venv\Lib\site-packages (12.3.0)
-Requirement already satisfied: winocr in .\venv\Lib\site-packages (0.0.15)
-Requirement already satisfied: pytest in .\venv\Lib\site-packages (9.1.1)
-Requirement already satisfied: winrt-windows-foundation-collections in .\venv\Lib\site-packages (from winocr) (3.2.1)
-Requirement already satisfied: winrt-windows-foundation in .\venv\Lib\site-packages (from winocr) (3.2.1)
-Requirement already satisfied: winrt-windows-globalization in .\venv\Lib\site-packages (from winocr) (3.2.1)
-Requirement already satisfied: winrt-windows-graphics-imaging in .\venv\Lib\site-packages (from winocr) (3.2.1)
-Requirement already satisfied: winrt-windows-media-ocr in .\venv\Lib\site-packages (from winocr) (3.2.1)
-Requirement already satisfied: winrt-windows-storage-streams in .\venv\Lib\site-packages (from winocr) (3.2.1)
-Requirement already satisfied: colorama>=0.4 in .\venv\Lib\site-packages (from pytest) (0.4.6)
-Requirement already satisfied: iniconfig>=1.0.1 in .\venv\Lib\site-packages (from pytest) (2.3.0)
-Requirement already satisfied: packaging>=22 in .\venv\Lib\site-packages (from pytest) (26.3)
-Requirement already satisfied: pluggy<2,>=1.5 in .\venv\Lib\site-packages (from pytest) (1.6.0)
-Requirement already satisfied: pygments>=2.7.2 in .\venv\Lib\site-packages (from pytest) (2.21.0)
-Requirement already satisfied: winrt-runtime~=3.2.1.0 in .\venv\Lib\site-packages (from winrt-windows-foundation->winocr) (3.2.1)
-Requirement already satisfied: typing_extensions>=4.12.2 in .\venv\Lib\site-packages (from winrt-runtime~=3.2.1.0->winrt-windows-foundation->winocr) (4.16.0)
+Collecting pillow
+  Using cached pillow-12.3.0-cp311-cp311-win_amd64.whl.metadata (9.3 kB)
+Collecting winocr
+  Using cached winocr-0.0.15-py3-none-any.whl.metadata (15 kB)
+Collecting pytest
+  Using cached pytest-9.1.1-py3-none-any.whl.metadata (7.6 kB)
+Collecting winrt-windows-foundation-collections (from winocr)
+  Using cached winrt_windows_foundation_collections-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.1 kB)
+Collecting winrt-windows-foundation (from winocr)
+  Using cached winrt_windows_foundation-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.0 kB)
+Collecting winrt-windows-globalization (from winocr)
+  Using cached winrt_windows_globalization-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.2 kB)
+Collecting winrt-windows-graphics-imaging (from winocr)
+  Using cached winrt_windows_graphics_imaging-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.3 kB)
+Collecting winrt-windows-media-ocr (from winocr)
+  Using cached winrt_windows_media_ocr-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.3 kB)
+Collecting winrt-windows-storage-streams (from winocr)
+  Using cached winrt_windows_storage_streams-3.2.1-cp311-cp311-win_amd64.whl.metadata (1.3 kB)
+Collecting colorama>=0.4 (from pytest)
+  Using cached colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
+Collecting iniconfig>=1.0.1 (from pytest)
+  Using cached iniconfig-2.3.0-py3-none-any.whl.metadata (2.5 kB)
+Collecting packaging>=22 (from pytest)
+  Using cached packaging-26.3-py3-none-any.whl.metadata (3.5 kB)
+Collecting pluggy<2,>=1.5 (from pytest)
+  Using cached pluggy-1.6.0-py3-none-any.whl.metadata (4.8 kB)
+Collecting pygments>=2.7.2 (from pytest)
+  Using cached pygments-2.21.0-py3-none-any.whl.metadata (2.5 kB)
+Collecting winrt-runtime~=3.2.1.0 (from winrt-windows-foundation->winocr)
+  Using cached winrt_runtime-3.2.1-cp311-cp311-win_amd64.whl.metadata (780 bytes)
+Collecting typing_extensions>=4.12.2 (from winrt-runtime~=3.2.1.0->winrt-windows-foundation->winocr)
+  Using cached typing_extensions-4.16.0-py3-none-any.whl.metadata (3.3 kB)
+Using cached pillow-12.3.0-cp311-cp311-win_amd64.whl (7.2 MB)
+Using cached winocr-0.0.15-py3-none-any.whl (7.7 kB)
+Using cached pytest-9.1.1-py3-none-any.whl (386 kB)
+Using cached pluggy-1.6.0-py3-none-any.whl (20 kB)
+Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
+Using cached iniconfig-2.3.0-py3-none-any.whl (7.5 kB)
+Using cached packaging-26.3-py3-none-any.whl (129 kB)
+Using cached pygments-2.21.0-py3-none-any.whl (1.3 MB)
+Using cached winrt_windows_foundation-3.2.1-cp311-cp311-win_amd64.whl (118 kB)
+Using cached winrt_runtime-3.2.1-cp311-cp311-win_amd64.whl (242 kB)
+Using cached typing_extensions-4.16.0-py3-none-any.whl (45 kB)
+Using cached winrt_windows_foundation_collections-3.2.1-cp311-cp311-win_amd64.whl (70 kB)
+Using cached winrt_windows_globalization-3.2.1-cp311-cp311-win_amd64.whl (138 kB)
+Using cached winrt_windows_graphics_imaging-3.2.1-cp311-cp311-win_amd64.whl (144 kB)
+Using cached winrt_windows_media_ocr-3.2.1-cp311-cp311-win_amd64.whl (42 kB)
+Using cached winrt_windows_storage_streams-3.2.1-cp311-cp311-win_amd64.whl (132 kB)
+Installing collected packages: typing_extensions, pygments, pluggy, pillow, packaging, iniconfig, colorama, winrt-runtime, pytest, winrt-windows-storage-streams, winrt-windows-media-ocr, winrt-windows-graphics-imaging, winrt-windows-globalization, winrt-windows-foundation-collections, winrt-windows-foundation, winocr
+
+Successfully installed colorama-0.4.6 iniconfig-2.3.0 packaging-26.3 pillow-12.3.0 pluggy-1.6.0 pygments-2.21.0 pytest-9.1.1 typing_extensions-4.16.0 winocr-0.0.15 winrt-runtime-3.2.1 winrt-windows-foundation-3.2.1 winrt-windows-foundation-collections-3.2.1 winrt-windows-globalization-3.2.1 winrt-windows-graphics-imaging-3.2.1 winrt-windows-media-ocr-3.2.1 winrt-windows-storage-streams-3.2.1
 [exit 0]
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe -m pip list
@@ -322,7 +377,6 @@ IMAGE D:/cc-scrub-proof/samples/sample-notext.png
 === 9. scrub each sample: candidate, verify, then publish ===
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
-FATAL: output D:/cc-scrub-proof/out\sample-normal-scrubbed.png already exists. Refusing to replace it - it may be an output that has already passed verification. Delete it, point -o somewhere else, or pass --force to replace it.
 cc-scrub
   ocr engine : Windows OCR (winocr / WinRT)
   terms file : D:/cc-scrub-proof/terms.txt (3 terms)
@@ -339,10 +393,18 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-[exit 2]
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.89hqy8iv.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.89hqy8iv.tmp
+    verify scale 1: 19 words in 5 lines
+    verify scale 2: 19 words in 5 lines
+    verify scale 3: 19 words in 5 lines
+  WROTE D:/cc-scrub-proof/out\sample-normal-scrubbed.png (mode=blur pad=4)
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 57 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-small-ui.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
-FATAL: output D:/cc-scrub-proof/out\sample-small-ui-scrubbed.png already exists. Refusing to replace it - it may be an output that has already passed verification. Delete it, point -o somewhere else, or pass --force to replace it.
 cc-scrub
   ocr engine : Windows OCR (winocr / WinRT)
   terms file : D:/cc-scrub-proof/terms.txt (3 terms)
@@ -359,10 +421,18 @@ IMAGE D:/cc-scrub-proof/samples/sample-small-ui.png
   ocr scale 3: 18 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=41 y=78 w=84 h=10) scales=2,3 ocr_line='repo myorg/secret-repo'
-[exit 2]
+  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.wl5f5_v6.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.wl5f5_v6.tmp
+    verify scale 1: 16 words in 5 lines
+    verify scale 2: 17 words in 6 lines
+    verify scale 3: 17 words in 6 lines
+  WROTE D:/cc-scrub-proof/out\sample-small-ui-scrubbed.png (mode=blur pad=4)
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 50 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-glyph.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
-FATAL: output D:/cc-scrub-proof/out\sample-glyph-scrubbed.png already exists. Refusing to replace it - it may be an output that has already passed verification. Delete it, point -o somewhere else, or pass --force to replace it.
 cc-scrub
   ocr engine : Windows OCR (winocr / WinRT)
   terms file : D:/cc-scrub-proof/terms.txt (3 terms)
@@ -379,7 +449,16 @@ IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
   ocr scale 3: 17 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=18 y=72 w=233 h=10) scales=2,3 ocr_line='https:/ftnternal-hostname.local/status/session'
-[exit 2]
+  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.w1si8l5l.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.w1si8l5l.tmp
+    verify scale 1: 16 words in 3 lines
+    verify scale 2: 17 words in 3 lines
+    verify scale 3: 16 words in 3 lines
+  WROTE D:/cc-scrub-proof/out\sample-glyph-scrubbed.png (mode=blur pad=4)
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 49 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
 
 === 10. nothing unverified is left lying about ===
 (the output directory holds three published outputs and no candidates)
@@ -431,8 +510,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.0vlhz4t2.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.0vlhz4t2.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.o4y1gv15.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.o4y1gv15.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -573,65 +652,69 @@ platform win32 -- Python 3.11.6, pytest-9.1.1, pluggy-1.6.0 -- D:\cc-scrub-proof
 cachedir: .pytest_cache
 rootdir: D:\cc-scrub-proof\cc-scrub
 configfile: pyproject.toml
-collecting ... collected 56 items
+collecting ... collected 60 items
 
 tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  1%]
 tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  3%]
 tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  5%]
-tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  7%]
+tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  6%]
 tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [  8%]
 tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 10%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 12%]
-tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 14%]
-tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 16%]
-tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 17%]
-tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 19%]
-tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 21%]
-tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 23%]
-tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 25%]
-tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 26%]
-tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 28%]
-tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 30%]
-tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 32%]
-tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 33%]
-tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 35%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 37%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 39%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 41%]
-tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 42%]
-tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 44%]
-tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 46%]
-tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 48%]
-tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 50%]
-tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 51%]
-tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 53%]
-tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 55%]
-tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 57%]
-tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 58%]
-tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 60%]
-tests/test_cc_scrub.py::test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer PASSED [ 62%]
-tests/test_cc_scrub.py::test_a_probe_that_cannot_be_removed_is_an_error_not_a_warning PASSED [ 64%]
-tests/test_cc_scrub.py::test_a_genuinely_missing_swapped_name_is_the_case_sensitive_answer PASSED [ 66%]
-tests/test_cc_scrub.py::test_the_megapixel_budget_is_decimal_megapixels_not_mebipixels PASSED [ 67%]
-tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 69%]
-tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 71%]
-tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 73%]
-tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 75%]
-tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 76%]
-tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 78%]
-tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 80%]
-tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 82%]
-tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 83%]
-tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 85%]
-tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 87%]
-tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 89%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 11%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 13%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 15%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 16%]
+tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 18%]
+tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 20%]
+tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 21%]
+tests/test_cc_scrub.py::test_folding_finds_a_misread_term_and_no_fold_misses_it PASSED [ 23%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 25%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 26%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 28%]
+tests/test_cc_scrub.py::test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted PASSED [ 30%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_must_be_at_least_one PASSED [ 31%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 33%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 35%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 36%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 38%]
+tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 40%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 41%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 43%]
+tests/test_cc_scrub.py::test_word_ranges_count_utf16_code_units_not_code_points PASSED [ 45%]
+tests/test_cc_scrub.py::test_word_ranges_match_code_points_for_plain_text PASSED [ 46%]
+tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 48%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 50%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 51%]
+tests/test_cc_scrub.py::test_two_inputs_whose_stems_differ_only_in_case_are_refused PASSED [ 53%]
+tests/test_cc_scrub.py::test_collision_detection_does_not_depend_on_the_host_normcase PASSED [ 55%]
+tests/test_cc_scrub.py::test_the_case_probe_answers_from_the_filesystem_and_cleans_up PASSED [ 56%]
+tests/test_cc_scrub.py::test_is_same_file_refuses_when_it_cannot_tell_whether_a_path_exists PASSED [ 58%]
+tests/test_cc_scrub.py::test_an_unreadable_output_path_stops_the_run_instead_of_publishing_over_it PASSED [ 60%]
+tests/test_cc_scrub.py::test_an_unreadable_terms_file_is_reported_as_unreadable_not_as_missing PASSED [ 61%]
+tests/test_cc_scrub.py::test_a_candidate_that_cannot_be_removed_warns_and_never_masks_the_failure PASSED [ 63%]
+tests/test_cc_scrub.py::test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer PASSED [ 65%]
+tests/test_cc_scrub.py::test_a_probe_that_cannot_be_removed_is_an_error_not_a_warning PASSED [ 66%]
+tests/test_cc_scrub.py::test_a_genuinely_missing_swapped_name_is_the_case_sensitive_answer PASSED [ 68%]
+tests/test_cc_scrub.py::test_the_megapixel_budget_is_decimal_megapixels_not_mebipixels PASSED [ 70%]
+tests/test_cc_scrub.py::test_the_case_probe_refuses_to_guess_when_it_cannot_be_created PASSED [ 71%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 73%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 75%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 76%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 78%]
+tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 80%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 81%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 83%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 85%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 86%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 88%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 90%]
 tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 91%]
-tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 92%]
-tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 94%]
+tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 93%]
+tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 95%]
 tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 96%]
 tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 98%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-============================= 56 passed in 2.73s ==============================
+============================= 60 passed in 2.52s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-windows.md
+++ b/tools/cc-scrub/PROOF-windows.md
@@ -19,7 +19,7 @@ all deliberately fake.
   executable, no tesseract, no subprocess. Pillow 12.3.0, winocr 0.0.15 and
   their winrt wheels, on Python 3.11.6, Windows 10.0.26200.9278.
 - **check-only finds each planted term and prints its coordinates**, and
-  exits 1 while leaving the image untouched (steps 6).
+  exits 1 while leaving the image untouched (step 6).
 - **Multi-scale reading is load bearing.** The 10 px grey line in
   `sample-small-ui.png` is reported as `scales=2,3`: the recognizer cannot
   resolve it at native resolution and only reads it once the image is
@@ -33,15 +33,25 @@ all deliberately fake.
 - **An image with no text is a broken read, not a clean image.**
   `sample-notext.png` reads zero words at every scale and the tool exits 2
   refusing to call it scrubbed (step 8).
+- **Nothing unverified is ever published.** Each scrub writes a `.tmp`
+  CANDIDATE beside the destination, verifies THAT file, and only then renames
+  it onto the `*-scrubbed.png` name (step 9). After three scrubs the output
+  directory holds exactly three published files and no candidates (step 10).
 - **The verify pass is presence shaped.** Each scrub prints
   `VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read N
-  words in the output and 0 denylist hit(s) remain` - and the N is asserted
-  to be non-zero, so a verify instrument that reads nothing cannot certify
-  anything (step 9).
-- **The outputs really are clean.** Each written file is re-opened from disk
-  and read again, independently of the scrub run, with zero hits (step 10).
-- **The whole test suite passes in that same clean environment**: 25 tests,
-  including the three end-to-end scrub-and-verify cases (step 12).
+  words in the output and 0 denylist hit(s) remain` - and N is checked as a
+  number, so a verify instrument that reads nothing cannot certify anything.
+- **An existing output is not replaced by accident.** Re-running the same
+  scrub exits 2 and names the file; `--force` is how you say you meant it
+  (steps 11 and 12).
+- **The input is never a legal destination, in any spelling.** Addressing the
+  same file as `shot.png` and `SHOT.PNG` is refused - and refused even with
+  `--force`, because that would destroy the only unredacted copy (step 13).
+- **The outputs really are clean.** Each published file is re-opened from
+  disk and read again, independently of the scrub run, with zero hits
+  (step 14).
+- **The whole test suite passes in that same clean environment**: 43 tests,
+  including the three end-to-end scrub-and-verify cases (step 16).
 
 ## What this does NOT prove
 
@@ -58,6 +68,12 @@ all deliberately fake.
   chrome.
 - **Nothing about a packaged executable.** cc-scrub is run from source here.
   It has no PyInstaller build and is not in the shipped tool bundle.
+- **The two verify FAILURE arms are not in this transcript.** No real
+  screenshot makes an engine read zero words from a file it has just read
+  words from, and none reliably leaves a redacted term readable. Those arms
+  are proved in the test suite instead, driven by a scripted backend, and
+  they are the tests named `test_a_verify_read_of_zero_words_...` and
+  `test_a_term_surviving_in_the_output_...` in step 16.
 
 ## The transcript
 
@@ -320,7 +336,7 @@ IMAGE D:/cc-scrub-proof/samples/sample-notext.png
   ocr scale 3: 0 words in 0 lines
 [exit 2]
 
-=== 9. scrub each sample and let the verify pass rule on it ===
+=== 9. scrub each sample: candidate, verify, then publish ===
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
 cc-scrub
@@ -339,11 +355,12 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  WROTE D:/cc-scrub-proof/out\sample-normal-scrubbed.png (mode=blur pad=4)
-  VERIFY: re-reading D:/cc-scrub-proof/out\sample-normal-scrubbed.png
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.__1cl6r7.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.__1cl6r7.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
+  WROTE D:/cc-scrub-proof/out\sample-normal-scrubbed.png (mode=blur pad=4)
   VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 57 words in the output and 0 denylist hit(s) remain.
 
 SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
@@ -366,11 +383,12 @@ IMAGE D:/cc-scrub-proof/samples/sample-small-ui.png
   ocr scale 3: 18 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=41 y=78 w=84 h=10) scales=2,3 ocr_line='repo myorg/secret-repo'
-  WROTE D:/cc-scrub-proof/out\sample-small-ui-scrubbed.png (mode=blur pad=4)
-  VERIFY: re-reading D:/cc-scrub-proof/out\sample-small-ui-scrubbed.png
+  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.v4rhn78t.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.v4rhn78t.tmp
     verify scale 1: 16 words in 5 lines
     verify scale 2: 17 words in 6 lines
     verify scale 3: 17 words in 6 lines
+  WROTE D:/cc-scrub-proof/out\sample-small-ui-scrubbed.png (mode=blur pad=4)
   VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 50 words in the output and 0 denylist hit(s) remain.
 
 SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
@@ -393,17 +411,101 @@ IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
   ocr scale 3: 17 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=18 y=72 w=233 h=10) scales=2,3 ocr_line='https:/ftnternal-hostname.local/status/session'
-  WROTE D:/cc-scrub-proof/out\sample-glyph-scrubbed.png (mode=blur pad=4)
-  VERIFY: re-reading D:/cc-scrub-proof/out\sample-glyph-scrubbed.png
+  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.8k2vatg9.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.8k2vatg9.tmp
     verify scale 1: 16 words in 3 lines
     verify scale 2: 17 words in 3 lines
     verify scale 3: 16 words in 3 lines
+  WROTE D:/cc-scrub-proof/out\sample-glyph-scrubbed.png (mode=blur pad=4)
   VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 49 words in the output and 0 denylist hit(s) remain.
 
 SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
 [exit 0]
 
-=== 10. re-check every scrubbed output - nothing left to find ===
+=== 10. nothing unverified is left lying about ===
+(the output directory holds three published outputs and no candidates)
+
+$ ls -1 D:/cc-scrub-proof/out
+sample-glyph-scrubbed.png
+sample-normal-scrubbed.png
+sample-small-ui-scrubbed.png
+[exit 0]
+
+=== 11. an existing output is not replaced by accident ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png -o D:/cc-scrub-proof/out --terms-file D:/cc-scrub-proof/terms.txt
+FATAL: output D:/cc-scrub-proof/out\sample-normal-scrubbed.png already exists. Refusing to replace it - it may be an output that has already passed verification. Delete it, point -o somewhere else, or pass --force to replace it.
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : blur
+
+IMAGE D:/cc-scrub-proof/samples/sample-normal.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 20 words in 5 lines
+  ocr scale 2: 20 words in 5 lines
+  ocr scale 3: 20 words in 5 lines
+  HITS: 1
+    term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
+[exit 2]
+
+=== 12. --force is how you say you meant it ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png -o D:/cc-scrub-proof/out --force --terms-file D:/cc-scrub-proof/terms.txt
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : blur
+
+IMAGE D:/cc-scrub-proof/samples/sample-normal.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 20 words in 5 lines
+  ocr scale 2: 20 words in 5 lines
+  ocr scale 3: 20 words in 5 lines
+  HITS: 1
+    term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.vxlw9_jr.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.vxlw9_jr.tmp
+    verify scale 1: 19 words in 5 lines
+    verify scale 2: 19 words in 5 lines
+    verify scale 3: 19 words in 5 lines
+  WROTE D:/cc-scrub-proof/out\sample-normal-scrubbed.png (mode=blur pad=4)
+  VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read 57 words in the output and 0 denylist hit(s) remain.
+
+SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
+[exit 0]
+
+=== 13. the input is never a legal destination, in any spelling ===
+
+$ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/shot.png -o D:/cc-scrub-proof/SHOT.PNG --force --terms-file D:/cc-scrub-proof/terms.txt
+FATAL: refusing to overwrite the input image D:/cc-scrub-proof/shot.png (the output path D:/cc-scrub-proof/SHOT.PNG is the same file)
+cc-scrub
+  ocr engine : Windows OCR (winocr / WinRT)
+  terms file : D:/cc-scrub-proof/terms.txt (3 terms)
+    - example@example.com
+    - myorg/secret-repo
+    - internal-hostname.local
+  images     : 1
+  mode       : blur
+
+IMAGE D:/cc-scrub-proof/shot.png
+  size 900x260  scales 1,2,3  fold on
+  ocr scale 1: 20 words in 5 lines
+  ocr scale 2: 20 words in 5 lines
+  ocr scale 3: 20 words in 5 lines
+  HITS: 1
+    term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
+[exit 2]
+
+=== 14. re-check every published output - nothing left to find ===
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/out/sample-normal-scrubbed.png --check-only --terms-file D:/cc-scrub-proof/terms.txt
 cc-scrub
@@ -468,7 +570,7 @@ IMAGE D:/cc-scrub-proof/out/sample-glyph-scrubbed.png
 SUMMARY: 1 image(s) processed, 1 clean, 0 failed.
 [exit 0]
 
-=== 11. a folder holding only outputs is an empty input set ===
+=== 15. a folder holding only outputs is an empty input set ===
 (the *-scrubbed suffix is skipped by design, which is what makes
  re-running a folder safe - the tool says so rather than doing nothing)
 
@@ -476,7 +578,7 @@ $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/out --chec
 FATAL: no images found in directory D:/cc-scrub-proof/out
 [exit 2]
 
-=== 12. the full test suite, in the same clean environment ===
+=== 16. the full test suite, in the same clean environment ===
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe -m pytest tests/ -v
 ============================= test session starts =============================
@@ -484,34 +586,52 @@ platform win32 -- Python 3.11.6, pytest-9.1.1, pluggy-1.6.0 -- D:\cc-scrub-proof
 cachedir: .pytest_cache
 rootdir: D:\cc-scrub-proof\cc-scrub
 configfile: pyproject.toml
-collecting ... collected 25 items
+collecting ... collected 43 items
 
-tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  4%]
-tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  8%]
-tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [ 12%]
-tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [ 16%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [ 20%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 24%]
-tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 28%]
-tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 32%]
-tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 36%]
-tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 40%]
-tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 44%]
+tests/test_cc_scrub.py::test_generator_writes_all_four_samples PASSED    [  2%]
+tests/test_cc_scrub.py::test_check_only_finds_the_planted_email_with_coordinates PASSED [  4%]
+tests/test_cc_scrub.py::test_check_only_finds_small_grey_ui_text_only_after_upscaling PASSED [  6%]
+tests/test_cc_scrub.py::test_glyph_confusion_is_caught_by_folding_and_missed_without_it PASSED [  9%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-normal.png-example@example.com] PASSED [ 11%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-small-ui.png-myorg/secret-repo] PASSED [ 13%]
+tests/test_cc_scrub.py::test_scrub_redacts_and_the_verify_pass_proves_it[sample-glyph.png-internal-hostname.local] PASSED [ 16%]
+tests/test_cc_scrub.py::test_the_scrubbed_output_is_clean_when_checked_again PASSED [ 18%]
+tests/test_cc_scrub.py::test_a_directory_run_skips_files_already_scrubbed PASSED [ 20%]
+tests/test_cc_scrub.py::test_an_image_with_no_text_is_a_broken_read_not_a_clean_image PASSED [ 23%]
+tests/test_cc_scrub.py::test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two PASSED [ 25%]
+tests/test_cc_scrub.py::test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing PASSED [ 27%]
+tests/test_cc_scrub.py::test_a_passing_scripted_run_publishes_the_candidate PASSED [ 30%]
+tests/test_cc_scrub.py::test_a_term_split_across_adjacent_words_on_one_line_is_joined PASSED [ 32%]
+tests/test_cc_scrub.py::test_a_term_split_across_two_lines_is_not_joined PASSED [ 34%]
+tests/test_cc_scrub.py::test_a_scaled_read_maps_back_to_native_coordinates_exactly PASSED [ 37%]
+tests/test_cc_scrub.py::test_an_image_too_big_for_the_engine_is_refused_before_it_is_read PASSED [ 39%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_image PASSED [ 41%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_addressed_in_a_different_case PASSED [ 44%]
+tests/test_cc_scrub.py::test_refuses_to_overwrite_the_input_reached_through_a_hard_link PASSED [ 46%]
 tests/test_cc_scrub.py::test_a_missing_terms_file_names_the_example_to_copy PASSED [ 48%]
-tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 52%]
-tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 56%]
-tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 60%]
-tests/test_cc_scrub.py::test_normalise_folds_the_glyph_classes PASSED    [ 64%]
-tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 68%]
-tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 72%]
-tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 76%]
-tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 80%]
-tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 84%]
-tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 88%]
-tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 92%]
-tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 96%]
+tests/test_cc_scrub.py::test_the_shipped_example_denylist_parses PASSED  [ 51%]
+tests/test_cc_scrub.py::test_bad_scales_are_a_usage_error PASSED         [ 53%]
+tests/test_cc_scrub.py::test_a_denylist_term_that_can_never_match_is_refused PASSED [ 55%]
+tests/test_cc_scrub.py::test_term_validation_follows_the_normalisation_actually_in_force PASSED [ 58%]
+tests/test_cc_scrub.py::test_two_inputs_that_would_share_one_output_are_refused PASSED [ 60%]
+tests/test_cc_scrub.py::test_an_output_directory_that_cannot_be_created_exits_two PASSED [ 62%]
+tests/test_cc_scrub.py::test_pad_box_grows_outwards_to_whole_pixels PASSED [ 65%]
+tests/test_cc_scrub.py::test_pad_box_pads_and_clamps_to_the_image PASSED [ 67%]
+tests/test_cc_scrub.py::test_normalise_drops_punctuation_and_case PASSED [ 69%]
+tests/test_cc_scrub.py::test_normalise_folds_every_advertised_glyph_class PASSED [ 72%]
+tests/test_cc_scrub.py::test_parse_scales_sorts_and_deduplicates PASSED  [ 74%]
+tests/test_cc_scrub.py::test_parse_scales_rejects_rubbish PASSED         [ 76%]
+tests/test_cc_scrub.py::test_load_terms_ignores_comments_and_blank_lines PASSED [ 79%]
+tests/test_cc_scrub.py::test_load_terms_rejects_an_empty_denylist PASSED [ 81%]
+tests/test_cc_scrub.py::test_merge_hits_unions_overlapping_rectangles_of_one_term PASSED [ 83%]
+tests/test_cc_scrub.py::test_merge_hits_keeps_different_terms_apart PASSED [ 86%]
+tests/test_cc_scrub.py::test_gather_inputs_skips_already_scrubbed_files PASSED [ 88%]
+tests/test_cc_scrub.py::test_gather_inputs_rejects_a_missing_path PASSED [ 90%]
+tests/test_cc_scrub.py::test_is_same_file_sees_through_a_case_variant_of_an_existing_path PASSED [ 93%]
+tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_is_not_created_yet PASSED [ 95%]
+tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 97%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-============================= 25 passed in 2.54s ==============================
+============================= 43 passed in 2.90s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/PROOF-windows.md
+++ b/tools/cc-scrub/PROOF-windows.md
@@ -400,8 +400,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.ubs6jcgv.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.ubs6jcgv.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.ptvh3t2o.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.ptvh3t2o.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -428,8 +428,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-small-ui.png
   ocr scale 3: 18 words in 6 lines
   HITS: 1
     term='myorg/secret-repo' rect=(x=41 y=78 w=84 h=10) scales=2,3 ocr_line='repo myorg/secret-repo'
-  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.l50csjte.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.l50csjte.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.vayob1ky.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-small-ui-scrubbed.png.vayob1ky.tmp
     verify scale 1: 16 words in 5 lines
     verify scale 2: 17 words in 6 lines
     verify scale 3: 17 words in 6 lines
@@ -456,8 +456,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-glyph.png
   ocr scale 3: 17 words in 4 lines
   HITS: 1
     term='internal-hostname.local' rect=(x=18 y=72 w=233 h=10) scales=2,3 ocr_line='https:/ftnternal-hostname.local/status/session'
-  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.jd18wq6c.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.jd18wq6c.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.fnbtaq_h.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-glyph-scrubbed.png.fnbtaq_h.tmp
     verify scale 1: 16 words in 3 lines
     verify scale 2: 17 words in 3 lines
     verify scale 3: 16 words in 3 lines
@@ -517,8 +517,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.r6ok7tkm.tmp (mode=blur pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.r6ok7tkm.tmp
+  CANDIDATE D:\cc-scrub-proof\out\sample-normal-scrubbed.png.xeu4xj2q.tmp (mode=blur pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\out\sample-normal-scrubbed.png.xeu4xj2q.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -559,8 +559,11 @@ FATAL: D:/cc-scrub-proof/collide\Shot.png and D:/cc-scrub-proof/collide\shot.jpg
 [exit 2]
 
 === 15. a read over the megapixel budget is refused before it is tried ===
-(900x260 at scale 8 is 7200x2080 - inside the engine's side limit, and
- 14,976,000 pixels, which is 15.0 megapixels and over a 1 megapixel budget)
+(the scaled read is inside the engine's side limit and over the
+ budget, so it is the AREA check firing and not the side check.
+ The exact count is the tool's to print, below - this commentary
+ deliberately restates no figure, because a narrative number that
+ has to be kept in step with the tool is a number that drifts)
 
 $ D:/cc-scrub-proof/venv/Scripts/python.exe main.py D:/cc-scrub-proof/samples/sample-normal.png --check-only --scales 8 --max-megapixels 1 --terms-file D:/cc-scrub-proof/terms.txt
 FATAL: D:/cc-scrub-proof/samples/sample-normal.png is 900x260; at scale 8 that is 7200x2080, 14,976,000 pixels (14.976 megapixels), over the 1 megapixel budget for one read. Use a smaller --scales value, a smaller image, or raise --max-megapixels if this machine has the memory for it.
@@ -597,8 +600,8 @@ IMAGE D:/cc-scrub-proof/samples/sample-normal.png
   ocr scale 3: 20 words in 5 lines
   HITS: 1
     term='example@example.com' rect=(x=182 y=122 w=213 h=20) scales=1,2,3 ocr_line='Contact address: example@example.com'
-  CANDIDATE D:\cc-scrub-proof\patched\sample-normal-scrubbed.png.qsi5weds.tmp (mode=patch pad=4)
-  VERIFY: re-reading D:\cc-scrub-proof\patched\sample-normal-scrubbed.png.qsi5weds.tmp
+  CANDIDATE D:\cc-scrub-proof\patched\sample-normal-scrubbed.png.xlznce1x.tmp (mode=patch pad=4)
+  VERIFY: re-reading D:\cc-scrub-proof\patched\sample-normal-scrubbed.png.xlznce1x.tmp
     verify scale 1: 19 words in 5 lines
     verify scale 2: 19 words in 5 lines
     verify scale 3: 19 words in 5 lines
@@ -783,6 +786,6 @@ tests/test_cc_scrub.py::test_is_same_file_compares_canonically_when_the_target_i
 tests/test_cc_scrub.py::test_is_same_file_says_no_to_two_genuinely_different_files PASSED [ 98%]
 tests/test_cc_scrub.py::test_output_path_defaults_to_the_scrubbed_name_beside_the_input PASSED [100%]
 
-============================= 68 passed in 3.36s ==============================
+============================= 68 passed in 2.85s ==============================
 [exit 0]
 ```

--- a/tools/cc-scrub/README.md
+++ b/tools/cc-scrub/README.md
@@ -41,6 +41,7 @@ Python 3.14.6 with Pillow 12.3.0 and pyobjc 12.2.2; see
 python main.py <image-or-dir> [-o <out>] [--terms-file terms.txt]
                [--check-only] [--patch|--blur] [--force]
                [--pad N] [--scales 1,2,3] [--lang en] [--no-fold]
+               [--max-megapixels N]
 ```
 
 Common runs:
@@ -78,10 +79,20 @@ When there are no hits, no output file is written at all.
   be one that has already passed verification, so replacing it is a decision
   you make on purpose. Delete it, point `-o` elsewhere, or pass `--force`.
 - **Two inputs that want one output.** Names are built from the input's stem,
-  so `shot.png` and `shot.jpg` both want `shot-scrubbed.png` - and on a
-  case-insensitive filesystem so do `Shot.png` and `shot.png`. Every
-  destination is worked out before any image is read, and a collision stops
-  the run rather than letting the second result quietly replace the first.
+  so `shot.png` and `shot.jpg` both want `shot-scrubbed.png` - and wherever
+  the volume treats two spellings as one file, so do `Shot.png` and
+  `shot.jpg`. Every destination is worked out before any image is read, and a
+  collision stops the run rather than letting the second result quietly
+  replace the first.
+
+  Whether two spellings are one file is answered by the **destination
+  directory**, probed once per directory: a probe file is created under a
+  mixed-case name, looked up with its case swapped, and removed again. It is
+  not answered by `os.path.normcase`, which is the *host's* rule - it
+  lower-cases on Windows and is the identity function on POSIX, so a lexical
+  comparison would silently stop detecting anything on a case-insensitive
+  volume under a POSIX host, which is the normal state of a Mac. A probe that
+  cannot be created or read back is exit 2, never an assumption.
 
 Directory input picks up `.png`, `.jpg`, `.jpeg`, `.bmp` and skips anything
 already named `*-scrubbed.*`, so re-running a folder picks up the same inputs
@@ -93,7 +104,7 @@ each time (and then refuses to replace the outputs unless you pass `--force`).
 | ---- | ------- |
 | 0    | work done and proved, or `--check-only` found nothing |
 | 1    | denylist hits remain readable in an output, or `--check-only` found hits |
-| 2    | broken instrument or usage error - OCR unavailable, unreadable image, zero text read, an image too big for the engine, an output that already exists, two inputs colliding on one output, an unmatchable denylist term, a failed write, bad arguments |
+| 2    | broken instrument or usage error - OCR unavailable, unreadable image, zero text read, an image too big for the engine or over the megapixel budget, an output that already exists, two inputs colliding on one output, an unmatchable denylist term, a failed write, bad arguments |
 
 `--check-only` is the linter: it prints every hit with its coordinates,
 changes nothing, and exits 1 if there is anything to scrub. Point it at a
@@ -131,9 +142,15 @@ survive: `!!!` folds onto `lll` and can match, and with `--no-fold` it cannot.
    as `scales=2,3`. Every scale always runs and the hits are unioned. This is
    not a fallback chain - different scales misread the same text in
    different ways, and the union is what makes detection reliable. Every
-   scale, scale 1 included, is measured against the engine's limit on the
-   longest side before the image is decoded, so an image too big to read is
-   refused by name rather than failing inside the engine.
+   scale, scale 1 included, is measured before the image is decoded against
+   two limits: the engine's limit on the longest side, and a budget on the
+   pixels one scaled read may ask for (`--max-megapixels`, default 192).
+   Passing the side limit says nothing about the allocation - a square input
+   just under a 16383 px side limit is about 268 megapixels, roughly 800 MB
+   of RGB data for the scaled copy alone - so an image too big to read is
+   refused by name rather than taken as far as the allocation. The default
+   allows the sizes people actually scrub: a 4K screenshot at scale 3 is 75
+   megapixels, a 5K one is 132.
 2. **Line joining.** Each OCR line is concatenated into one string with a map
    back to the word each character came from, so a term split across
    adjacent OCR words still matches and the covering words' rectangles are
@@ -213,6 +230,29 @@ Three ways it refuses to certify a run:
 In both failure cases nothing is published: the candidate is removed and the
 destination is untouched.
 
+### What the verify pass does not prove
+
+The verify pass is run by the **same recognizer that found the text in the
+first place**. That is true of every backend, on every platform, and it is a
+property of the design rather than a defect in any one engine.
+
+So a pass proves that *this engine* can no longer read the term in the
+written file. It does not prove that no trace of the text survives in the
+pixels. A different engine, a better one, or the same one at a scale this run
+did not try, is not what was asked.
+
+Two things follow, and neither of them weakens what the tool actually does:
+
+- **The rectangle is the engine's own estimate of where the text is**, and
+  nothing guarantees it is tight around the glyphs. `--pad` is the margin over
+  it and it defaults to 4 pixels; `--pad 0` removes the only margin there is.
+- **What is inside the rectangle really is destroyed.** `--blur` mosaics the
+  region down and scales it back with NEAREST, which throws the pixels away
+  outright - that claim is not hedged by anything in this section.
+
+There is deliberately no "safety margin" beyond `--pad`. A number nobody has
+measured, added to look careful, would be a guess presented as a guarantee.
+
 ## The OCR seam
 
 All the platform-specific code lives in [`src/ocr_backend.py`](src/ocr_backend.py)
@@ -282,7 +322,7 @@ portable fallback engine and none will be added.
 
 ```
 python gen_samples.py samples     # draw the synthetic test images
-python -m pytest tests/ -q        # 43 tests
+python -m pytest tests/ -q        # 49 tests
 ```
 
 The integration tests drive the **real recognizer** over the generated
@@ -322,6 +362,16 @@ inferred from a hit count.
 - **`--check-only` is a linter, not a guarantee.** It reports what the OCR can
   see. It cannot report sensitive text the OCR cannot read, which is why the
   scrub path always re-reads its own output.
+- **The verify pass uses the same engine that found the text**, on every
+  platform, so it proves the term is no longer readable *by that engine* -
+  not that no trace survives. The rectangle it redacts is that engine's own
+  estimate of where the text is and is not guaranteed tight; `--pad` (default
+  4) is the only margin over it, and `--pad 0` removes it. See
+  [What the verify pass does not prove](#what-the-verify-pass-does-not-prove).
+- **Case aliasing is the aliasing the output-collision check covers.** The
+  destination directory is probed for it directly. Other ways a filesystem can
+  make two names one file - Unicode normalisation, for one - are not probed
+  for.
 - **The engine is not deterministic across operating system versions.** The
   hit counts in `PROOF-windows.md` were produced on one machine; re-run the
   proof rather than assuming the numbers.

--- a/tools/cc-scrub/README.md
+++ b/tools/cc-scrub/README.md
@@ -322,13 +322,20 @@ portable fallback engine and none will be added.
 
 ```
 python gen_samples.py samples     # draw the synthetic test images
-python -m pytest tests/ -q        # 50 tests
+python -m pytest tests/ -q        # 52 tests
 ```
 
 The integration tests drive the **real recognizer** over the generated
 samples. On a platform with no backend yet they skip by platform name - never
 by probing whether OCR happens to work, so a broken install on a supported
 platform fails the suite instead of quietly passing it.
+
+A few arms need a volume on which two spellings name one file. That is
+measured on the directory the test writes to, using the same probe the tool
+uses, and never inferred from `sys.platform` - a Mac's default volume is
+case-insensitive, so a platform gate skipped those arms exactly where they
+would have run. Where such an arm skips, the reason names the directory and
+says the answer was measured.
 
 Alongside them the suite carries a `ScriptedBackend`: a deliberate test double
 that implements the seam contract and returns reads written down in the test.

--- a/tools/cc-scrub/README.md
+++ b/tools/cc-scrub/README.md
@@ -1,0 +1,257 @@
+# cc-scrub
+
+Finds denylisted text in screenshots and destroys it, so a screenshot can go
+into a public video, a documentation site or a website without a manual pixel
+hunt.
+
+Pure Python. Every dependency is a pip wheel. The text recognizer is the
+operating system's own, reached through one seam. No external executable is
+installed, required or looked for - in particular this tool never calls
+tesseract, even on a machine where one happens to be present - and it
+launches no subprocess at all.
+
+## Install
+
+```
+python -m pip install Pillow winocr
+```
+
+`winocr` is a pip wheel that wraps the OCR engine built into Windows through
+WinRT. There is no installer and no .exe. Proved on Python 3.11.6 with
+Pillow 12.3.0 and winocr 0.0.15; see [PROOF-windows.md](PROOF-windows.md) for
+the full clean-install transcript.
+
+On macOS the engine is Apple's Vision text recognizer. That backend is not
+implemented yet - see [Per-operating-system notes](#per-operating-system-notes).
+
+## Use
+
+```
+python main.py <image-or-dir> [-o <out>] [--terms-file terms.txt]
+               [--check-only] [--patch|--blur]
+               [--pad N] [--scales 1,2,3] [--lang en] [--no-fold]
+```
+
+Common runs:
+
+```
+python main.py shot.png                  # scrub one image next to itself
+python main.py shots -o out/             # scrub a whole folder into out/
+python main.py shots --check-only        # lint a folder, change nothing
+python main.py shot.png --patch          # opaque patch instead of a blur
+```
+
+The output is always written as `<name>-scrubbed.png`. The input is never
+overwritten; the tool refuses outright if `-o` resolves to the input path.
+When there are no hits, no output file is written at all.
+
+Directory input picks up `.png`, `.jpg`, `.jpeg`, `.bmp` and skips anything
+already named `*-scrubbed.*`, so re-running a folder is safe.
+
+`-o` pointed at a directory that does not exist yet is treated as an output
+*file* name, which is what you want for a single image and not what you want
+for a folder. Create the folder first.
+
+### Exit codes
+
+| code | meaning |
+| ---- | ------- |
+| 0    | work done and proved, or `--check-only` found nothing |
+| 1    | denylist hits remain readable in an output, or `--check-only` found hits |
+| 2    | broken instrument or usage error - OCR unavailable, unreadable image, zero text read, bad arguments |
+
+`--check-only` is the linter: it prints every hit with its coordinates,
+changes nothing, and exits 1 if there is anything to scrub. Point it at a
+screenshots folder before publishing.
+
+## The denylist
+
+`terms.txt` in this folder, one term per line, `#` starts a comment.
+Matching is case-insensitive and by substring, so `myorg` also hits
+`myorg/secret-repo`. Override the location with `--terms-file`.
+
+**`terms.txt` is your own configuration and is never committed.** A real
+denylist is a list of the exact strings you are trying to keep out of public
+screenshots, so committing it publishes them. This folder's `.gitignore`
+excludes it. What ships instead is
+[`terms.example.txt`](terms.example.txt), whose entries
+(`example@example.com`, `myorg/secret-repo`, `internal-hostname.local`) are
+deliberately fake. Copy it to `terms.txt` and put your terms in the copy.
+
+## How matching works
+
+1. **OCR at several scales.** The image is read once per factor in
+   `--scales` (default `1,2,3`), enlarged with LANCZOS before each read and
+   every rectangle divided back down afterwards. Small grey interface text
+   around 10 px is unreadable to the engine at native resolution: in the
+   proof run the line `repo myorg/secret-repo` collapses to a three-character
+   fragment at scale 1 and only resolves at 2 and 3, so the hit is reported
+   as `scales=2,3`. Every scale always runs and the hits are unioned. This is
+   not a fallback chain - different scales misread the same text in
+   different ways, and the union is what makes detection reliable.
+2. **Line joining.** Each OCR line is concatenated into one string with a map
+   back to the word each character came from, so a term split across
+   adjacent OCR words still matches and the covering words' rectangles are
+   unioned into one hit rectangle. Joining happens within a line only.
+3. **Normalisation.** Both the term and the OCR text are lowercased and
+   stripped of everything that is not `a-z0-9`. That is what absorbs the
+   punctuation and the spaces the engine injects into a URL - it returns
+   `https : / /example. ai/path/session_011` for a line whose pixels read
+   `https://example.ai/path/session_011`.
+4. **Glyph folding** (on by default, `--no-fold` turns it off). Characters
+   that share a shape are folded to one representative on both sides:
+   `o0`, `li1tj!|`, `s5`, `z2`, `b8`, `g9`. Small anti-aliased interface text
+   provokes exactly these confusions. A URL like `example.ai` can come back
+   as `exampte.ai` - the engine misreads the `l` as a `t` - and without
+   folding that URL is missed entirely. The proof run shows the same thing on
+   a host name: `internal-hostname.local` is read as
+   `https:/ftnternal-hostname.local/...`, found with folding, reported as
+   `HITS: 0` with `--no-fold`.
+
+   Folding deliberately over-matches in the safe direction: the worst case is
+   a few extra blurred pixels, and every hit is printed with its coordinates
+   and its source line so it can be checked by eye.
+5. **Merging.** Overlapping rectangles for the same term collapse into one,
+   so a hit seen at three scales is redacted once.
+
+## How the redaction works
+
+Each hit rectangle is padded by `--pad` pixels (default 4) and then:
+
+- **`--blur`** (default) mosaics the region down to a handful of cells and
+  scales it back with NEAREST, which throws the pixels away outright, then
+  smooths the blocks with a Gaussian pass at radius `max(6, height/2)`. The
+  text is not merely hard to read - the information is gone.
+- **`--patch`** fills a rounded rectangle with the region's per-channel
+  median colour, which is its background colour, so the redaction reads as a
+  deliberate one rather than a black bar.
+
+## How the verify pass works
+
+The verify pass is mandatory and it is not a re-read of anything held in
+memory. After the output is saved, the tool opens the **output file from
+disk**, runs the same multi-scale OCR and the same matcher over it, and only
+then decides.
+
+The pass condition is a presence, never an absence:
+
+```
+VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read
+57 words in the output and 0 denylist hit(s) remain.
+```
+
+Three ways it refuses to certify a run:
+
+- **Any denylist term still readable in the output** - prints each surviving
+  hit with coordinates, exit 1.
+- **The original OCR read zero words** - that is a broken read, never a clean
+  image, so the tool refuses to call it scrubbed. Exit 2.
+- **The verify OCR read zero words from the output** - the instrument itself
+  is broken and proves nothing. Exit 2.
+
+## The OCR seam
+
+All the platform-specific code lives in [`src/ocr_backend.py`](src/ocr_backend.py)
+and nowhere else. Everything above it - the multi-scale reads, the line
+joining, the normalisation, the folding, the merging, the redaction, the
+verify pass, the exit codes - is platform independent and does not know which
+engine answered.
+
+```
+backend = get_backend()
+words = backend.recognize(pil_image, lang)
+```
+
+`recognize` returns a flat list of dictionaries in reading order:
+
+```
+{"text": str, "x": float, "y": float, "w": float, "h": float, "line": int}
+```
+
+`x`, `y`, `w` and `h` are pixels in the coordinate space of the image handed
+in, origin at the top left. `line` is the index of the recognized line the
+word came from: words that share a `line` value are on one line, and that is
+what the line-joining step above needs. It is not decorative - a backend that
+gave every word a different `line` value would silently switch joining off
+and start missing terms.
+
+A backend also declares `name` (used in error messages) and
+`max_image_dimension` (the longest side the engine accepts, which is what
+bounds `--scales`).
+
+`get_backend()` picks by platform and nothing else. There is no probing, no
+trying one engine and then another, and no silent substitution: an operating
+system whose recognizer this tool cannot drive is an error, not a degraded
+mode.
+
+## Per-operating-system notes
+
+**Windows** - `WindowsOcrBackend`, the engine built into the operating
+system, reached through the `winocr` pip wheel and WinRT. Implemented and
+proved; see [PROOF-windows.md](PROOF-windows.md). The engine reports its own
+installed recognizer languages and names them in the error if `--lang` does
+not resolve. Its limit on the longest side is what `--scales` is bounded by,
+and the tool says so by name rather than silently skipping a scale.
+
+**macOS** - `MacVisionBackend`, Apple's Vision text recognizer
+(`VNRecognizeTextRequest`). **Implemented by the macOS backend** - it is
+present in `ocr_backend.py` today and raises on construction, naming exactly
+what it needs to return. It is deliberately loud rather than a stub that
+returns an empty word list, because an empty word list looks exactly like a
+clean screenshot, which is the one failure this tool must never produce. The
+macOS proof is recorded separately when that backend lands.
+
+**Anything else** - `get_backend()` raises, naming the platform. There is no
+portable fallback engine and none will be added.
+
+## Development
+
+```
+python gen_samples.py samples     # draw the synthetic test images
+python -m pytest tests/ -q        # 25 tests, end to end over those images
+```
+
+The tests drive the real recognizer over the generated samples. Nothing is
+mocked: a mocked engine would prove nothing about the engine this tool
+actually depends on. On a platform with no backend yet the OCR tests skip by
+platform name - never by probing whether OCR happens to work, so a broken
+install on a supported platform fails the suite instead of quietly passing
+it.
+
+## Known limits
+
+- **A term split across two OCR *lines* is not matched.** Joining happens
+  within a line only.
+- **An inserted glyph defeats a match.** Folding handles a character read as
+  the wrong character; it cannot handle a character the engine invents. A
+  slash read as an `i` turns `myorg/secret-repo` into `myorgisecret-repo`,
+  which normalises to one character more than the term and does not match.
+- **Detection is OCR-bound.** If the engine cannot resolve the text at any
+  configured scale, the tool cannot find it. Very small, very low-contrast or
+  heavily-kerned text may need a higher `--scales` value; the ceiling is the
+  engine's own limit on the longest side.
+- **Glyph folding can over-match.** Short terms are the risk - a two or three
+  character term after folding will hit far more than intended. Keep terms
+  specific, read the printed hits, and use `--no-fold` if an exact match is
+  wanted.
+- **`--check-only` is a linter, not a guarantee.** It reports what the OCR can
+  see. It cannot report sensitive text the OCR cannot read, which is why the
+  scrub path always re-reads its own output.
+- **The engine is not deterministic across operating system versions.** The
+  hit counts in `PROOF-windows.md` were produced on one machine; re-run the
+  proof rather than assuming the numbers.
+- **Not in the shipped tool bundle.** cc-scrub is a repository tool, run from
+  source. It has no PyInstaller build and is not selected for the installer.
+
+## Files
+
+| file | what it is |
+| ---- | ---------- |
+| `main.py` | the entry point |
+| `src/cli.py` | everything above the OCR seam |
+| `src/ocr_backend.py` | the OCR seam and the per-platform backends |
+| `gen_samples.py` | draws the four synthetic test images |
+| `terms.example.txt` | the example denylist, all entries fake |
+| `terms.txt` | your denylist - git-ignored, never committed |
+| `tests/` | the test suite |
+| `PROOF-windows.md` | the recorded clean-install proof run, Windows |

--- a/tools/cc-scrub/README.md
+++ b/tools/cc-scrub/README.md
@@ -322,7 +322,7 @@ portable fallback engine and none will be added.
 
 ```
 python gen_samples.py samples     # draw the synthetic test images
-python -m pytest tests/ -q        # 49 tests
+python -m pytest tests/ -q        # 50 tests
 ```
 
 The integration tests drive the **real recognizer** over the generated

--- a/tools/cc-scrub/README.md
+++ b/tools/cc-scrub/README.md
@@ -1,8 +1,16 @@
 # cc-scrub
 
-Finds denylisted text in screenshots and destroys it, so a screenshot can go
+Finds denylisted text in screenshots and covers it, so a screenshot can go
 into a public video, a documentation site or a website without a manual pixel
 hunt.
+
+**How strongly it is covered depends on the mode, and the default is the
+weaker one.** `--blur` removes the original pixel values but leaves a
+low-frequency average of the region, which is attackable; `--patch` paints an
+opaque colour over the whole rectangle and leaves no signal from the covered
+pixels at all. Use `--patch` for anything leaving the organisation, and read
+[How the redaction works](#how-the-redaction-works) before deciding that a
+blurred screenshot is safe to publish.
 
 Pure Python. Every dependency is a pip wheel. The text recognizer is the
 operating system's own, reached through one seam. No external executable is
@@ -197,10 +205,17 @@ of a fractional rectangle is left uncovered, and only then is `--pad` applied
   recovering text from a mosaic is a documented attack when the alphabet is
   small, and a Gaussian blur is a linear low-pass filter, not an eraser. This
   mode is not proof against a determined recovery attempt.
-- **`--patch`** fills a rounded rectangle with the region's per-channel
-  median colour, which is its background colour, so the redaction reads as a
-  deliberate one rather than a black bar. Because it paints an opaque solid
-  colour, **no signal from the covered pixels survives at all.**
+- **`--patch`** fills the **whole** hit rectangle with the region's
+  per-channel median colour, which is its background colour, so the redaction
+  reads as a deliberate one rather than a black bar. Because it paints an
+  opaque solid colour over every pixel of the box, **no signal from the
+  covered pixels survives at all.**
+
+  It is a plain rectangle and not a rounded one, deliberately. It was drawn
+  rounded, and the corners were therefore never painted - which made the mode
+  documented as the safe one the only one that provably left original pixels
+  inside the hit rectangle. Coverage beats the nicer shape, and a pixel-level
+  test now plants pixels in all four corners and requires that none survives.
 
 **For anything leaving the organisation, use `--patch`.** It is the only one
 of the two that leaves nothing behind to attack. `--blur` remains the default
@@ -216,12 +231,33 @@ memory. The redacted image is written to a **candidate file on disk**, beside
 where the output will go; the tool then opens that file, runs the same
 multi-scale OCR and the same matcher over it, and only then decides.
 
-Nothing unverified ever appears under the authoritative `*-scrubbed` name. On
-success the candidate is published with a single atomic rename onto the same
-volume. On failure the candidate is deleted and any existing output is left
-exactly as it was - a run that fails is not allowed to destroy a result that
-passed. Writing straight to the final name and checking afterwards gets both
-of those wrong.
+Nothing unverified ever appears under the authoritative `*-scrubbed` name,
+and any existing output is left exactly as it was - a run that fails is not
+allowed to destroy a result that passed. Writing straight to the final name
+and checking afterwards gets both of those wrong.
+
+Publishing is one atomic operation on the same volume, and which one depends
+on `--force`:
+
+- **Without `--force`** the candidate is hard-linked onto the destination
+  name, which fails rather than replacing if anything is there. That matters
+  because the "does an output already exist" check runs *before* the
+  candidate is written, and everything since - the write and the whole
+  verification - is a window in which another process can create that file. A
+  correct answer at inspection time does not make the write safe, so the
+  write itself carries the guarantee. On a volume with no hard links this is
+  a loud exit 2, never a silent replace.
+- **With `--force`** it is a rename, which replaces. That is what `--force`
+  asks for.
+
+**Removing the candidate after a failure is best effort.** The tool attempts
+it and, if the removal fails, prints a `WARNING` naming the file it left
+behind and continues - because an exception is usually already in flight at
+that point (the verify failure that stopped the publish) and raising there
+would replace the real reason with a housekeeping complaint. So a `*.tmp`
+candidate can survive next to the output directory, and **a candidate from a
+failed verify can still contain readable denylisted text.** If you see that
+warning, delete the file it names.
 
 The pass condition is a presence, never an absence:
 
@@ -239,8 +275,8 @@ Three ways it refuses to certify a run:
 - **The verify OCR read zero words from the candidate** - the instrument
   itself is broken and proves nothing. Exit 2.
 
-In both failure cases nothing is published: the candidate is removed and the
-destination is untouched.
+In both failure cases nothing is published and the destination is untouched.
+Removal of the candidate is best effort, as above.
 
 ### What the verify pass does not prove
 
@@ -339,7 +375,7 @@ portable fallback engine and none will be added.
 
 ```
 python gen_samples.py samples     # draw the synthetic test images
-python -m pytest tests/ -q        # 60 tests
+python -m pytest tests/ -q        # 68 tests
 ```
 
 The integration tests drive the **real recognizer** over the generated

--- a/tools/cc-scrub/README.md
+++ b/tools/cc-scrub/README.md
@@ -12,6 +12,8 @@ launches no subprocess at all.
 
 ## Install
 
+On Windows:
+
 ```
 python -m pip install Pillow winocr
 ```
@@ -21,8 +23,17 @@ WinRT. There is no installer and no .exe. Proved on Python 3.11.6 with
 Pillow 12.3.0 and winocr 0.0.15; see [PROOF-windows.md](PROOF-windows.md) for
 the full clean-install transcript.
 
-On macOS the engine is Apple's Vision text recognizer. That backend is not
-implemented yet - see [Per-operating-system notes](#per-operating-system-notes).
+On macOS:
+
+```
+python -m pip install Pillow pyobjc-framework-Vision
+```
+
+`pyobjc-framework-Vision` is a pip wheel that binds the Vision text
+recognizer built into macOS, and it pulls in the Quartz and Foundation
+bindings it needs. There is no installer and no external engine. Proved on
+Python 3.14.6 with Pillow 12.3.0 and pyobjc 12.2.2; see
+[PROOF-macos.md](PROOF-macos.md) for the full clean-install transcript.
 
 ## Use
 
@@ -246,13 +257,23 @@ installed recognizer languages and names them in the error if `--lang` does
 not resolve. Its limit on the longest side is what `--scales` is bounded by,
 and the tool says so by name rather than silently skipping a scale.
 
-**macOS** - `MacVisionBackend`, Apple's Vision text recognizer
-(`VNRecognizeTextRequest`). **In progress on this branch.** It is present in
-`ocr_backend.py` today and raises on construction, naming exactly what it
-needs to return. It is deliberately loud rather than a stub that
-returns an empty word list, because an empty word list looks exactly like a
-clean screenshot, which is the one failure this tool must never produce. The
-macOS proof is recorded separately when that backend lands.
+**macOS** - `MacVisionBackend`, the Vision text recognizer built into the
+operating system (`VNRecognizeTextRequest`, accurate recognition level),
+reached through the `pyobjc-framework-Vision` pip wheel. Implemented and
+proved; see [PROOF-macos.md](PROOF-macos.md). The image goes to the
+recognizer as an in-memory CGImage - no temporary file, no subprocess. The
+recognizer reports rectangles normalized to 0..1 and measured from the
+bottom-left corner; the backend converts them to the seam's top-left pixel
+coordinates and asks the recognizer itself for each word's rectangle within
+its line. Language correction is off on purpose: correction rewrites what
+was read toward dictionary words, and the strings this tool hunts -
+addresses, host names, repository paths - are exactly the ones a dictionary
+does not hold. This engine reads small text noticeably better than the
+Windows one: it reads the 11 px glyph sample cleanly at every scale, which
+is why the unfolded-miss half of the glyph test asserts on Windows only.
+`--lang` tags resolve against the recognizer's supported list (`en` names
+`en-US`); a tag that names no supported language stops the run and prints
+the full list. The longest side accepted is 16384 px.
 
 **Anything else** - `get_backend()` raises, naming the platform. There is no
 portable fallback engine and none will be added.

--- a/tools/cc-scrub/README.md
+++ b/tools/cc-scrub/README.md
@@ -28,7 +28,7 @@ implemented yet - see [Per-operating-system notes](#per-operating-system-notes).
 
 ```
 python main.py <image-or-dir> [-o <out>] [--terms-file terms.txt]
-               [--check-only] [--patch|--blur]
+               [--check-only] [--patch|--blur] [--force]
                [--pad N] [--scales 1,2,3] [--lang en] [--no-fold]
 ```
 
@@ -39,18 +39,42 @@ python main.py shot.png                  # scrub one image next to itself
 python main.py shots -o out/             # scrub a whole folder into out/
 python main.py shots --check-only        # lint a folder, change nothing
 python main.py shot.png --patch          # opaque patch instead of a blur
+python main.py shots -o out/ --force     # replace outputs already in out/
 ```
 
-The output is always written as `<name>-scrubbed.png`. The input is never
-overwritten; the tool refuses outright if `-o` resolves to the input path.
+### Where the output goes
+
+- No `-o`: beside the input, as `<stem>-scrubbed.png`.
+- `-o` naming a directory, or more than one input: into that directory, as
+  `<stem>-scrubbed.png`.
+- `-o` naming a file with exactly one input: **that file, verbatim** - the
+  name and the suffix are yours. The file is still written as PNG data.
+
+`-o` pointed at a path that does not exist yet is treated as an output *file*
+name, which is what you want for a single image and not what you want for a
+folder. Create the folder first.
+
 When there are no hits, no output file is written at all.
 
-Directory input picks up `.png`, `.jpg`, `.jpeg`, `.bmp` and skips anything
-already named `*-scrubbed.*`, so re-running a folder is safe.
+### What the tool refuses to write over
 
-`-o` pointed at a directory that does not exist yet is treated as an output
-*file* name, which is what you want for a single image and not what you want
-for a folder. Create the folder first.
+- **The input, always.** If the output resolves to the input file the run
+  stops. That check asks the operating system whether the two paths are the
+  same file, so a different letter case, a hard link, a symbolic link or a
+  junction is caught, not just an identical spelling. `--force` does not
+  lift this - it would destroy the only unredacted copy.
+- **An existing output, unless you say so.** An existing `*-scrubbed.png` may
+  be one that has already passed verification, so replacing it is a decision
+  you make on purpose. Delete it, point `-o` elsewhere, or pass `--force`.
+- **Two inputs that want one output.** Names are built from the input's stem,
+  so `shot.png` and `shot.jpg` both want `shot-scrubbed.png` - and on a
+  case-insensitive filesystem so do `Shot.png` and `shot.png`. Every
+  destination is worked out before any image is read, and a collision stops
+  the run rather than letting the second result quietly replace the first.
+
+Directory input picks up `.png`, `.jpg`, `.jpeg`, `.bmp` and skips anything
+already named `*-scrubbed.*`, so re-running a folder picks up the same inputs
+each time (and then refuses to replace the outputs unless you pass `--force`).
 
 ### Exit codes
 
@@ -58,7 +82,7 @@ for a folder. Create the folder first.
 | ---- | ------- |
 | 0    | work done and proved, or `--check-only` found nothing |
 | 1    | denylist hits remain readable in an output, or `--check-only` found hits |
-| 2    | broken instrument or usage error - OCR unavailable, unreadable image, zero text read, bad arguments |
+| 2    | broken instrument or usage error - OCR unavailable, unreadable image, zero text read, an image too big for the engine, an output that already exists, two inputs colliding on one output, an unmatchable denylist term, a failed write, bad arguments |
 
 `--check-only` is the linter: it prints every hit with its coordinates,
 changes nothing, and exits 1 if there is anything to scrub. Point it at a
@@ -78,6 +102,13 @@ excludes it. What ships instead is
 (`example@example.com`, `myorg/secret-repo`, `internal-hostname.local`) are
 deliberately fake. Copy it to `terms.txt` and put your terms in the copy.
 
+A term with nothing left after normalisation - all punctuation, or all
+non-ASCII - is an error, not a warning. Such a term would be counted in the
+banner and then skipped in the matcher, so a run could report "no hits
+against 6 terms" having actually checked five. The check is made under the
+normalisation actually in force, because folding changes which characters
+survive: `!!!` folds onto `lll` and can match, and with `--no-fold` it cannot.
+
 ## How matching works
 
 1. **OCR at several scales.** The image is read once per factor in
@@ -88,16 +119,19 @@ deliberately fake. Copy it to `terms.txt` and put your terms in the copy.
    fragment at scale 1 and only resolves at 2 and 3, so the hit is reported
    as `scales=2,3`. Every scale always runs and the hits are unioned. This is
    not a fallback chain - different scales misread the same text in
-   different ways, and the union is what makes detection reliable.
+   different ways, and the union is what makes detection reliable. Every
+   scale, scale 1 included, is measured against the engine's limit on the
+   longest side before the image is decoded, so an image too big to read is
+   refused by name rather than failing inside the engine.
 2. **Line joining.** Each OCR line is concatenated into one string with a map
    back to the word each character came from, so a term split across
    adjacent OCR words still matches and the covering words' rectangles are
    unioned into one hit rectangle. Joining happens within a line only.
-3. **Normalisation.** Both the term and the OCR text are lowercased and
-   stripped of everything that is not `a-z0-9`. That is what absorbs the
-   punctuation and the spaces the engine injects into a URL - it returns
-   `https : / /example. ai/path/session_011` for a line whose pixels read
-   `https://example.ai/path/session_011`.
+3. **Normalisation.** Both the term and the OCR text are lowercased, then
+   folded (step 4), then stripped of everything that is not `a-z0-9`. The
+   stripping is what absorbs the punctuation and the spaces the engine
+   injects into a URL - it returns `https : / /example. ai/path/session_011`
+   for a line whose pixels read `https://example.ai/path/session_011`.
 4. **Glyph folding** (on by default, `--no-fold` turns it off). Characters
    that share a shape are folded to one representative on both sides:
    `o0`, `li1tj!|`, `s5`, `z2`, `b8`, `g9`. Small anti-aliased interface text
@@ -108,6 +142,12 @@ deliberately fake. Copy it to `terms.txt` and put your terms in the copy.
    `https:/ftnternal-hostname.local/...`, found with folding, reported as
    `HITS: 0` with `--no-fold`.
 
+   Folding happens *before* the non-alphanumeric characters are dropped, and
+   the order is load bearing. Two members of the `l` class, `!` and `|`, are
+   not alphanumeric: filtering first threw them away instead of folding them,
+   so two of the six advertised folds did nothing at all and an engine that
+   read `internal` as `!nternal` produced a false negative.
+
    Folding deliberately over-matches in the safe direction: the worst case is
    a few extra blurred pixels, and every hit is printed with its coordinates
    and its source line so it can be checked by eye.
@@ -116,7 +156,10 @@ deliberately fake. Copy it to `terms.txt` and put your terms in the copy.
 
 ## How the redaction works
 
-Each hit rectangle is padded by `--pad` pixels (default 4) and then:
+Each hit rectangle arrives as floats. Every edge is first grown outwards to a
+whole pixel - floor the left and top, ceil the right and bottom - so no part
+of a fractional rectangle is left uncovered, and only then is `--pad` applied
+(default 4 pixels). Then:
 
 - **`--blur`** (default) mosaics the region down to a handful of cells and
   scales it back with NEAREST, which throws the pixels away outright, then
@@ -129,9 +172,16 @@ Each hit rectangle is padded by `--pad` pixels (default 4) and then:
 ## How the verify pass works
 
 The verify pass is mandatory and it is not a re-read of anything held in
-memory. After the output is saved, the tool opens the **output file from
-disk**, runs the same multi-scale OCR and the same matcher over it, and only
-then decides.
+memory. The redacted image is written to a **candidate file on disk**, beside
+where the output will go; the tool then opens that file, runs the same
+multi-scale OCR and the same matcher over it, and only then decides.
+
+Nothing unverified ever appears under the authoritative `*-scrubbed` name. On
+success the candidate is published with a single atomic rename onto the same
+volume. On failure the candidate is deleted and any existing output is left
+exactly as it was - a run that fails is not allowed to destroy a result that
+passed. Writing straight to the final name and checking afterwards gets both
+of those wrong.
 
 The pass condition is a presence, never an absence:
 
@@ -146,8 +196,11 @@ Three ways it refuses to certify a run:
   hit with coordinates, exit 1.
 - **The original OCR read zero words** - that is a broken read, never a clean
   image, so the tool refuses to call it scrubbed. Exit 2.
-- **The verify OCR read zero words from the output** - the instrument itself
-  is broken and proves nothing. Exit 2.
+- **The verify OCR read zero words from the candidate** - the instrument
+  itself is broken and proves nothing. Exit 2.
+
+In both failure cases nothing is published: the candidate is removed and the
+destination is untouched.
 
 ## The OCR seam
 
@@ -194,9 +247,9 @@ not resolve. Its limit on the longest side is what `--scales` is bounded by,
 and the tool says so by name rather than silently skipping a scale.
 
 **macOS** - `MacVisionBackend`, Apple's Vision text recognizer
-(`VNRecognizeTextRequest`). **Implemented by the macOS backend** - it is
-present in `ocr_backend.py` today and raises on construction, naming exactly
-what it needs to return. It is deliberately loud rather than a stub that
+(`VNRecognizeTextRequest`). **In progress on this branch.** It is present in
+`ocr_backend.py` today and raises on construction, naming exactly what it
+needs to return. It is deliberately loud rather than a stub that
 returns an empty word list, because an empty word list looks exactly like a
 clean screenshot, which is the one failure this tool must never produce. The
 macOS proof is recorded separately when that backend lands.
@@ -208,15 +261,24 @@ portable fallback engine and none will be added.
 
 ```
 python gen_samples.py samples     # draw the synthetic test images
-python -m pytest tests/ -q        # 25 tests, end to end over those images
+python -m pytest tests/ -q        # 43 tests
 ```
 
-The tests drive the real recognizer over the generated samples. Nothing is
-mocked: a mocked engine would prove nothing about the engine this tool
-actually depends on. On a platform with no backend yet the OCR tests skip by
-platform name - never by probing whether OCR happens to work, so a broken
-install on a supported platform fails the suite instead of quietly passing
-it.
+The integration tests drive the **real recognizer** over the generated
+samples. On a platform with no backend yet they skip by platform name - never
+by probing whether OCR happens to work, so a broken install on a supported
+platform fails the suite instead of quietly passing it.
+
+Alongside them the suite carries a `ScriptedBackend`: a deliberate test double
+that implements the seam contract and returns reads written down in the test.
+It is test tooling, not a runtime fallback - `get_backend()` cannot reach it
+and it never ships. It exists because the verify pass's failure arms cannot be
+reached with a real engine: no screenshot makes a recognizer read zero words
+from a file it has just read words from, and none reliably leaves a redacted
+term readable. Those arms are the ones that must never rot, so they are driven
+directly - along with the exact scale-to-native coordinate mapping and the
+adjacent-word joining, both of which are asserted as numbers rather than
+inferred from a hit count.
 
 ## Known limits
 
@@ -231,9 +293,11 @@ it.
   heavily-kerned text may need a higher `--scales` value; the ceiling is the
   engine's own limit on the longest side.
 - **Glyph folding can over-match.** Short terms are the risk - a two or three
-  character term after folding will hit far more than intended. Keep terms
-  specific, read the printed hits, and use `--no-fold` if an exact match is
-  wanted.
+  character term after folding will hit far more than intended. `|` and `!`
+  fold onto `l`, so a run of table borders or box drawing normalises to a run
+  of `l`s. That is over-matching in the safe direction - the cost is a few
+  extra blurred pixels, and every hit is printed - but keep terms specific,
+  read the printed hits, and use `--no-fold` if an exact match is wanted.
 - **`--check-only` is a linter, not a guarantee.** It reports what the OCR can
   see. It cannot report sensitive text the OCR cannot read, which is why the
   scrub path always re-reads its own output.

--- a/tools/cc-scrub/README.md
+++ b/tools/cc-scrub/README.md
@@ -339,13 +339,21 @@ portable fallback engine and none will be added.
 
 ```
 python gen_samples.py samples     # draw the synthetic test images
-python -m pytest tests/ -q        # 56 tests
+python -m pytest tests/ -q        # 60 tests
 ```
 
 The integration tests drive the **real recognizer** over the generated
 samples. On a platform with no backend yet they skip by platform name - never
 by probing whether OCR happens to work, so a broken install on a supported
 platform fails the suite instead of quietly passing it.
+
+**One invariant to hold when changing this tool.** `os.path.exists`, `isfile`
+and `isdir` return `False` for *every* error, and in this tool `False` is
+routinely the answer that PERMITS an action - publish over that file, treat
+those two paths as different files. So none of them are used: `stat_or_none`
+is, and it treats only `FileNotFoundError` and `NotADirectoryError` as
+genuine absences and raises on everything else. If you add a check, ask what
+`False` causes there before you reach for `os.path.exists`.
 
 A few arms need a volume on which two spellings name one file. That is
 measured on the directory the test writes to, using the same probe the tool

--- a/tools/cc-scrub/README.md
+++ b/tools/cc-scrub/README.md
@@ -190,12 +190,24 @@ of a fractional rectangle is left uncovered, and only then is `--pad` applied
 (default 4 pixels). Then:
 
 - **`--blur`** (default) mosaics the region down to a handful of cells and
-  scales it back with NEAREST, which throws the pixels away outright, then
-  smooths the blocks with a Gaussian pass at radius `max(6, height/2)`. The
-  text is not merely hard to read - the information is gone.
+  scales it back with NEAREST, then smooths the blocks with a Gaussian pass
+  at radius `max(6, height/2)`. The original pixel values are not present in
+  the output - the downsampling discards them. **What remains is a
+  low-frequency average of the covered region**, which is not nothing:
+  recovering text from a mosaic is a documented attack when the alphabet is
+  small, and a Gaussian blur is a linear low-pass filter, not an eraser. This
+  mode is not proof against a determined recovery attempt.
 - **`--patch`** fills a rounded rectangle with the region's per-channel
   median colour, which is its background colour, so the redaction reads as a
-  deliberate one rather than a black bar.
+  deliberate one rather than a black bar. Because it paints an opaque solid
+  colour, **no signal from the covered pixels survives at all.**
+
+**For anything leaving the organisation, use `--patch`.** It is the only one
+of the two that leaves nothing behind to attack. `--blur` remains the default
+because it is the right choice for the common case of tidying an internal
+screenshot, where the redaction should still read as part of the picture -
+but the choice of default is a judgement about the common case, not a claim
+that the two modes are equally strong.
 
 ## How the verify pass works
 
@@ -236,19 +248,24 @@ The verify pass is run by the **same recognizer that found the text in the
 first place**. That is true of every backend, on every platform, and it is a
 property of the design rather than a defect in any one engine.
 
-So a pass proves that *this engine* can no longer read the term in the
-written file. It does not prove that no trace of the text survives in the
-pixels. A different engine, a better one, or the same one at a scale this run
-did not try, is not what was asked.
+So a pass proves that *this engine*, at *the scales this run configured*,
+can no longer read the term in the written file. It does not prove that no
+trace of the text survives in the pixels. A different engine, a better one,
+or the same one at a scale this run did not try, is not what was asked.
 
-Two things follow, and neither of them weakens what the tool actually does:
+Three things follow:
 
 - **The rectangle is the engine's own estimate of where the text is**, and
   nothing guarantees it is tight around the glyphs. `--pad` is the margin over
   it and it defaults to 4 pixels; `--pad 0` removes the only margin there is.
-- **What is inside the rectangle really is destroyed.** `--blur` mosaics the
-  region down and scales it back with NEAREST, which throws the pixels away
-  outright - that claim is not hedged by anything in this section.
+- **What is inside the rectangle is covered, and how well depends on the
+  mode.** `--blur` removes the original pixel values but leaves a
+  low-frequency average of the region, which is attackable. `--patch` leaves
+  no signal from the covered pixels at all. See
+  [How the redaction works](#how-the-redaction-works).
+- **The verify pass cannot tell those two apart.** It asks the recognizer
+  whether it can still read the term, and the recognizer says no to both. A
+  pass is not a statement about how recoverable the covered pixels are.
 
 There is deliberately no "safety margin" beyond `--pad`. A number nobody has
 measured, added to look careful, would be a guess presented as a guarantee.
@@ -322,7 +339,7 @@ portable fallback engine and none will be added.
 
 ```
 python gen_samples.py samples     # draw the synthetic test images
-python -m pytest tests/ -q        # 52 tests
+python -m pytest tests/ -q        # 56 tests
 ```
 
 The integration tests drive the **real recognizer** over the generated
@@ -369,12 +386,18 @@ inferred from a hit count.
 - **`--check-only` is a linter, not a guarantee.** It reports what the OCR can
   see. It cannot report sensitive text the OCR cannot read, which is why the
   scrub path always re-reads its own output.
-- **The verify pass uses the same engine that found the text**, on every
-  platform, so it proves the term is no longer readable *by that engine* -
-  not that no trace survives. The rectangle it redacts is that engine's own
-  estimate of where the text is and is not guaranteed tight; `--pad` (default
-  4) is the only margin over it, and `--pad 0` removes it. See
+- **The verify pass uses the same engine that found the text**, at the scales
+  the run configured, on every platform. It proves the term is no longer
+  readable *by that engine at those scales* - not that no trace survives. The
+  rectangle it redacts is that engine's own estimate of where the text is and
+  is not guaranteed tight; `--pad` (default 4) is the only margin over it, and
+  `--pad 0` removes it. See
   [What the verify pass does not prove](#what-the-verify-pass-does-not-prove).
+- **`--blur` is not proof against a determined recovery attempt.** It removes
+  the original pixel values but what remains is a low-frequency average of the
+  covered region; depixelation attacks on text from a small alphabet are
+  documented, and a Gaussian is a linear filter. Use `--patch` for anything
+  leaving the organisation.
 - **Case aliasing is the aliasing the output-collision check covers.** The
   destination directory is probed for it directly. Other ways a filesystem can
   make two names one file - Unicode normalisation, for one - are not probed

--- a/tools/cc-scrub/gen_samples.py
+++ b/tools/cc-scrub/gen_samples.py
@@ -129,8 +129,10 @@ def _notext(path):
 
 def generate(out_dir):
     """Write all four samples into out_dir; return their paths in order."""
-    if not os.path.isdir(out_dir):
-        os.makedirs(out_dir)
+    # makedirs decides for itself rather than an isdir predicate deciding
+    # for it, so this file holds no os.path.exists/isfile/isdir either - the
+    # invariant in the README is true of the whole tool, not just of src/.
+    os.makedirs(out_dir, exist_ok=True)
     return [
         _normal(os.path.join(out_dir, "sample-normal.png")),
         _small_ui(os.path.join(out_dir, "sample-small-ui.png")),

--- a/tools/cc-scrub/gen_samples.py
+++ b/tools/cc-scrub/gen_samples.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+"""Render the synthetic sample screenshots cc-scrub is tested against.
+
+Real screenshots cannot be committed to a public repository, and a test
+that needs a private file is a test nobody else can run. So the samples are
+drawn here, from nothing but Pillow, and every planted term is one of the
+deliberately fake ones in terms.example.txt.
+
+Four images, each aimed at one thing the tool has to survive:
+
+    sample-normal.png    ordinary dark-on-light text at a readable size
+    sample-small-ui.png  ~10 px grey-on-dark text, the size real product
+                         chrome uses, which the recognizer cannot resolve at
+                         native resolution and only reads once upscaled
+    sample-glyph.png     a host name full of the letter l, the glyph the
+                         recognizer most often returns as a t
+    sample-notext.png    shapes and a gradient, no text at all - the image
+                         that must exit 2 as a broken read rather than pass
+                         as clean
+
+Run it directly to write them somewhere:
+
+    python gen_samples.py out/
+
+All output is ASCII only.
+"""
+
+import os
+import sys
+
+try:
+    from PIL import Image, ImageDraw, ImageFilter, ImageFont
+except ImportError as exc:
+    sys.stderr.write("FATAL: Pillow is not installed (%s).\n" % exc)
+    sys.stderr.write("Fix: python -m pip install Pillow\n")
+    sys.exit(2)
+
+
+# The planted terms. These are the example denylist entries, so nothing
+# real is ever drawn into a committed or published sample.
+TERM_EMAIL = "example@example.com"
+TERM_REPO = "myorg/secret-repo"
+TERM_HOST = "internal-hostname.local"
+
+SAMPLE_NAMES = ("sample-normal.png", "sample-small-ui.png",
+                "sample-glyph.png", "sample-notext.png")
+
+
+def _font(size):
+    """A scalable font with no system font hunting and no download.
+
+    Pillow ships one, and load_default takes a size from 10.1.0 onward.
+    Asking for it by size is what keeps these samples identical on every
+    machine - a system font would render differently per operating system
+    and the recognizer would read different words.
+    """
+    return ImageFont.load_default(size=size)
+
+
+def _text_block(draw, x, y, lines, font, fill, leading):
+    for index, line in enumerate(lines):
+        draw.text((x, y + index * leading), line, font=font, fill=fill)
+
+
+def _normal(path):
+    """Ordinary text at a readable size, dark on light."""
+    image = Image.new("RGB", (900, 260), (250, 250, 248))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 0, 899, 46), fill=(232, 232, 228))
+    _text_block(draw, 24, 14, ["Account settings"], _font(22), (20, 20, 20), 0)
+    _text_block(draw, 24, 78, [
+        "Owner of this workspace",
+        "Contact address: " + TERM_EMAIL,
+        "Plan: standard, renews every month",
+        "Seats in use: 4 of 10",
+    ], _font(20), (35, 35, 40), 40)
+    image.save(path)
+    return path
+
+
+def _small_ui(path):
+    """About 10 px grey on a dark ground - product chrome, not body text."""
+    image = Image.new("RGB", (900, 220), (28, 28, 32))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 0, 899, 30), fill=(38, 38, 44))
+    _text_block(draw, 18, 9, ["Session detail"], _font(13), (210, 210, 214), 0)
+    _text_block(draw, 18, 54, [
+        "branch feature/rendering",
+        "repo " + TERM_REPO,
+        "machine build agent two",
+        "started eleven minutes ago",
+        "last commit touched four files",
+    ], _font(10), (175, 175, 182), 22)
+    image.save(path)
+    return path
+
+
+def _glyph(path):
+    """A host name made mostly of the letter l, on a terminal-like ground."""
+    image = Image.new("RGB", (900, 220), (24, 26, 30))
+    draw = ImageDraw.Draw(image)
+    _text_block(draw, 18, 30, [
+        "connecting to the build host",
+        "https://" + TERM_HOST + "/status/session",
+        "handshake complete after two seconds",
+        "streaming the log until the run ends",
+    ], _font(11), (198, 200, 206), 40)
+    image.save(path)
+    return path
+
+
+def _notext(path):
+    """A gradient and some shapes. No glyphs anywhere."""
+    image = Image.new("RGB", (640, 400))
+    draw = ImageDraw.Draw(image)
+    for y in range(400):
+        shade = 40 + int(y * 0.35)
+        draw.line((0, y, 639, y), fill=(shade, shade // 2 + 20, 120 - shade // 4))
+    draw.ellipse((80, 90, 300, 310), fill=(220, 190, 90))
+    draw.ellipse((360, 140, 520, 300), fill=(90, 170, 200))
+    # Blurred on purpose. Sharp shapes give the recognizer edges it will
+    # occasionally return as a stray glyph, and one stray glyph would turn
+    # this from "reads nothing" into "reads something", which is not the
+    # case this sample exists to cover.
+    image = image.filter(ImageFilter.GaussianBlur(radius=6))
+    image.save(path)
+    return path
+
+
+def generate(out_dir):
+    """Write all four samples into out_dir; return their paths in order."""
+    if not os.path.isdir(out_dir):
+        os.makedirs(out_dir)
+    return [
+        _normal(os.path.join(out_dir, "sample-normal.png")),
+        _small_ui(os.path.join(out_dir, "sample-small-ui.png")),
+        _glyph(os.path.join(out_dir, "sample-glyph.png")),
+        _notext(os.path.join(out_dir, "sample-notext.png")),
+    ]
+
+
+def main(argv):
+    out_dir = argv[0] if argv else "samples"
+    print("cc-scrub sample generator")
+    for path in generate(out_dir):
+        with Image.open(path) as image:
+            print("  WROTE %s (%dx%d)" % (path, image.size[0], image.size[1]))
+    print("Planted terms: %s, %s, %s" % (TERM_EMAIL, TERM_REPO, TERM_HOST))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/cc-scrub/main.py
+++ b/tools/cc-scrub/main.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Entry point for cc-scrub."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from src.cli import main_entry
+
+if __name__ == "__main__":
+    main_entry()

--- a/tools/cc-scrub/make-proof-macos.sh
+++ b/tools/cc-scrub/make-proof-macos.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# The driver that produced tools/cc-scrub/PROOF-macos.md - the macOS half
+# ONLY. PROOF-windows.md is produced by its own driver on a Windows
+# machine; one script does not make both proofs.
+#
+# Nothing in the tool, its tests or its build references this file. It is
+# committed because a transcript only one machine can regenerate is weaker
+# than it looks: this is the exact sequence of commands whose recorded
+# output is the fenced transcript in PROOF-macos.md, so anyone with a Mac
+# can reproduce the run and compare.
+#
+# Usage, on a macOS machine with python3 on the path:
+#
+#   BASE=/private/tmp/cc-scrub-proof     # a neutral path: the transcript
+#   rm -rf "$BASE" && mkdir -p "$BASE"   # must name no person or machine
+#   git archive HEAD tools/cc-scrub | tar -x -C "$BASE" --strip-components=1
+#   bash tools/cc-scrub/make-proof-macos.sh run
+#
+# The transcript lands at $BASE/transcript.txt. The narrative half of
+# PROOF-macos.md is written by hand against that transcript; the fenced
+# transcript section is then replaced mechanically, never edited:
+#
+#   bash tools/cc-scrub/make-proof-macos.sh splice tools/cc-scrub/PROOF-macos.md
+#
+# Everything here is ASCII only, and every command is echoed before its
+# output with its exit code printed after it - the transcript records
+# failures as faithfully as passes.
+set -u
+
+BASE=/private/tmp/cc-scrub-proof
+T="$BASE/transcript.txt"
+MODE="${1:-run}"
+
+if [ "$MODE" = "splice" ]; then
+  if [ $# -ne 2 ]; then
+    echo "usage: make-proof-macos.sh splice <path-to-PROOF-macos.md>" >&2
+    exit 2
+  fi
+  PROOF="$2" TRANSCRIPT="$T" python3 - <<'PYEOF'
+import os
+import sys
+
+transcript_path = os.environ["TRANSCRIPT"]
+proof_path = os.environ["PROOF"]
+transcript = open(transcript_path).read().rstrip("\n")
+doc = open(proof_path).read()
+marker = "## The transcript\n\n```\n"
+head, sep, _old = doc.partition(marker)
+if not sep:
+    sys.exit("FATAL: transcript marker not found in %s" % proof_path)
+doc = head + marker + transcript + "\n```\n"
+if not all(ord(ch) < 128 for ch in doc):
+    sys.exit("FATAL: non-ASCII character in the assembled proof")
+open(proof_path, "w", newline="").write(doc)
+print("spliced %s into %s" % (transcript_path, proof_path))
+PYEOF
+  exit $?
+fi
+
+if [ "$MODE" != "run" ]; then
+  echo "usage: make-proof-macos.sh [run|splice <proof-file>]" >&2
+  exit 2
+fi
+
+cd "$BASE/cc-scrub" || exit 9
+: > "$T"
+
+say() { printf '%s\n' "$@" >> "$T"; }
+
+run() {
+  printf '$ %s\n' "$*" >> "$T"
+  "$@" >> "$T" 2>&1
+  printf '[exit %d]\n\n' "$?" >> "$T"
+}
+
+say "=== 1. the machine and the interpreter ==="
+say ""
+run sw_vers
+run python3 -V
+
+say "=== 2. a brand new virtual environment ==="
+say ""
+run python3 -m venv "$BASE/venv"
+
+say "=== 3. install from pip only - Pillow, the Vision binding, pytest ==="
+say ""
+run ../venv/bin/python -m pip install --upgrade pip
+run ../venv/bin/python -m pip install pillow pyobjc-framework-Vision pytest
+run ../venv/bin/python -m pip list
+
+say "=== 4. draw the synthetic samples ==="
+say ""
+run ../venv/bin/python gen_samples.py ../samples
+
+say "=== 5. the denylist used for the proof (the shipped example, copied) ==="
+say ""
+cp terms.example.txt ../terms.txt
+run cat ../terms.txt
+
+say "=== 6. check-only finds the planted terms, with coordinates ==="
+say ""
+run ../venv/bin/python main.py ../samples/sample-normal.png --check-only --terms-file ../terms.txt
+run ../venv/bin/python main.py ../samples/sample-small-ui.png --check-only --terms-file ../terms.txt
+run ../venv/bin/python main.py ../samples/sample-glyph.png --check-only --terms-file ../terms.txt
+
+say "=== 7. the same glyph case with folding turned off ==="
+say "(this recognizer reads the sample cleanly, so the term is still found -"
+say " see the notes above the transcript; the fold-miss property is proven"
+say " by the scripted-backend tests in step 12 instead)"
+say ""
+run ../venv/bin/python main.py ../samples/sample-glyph.png --check-only --no-fold --terms-file ../terms.txt
+
+say "=== 8. an image with no text at all is a broken read, not a clean image ==="
+say ""
+run ../venv/bin/python main.py ../samples/sample-notext.png --check-only --terms-file ../terms.txt
+
+say "=== 9. scrub each sample and let the verify pass rule on it ==="
+say "(-o naming a directory requires the directory to exist - a path that"
+say " does not exist yet is read as an output file name, so it is created"
+say " here first, exactly as the README says to)"
+say ""
+run mkdir ../out
+run ../venv/bin/python main.py ../samples/sample-normal.png -o ../out --terms-file ../terms.txt
+run ../venv/bin/python main.py ../samples/sample-small-ui.png -o ../out --terms-file ../terms.txt
+run ../venv/bin/python main.py ../samples/sample-glyph.png -o ../out --terms-file ../terms.txt
+
+say "=== 9b. the same scrub in --patch mode - exercised, not just described ==="
+say ""
+run mkdir ../out-patch
+run ../venv/bin/python main.py ../samples/sample-normal.png -o ../out-patch --patch --terms-file ../terms.txt
+
+say "=== 10. re-check every scrubbed output with the same engine ==="
+say ""
+run ../venv/bin/python main.py ../out/sample-normal-scrubbed.png --check-only --terms-file ../terms.txt
+run ../venv/bin/python main.py ../out/sample-small-ui-scrubbed.png --check-only --terms-file ../terms.txt
+run ../venv/bin/python main.py ../out/sample-glyph-scrubbed.png --check-only --terms-file ../terms.txt
+run ../venv/bin/python main.py ../out-patch/sample-normal-scrubbed.png --check-only --terms-file ../terms.txt
+
+say "=== 11. a folder holding only outputs is an empty input set ==="
+say "(the *-scrubbed suffix is skipped by design, which is what makes"
+say " re-running a folder safe - the tool says so rather than doing nothing)"
+say ""
+run ../venv/bin/python main.py ../out --check-only --terms-file ../terms.txt
+
+say "=== 12. the full test suite, in the same clean environment ==="
+say ""
+run ../venv/bin/python -m pytest tests/ -v -rs
+
+echo "DRIVER DONE - transcript at $T"

--- a/tools/cc-scrub/proof-build-windows.py
+++ b/tools/cc-scrub/proof-build-windows.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+"""Wrap a cc-scrub proof transcript in its header and write PROOF-windows.md.
+
+The transcript is machine produced by proof-run-windows.sh. This header is
+hand written, which is the whole reason this script exists: a figure the
+header states is a number that can drift away from the tool, and it has
+drifted twice - once on 14.3 and once on 15.0 - both times in narrative and
+never in tool output.
+
+So before writing anything, every number-like token the header quotes is
+checked against the transcript, and the build FAILS naming the offender if
+one is missing. Fix the header or fix the driver. Never hand-edit the
+transcript: it is evidence, and an edited transcript is not.
+
+Usage:
+    python proof-build-windows.py <transcript.txt> [output.md]
+
+Output defaults to PROOF-windows.md beside this script.
+
+This script is not part of the tool. Nothing imports it, nothing runs it
+during the test suite, and no build references it.
+"""
+
+import os
+import re
+import sys
+
+
+HEADER = """\
+# cc-scrub - clean install proof, Windows
+
+This is the real transcript of a real run, not a summary of one. It was
+produced by creating an empty virtual environment on a Windows machine,
+installing Pillow, winocr and pytest from pip and nothing else, drawing the
+synthetic samples, and then driving cc-scrub over them. Every command below
+is echoed before its output and every exit code is printed after it.
+
+It was run from `D:/cc-scrub-proof` rather than from a checkout, so nothing
+in the transcript names a person, a machine or a private repository. The
+samples are drawn by `gen_samples.py` and the denylist is the shipped
+`terms.example.txt` copied unchanged - the three planted terms are
+`example@example.com`, `myorg/secret-repo` and `internal-hostname.local`,
+all deliberately fake.
+
+## What this proves
+
+- **A clean install works from pip alone.** No installer, no external
+  executable, no tesseract, no subprocess. Pillow 12.3.0, winocr 0.0.15 and
+  their winrt wheels, on Python 3.11.6, Windows 10.0.26200.9278.
+- **check-only finds each planted term and prints its coordinates**, and
+  exits 1 while leaving the image untouched (step 6).
+- **Multi-scale reading is load bearing.** The 10 px grey line in
+  `sample-small-ui.png` is reported as `scales=2,3`: the recognizer cannot
+  resolve it at native resolution and only reads it once the image is
+  enlarged. Read at scale 1 alone, that term is missed.
+- **Glyph folding is load bearing.** In `sample-glyph.png` the recognizer
+  returns `https:/ftnternal-hostname.local/...` - the leading `i` of
+  `internal` comes back as a `t`. With folding on the term is found (step
+  6); with `--no-fold` the same image reports `HITS: 0` and exits 0 (step
+  7). That pair is the whole argument for folding, and it is why folding is
+  on by default.
+- **An image with no text is a broken read, not a clean image.**
+  `sample-notext.png` reads zero words at every scale and the tool exits 2
+  refusing to call it scrubbed (step 8).
+- **Nothing unverified is ever published.** Each scrub writes a `.tmp`
+  CANDIDATE beside the destination, verifies THAT file, and only then renames
+  it onto the `*-scrubbed.png` name (step 9). After three scrubs the output
+  directory holds exactly three published files and no candidates (step 10).
+- **The verify pass is presence shaped.** Each scrub prints
+  `VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR read N
+  words in the output and 0 denylist hit(s) remain` - and N is checked as a
+  number, so a verify instrument that reads nothing cannot certify anything.
+- **An existing output is not replaced by accident.** Re-running the same
+  scrub exits 2 and names the file; `--force` is how you say you meant it
+  (steps 11 and 12).
+- **The input is never a legal destination, in any spelling.** Addressing the
+  same file as `shot.png` and `SHOT.PNG` is refused - and refused even with
+  `--force`, because that would destroy the only unredacted copy (step 13).
+- **Two inputs cannot land on one output.** `Shot.png` and `shot.jpg` both
+  resolve to one file on this volume and the run stops before any image is
+  read (step 14).
+- **A read over the megapixel budget is refused before it is attempted.**
+  900x260 at scale 8 is 7200x2080, and the message names the exact count:
+  14,976,000 pixels (14.976 megapixels, decimal, as the flag name says) over
+  a 1 megapixel budget, with the engine never reached (step 15). The count
+  leads and the megapixel figure carries three decimals so that a value just
+  over the cap can never print AS the cap.
+- **`--patch` is exercised, not merely mentioned.** The mode recommended for
+  anything leaving the organisation is run end to end and its output
+  re-checked (step 16). An earlier version of this transcript named `--patch`
+  in prose and never ran a single `--patch` command, which certified a mode
+  it had not exercised.
+- **The published outputs read clean on a second, independent pass.** Each
+  file is re-opened from disk after the run that wrote it and read again with
+  zero hits (step 17). That is a statement about this engine at these scales,
+  not about the pixels: see "What this does NOT prove".
+- **The whole test suite passes in that same clean environment**: 68 tests,
+  NONE SKIPPED, including the three end-to-end scrub-and-verify cases
+  (step 19). It is run with `-rs`, so a skip would be printed with its
+  reason - a skip nobody prints reads exactly like a pass. The arms that
+  need a volume on which two spellings name one file measure that on the
+  directory they write to; on this volume all of them run.
+- **An unreadable path stops the run rather than granting permission.** Six
+  tests inject a permission error into os.stat or os.remove at a guard - the
+  input-overwrite check, the existing-output refusal, the case probe's
+  readback, the case probe's cleanup, the denylist lookup, and the candidate
+  cleanup. Injection is the only way in: these arms cannot be reached on a
+  working filesystem. Five of the six FAILED against the code before this
+  round, which is what makes them tests rather than comments; the sixth, the
+  candidate cleanup, passed already and is pinned so it stays that way. A
+  seventh pins the one error that IS an answer - a genuinely missing name
+  still means absent.
+
+## What this does NOT prove
+
+- **That no trace of the redacted text survives in the pixels.** The verify
+  pass is run by the same recognizer that found the text, at the scales this
+  run configured, so a pass proves the term is no longer readable BY THAT
+  ENGINE AT THOSE SCALES. Every scrub here used the default `--blur`, which
+  removes the original pixel values but leaves a low-frequency average of the
+  covered region - that is attackable, and nothing in this transcript says
+  otherwise. `--patch` is the mode that leaves no signal from the covered
+  pixels at all. See "How the redaction works" in the README.
+- **Nothing about macOS.** This is a Windows run. `MacVisionBackend` is a
+  different engine with its own clean-install transcript in
+  [PROOF-macos.md](PROOF-macos.md); nothing here carries over to it.
+  In particular, the output-collision check asks the destination directory
+  whether it treats two spellings as one file, and a Windows volume always
+  answers yes - so this transcript exercises the check but cannot demonstrate
+  the case it was written for, which is a case-insensitive volume under a
+  POSIX host. The regression test for that half neutralises
+  `os.path.normcase` so it runs anywhere, and it is in step 19; a real
+  case-insensitive POSIX volume is verified on the macOS side.
+- **Nothing about other people's Windows builds.** The recognizer is the
+  operating system's own and its output is not identical across Windows
+  versions or installed language packs. The word counts and the exact
+  misreadings below are what this machine produced. Re-run the proof rather
+  than trusting the numbers.
+- **Nothing about real screenshots.** These are synthetic images drawn by
+  Pillow. They are built to exercise the small-text and glyph-confusion
+  cases on purpose, which is not the same thing as a survey of real product
+  chrome.
+- **Nothing about a packaged executable.** cc-scrub is run from source here.
+  It has no PyInstaller build and is not in the shipped tool bundle.
+- **The two verify FAILURE arms are not in this transcript.** No real
+  screenshot makes an engine read zero words from a file it has just read
+  words from, and none reliably leaves a redacted term readable. Those arms
+  are proved in the test suite instead, driven by a scripted backend, and
+  they are the tests named `test_a_verify_read_of_zero_words_...` and
+  `test_a_term_surviving_in_the_output_...` in step 19.
+
+## The transcript
+
+```
+"""
+
+FOOTER = "```" + chr(10)
+
+# Small integers are step numbers, bullet counts and the like, not figures
+# quoted from the tool, so they are not required to appear in the transcript.
+STRUCTURAL = set(str(n) for n in range(0, 40))
+
+
+def check_header_against(transcript):
+    quoted = set(re.findall(r"\b\d[\d,]*(?:\.\d+)?\b", HEADER))
+    missing = sorted(n for n in quoted
+                     if n not in STRUCTURAL and n not in transcript)
+    if missing:
+        raise SystemExit(
+            "PROOF HEADER DRIFT: the header quotes figures the transcript "
+            "does not contain: %s. Fix the header or the driver - never "
+            "hand-edit the transcript." % ", ".join(missing))
+
+
+def main(argv):
+    if not argv:
+        raise SystemExit(__doc__)
+    transcript_path = argv[0]
+    here = os.path.dirname(os.path.abspath(__file__))
+    out_path = argv[1] if len(argv) > 1 else os.path.join(
+        here, "PROOF-windows.md")
+
+    with open(transcript_path, "r", encoding="ascii") as handle:
+        transcript = handle.read()
+
+    check_header_against(transcript)
+
+    # No newline= argument: the file is written with this platform's line
+    # endings, which is how the committed transcript was produced. Forcing
+    # them either way here would make the rebuilt file differ from the
+    # committed one on a byte comparison for a reason nobody cares about.
+    with open(out_path, "w", encoding="ascii") as handle:
+        handle.write(HEADER + transcript.rstrip(chr(10)) + chr(10) + FOOTER)
+    print("wrote %s (header figures checked against the transcript)" % out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/cc-scrub/proof-run-windows.sh
+++ b/tools/cc-scrub/proof-run-windows.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# The driver that produced PROOF-windows.md.
+#
+# It builds a brand new virtual environment, installs Pillow, winocr and
+# pytest from pip and nothing else, draws the synthetic samples, and drives
+# cc-scrub over them. Every command is echoed before it runs and its exit
+# code is printed after it, so the transcript can be read without trusting
+# any summary of it.
+#
+# Usage:
+#     bash proof-run-windows.sh [work-directory] > transcript.txt 2>&1
+#
+# The work directory defaults to ./proof-work. The committed transcript was
+# produced with it set to D:/cc-scrub-proof, which is why the paths in that
+# file read the way they do: the run is deliberately done from OUTSIDE any
+# checkout so no path in the published transcript names a person, a machine
+# or a private repository. Pick a neutral path if you regenerate it.
+#
+# Windows only - it installs winocr. The macOS transcript has its own driver.
+#
+# This script is not part of the tool. Nothing imports it, nothing runs it
+# during the test suite, and no build references it.
+#
+# Nothing here restates a figure the tool prints. A narrative number that has
+# to be kept in step with the tool is a number that drifts, and this file has
+# drifted twice - once on 14.3 and once on 15.0 - both times in commentary
+# and never in tool output.
+
+set -u
+
+WORK="${1:-$PWD/proof-work}"
+TOOL_DIR="$(cd "$(dirname "$0")" && pwd)"
+TERMS="$WORK/terms.txt"
+
+mkdir -p "$WORK"
+
+# A virtual environment puts its interpreter in Scripts on Windows and in bin
+# everywhere else. This picks the one that is there; if neither is, that is
+# an error and the run stops rather than guessing.
+venv_python() {
+  if [ -x "$WORK/venv/Scripts/python.exe" ]; then
+    echo "$WORK/venv/Scripts/python.exe"
+  elif [ -x "$WORK/venv/bin/python" ]; then
+    echo "$WORK/venv/bin/python"
+  else
+    echo "FATAL: no interpreter in $WORK/venv - the environment was not created" >&2
+    exit 2
+  fi
+}
+
+run() {
+  echo ""
+  echo "\$ $*"
+  "$@" 2>&1
+  echo "[exit $?]"
+}
+
+echo "=== 1. the machine and the interpreter ==="
+run cmd //c ver
+run python -V
+
+echo ""
+echo "=== 2. a brand new virtual environment ==="
+run python -m venv "$WORK/venv"
+
+PY="$(venv_python)"
+
+echo ""
+echo "=== 3. install from pip only - Pillow, winocr, pytest ==="
+run "$PY" -m pip install --upgrade pip
+run "$PY" -m pip install pillow winocr pytest
+run "$PY" -m pip list
+
+echo ""
+echo "=== 4. draw the synthetic samples ==="
+cd "$TOOL_DIR"
+run "$PY" gen_samples.py "$WORK/samples"
+
+echo ""
+echo "=== 5. the denylist used for the proof (the shipped example, copied) ==="
+cp terms.example.txt "$TERMS"
+run cat "$TERMS"
+
+echo ""
+echo "=== 6. check-only finds the planted terms, with coordinates ==="
+run "$PY" main.py "$WORK/samples/sample-normal.png" --check-only --terms-file "$TERMS"
+run "$PY" main.py "$WORK/samples/sample-small-ui.png" --check-only --terms-file "$TERMS"
+run "$PY" main.py "$WORK/samples/sample-glyph.png" --check-only --terms-file "$TERMS"
+
+echo ""
+echo "=== 7. the same glyph case with folding turned off - it is missed ==="
+run "$PY" main.py "$WORK/samples/sample-glyph.png" --check-only --no-fold --terms-file "$TERMS"
+
+echo ""
+echo "=== 8. an image with no text at all is a broken read, not a clean image ==="
+run "$PY" main.py "$WORK/samples/sample-notext.png" --check-only --terms-file "$TERMS"
+
+echo ""
+echo "=== 9. scrub each sample: candidate, verify, then publish ==="
+mkdir -p "$WORK/out"
+run "$PY" main.py "$WORK/samples/sample-normal.png" -o "$WORK/out" --terms-file "$TERMS"
+run "$PY" main.py "$WORK/samples/sample-small-ui.png" -o "$WORK/out" --terms-file "$TERMS"
+run "$PY" main.py "$WORK/samples/sample-glyph.png" -o "$WORK/out" --terms-file "$TERMS"
+
+echo ""
+echo "=== 10. nothing unverified is left lying about ==="
+echo "(the output directory holds the published outputs and no candidates)"
+run ls -1 "$WORK/out"
+
+echo ""
+echo "=== 11. an existing output is not replaced by accident ==="
+run "$PY" main.py "$WORK/samples/sample-normal.png" -o "$WORK/out" --terms-file "$TERMS"
+
+echo ""
+echo "=== 12. --force is how you say you meant it ==="
+run "$PY" main.py "$WORK/samples/sample-normal.png" -o "$WORK/out" --force --terms-file "$TERMS"
+
+echo ""
+echo "=== 13. the input is never a legal destination, in any spelling ==="
+cp "$WORK/samples/sample-normal.png" "$WORK/shot.png"
+run "$PY" main.py "$WORK/shot.png" -o "$WORK/SHOT.PNG" --force --terms-file "$TERMS"
+
+echo ""
+echo "=== 14. two inputs that would land on one output file ==="
+echo "(stems differing only in case; the destination directory is asked"
+echo " whether it treats the two spellings as one file, and it does here)"
+mkdir -p "$WORK/collide"
+cp "$WORK/samples/sample-normal.png" "$WORK/collide/Shot.png"
+cp "$WORK/samples/sample-normal.png" "$WORK/collide/shot.jpg"
+run "$PY" main.py "$WORK/collide" --terms-file "$TERMS"
+
+echo ""
+echo "=== 15. a read over the megapixel budget is refused before it is tried ==="
+echo "(the scaled read is inside the engine's side limit and over the"
+echo " budget, so it is the AREA check firing and not the side check."
+echo " The exact count is the tool's to print, below - this commentary"
+echo " deliberately restates no figure, because a narrative number that"
+echo " has to be kept in step with the tool is a number that drifts)"
+run "$PY" main.py "$WORK/samples/sample-normal.png" --check-only --scales 8 --max-megapixels 1 --terms-file "$TERMS"
+
+echo ""
+echo "=== 16. --patch, the mode recommended for anything leaving the org ==="
+echo "(the transcript used to MENTION --patch in prose and never run it,"
+echo " which certifies a mode it never exercised)"
+mkdir -p "$WORK/patched"
+run "$PY" main.py "$WORK/samples/sample-normal.png" -o "$WORK/patched" --patch --terms-file "$TERMS"
+run "$PY" main.py "$WORK/patched/sample-normal-scrubbed.png" --check-only --terms-file "$TERMS"
+
+echo ""
+echo "=== 17. re-check every published output - nothing left to find ==="
+run "$PY" main.py "$WORK/out/sample-normal-scrubbed.png" --check-only --terms-file "$TERMS"
+run "$PY" main.py "$WORK/out/sample-small-ui-scrubbed.png" --check-only --terms-file "$TERMS"
+run "$PY" main.py "$WORK/out/sample-glyph-scrubbed.png" --check-only --terms-file "$TERMS"
+
+echo ""
+echo "=== 18. a folder holding only outputs is an empty input set ==="
+echo "(the *-scrubbed suffix is skipped by design, which is what makes"
+echo " re-running a folder safe - the tool says so rather than doing nothing)"
+run "$PY" main.py "$WORK/out" --check-only --terms-file "$TERMS"
+
+echo ""
+echo "=== 19. the full test suite, in the same clean environment ==="
+echo "(-rs so that anything SKIPPED is printed with its reason, because a"
+echo " skip that is not shown reads exactly like a pass)"
+run "$PY" -m pytest tests/ -v -rs

--- a/tools/cc-scrub/pyproject.toml
+++ b/tools/cc-scrub/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cc-scrub"
+version = "0.1.0"
+description = "Find denylisted text in screenshots with the operating system's own OCR engine and destroy it"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+keywords = ["screenshot", "redaction", "ocr", "privacy", "denylist"]
+dependencies = [
+    "pillow>=10.1.0",
+]
+
+[project.optional-dependencies]
+# The OCR engine is the operating system's own, so the binding is per platform
+# and is selected by the marker, never by a runtime fallback.
+windows = ["winocr>=0.0.15; sys_platform == 'win32'"]
+dev = ["pytest>=7.0.0"]
+
+[project.scripts]
+cc-scrub = "cc_scrub.cli:main_entry"
+
+[tool.setuptools]
+# src/ installs as the unique import package so all tools share one venv.
+packages = ["cc_scrub"]
+package-dir = {"cc_scrub" = "src"}

--- a/tools/cc-scrub/pyproject.toml
+++ b/tools/cc-scrub/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 # The OCR engine is the operating system's own, so the binding is per platform
 # and is selected by the marker, never by a runtime fallback.
 windows = ["winocr>=0.0.15; sys_platform == 'win32'"]
+macos = ["pyobjc-framework-Vision>=12.2; sys_platform == 'darwin'"]
 dev = ["pytest>=7.0.0"]
 
 [project.scripts]

--- a/tools/cc-scrub/src/__init__.py
+++ b/tools/cc-scrub/src/__init__.py
@@ -1,0 +1,3 @@
+"""cc-scrub - find denylisted text in screenshots and destroy it."""
+
+__version__ = "0.1.0"

--- a/tools/cc-scrub/src/cli.py
+++ b/tools/cc-scrub/src/cli.py
@@ -92,8 +92,39 @@ def stat_or_none(path, purpose):
             % (path, purpose, exc))
 
 
+def lstat_or_none(path, purpose):
+    """os.lstat, for questions about the ENTRY rather than about its target.
+
+    stat_or_none follows symbolic links, which is right for classification -
+    is this a file, is this a directory - and wrong for "is there something
+    here that a write would clobber". A DANGLING SYMLINK is the case that
+    separates them: the entry plainly exists, and a following stat raises
+    FileNotFoundError, so the existence question answered "absent" and a run
+    with no --force replaced the link and reported success.
+    """
+    try:
+        return os.lstat(path)
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    except OSError as exc:
+        raise ScrubError(
+            "cannot inspect the directory entry %s, which is needed to %s: "
+            "%s. Refusing to guess, because an unreadable path is not an "
+            "answer - and here the convenient guess is the one that permits "
+            "the write." % (path, purpose, exc))
+
+
 def path_exists(path, purpose):
+    """Does the TARGET exist? Follows links. For identity questions."""
     return stat_or_none(path, purpose) is not None
+
+
+def entry_exists(path, purpose):
+    """Is there a directory entry here at all? Does not follow links.
+
+    This is the question to ask before writing to a name.
+    """
+    return lstat_or_none(path, purpose) is not None
 
 
 def path_is_directory(path, purpose):
@@ -176,12 +207,20 @@ def load_terms(path):
             "terms file not found: %s. The denylist is your own config and is "
             "never committed; copy %s to %s and put your terms in it."
             % (path, EXAMPLE_TERMS_FILE, DEFAULT_TERMS_FILE))
+    # The boundary goes around the READ. Asking whether the path is a
+    # regular file and then opening it outside any boundary leaves two ways
+    # out: the file can change between the two, and its contents can be
+    # invalid UTF-8, which escaped as a raw UnicodeDecodeError rather than
+    # the documented exit 2.
     terms = []
-    with open(path, "r", encoding="utf-8") as handle:
-        for raw in handle:
-            line = raw.split("#", 1)[0].strip()
-            if line:
-                terms.append(line)
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            for raw in handle:
+                line = raw.split("#", 1)[0].strip()
+                if line:
+                    terms.append(line)
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ScrubError("cannot read the terms file %s: %s" % (path, exc))
     if not terms:
         raise ScrubError("terms file %s has no terms in it" % path)
     return terms
@@ -248,13 +287,17 @@ def check_scales_fit(size, scales, backend, label,
                    backend.name, backend.max_image_dimension))
         pixels = scaled_width * scaled_height
         if pixels > budget:
+            # The exact count leads, and the megapixel figure carries enough
+            # precision that a value just over the cap cannot print AS the
+            # cap: 192,020,000 pixels used to render as "192.0 megapixels,
+            # over the 192 megapixel budget", which reads as nonsense.
             raise ScrubError(
-                "%s is %dx%d; at scale %d that is %dx%d, %.1f megapixels, over "
-                "the %d megapixel budget for one read. Use a smaller --scales "
-                "value, a smaller image, or raise --max-megapixels if this "
-                "machine has the memory for it."
+                "%s is %dx%d; at scale %d that is %dx%d, %s pixels (%.3f "
+                "megapixels), over the %d megapixel budget for one read. Use "
+                "a smaller --scales value, a smaller image, or raise "
+                "--max-megapixels if this machine has the memory for it."
                 % (label, width, height, scale, scaled_width, scaled_height,
-                   pixels / 1000000.0, max_megapixels))
+                   "{:,}".format(pixels), pixels / 1000000.0, max_megapixels))
 
 
 def ocr_image(image, scale, lang, backend,
@@ -489,10 +532,15 @@ def redact(image, hits, pad, mode):
                              % (ascii_safe(hit.term), box))
         region = out.crop(box)
         if mode == "patch":
+            # A PLAIN rectangle, not a rounded one. The contract of this mode
+            # is full coverage of the hit rectangle, and rounded corners are
+            # a cosmetic preference that broke it: the corners were never
+            # painted, so the mode documented as leaving no signal from the
+            # covered pixels was the only one that provably left ORIGINAL
+            # pixels inside the rectangle. Coverage wins over the shape.
             colour = _median_colour(region)
             draw = ImageDraw.Draw(out)
-            radius = max(2, min(8, (box[3] - box[1]) // 2))
-            draw.rounded_rectangle(box, radius=radius, fill=colour)
+            draw.rectangle(box, fill=colour)
         else:
             out.paste(_destroy(region), box)
     return out
@@ -626,7 +674,7 @@ def process_image(path, out_path, terms, args, backend):
 
     # An existing output may be one that has already been verified. Replacing
     # it is a decision the caller makes on purpose, never a side effect.
-    if path_exists(out_path, "tell whether an output is already there") \
+    if entry_exists(out_path, "tell whether an output is already there") \
             and not args.force:
         raise ScrubError(
             "output %s already exists. Refusing to replace it - it may be an "
@@ -696,11 +744,54 @@ def process_image(path, out_path, terms, args, backend):
             print("  NOT PUBLISHED: %s was not written." % out_path)
             return False
 
-        try:
-            os.replace(temp_path, out_path)
-        except OSError as exc:
-            raise ScrubError("cannot publish the verified candidate %s to %s: %s"
-                             % (temp_path, out_path, exc))
+        # The existence check above ran BEFORE the candidate was written, and
+        # everything since - the write, three OCR passes, the matching - is a
+        # window in which something else can put a file at the destination. A
+        # correct answer at inspection time does not make this write safe, so
+        # the write itself has to carry the guarantee.
+        #
+        # os.link is the portable no-clobber publish: it raises
+        # FileExistsError rather than replacing. os.replace is the opposite -
+        # it silently overwrites - so it is used ONLY when --force has asked
+        # for exactly that.
+        if args.force:
+            try:
+                os.replace(temp_path, out_path)
+            except OSError as exc:
+                raise ScrubError(
+                    "cannot publish the verified candidate %s to %s: %s"
+                    % (temp_path, out_path, exc))
+        else:
+            try:
+                os.link(temp_path, out_path)
+            except FileExistsError:
+                raise ScrubError(
+                    "%s appeared while this image was being verified. "
+                    "Refusing to replace it - nothing was published. Re-run, "
+                    "or pass --force if you mean to replace it." % out_path)
+            except OSError as exc:
+                # A volume with no hard links cannot give a no-clobber
+                # publish, and there is no fallback: falling back to
+                # os.replace would silently destroy whatever is at the
+                # destination, which is the entire thing this branch exists
+                # to prevent. It stops here, loudly.
+                raise ScrubError(
+                    "cannot publish %s without replacing whatever is there: "
+                    "%s. The no-clobber publish is a hard link, and this "
+                    "volume does not support one. There is no fallback - "
+                    "replacing is only ever done when --force asks for it. "
+                    "Pass --force if you mean to replace, or write the output "
+                    "to a volume that supports hard links."
+                    % (out_path, exc))
+            # The destination and the candidate are now two names for one
+            # file. Dropping the candidate name leaves exactly the published
+            # one behind.
+            try:
+                os.remove(temp_path)
+            except OSError as exc:
+                sys.stderr.write(
+                    "WARNING: published %s but could not remove the candidate "
+                    "name %s: %s\n" % (out_path, temp_path, exc))
         published = True
         print("  WROTE %s (mode=%s pad=%d)" % (out_path, args.mode, args.pad))
         print("  VERIFY PASSED: %d hit(s) found, %d region(s) redacted, verify "

--- a/tools/cc-scrub/src/cli.py
+++ b/tools/cc-scrub/src/cli.py
@@ -36,6 +36,11 @@ SCRUBBED_MARK = "-scrubbed"
 
 # A ceiling on the pixels ONE scaled read may ask for, in megapixels.
 #
+# Megapixels here means 1,000,000 pixels, the decimal unit the flag name and
+# the documentation say. It was implemented as 1024*1024 - mebipixels - so a
+# documented 192 megapixel ceiling actually admitted 201,326,592 pixels, and
+# a genuine 200 megapixel image passed under it.
+#
 # The engine's limit on the longest side is not a limit on area: a square
 # input just under that limit, read at scale 3, is about 268 megapixels -
 # roughly 800 MB of RGB data for the scaled copy alone, before the resize's
@@ -186,7 +191,7 @@ def check_scales_fit(size, scales, backend, label,
     DEFAULT_MAX_MEGAPIXELS.
     """
     width, height = size
-    budget = max_megapixels * 1024 * 1024
+    budget = max_megapixels * 1000000
     for scale in scales:
         scaled_width, scaled_height = width * scale, height * scale
         if max(scaled_width, scaled_height) > backend.max_image_dimension:
@@ -204,7 +209,7 @@ def check_scales_fit(size, scales, backend, label,
                 "value, a smaller image, or raise --max-megapixels if this "
                 "machine has the memory for it."
                 % (label, width, height, scale, scaled_width, scaled_height,
-                   pixels / float(1024 * 1024), max_megapixels))
+                   pixels / 1000000.0, max_megapixels))
 
 
 def ocr_image(image, scale, lang, backend,
@@ -404,9 +409,21 @@ def _median_colour(region):
 def _destroy(region):
     """Mosaic the region down to a handful of cells, then blur it smooth.
 
-    Downsampling throws the pixels away outright, so the text is not merely
-    hard to read - the information is gone. The Gaussian pass on top only
+    What this does, and what it does not do, stated exactly - because this
+    is the sentence someone leans on when deciding whether to publish.
+
+    The original pixel values are not present in the output. Downsampling to
+    a handful of cells discards them, and the Gaussian pass on top only
     removes the blocky edges.
+
+    What remains is a low-frequency AVERAGE of the covered region. That is
+    not nothing, and it is not proof against a determined recovery attempt:
+    recovering text from a mosaic is a documented attack when the alphabet is
+    small, and a Gaussian blur is a linear low-pass filter, not an eraser.
+
+    For anything leaving the organisation, --patch is the mode to use. It
+    paints an opaque solid colour over the region and leaves no signal from
+    the covered pixels at all.
     """
     width, height = region.size
     cells_x = max(1, width // 14)
@@ -715,22 +732,52 @@ def directory_is_case_insensitive(directory):
             "treats two spellings of a name as one file: %s. Refusing to "
             "guess, because guessing wrong lets one output silently replace "
             "another." % (directory, exc))
+    # os.path.exists is not usable here. It swallows every OSError and
+    # returns False, and False is the answer that switches the
+    # output-collision check OFF - so a permission error, an I/O error or a
+    # race read as "case-sensitive" and let one output overwrite another.
+    # That is the failure this whole check exists to prevent, arriving
+    # through the check itself.
+    #
+    # Exactly one error is an answer: FileNotFoundError, which is what a
+    # case-sensitive volume genuinely looks like. Every other error is a
+    # broken instrument and stops the run.
+    answer = None
+    read_error = None
     try:
         swapped = os.path.join(directory,
                                os.path.basename(probe).swapcase())
-        if not os.path.exists(swapped):
-            return False
-        return os.path.samefile(swapped, probe)
-    except OSError as exc:
-        raise ScrubError(
-            "cannot read back the case probe in %s: %s. Refusing to guess."
-            % (directory, exc))
-    finally:
         try:
-            os.remove(probe)
-        except OSError as exc:
-            sys.stderr.write("WARNING: could not remove the case probe %s: "
-                             "%s\n" % (probe, exc))
+            os.stat(swapped)
+        except FileNotFoundError:
+            answer = False
+        else:
+            answer = os.path.samefile(swapped, probe)
+    except OSError as exc:
+        read_error = exc
+
+    remove_error = None
+    try:
+        os.remove(probe)
+    except OSError as exc:
+        remove_error = exc
+
+    if read_error is not None:
+        raise ScrubError(
+            "cannot read back the case probe %s: %s. Refusing to guess, "
+            "because guessing case-sensitive would switch the "
+            "output-collision check off and let one result overwrite "
+            "another.%s"
+            % (probe, read_error,
+               "" if remove_error is None else
+               " The probe could not be removed either (%s) and is still "
+               "there." % remove_error))
+    if remove_error is not None:
+        raise ScrubError(
+            "the case probe %s could not be removed: %s. Refusing to return a "
+            "verdict from a directory that is not behaving as this check "
+            "assumes." % (probe, remove_error))
+    return answer
 
 
 def plan_outputs(sources, out_option):

--- a/tools/cc-scrub/src/cli.py
+++ b/tools/cc-scrub/src/cli.py
@@ -16,8 +16,10 @@ All output is ASCII only.
 """
 
 import argparse
+import math
 import os
 import sys
+import tempfile
 
 try:
     from PIL import Image, ImageDraw, ImageFilter
@@ -76,17 +78,29 @@ for _target, _members in _FOLD_CLASSES:
 
 
 def normalise(text, fold=True):
-    """Lowercase, drop everything that is not a-z0-9, then fold glyph classes.
+    """Fold glyph classes first, then drop everything that is not a-z0-9.
 
-    Dropping the non-alphanumerics is what lets a term match across OCR
-    word splits and injected punctuation noise: the OCR reads
+    The order matters, and getting it the wrong way round silently killed
+    two of the six advertised folds. Two members of the l class - '!' and
+    '|' - are not alphanumeric, so filtering first threw them away instead
+    of folding them: an engine that read "internal" as "!nternal" produced
+    "nternal" while the term produced "lnternal", and the term was missed.
+    Folding first means a mapped character always becomes its
+    representative, and only unmapped characters face the alphanumeric
+    filter.
+
+    Dropping the remaining non-alphanumerics is what lets a term match
+    across OCR word splits and injected punctuation noise: the OCR reads
     "https : //example. ai/path/session_011" and the term
     "example.ai/path/session" still lands.
     """
     out = []
     for ch in text.lower():
+        if fold and ch in _FOLD_MAP:
+            out.append(_FOLD_MAP[ch])
+            continue
         if ch.isascii() and (ch.isalpha() or ch.isdigit()):
-            out.append(_FOLD_MAP.get(ch, ch) if fold else ch)
+            out.append(ch)
     return "".join(out)
 
 
@@ -108,6 +122,28 @@ def load_terms(path):
     return terms
 
 
+def validate_terms(terms, fold):
+    """Refuse any term with nothing left to match on after normalisation.
+
+    A term made only of punctuation or non-ASCII normalises to the empty
+    string. Such a term used to be counted in the banner and then skipped
+    in silence, so a run could report "no hits against 6 terms" having
+    actually checked five. The banner and the work must agree, so this is
+    an error and not a warning - and it is judged under the normalisation
+    that is actually in force, because folding changes which characters
+    survive.
+    """
+    dead = [term for term in terms if not normalise(term, fold)]
+    if dead:
+        raise ScrubError(
+            "these denylist terms have nothing left to match on after "
+            "normalisation%s, so they would be counted in the banner and "
+            "never checked: %s. Remove them, or write them with letters or "
+            "digits."
+            % (" with glyph folding on" if fold else " with --no-fold",
+               ", ".join("'%s'" % ascii_safe(term) for term in dead)))
+
+
 # ------------------------------------------------------------------------ ocr
 
 class OcrPass(object):
@@ -119,6 +155,27 @@ class OcrPass(object):
         self.word_count = word_count
 
 
+def check_scales_fit(size, scales, backend, label):
+    """Refuse before reading if any scale would exceed the engine's limit.
+
+    Scale 1 is checked too. It used to be exempt, on the assumption that a
+    native image is always small enough - which is not true. An oversized
+    screenshot reached the engine unchecked and failed there, after the
+    whole file had been decoded into memory, instead of failing here
+    deterministically and by name.
+    """
+    width, height = size
+    for scale in scales:
+        scaled_width, scaled_height = width * scale, height * scale
+        if max(scaled_width, scaled_height) > backend.max_image_dimension:
+            raise ScrubError(
+                "%s is %dx%d; at scale %d that is %dx%d, over the %s limit of "
+                "%d px on the longest side. Use a smaller --scales value, or "
+                "a smaller image."
+                % (label, width, height, scale, scaled_width, scaled_height,
+                   backend.name, backend.max_image_dimension))
+
+
 def ocr_image(image, scale, lang, backend):
     """OCR image upscaled by 'scale'; return an OcrPass with rects at scale 1.
 
@@ -126,15 +183,9 @@ def ocr_image(image, scale, lang, backend):
     the image is enlarged with LANCZOS before the read and every rectangle
     is divided back down afterwards.
     """
-    width, height = image.size
+    check_scales_fit(image.size, [scale], backend, "the image")
     if scale != 1:
-        width, height = width * scale, height * scale
-        if max(width, height) > backend.max_image_dimension:
-            raise ScrubError(
-                "scale %d makes the image %dx%d, over the %s limit of %d px. "
-                "Use a smaller --scales value."
-                % (scale, width, height, backend.name,
-                   backend.max_image_dimension))
+        width, height = image.size[0] * scale, image.size[1] * scale
         scaled = image.resize((width, height), Image.LANCZOS)
     else:
         scaled = image
@@ -203,7 +254,10 @@ def find_hits(ocr_pass, terms, fold):
         for term in terms:
             needle = normalise(term, fold)
             if not needle:
-                continue
+                raise ScrubError(
+                    "term '%s' normalises to nothing and cannot be matched; "
+                    "validate_terms must reject it before any image is read."
+                    % ascii_safe(term))
             start = line_norm.find(needle)
             while start != -1:
                 covered = sorted(set(owner[start:start + len(needle)]))
@@ -269,10 +323,18 @@ def _overlaps(a, b):
 # -------------------------------------------------------------------- redaction
 
 def _pad_box(box, pad, size):
-    x0 = max(0, int(box[0]) - pad)
-    y0 = max(0, int(box[1]) - pad)
-    x1 = min(size[0], int(round(box[2])) + pad)
-    y1 = min(size[1], int(round(box[3])) + pad)
+    """Grow the float rectangle outwards to whole pixels, then pad it.
+
+    Every edge moves away from the text: floor the left and top, ceil the
+    right and bottom. Rounding the far edges instead used to lose the last
+    column or row of pixels whenever the rectangle ended on a fraction
+    below .5 - invisible at the default padding, and a strip of readable
+    text left behind at --pad 0.
+    """
+    x0 = max(0, int(math.floor(box[0])) - pad)
+    y0 = max(0, int(math.floor(box[1])) - pad)
+    x1 = min(size[0], int(math.ceil(box[2])) + pad)
+    y1 = min(size[1], int(math.ceil(box[3])) + pad)
     return (x0, y0, x1, y1)
 
 
@@ -343,15 +405,53 @@ def describe(hit):
 
 # ----------------------------------------------------------------- per image
 
+def is_same_file(first, second):
+    """True when the two paths name the same file on disk.
+
+    Comparing os.path.abspath strings is not enough and the difference is
+    not academic. Windows paths are case-insensitive, so 'shot.png' and
+    'SHOT.PNG' are one file whose absolute paths compare unequal; the same
+    goes for a hard link, a symbolic link, a junction and an 8.3 short name.
+    Every one of those would have slipped past a string comparison and let
+    the tool overwrite the very input it says it refuses to touch - which
+    would destroy the only unredacted copy.
+
+    os.path.samefile asks the operating system, which is the only answer
+    that covers all of those. It needs both paths to exist, so a destination
+    that has not been created yet is compared canonically instead. That is a
+    precondition, not a degraded mode: the two branches answer the same
+    question about two different situations, and neither one guesses.
+    """
+    if os.path.exists(second) and os.path.exists(first):
+        try:
+            return os.path.samefile(first, second)
+        except OSError as exc:
+            raise ScrubError(
+                "cannot tell whether %s and %s are the same file: %s. "
+                "Refusing to write, because writing would risk destroying "
+                "the input." % (first, second, exc))
+    return (os.path.normcase(os.path.realpath(first))
+            == os.path.normcase(os.path.realpath(second)))
+
+
 def process_image(path, out_path, terms, args, backend):
     """Scrub one image. Returns True if the image ends up proved clean."""
     print("")
     print("IMAGE %s" % path)
     try:
         image = Image.open(path)
-        image.load()
     except Exception as exc:
         raise ScrubError("cannot read image %s: %s" % (path, exc))
+
+    # Size comes off the header, before the pixels are decoded. An image too
+    # big for the engine is refused here rather than after megabytes have
+    # been read into memory for a read that could never have happened.
+    check_scales_fit(image.size, args.scales, backend, path)
+
+    try:
+        image.load()
+    except Exception as exc:
+        raise ScrubError("cannot decode image %s: %s" % (path, exc))
     image = image.convert("RGB")
     print("  size %dx%d  scales %s  fold %s"
           % (image.size[0], image.size[1],
@@ -390,40 +490,101 @@ def process_image(path, out_path, terms, args, backend):
         return True
 
     scrubbed = redact(image, hits, args.pad, args.mode)
-    if os.path.abspath(out_path) == os.path.abspath(path):
-        raise ScrubError("refusing to overwrite the input image %s" % path)
-    scrubbed.save(out_path)
-    print("  WROTE %s (mode=%s pad=%d)" % (out_path, args.mode, args.pad))
 
-    # Mandatory verify pass: re-OCR the OUTPUT, from disk.
-    print("  VERIFY: re-reading %s" % out_path)
-    verify_image = Image.open(out_path)
-    verify_image.load()
-    verify_image = verify_image.convert("RGB")
-    remaining, verify_passes, verify_words = collect_hits(
-        verify_image, terms, args.scales, args.lang, not args.no_fold, backend)
-    for ocr_pass in verify_passes:
-        print("    verify scale %d: %d words in %d lines"
-              % (ocr_pass.scale, ocr_pass.word_count, len(ocr_pass.lines)))
+    # The input is never a legal destination, and --force does not change
+    # that: it would destroy the only unredacted copy.
+    if is_same_file(out_path, path):
+        raise ScrubError("refusing to overwrite the input image %s (the output "
+                         "path %s is the same file)" % (path, out_path))
 
-    # The verify instrument must itself prove it can read. A verify pass
-    # that reads nothing proves nothing.
-    if verify_words == 0:
+    # An existing output may be one that has already been verified. Replacing
+    # it is a decision the caller makes on purpose, never a side effect.
+    if os.path.exists(out_path) and not args.force:
         raise ScrubError(
-            "verify OCR read ZERO words from the output %s. The verify "
-            "instrument is broken; the result is not proved." % out_path)
+            "output %s already exists. Refusing to replace it - it may be an "
+            "output that has already passed verification. Delete it, point -o "
+            "somewhere else, or pass --force to replace it." % out_path)
 
-    if remaining:
-        print("  VERIFY FAILED: %d denylist hit(s) still readable in the output:"
-              % len(remaining))
-        for hit in remaining:
-            print("    %s" % describe(hit))
-        return False
+    # Write a candidate beside the destination, verify THAT file, and publish
+    # it to the authoritative name only once it has passed.
+    #
+    # Writing straight to the final name and verifying afterwards means a run
+    # that fails verification still leaves a file under the *-scrubbed name -
+    # a name whose whole meaning is "this was checked" - and worse, that file
+    # has already replaced whatever verified output was there before. The
+    # temporary lives in the same directory so the publish is one atomic
+    # rename on the same volume.
+    out_dir = os.path.dirname(os.path.abspath(out_path))
+    try:
+        handle, temp_path = tempfile.mkstemp(
+            prefix=os.path.basename(out_path) + ".", suffix=".tmp", dir=out_dir)
+        os.close(handle)
+    except OSError as exc:
+        raise ScrubError("cannot create a temporary file in %s: %s"
+                         % (out_dir, exc))
+    published = False
+    try:
+        try:
+            scrubbed.save(temp_path, format="PNG")
+        except Exception as exc:
+            raise ScrubError("cannot write the candidate output %s: %s"
+                             % (temp_path, exc))
+        print("  CANDIDATE %s (mode=%s pad=%d)" % (temp_path, args.mode, args.pad))
 
-    print("  VERIFY PASSED: %d hit(s) found, %d region(s) redacted, verify OCR "
-          "read %d words in the output and 0 denylist hit(s) remain."
-          % (len(hits), len(hits), verify_words))
-    return True
+        # Mandatory verify pass: re-OCR the CANDIDATE, from disk.
+        print("  VERIFY: re-reading %s" % temp_path)
+        try:
+            verify_image = Image.open(temp_path)
+            verify_image.load()
+        except Exception as exc:
+            raise ScrubError("cannot read back the candidate output %s: %s"
+                             % (temp_path, exc))
+        verify_image = verify_image.convert("RGB")
+        remaining, verify_passes, verify_words = collect_hits(
+            verify_image, terms, args.scales, args.lang, not args.no_fold,
+            backend)
+        verify_image.close()
+        for ocr_pass in verify_passes:
+            print("    verify scale %d: %d words in %d lines"
+                  % (ocr_pass.scale, ocr_pass.word_count, len(ocr_pass.lines)))
+
+        # The verify instrument must itself prove it can read. A verify pass
+        # that reads nothing proves nothing.
+        if verify_words == 0:
+            raise ScrubError(
+                "verify OCR read ZERO words from the candidate for %s. The "
+                "verify instrument is broken; the result is not proved and "
+                "nothing was published." % out_path)
+
+        if remaining:
+            print("  VERIFY FAILED: %d denylist hit(s) still readable in the "
+                  "candidate:" % len(remaining))
+            for hit in remaining:
+                print("    %s" % describe(hit))
+            print("  NOT PUBLISHED: %s was not written." % out_path)
+            return False
+
+        try:
+            os.replace(temp_path, out_path)
+        except OSError as exc:
+            raise ScrubError("cannot publish the verified candidate %s to %s: %s"
+                             % (temp_path, out_path, exc))
+        published = True
+        print("  WROTE %s (mode=%s pad=%d)" % (out_path, args.mode, args.pad))
+        print("  VERIFY PASSED: %d hit(s) found, %d region(s) redacted, verify "
+              "OCR read %d words in the output and 0 denylist hit(s) remain."
+              % (len(hits), len(hits), verify_words))
+        return True
+    finally:
+        if not published and os.path.exists(temp_path):
+            try:
+                os.remove(temp_path)
+            except OSError as exc:
+                # Never mask the failure that brought us here; say what was
+                # left behind so it can be cleaned up by hand.
+                sys.stderr.write(
+                    "WARNING: could not remove the unpublished candidate %s: "
+                    "%s\n" % (temp_path, exc))
 
 
 # ----------------------------------------------------------------------- main
@@ -443,19 +604,60 @@ def gather_inputs(target):
     raise ScrubError("no such file or directory: %s" % target)
 
 
+def _make_directory(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        raise ScrubError("cannot create the output directory %s: %s"
+                         % (path, exc))
+
+
 def output_path_for(source, out_option, many):
+    """Where one input's output goes.
+
+    With no -o, beside the input as <stem>-scrubbed.png. With -o naming a
+    directory, or with more than one input, into that directory under the
+    same name. With -o naming a file and exactly one input, that file
+    verbatim - the name is the caller's, suffix and all.
+    """
     stem, _suffix = os.path.splitext(os.path.basename(source))
     default_name = stem + SCRUBBED_MARK + ".png"
     if not out_option:
         return os.path.join(os.path.dirname(os.path.abspath(source)), default_name)
     if many or os.path.isdir(out_option):
         if not os.path.isdir(out_option):
-            os.makedirs(out_option)
+            _make_directory(out_option)
         return os.path.join(out_option, default_name)
     parent = os.path.dirname(os.path.abspath(out_option))
     if parent and not os.path.isdir(parent):
-        os.makedirs(parent)
+        _make_directory(parent)
     return out_option
+
+
+def plan_outputs(sources, out_option):
+    """Map every input to its output up front, and refuse any collision.
+
+    Output names are built from the input's STEM, so shot.png and shot.jpg
+    both want shot-scrubbed.png - and on a case-insensitive filesystem so do
+    Shot.png and shot.png. Left alone, the second run silently overwrites
+    the first and the summary reports two images cleaned when only one
+    survived. Every destination is therefore worked out before any image is
+    read, and a collision stops the run instead of destroying a result.
+    """
+    many = len(sources) > 1
+    plan = []
+    claimed = {}
+    for source in sources:
+        destination = output_path_for(source, out_option, many)
+        key = os.path.normcase(os.path.abspath(destination))
+        if key in claimed:
+            raise ScrubError(
+                "%s and %s would both be written to %s. Rename one input, "
+                "give -o separate directories, or scrub them in separate "
+                "runs." % (claimed[key], source, destination))
+        claimed[key] = source
+        plan.append((source, destination))
+    return plan
 
 
 def parse_scales(text):
@@ -492,6 +694,9 @@ def build_parser():
                         help="paint an opaque rounded patch instead of blurring")
     parser.add_argument("--blur", dest="mode", action="store_const",
                         const="blur", help="mosaic and blur the region (default)")
+    parser.add_argument("--force", action="store_true",
+                        help="replace an existing output file (never the "
+                             "input, which is always refused)")
     parser.add_argument("--pad", type=int, default=4,
                         help="pixels of padding around each hit (default 4)")
     parser.add_argument("--scales", default="1,2,3",
@@ -515,7 +720,10 @@ def main(argv):
         if args.pad < 0:
             raise ScrubError("--pad cannot be negative")
         terms = load_terms(args.terms_file)
+        validate_terms(terms, not args.no_fold)
         sources = gather_inputs(args.target)
+        plan = ([(source, None) for source in sources] if args.check_only
+                else plan_outputs(sources, args.out))
         backend = get_backend()
     except ScrubError as exc:
         sys.stderr.write("FATAL: %s\n" % ascii_safe(str(exc)))
@@ -530,9 +738,7 @@ def main(argv):
     print("  mode       : %s" % ("check-only" if args.check_only else args.mode))
 
     failures = []
-    for source in sources:
-        out_path = (None if args.check_only
-                    else output_path_for(source, args.out, len(sources) > 1))
+    for source, out_path in plan:
         try:
             ok = process_image(source, out_path, terms, args, backend)
         except ScrubError as exc:

--- a/tools/cc-scrub/src/cli.py
+++ b/tools/cc-scrub/src/cli.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python
+"""cc-scrub - find denylisted text in screenshots and destroy it.
+
+Pure Python. Every dependency is a pip wheel. The text recognizer is the
+operating system's own, reached through the single seam in ocr_backend.py.
+No external executable is installed, required or looked for - in particular
+this tool never calls tesseract - and it launches no subprocess at all.
+
+Exit codes:
+    0   work done and proved (or --check-only found nothing)
+    1   denylist hits remain readable, or --check-only found hits
+    2   broken instrument / usage error (OCR unavailable, unreadable image,
+        zero text read from an image, bad arguments)
+
+All output is ASCII only.
+"""
+
+import argparse
+import os
+import sys
+
+try:
+    from PIL import Image, ImageDraw, ImageFilter
+except ImportError as exc:
+    sys.stderr.write("FATAL: Pillow is not installed (%s).\n" % exc)
+    sys.stderr.write("Fix: python -m pip install Pillow\n")
+    sys.exit(2)
+
+from .ocr_backend import ScrubError, get_backend
+
+
+IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".bmp")
+SCRUBBED_MARK = "-scrubbed"
+
+TOOL_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_TERMS_FILE = os.path.join(TOOL_ROOT, "terms.txt")
+EXAMPLE_TERMS_FILE = os.path.join(TOOL_ROOT, "terms.example.txt")
+
+
+# ----------------------------------------------------------------- text tools
+
+def ascii_safe(text):
+    """Return text with every non-ASCII character replaced by '?'.
+
+    Repo rule: nothing this tool prints may contain non-ASCII. OCR output
+    routinely contains them, so every string that reaches stdout goes
+    through here.
+    """
+    return text.encode("ascii", "replace").decode("ascii")
+
+
+# Glyph confusion classes. OCR of small anti-aliased UI text confuses
+# characters that share a shape. These classes are applied identically to
+# the denylist term and to the OCR text, so matching survives the
+# confusion. This is deliberate over-matching in the safe direction: the
+# worst case is that a few extra pixels get blurred, and every hit is
+# printed with its coordinates and its source text so it can be checked by
+# eye. Turn it off with --no-fold to require an exact match.
+#
+# The 'l'/'t' pair is in here because it is the confusion that actually
+# bites on screenshots of terminals: a URL like example.ai can come back as
+# exampte.ai, because the engine misreads the l as a t.
+_FOLD_CLASSES = (
+    ("o", "o0"),
+    ("l", "li1tj!|"),
+    ("s", "s5"),
+    ("z", "z2"),
+    ("b", "b8"),
+    ("g", "g9"),
+)
+
+_FOLD_MAP = {}
+for _target, _members in _FOLD_CLASSES:
+    for _ch in _members:
+        _FOLD_MAP[_ch] = _target
+
+
+def normalise(text, fold=True):
+    """Lowercase, drop everything that is not a-z0-9, then fold glyph classes.
+
+    Dropping the non-alphanumerics is what lets a term match across OCR
+    word splits and injected punctuation noise: the OCR reads
+    "https : //example. ai/path/session_011" and the term
+    "example.ai/path/session" still lands.
+    """
+    out = []
+    for ch in text.lower():
+        if ch.isascii() and (ch.isalpha() or ch.isdigit()):
+            out.append(_FOLD_MAP.get(ch, ch) if fold else ch)
+    return "".join(out)
+
+
+def load_terms(path):
+    """Read the denylist. One term per line; '#' starts a comment."""
+    if not os.path.isfile(path):
+        raise ScrubError(
+            "terms file not found: %s. The denylist is your own config and is "
+            "never committed; copy %s to %s and put your terms in it."
+            % (path, EXAMPLE_TERMS_FILE, DEFAULT_TERMS_FILE))
+    terms = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for raw in handle:
+            line = raw.split("#", 1)[0].strip()
+            if line:
+                terms.append(line)
+    if not terms:
+        raise ScrubError("terms file %s has no terms in it" % path)
+    return terms
+
+
+# ------------------------------------------------------------------------ ocr
+
+class OcrPass(object):
+    """One OCR read of one image at one scale."""
+
+    def __init__(self, scale, lines, word_count):
+        self.scale = scale
+        self.lines = lines          # list of list of (text, rect) at scale 1
+        self.word_count = word_count
+
+
+def ocr_image(image, scale, lang, backend):
+    """OCR image upscaled by 'scale'; return an OcrPass with rects at scale 1.
+
+    Small grey UI text is invisible to the engine at native resolution, so
+    the image is enlarged with LANCZOS before the read and every rectangle
+    is divided back down afterwards.
+    """
+    width, height = image.size
+    if scale != 1:
+        width, height = width * scale, height * scale
+        if max(width, height) > backend.max_image_dimension:
+            raise ScrubError(
+                "scale %d makes the image %dx%d, over the %s limit of %d px. "
+                "Use a smaller --scales value."
+                % (scale, width, height, backend.name,
+                   backend.max_image_dimension))
+        scaled = image.resize((width, height), Image.LANCZOS)
+    else:
+        scaled = image
+
+    try:
+        words = backend.recognize(scaled, lang)
+    except ScrubError as exc:
+        raise ScrubError("at scale %d: %s" % (scale, exc))
+
+    lines = []
+    current_line = None
+    current_words = []
+    words_seen = 0
+    for word in words:
+        if current_line is not None and word["line"] != current_line:
+            if current_words:
+                lines.append(current_words)
+            current_words = []
+        current_line = word["line"]
+        box = (word["x"] / float(scale),
+               word["y"] / float(scale),
+               word["w"] / float(scale),
+               word["h"] / float(scale))
+        current_words.append((word["text"], box))
+        words_seen += 1
+    if current_words:
+        lines.append(current_words)
+    return OcrPass(scale, lines, words_seen)
+
+
+# -------------------------------------------------------------------- matching
+
+class Hit(object):
+    def __init__(self, term, box, scale, source_text):
+        self.term = term
+        self.box = box                    # (x0, y0, x1, y1) floats, scale 1
+        self.scales = [scale]
+        self.source_text = source_text
+
+    def as_rect(self):
+        x0, y0, x1, y1 = self.box
+        return (int(x0), int(y0), int(x1 - x0), int(y1 - y0))
+
+
+def find_hits(ocr_pass, terms, fold):
+    """Match every term against every OCR line of one pass.
+
+    Each line is concatenated into one normalised string with a map back to
+    the word that produced each character, so a term split across adjacent
+    OCR words still matches and the covering words' rectangles are unioned
+    into a single hit rectangle.
+    """
+    hits = []
+    for words in ocr_pass.lines:
+        joined = []
+        owner = []
+        for index, (text, _box) in enumerate(words):
+            piece = normalise(text, fold)
+            joined.append(piece)
+            owner.extend([index] * len(piece))
+        line_norm = "".join(joined)
+        if not line_norm:
+            continue
+        line_text = " ".join(text for text, _box in words)
+
+        for term in terms:
+            needle = normalise(term, fold)
+            if not needle:
+                continue
+            start = line_norm.find(needle)
+            while start != -1:
+                covered = sorted(set(owner[start:start + len(needle)]))
+                boxes = [words[i][1] for i in covered]
+                x0 = min(b[0] for b in boxes)
+                y0 = min(b[1] for b in boxes)
+                x1 = max(b[0] + b[2] for b in boxes)
+                y1 = max(b[1] + b[3] for b in boxes)
+                hits.append(Hit(term, (x0, y0, x1, y1),
+                                ocr_pass.scale, line_text))
+                start = line_norm.find(needle, start + 1)
+    return hits
+
+
+def collect_hits(image, terms, scales, lang, fold, backend):
+    """Run every scale, union the hits, merge overlapping rectangles.
+
+    Every scale always runs - this is not a fallback chain. Different
+    scales read the same small text differently, and the union is what
+    makes detection reliable.
+    """
+    passes = []
+    for scale in scales:
+        passes.append(ocr_image(image, scale, lang, backend))
+
+    total_words = sum(p.word_count for p in passes)
+    raw = []
+    for ocr_pass in passes:
+        raw.extend(find_hits(ocr_pass, terms, fold))
+
+    merged = merge_hits(raw)
+    return merged, passes, total_words
+
+
+def merge_hits(hits):
+    """Merge hits of the same term whose rectangles overlap or touch."""
+    merged = []
+    for hit in hits:
+        for other in merged:
+            if other.term == hit.term and _overlaps(other.box, hit.box):
+                other.box = (min(other.box[0], hit.box[0]),
+                             min(other.box[1], hit.box[1]),
+                             max(other.box[2], hit.box[2]),
+                             max(other.box[3], hit.box[3]))
+                for scale in hit.scales:
+                    if scale not in other.scales:
+                        other.scales.append(scale)
+                if len(hit.source_text) > len(other.source_text):
+                    other.source_text = hit.source_text
+                break
+        else:
+            merged.append(hit)
+    for hit in merged:
+        hit.scales.sort()
+    merged.sort(key=lambda h: (h.box[1], h.box[0]))
+    return merged
+
+
+def _overlaps(a, b):
+    return not (a[2] < b[0] or b[2] < a[0] or a[3] < b[1] or b[3] < a[1])
+
+
+# -------------------------------------------------------------------- redaction
+
+def _pad_box(box, pad, size):
+    x0 = max(0, int(box[0]) - pad)
+    y0 = max(0, int(box[1]) - pad)
+    x1 = min(size[0], int(round(box[2])) + pad)
+    y1 = min(size[1], int(round(box[3])) + pad)
+    return (x0, y0, x1, y1)
+
+
+def _median_colour(region):
+    """Per-channel median of the region, read off the channel histograms.
+
+    The median of a text region is its background colour, so a patch filled
+    with it reads as a deliberate redaction rather than a black bar.
+    """
+    rgb = region.convert("RGB")
+    total = rgb.size[0] * rgb.size[1]
+    colour = []
+    for channel in rgb.split():
+        histogram = channel.histogram()
+        seen = 0
+        for value, count in enumerate(histogram):
+            seen += count
+            if seen * 2 >= total:
+                colour.append(value)
+                break
+    return tuple(colour)
+
+
+def _destroy(region):
+    """Mosaic the region down to a handful of cells, then blur it smooth.
+
+    Downsampling throws the pixels away outright, so the text is not merely
+    hard to read - the information is gone. The Gaussian pass on top only
+    removes the blocky edges.
+    """
+    width, height = region.size
+    cells_x = max(1, width // 14)
+    cells_y = max(1, height // 6)
+    mosaic = region.resize((cells_x, cells_y), Image.BILINEAR)
+    mosaic = mosaic.resize((width, height), Image.NEAREST)
+    radius = max(6.0, height / 2.0)
+    return mosaic.filter(ImageFilter.GaussianBlur(radius=radius))
+
+
+def redact(image, hits, pad, mode):
+    """Return a new image with every hit rectangle destroyed."""
+    out = image.copy()
+    for hit in hits:
+        box = _pad_box(hit.box, pad, out.size)
+        if box[2] <= box[0] or box[3] <= box[1]:
+            raise ScrubError("hit for term '%s' produced an empty rectangle %s"
+                             % (ascii_safe(hit.term), box))
+        region = out.crop(box)
+        if mode == "patch":
+            colour = _median_colour(region)
+            draw = ImageDraw.Draw(out)
+            radius = max(2, min(8, (box[3] - box[1]) // 2))
+            draw.rounded_rectangle(box, radius=radius, fill=colour)
+        else:
+            out.paste(_destroy(region), box)
+    return out
+
+
+# ------------------------------------------------------------------- reporting
+
+def describe(hit):
+    x, y, w, h = hit.as_rect()
+    return ("term='%s' rect=(x=%d y=%d w=%d h=%d) scales=%s ocr_line='%s'"
+            % (ascii_safe(hit.term), x, y, w, h,
+               ",".join(str(s) for s in hit.scales),
+               ascii_safe(hit.source_text)))
+
+
+# ----------------------------------------------------------------- per image
+
+def process_image(path, out_path, terms, args, backend):
+    """Scrub one image. Returns True if the image ends up proved clean."""
+    print("")
+    print("IMAGE %s" % path)
+    try:
+        image = Image.open(path)
+        image.load()
+    except Exception as exc:
+        raise ScrubError("cannot read image %s: %s" % (path, exc))
+    image = image.convert("RGB")
+    print("  size %dx%d  scales %s  fold %s"
+          % (image.size[0], image.size[1],
+             ",".join(str(s) for s in args.scales),
+             "on" if not args.no_fold else "off"))
+
+    hits, passes, total_words = collect_hits(
+        image, terms, args.scales, args.lang, not args.no_fold, backend)
+
+    for ocr_pass in passes:
+        print("  ocr scale %d: %d words in %d lines"
+              % (ocr_pass.scale, ocr_pass.word_count, len(ocr_pass.lines)))
+
+    # Broken instrument, not a clean image. An empty OCR result can never
+    # be read as "there was nothing sensitive here".
+    if total_words == 0:
+        raise ScrubError(
+            "OCR read ZERO words from %s across scales %s. That is a broken "
+            "read, not a clean image. Refusing to call this scrubbed."
+            % (path, ",".join(str(s) for s in args.scales)))
+
+    print("  HITS: %d" % len(hits))
+    for hit in hits:
+        print("    %s" % describe(hit))
+
+    if args.check_only:
+        if hits:
+            print("  CHECK-ONLY: %d hit(s) present, image NOT modified." % len(hits))
+            return False
+        print("  CHECK-ONLY: no hits against %d terms over %d OCR words."
+              % (len(terms), total_words))
+        return True
+
+    if not hits:
+        print("  Nothing to redact. No output written (input left untouched).")
+        return True
+
+    scrubbed = redact(image, hits, args.pad, args.mode)
+    if os.path.abspath(out_path) == os.path.abspath(path):
+        raise ScrubError("refusing to overwrite the input image %s" % path)
+    scrubbed.save(out_path)
+    print("  WROTE %s (mode=%s pad=%d)" % (out_path, args.mode, args.pad))
+
+    # Mandatory verify pass: re-OCR the OUTPUT, from disk.
+    print("  VERIFY: re-reading %s" % out_path)
+    verify_image = Image.open(out_path)
+    verify_image.load()
+    verify_image = verify_image.convert("RGB")
+    remaining, verify_passes, verify_words = collect_hits(
+        verify_image, terms, args.scales, args.lang, not args.no_fold, backend)
+    for ocr_pass in verify_passes:
+        print("    verify scale %d: %d words in %d lines"
+              % (ocr_pass.scale, ocr_pass.word_count, len(ocr_pass.lines)))
+
+    # The verify instrument must itself prove it can read. A verify pass
+    # that reads nothing proves nothing.
+    if verify_words == 0:
+        raise ScrubError(
+            "verify OCR read ZERO words from the output %s. The verify "
+            "instrument is broken; the result is not proved." % out_path)
+
+    if remaining:
+        print("  VERIFY FAILED: %d denylist hit(s) still readable in the output:"
+              % len(remaining))
+        for hit in remaining:
+            print("    %s" % describe(hit))
+        return False
+
+    print("  VERIFY PASSED: %d hit(s) found, %d region(s) redacted, verify OCR "
+          "read %d words in the output and 0 denylist hit(s) remain."
+          % (len(hits), len(hits), verify_words))
+    return True
+
+
+# ----------------------------------------------------------------------- main
+
+def gather_inputs(target):
+    if os.path.isfile(target):
+        return [target]
+    if os.path.isdir(target):
+        found = []
+        for name in sorted(os.listdir(target)):
+            stem, suffix = os.path.splitext(name)
+            if suffix.lower() in IMAGE_SUFFIXES and not stem.endswith(SCRUBBED_MARK):
+                found.append(os.path.join(target, name))
+        if not found:
+            raise ScrubError("no images found in directory %s" % target)
+        return found
+    raise ScrubError("no such file or directory: %s" % target)
+
+
+def output_path_for(source, out_option, many):
+    stem, _suffix = os.path.splitext(os.path.basename(source))
+    default_name = stem + SCRUBBED_MARK + ".png"
+    if not out_option:
+        return os.path.join(os.path.dirname(os.path.abspath(source)), default_name)
+    if many or os.path.isdir(out_option):
+        if not os.path.isdir(out_option):
+            os.makedirs(out_option)
+        return os.path.join(out_option, default_name)
+    parent = os.path.dirname(os.path.abspath(out_option))
+    if parent and not os.path.isdir(parent):
+        os.makedirs(parent)
+    return out_option
+
+
+def parse_scales(text):
+    scales = []
+    for piece in text.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        if not piece.isdigit() or int(piece) < 1:
+            raise ScrubError("--scales takes positive whole numbers, got '%s'"
+                             % ascii_safe(piece))
+        value = int(piece)
+        if value not in scales:
+            scales.append(value)
+    if not scales:
+        raise ScrubError("--scales is empty")
+    return sorted(scales)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="cc-scrub",
+        description="Blur denylisted text out of screenshots (pure Python).")
+    parser.add_argument("target", help="image file or directory of images")
+    parser.add_argument("-o", "--out",
+                        help="output file (single input) or directory")
+    parser.add_argument("--terms-file", default=DEFAULT_TERMS_FILE,
+                        help="denylist file, one term per line")
+    parser.add_argument("--check-only", action="store_true",
+                        help="report hits and coordinates, change nothing, "
+                             "exit 1 if any hit")
+    parser.add_argument("--patch", dest="mode", action="store_const",
+                        const="patch",
+                        help="paint an opaque rounded patch instead of blurring")
+    parser.add_argument("--blur", dest="mode", action="store_const",
+                        const="blur", help="mosaic and blur the region (default)")
+    parser.add_argument("--pad", type=int, default=4,
+                        help="pixels of padding around each hit (default 4)")
+    parser.add_argument("--scales", default="1,2,3",
+                        help="OCR upscale factors, comma separated "
+                             "(default 1,2,3)")
+    parser.add_argument("--lang", default="en",
+                        help="OCR language tag (default en)")
+    parser.add_argument("--no-fold", action="store_true",
+                        help="disable OCR glyph-confusion folding and require "
+                             "an exact normalised match")
+    parser.set_defaults(mode="blur")
+    return parser
+
+
+def main(argv):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        args.scales = parse_scales(args.scales)
+        if args.pad < 0:
+            raise ScrubError("--pad cannot be negative")
+        terms = load_terms(args.terms_file)
+        sources = gather_inputs(args.target)
+        backend = get_backend()
+    except ScrubError as exc:
+        sys.stderr.write("FATAL: %s\n" % ascii_safe(str(exc)))
+        return 2
+
+    print("cc-scrub")
+    print("  ocr engine : %s" % backend.name)
+    print("  terms file : %s (%d terms)" % (args.terms_file, len(terms)))
+    for term in terms:
+        print("    - %s" % ascii_safe(term))
+    print("  images     : %d" % len(sources))
+    print("  mode       : %s" % ("check-only" if args.check_only else args.mode))
+
+    failures = []
+    for source in sources:
+        out_path = (None if args.check_only
+                    else output_path_for(source, args.out, len(sources) > 1))
+        try:
+            ok = process_image(source, out_path, terms, args, backend)
+        except ScrubError as exc:
+            sys.stderr.write("FATAL: %s\n" % ascii_safe(str(exc)))
+            return 2
+        if not ok:
+            failures.append(source)
+
+    print("")
+    print("SUMMARY: %d image(s) processed, %d clean, %d failed."
+          % (len(sources), len(sources) - len(failures), len(failures)))
+    if failures:
+        for source in failures:
+            print("  FAILED %s" % source)
+        return 1
+    return 0
+
+
+def main_entry():
+    """Console-script entry point declared in pyproject.toml."""
+    sys.exit(main(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    main_entry()

--- a/tools/cc-scrub/src/cli.py
+++ b/tools/cc-scrub/src/cli.py
@@ -18,6 +18,7 @@ All output is ASCII only.
 import argparse
 import math
 import os
+import stat as stat_module
 import sys
 import tempfile
 
@@ -60,6 +61,50 @@ EXAMPLE_TERMS_FILE = os.path.join(TOOL_ROOT, "terms.example.txt")
 
 
 # ----------------------------------------------------------------- text tools
+
+def stat_or_none(path, purpose):
+    """os.stat, where a genuine absence is None and an error stops the run.
+
+    This exists because os.path.exists, isfile and isdir all return False for
+    EVERY error - and in this tool False is routinely the answer that PERMITS
+    an action: publish over that file, treat those two paths as different
+    files, that directory is not a directory. A permission error, an I/O
+    error or a race would therefore have switched a guard off silently, which
+    is the one way this tool can destroy something.
+
+    Exactly two errors are answers rather than failures. FileNotFoundError is
+    a genuine absence. NotADirectoryError is what a path whose parent
+    component is a file looks like, which is also a genuine absence of the
+    thing named. Everything else is a broken instrument and raises.
+
+    `purpose` is what the caller needed the answer for, so the error says why
+    the run stopped and not merely that it did.
+    """
+    try:
+        return os.stat(path)
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    except OSError as exc:
+        raise ScrubError(
+            "cannot inspect %s, which is needed to %s: %s. Refusing to guess, "
+            "because an unreadable path is not an answer - and here the "
+            "convenient guess is the one that permits the write."
+            % (path, purpose, exc))
+
+
+def path_exists(path, purpose):
+    return stat_or_none(path, purpose) is not None
+
+
+def path_is_directory(path, purpose):
+    info = stat_or_none(path, purpose)
+    return info is not None and stat_module.S_ISDIR(info.st_mode)
+
+
+def path_is_regular_file(path, purpose):
+    info = stat_or_none(path, purpose)
+    return info is not None and stat_module.S_ISREG(info.st_mode)
+
 
 def ascii_safe(text):
     """Return text with every non-ASCII character replaced by '?'.
@@ -126,7 +171,7 @@ def normalise(text, fold=True):
 
 def load_terms(path):
     """Read the denylist. One term per line; '#' starts a comment."""
-    if not os.path.isfile(path):
+    if not path_is_regular_file(path, "read the denylist"):
         raise ScrubError(
             "terms file not found: %s. The denylist is your own config and is "
             "never committed; copy %s to %s and put your terms in it."
@@ -481,8 +526,18 @@ def is_same_file(first, second):
     that has not been created yet is compared canonically instead. That is a
     precondition, not a degraded mode: the two branches answer the same
     question about two different situations, and neither one guesses.
+
+    Existence is established with stat_or_none and not with os.path.exists.
+    An errored exists() answers False, which drops straight through to the
+    canonical comparison - and that comparison is lexical, so on a
+    case-insensitive POSIX volume it answers "different files" and this
+    guard, the one standing between a run and the only unredacted copy of
+    the input, is switched off by an unreadable path.
     """
-    if os.path.exists(second) and os.path.exists(first):
+    first_there = path_exists(first, "tell whether it is the input image")
+    second_there = path_exists(second, "tell whether it is the input image")
+
+    if first_there and second_there:
         try:
             return os.path.samefile(first, second)
         except OSError as exc:
@@ -490,6 +545,16 @@ def is_same_file(first, second):
                 "cannot tell whether %s and %s are the same file: %s. "
                 "Refusing to write, because writing would risk destroying "
                 "the input." % (first, second, exc))
+
+    if first_there != second_there:
+        # One is there and the other genuinely is not, so they cannot be one
+        # file. No lexical guesswork needed or wanted.
+        return False
+
+    # Neither exists. Nothing on disk can be asked, and a path that does not
+    # exist cannot be an alias of a file that does, so the canonical
+    # spellings are all there is. In this tool's own call the input always
+    # exists, so this branch is only ever reached by a direct caller.
     return (os.path.normcase(os.path.realpath(first))
             == os.path.normcase(os.path.realpath(second)))
 
@@ -561,7 +626,8 @@ def process_image(path, out_path, terms, args, backend):
 
     # An existing output may be one that has already been verified. Replacing
     # it is a decision the caller makes on purpose, never a side effect.
-    if os.path.exists(out_path) and not args.force:
+    if path_exists(out_path, "tell whether an output is already there") \
+            and not args.force:
         raise ScrubError(
             "output %s already exists. Refusing to replace it - it may be an "
             "output that has already passed verification. Delete it, point -o "
@@ -642,12 +708,25 @@ def process_image(path, out_path, terms, args, backend):
               % (len(hits), len(hits), verify_words))
         return True
     finally:
-        if not published and os.path.exists(temp_path):
+        # No existence check here, deliberately. mkstemp created the file and
+        # `published` already records whether os.replace consumed it, so an
+        # exists() call would add nothing except one more place for an error
+        # to become a boolean. The removal is simply attempted.
+        #
+        # This is also the one place in the tool where a failure must NOT
+        # become the outcome. An exception is usually in flight - the verify
+        # failure that stopped the publish - and raising from a finally would
+        # replace the real reason with a housekeeping complaint. So it is
+        # reported loudly and nothing is gated on it. That is why this differs
+        # from the case probe, where a failed cleanup IS fatal: there, no
+        # exception is in flight and the function's whole job is to return a
+        # verdict about a directory that has just refused to behave.
+        if not published:
             try:
                 os.remove(temp_path)
+            except FileNotFoundError:
+                pass
             except OSError as exc:
-                # Never mask the failure that brought us here; say what was
-                # left behind so it can be cleaned up by hand.
                 sys.stderr.write(
                     "WARNING: could not remove the unpublished candidate %s: "
                     "%s\n" % (temp_path, exc))
@@ -656,11 +735,16 @@ def process_image(path, out_path, terms, args, backend):
 # ----------------------------------------------------------------------- main
 
 def gather_inputs(target):
-    if os.path.isfile(target):
+    if path_is_regular_file(target, "read it as an image"):
         return [target]
-    if os.path.isdir(target):
+    if path_is_directory(target, "read it as a folder of images"):
         found = []
-        for name in sorted(os.listdir(target)):
+        try:
+            names = sorted(os.listdir(target))
+        except OSError as exc:
+            raise ScrubError("cannot list the directory %s: %s"
+                             % (target, exc))
+        for name in names:
             stem, suffix = os.path.splitext(name)
             if suffix.lower() in IMAGE_SUFFIXES and not stem.endswith(SCRUBBED_MARK):
                 found.append(os.path.join(target, name))
@@ -690,12 +774,15 @@ def output_path_for(source, out_option, many):
     default_name = stem + SCRUBBED_MARK + ".png"
     if not out_option:
         return os.path.join(os.path.dirname(os.path.abspath(source)), default_name)
-    if many or os.path.isdir(out_option):
-        if not os.path.isdir(out_option):
+    out_option_is_directory = path_is_directory(
+        out_option, "decide whether -o names a folder or a file")
+    if many or out_option_is_directory:
+        if not out_option_is_directory:
             _make_directory(out_option)
         return os.path.join(out_option, default_name)
     parent = os.path.dirname(os.path.abspath(out_option))
-    if parent and not os.path.isdir(parent):
+    if parent and not path_is_directory(parent,
+                                        "create the output folder"):
         _make_directory(parent)
     return out_option
 

--- a/tools/cc-scrub/src/cli.py
+++ b/tools/cc-scrub/src/cli.py
@@ -34,6 +34,21 @@ from .ocr_backend import ScrubError, get_backend
 IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".bmp")
 SCRUBBED_MARK = "-scrubbed"
 
+# A ceiling on the pixels ONE scaled read may ask for, in megapixels.
+#
+# The engine's limit on the longest side is not a limit on area: a square
+# input just under that limit, read at scale 3, is about 268 megapixels -
+# roughly 800 MB of RGB data for the scaled copy alone, before the resize's
+# own working set and before the engine takes its copy. That allocation is
+# not a read the tool can perform; it is a way to bring the machine down.
+#
+# The default allows the sizes people actually scrub - a 4K screenshot at
+# scale 3 is 75 megapixels, a 5K one is 132 - and refuses the pathological
+# case by name. It is a guard, not a measurement of this machine, so it is
+# exposed as --max-megapixels for a caller who genuinely needs more and has
+# the memory for it.
+DEFAULT_MAX_MEGAPIXELS = 192
+
 TOOL_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_TERMS_FILE = os.path.join(TOOL_ROOT, "terms.txt")
 EXAMPLE_TERMS_FILE = os.path.join(TOOL_ROOT, "terms.example.txt")
@@ -155,16 +170,23 @@ class OcrPass(object):
         self.word_count = word_count
 
 
-def check_scales_fit(size, scales, backend, label):
-    """Refuse before reading if any scale would exceed the engine's limit.
+def check_scales_fit(size, scales, backend, label,
+                     max_megapixels=DEFAULT_MAX_MEGAPIXELS):
+    """Refuse before reading if any scale is beyond the engine or the budget.
 
-    Scale 1 is checked too. It used to be exempt, on the assumption that a
-    native image is always small enough - which is not true. An oversized
-    screenshot reached the engine unchecked and failed there, after the
-    whole file had been decoded into memory, instead of failing here
-    deterministically and by name.
+    Two separate limits, both checked at every scale including scale 1.
+    Scale 1 used to be exempt, on the assumption that a native image is
+    always small enough - which is not true. An oversized screenshot reached
+    the engine unchecked and failed there, after the whole file had been
+    decoded into memory, instead of failing here deterministically and by
+    name.
+
+    The side limit is the engine's own. The area limit is ours, because
+    passing the side limit says nothing about the allocation: see
+    DEFAULT_MAX_MEGAPIXELS.
     """
     width, height = size
+    budget = max_megapixels * 1024 * 1024
     for scale in scales:
         scaled_width, scaled_height = width * scale, height * scale
         if max(scaled_width, scaled_height) > backend.max_image_dimension:
@@ -174,19 +196,34 @@ def check_scales_fit(size, scales, backend, label):
                 "a smaller image."
                 % (label, width, height, scale, scaled_width, scaled_height,
                    backend.name, backend.max_image_dimension))
+        pixels = scaled_width * scaled_height
+        if pixels > budget:
+            raise ScrubError(
+                "%s is %dx%d; at scale %d that is %dx%d, %.1f megapixels, over "
+                "the %d megapixel budget for one read. Use a smaller --scales "
+                "value, a smaller image, or raise --max-megapixels if this "
+                "machine has the memory for it."
+                % (label, width, height, scale, scaled_width, scaled_height,
+                   pixels / float(1024 * 1024), max_megapixels))
 
 
-def ocr_image(image, scale, lang, backend):
+def ocr_image(image, scale, lang, backend,
+              max_megapixels=DEFAULT_MAX_MEGAPIXELS):
     """OCR image upscaled by 'scale'; return an OcrPass with rects at scale 1.
 
     Small grey UI text is invisible to the engine at native resolution, so
     the image is enlarged with LANCZOS before the read and every rectangle
     is divided back down afterwards.
     """
-    check_scales_fit(image.size, [scale], backend, "the image")
+    check_scales_fit(image.size, [scale], backend, "the image", max_megapixels)
     if scale != 1:
         width, height = image.size[0] * scale, image.size[1] * scale
-        scaled = image.resize((width, height), Image.LANCZOS)
+        try:
+            scaled = image.resize((width, height), Image.LANCZOS)
+        except (MemoryError, OSError, ValueError) as exc:
+            raise ScrubError(
+                "cannot enlarge the image to %dx%d for the scale %d read: %s"
+                % (width, height, scale, exc))
     else:
         scaled = image
 
@@ -194,6 +231,11 @@ def ocr_image(image, scale, lang, backend):
         words = backend.recognize(scaled, lang)
     except ScrubError as exc:
         raise ScrubError("at scale %d: %s" % (scale, exc))
+    except MemoryError as exc:
+        raise ScrubError(
+            "ran out of memory in the scale %d read of a %dx%d image: %s. Use "
+            "a smaller --scales value or a smaller image."
+            % (scale, scaled.size[0], scaled.size[1], exc))
 
     lines = []
     current_line = None
@@ -272,7 +314,8 @@ def find_hits(ocr_pass, terms, fold):
     return hits
 
 
-def collect_hits(image, terms, scales, lang, fold, backend):
+def collect_hits(image, terms, scales, lang, fold, backend,
+                 max_megapixels=DEFAULT_MAX_MEGAPIXELS):
     """Run every scale, union the hits, merge overlapping rectangles.
 
     Every scale always runs - this is not a fallback chain. Different
@@ -281,7 +324,7 @@ def collect_hits(image, terms, scales, lang, fold, backend):
     """
     passes = []
     for scale in scales:
-        passes.append(ocr_image(image, scale, lang, backend))
+        passes.append(ocr_image(image, scale, lang, backend, max_megapixels))
 
     total_words = sum(p.word_count for p in passes)
     raw = []
@@ -446,20 +489,22 @@ def process_image(path, out_path, terms, args, backend):
     # Size comes off the header, before the pixels are decoded. An image too
     # big for the engine is refused here rather than after megabytes have
     # been read into memory for a read that could never have happened.
-    check_scales_fit(image.size, args.scales, backend, path)
+    check_scales_fit(image.size, args.scales, backend, path,
+                     args.max_megapixels)
 
     try:
         image.load()
+        image = image.convert("RGB")
     except Exception as exc:
         raise ScrubError("cannot decode image %s: %s" % (path, exc))
-    image = image.convert("RGB")
     print("  size %dx%d  scales %s  fold %s"
           % (image.size[0], image.size[1],
              ",".join(str(s) for s in args.scales),
              "on" if not args.no_fold else "off"))
 
     hits, passes, total_words = collect_hits(
-        image, terms, args.scales, args.lang, not args.no_fold, backend)
+        image, terms, args.scales, args.lang, not args.no_fold, backend,
+        args.max_megapixels)
 
     for ocr_pass in passes:
         print("  ocr scale %d: %d words in %d lines"
@@ -539,10 +584,14 @@ def process_image(path, out_path, terms, args, backend):
         except Exception as exc:
             raise ScrubError("cannot read back the candidate output %s: %s"
                              % (temp_path, exc))
-        verify_image = verify_image.convert("RGB")
+        try:
+            verify_image = verify_image.convert("RGB")
+        except Exception as exc:
+            raise ScrubError("cannot decode the candidate output %s: %s"
+                             % (temp_path, exc))
         remaining, verify_passes, verify_words = collect_hits(
             verify_image, terms, args.scales, args.lang, not args.no_fold,
-            backend)
+            backend, args.max_megapixels)
         verify_image.close()
         for ocr_pass in verify_passes:
             print("    verify scale %d: %d words in %d lines"
@@ -634,22 +683,84 @@ def output_path_for(source, out_option, many):
     return out_option
 
 
+def directory_is_case_insensitive(directory):
+    """Ask the directory itself whether two spellings are one file.
+
+    A probe file is created under a deliberately mixed-case name, the same
+    name is looked up with its case swapped, and the filesystem's answer is
+    taken. The probe is always removed again.
+
+    This exists because os.path.normcase is the HOST's rule, not the
+    destination's. On Windows it lower-cases and on POSIX it is the identity
+    function, so a lexical comparison silently stops detecting anything on a
+    case-insensitive volume mounted under a POSIX host - which is the normal
+    state of a Mac. The question is about the volume the outputs land on, so
+    it is asked there.
+
+    It is not answerable without touching the disk, and it is not guessed: a
+    probe that cannot be created or cannot be read back is an error, never
+    an assumption of case sensitivity.
+
+    This covers case aliasing, which is the aliasing that output names built
+    from input stems actually run into. It is not a general test for every
+    way a filesystem can make two names one file.
+    """
+    try:
+        handle, probe = tempfile.mkstemp(prefix="ccScrubCase", suffix=".Probe",
+                                         dir=directory)
+        os.close(handle)
+    except OSError as exc:
+        raise ScrubError(
+            "cannot probe the output directory %s to find out whether it "
+            "treats two spellings of a name as one file: %s. Refusing to "
+            "guess, because guessing wrong lets one output silently replace "
+            "another." % (directory, exc))
+    try:
+        swapped = os.path.join(directory,
+                               os.path.basename(probe).swapcase())
+        if not os.path.exists(swapped):
+            return False
+        return os.path.samefile(swapped, probe)
+    except OSError as exc:
+        raise ScrubError(
+            "cannot read back the case probe in %s: %s. Refusing to guess."
+            % (directory, exc))
+    finally:
+        try:
+            os.remove(probe)
+        except OSError as exc:
+            sys.stderr.write("WARNING: could not remove the case probe %s: "
+                             "%s\n" % (probe, exc))
+
+
 def plan_outputs(sources, out_option):
     """Map every input to its output up front, and refuse any collision.
 
     Output names are built from the input's STEM, so shot.png and shot.jpg
-    both want shot-scrubbed.png - and on a case-insensitive filesystem so do
-    Shot.png and shot.png. Left alone, the second run silently overwrites
-    the first and the summary reports two images cleaned when only one
-    survived. Every destination is therefore worked out before any image is
-    read, and a collision stops the run instead of destroying a result.
+    both want shot-scrubbed.png - and on a filesystem that treats two
+    spellings as one file, so do Shot.png and shot.jpg. Left alone, the
+    second result silently overwrites the first and the summary reports two
+    images cleaned when only one survived. Every destination is therefore
+    worked out before any image is read, and a collision stops the run
+    instead of destroying a result.
+
+    Whether two spellings are one file is decided by the destination
+    directory, asked once per directory - never by the host's normcase,
+    which is the identity function on POSIX and would make this check do
+    nothing at all on a case-insensitive Mac volume.
     """
     many = len(sources) > 1
     plan = []
     claimed = {}
+    insensitive = {}
     for source in sources:
         destination = output_path_for(source, out_option, many)
-        key = os.path.normcase(os.path.abspath(destination))
+        directory = os.path.dirname(os.path.abspath(destination))
+        if directory not in insensitive:
+            insensitive[directory] = directory_is_case_insensitive(directory)
+        key = os.path.abspath(destination)
+        if insensitive[directory]:
+            key = key.lower()
         if key in claimed:
             raise ScrubError(
                 "%s and %s would both be written to %s. Rename one input, "
@@ -699,6 +810,11 @@ def build_parser():
                              "input, which is always refused)")
     parser.add_argument("--pad", type=int, default=4,
                         help="pixels of padding around each hit (default 4)")
+    parser.add_argument("--max-megapixels", type=int,
+                        default=DEFAULT_MAX_MEGAPIXELS,
+                        help="ceiling on the pixels one scaled read may ask "
+                             "for, in megapixels (default %d)"
+                             % DEFAULT_MAX_MEGAPIXELS)
     parser.add_argument("--scales", default="1,2,3",
                         help="OCR upscale factors, comma separated "
                              "(default 1,2,3)")
@@ -719,6 +835,8 @@ def main(argv):
         args.scales = parse_scales(args.scales)
         if args.pad < 0:
             raise ScrubError("--pad cannot be negative")
+        if args.max_megapixels < 1:
+            raise ScrubError("--max-megapixels must be at least 1")
         terms = load_terms(args.terms_file)
         validate_terms(terms, not args.no_fold)
         sources = gather_inputs(args.target)

--- a/tools/cc-scrub/src/ocr_backend.py
+++ b/tools/cc-scrub/src/ocr_backend.py
@@ -108,28 +108,163 @@ class WindowsOcrBackend(OcrBackend):
         return words
 
 
-class MacVisionBackend(OcrBackend):
-    """Apple's Vision text recognizer. NOT IMPLEMENTED YET.
+def _words_with_offsets(text):
+    """Split text on whitespace; return (word, start offset) pairs.
 
-    The macOS backend is deliberately present and deliberately loud. It is
-    not a stub that returns nothing - a backend that returned an empty word
-    list would look exactly like a clean screenshot, which is the one
-    failure this tool must never produce.
+    The offsets are what let the backend ask the recognizer for the exact
+    rectangle of each word inside its line, so this must not use split(),
+    which throws the positions away.
+    """
+    words = []
+    start = None
+    for index, ch in enumerate(text):
+        if ch.isspace():
+            if start is not None:
+                words.append((text[start:index], start))
+                start = None
+        elif start is None:
+            start = index
+    if start is not None:
+        words.append((text[start:], start))
+    return words
+
+
+class MacVisionBackend(OcrBackend):
+    """The text recognizer built into macOS, reached through pyobjc wheels.
+
+    pyobjc-framework-Vision is a pip wheel that binds the Vision framework
+    the operating system already ships (VNRecognizeTextRequest, accurate
+    recognition level). No external executable is installed, required or
+    looked for - in particular this tool never calls tesseract, even on a
+    machine where one happens to be present. It launches no subprocess at
+    all: the PIL image is handed to the recognizer as an in-memory CGImage,
+    never through a temporary file.
+
+    Vision reports text line by line, with every rectangle normalized to
+    0..1 and measured from the BOTTOM-left corner. This backend converts to
+    the seam's top-left pixel coordinates, asks the recognizer itself for
+    each word's rectangle within its line (boundingBoxForRange), and stamps
+    all words of one observation with that observation's index as 'line',
+    which is what keeps the matcher's adjacent-word joining alive.
     """
 
-    name = "macOS Vision text recognizer"
+    name = "macOS Vision text recognizer (pyobjc)"
 
     def __init__(self):
-        raise ScrubError(
-            "the macOS OCR backend is not implemented yet. cc-scrub needs a "
-            "MacVisionBackend that recognises text with Apple's Vision "
-            "framework (VNRecognizeTextRequest, accurate recognition level) "
-            "through a pip-installable binding, and returns one dictionary "
-            "per word with keys text, x, y, w, h in top-left pixel "
-            "coordinates of the image it was handed, plus 'line' set to the "
-            "index of the recognised line the word came from. It must also "
-            "set max_image_dimension to the engine's real limit. Until that "
-            "exists, run cc-scrub on Windows.")
+        try:
+            import Vision
+            import Quartz
+            from Foundation import NSData
+        except ImportError as exc:
+            raise ScrubError(
+                "the Vision binding is not installed (%s). Fix: python -m "
+                "pip install pyobjc-framework-Vision (it pulls in Quartz and "
+                "the Foundation binding with it). These are pip wheels that "
+                "bind the text recognizer built into macOS; there is no "
+                "installer and no external engine." % exc)
+        self._vision = Vision
+        self._quartz = Quartz
+        self._nsdata = NSData
+        # Vision publishes no numeric input limit of its own. Its
+        # recognizer runs on the graphics device, and the largest texture
+        # side every Mac that can run this framework accepts is 16384
+        # pixels, so that is the honest ceiling on what can be handed in
+        # without the framework resampling it behind our back.
+        self.max_image_dimension = 16384
+
+    def _cg_image(self, image):
+        """Build an in-memory CGImage from a PIL image. No temporary file."""
+        rgb = image.convert("RGB")
+        width, height = rgb.size
+        raw = rgb.tobytes()
+        data = self._nsdata.dataWithBytes_length_(raw, len(raw))
+        provider = self._quartz.CGDataProviderCreateWithCFData(data)
+        cg_image = self._quartz.CGImageCreate(
+            width, height, 8, 24, width * 3,
+            self._quartz.CGColorSpaceCreateDeviceRGB(),
+            self._quartz.kCGImageAlphaNone,
+            provider, None, False,
+            self._quartz.kCGRenderingIntentDefault)
+        if cg_image is None:
+            raise ScrubError(
+                "could not build a CGImage from the %dx%d input" % (width, height))
+        return cg_image
+
+    def _resolve_language(self, request, lang):
+        """Turn a tag like 'en' into the recognizer's own tags, or fail.
+
+        This is tag resolution, not a fallback: 'en' names the language the
+        recognizer spells 'en-US', and a tag that names no supported
+        language at all stops the run with the full supported list.
+        """
+        supported, error = request.supportedRecognitionLanguagesAndReturnError_(None)
+        if supported is None:
+            raise ScrubError(
+                "Vision would not report its supported recognition "
+                "languages: %s" % error)
+        tags = [str(tag) for tag in supported]
+        matches = [tag for tag in tags
+                   if tag == lang or tag.split("-")[0] == lang]
+        if not matches:
+            raise ScrubError(
+                "Vision does not support recognition language '%s'. "
+                "Supported: %s" % (lang, ", ".join(tags)))
+        return matches
+
+    def recognize(self, image, lang):
+        width, height = image.size
+        vision = self._vision
+
+        request = vision.VNRecognizeTextRequest.alloc().init()
+        request.setRecognitionLevel_(
+            vision.VNRequestTextRecognitionLevelAccurate)
+        # Language correction rewrites what was read toward dictionary
+        # words. The strings this tool hunts are exactly the ones a
+        # dictionary does not hold - addresses, host names, repository
+        # paths - so the raw read is the honest one, and glyph folding
+        # above this seam is the designed answer to misread glyphs.
+        request.setUsesLanguageCorrection_(False)
+        request.setRecognitionLanguages_(self._resolve_language(request, lang))
+
+        handler = vision.VNImageRequestHandler.alloc().initWithCGImage_options_(
+            self._cg_image(image), None)
+        success, error = handler.performRequests_error_([request], None)
+        if not success:
+            raise ScrubError(
+                "Vision text recognition failed for language '%s': %s"
+                % (lang, error))
+        observations = request.results()
+        if observations is None:
+            raise ScrubError(
+                "Vision reported success for language '%s' but returned no "
+                "results object. That is a broken read." % lang)
+
+        words = []
+        for index, observation in enumerate(observations):
+            candidates = observation.topCandidates_(1)
+            if not candidates:
+                raise ScrubError(
+                    "Vision observation %d carries no text candidate. That "
+                    "is a broken read." % index)
+            candidate = candidates[0]
+            text = str(candidate.string())
+            for word_text, offset in _words_with_offsets(text):
+                box_observation, box_error = candidate.boundingBoxForRange_error_(
+                    (offset, len(word_text)), None)
+                if box_observation is None:
+                    raise ScrubError(
+                        "Vision would not give a rectangle for word '%s' of "
+                        "line '%s': %s" % (word_text, text, box_error))
+                box = box_observation.boundingBox()
+                words.append({
+                    "text": word_text,
+                    "x": float(box.origin.x * width),
+                    "y": float((1.0 - box.origin.y - box.size.height) * height),
+                    "w": float(box.size.width * width),
+                    "h": float(box.size.height * height),
+                    "line": index,
+                })
+        return words
 
 
 def get_backend():

--- a/tools/cc-scrub/src/ocr_backend.py
+++ b/tools/cc-scrub/src/ocr_backend.py
@@ -108,25 +108,38 @@ class WindowsOcrBackend(OcrBackend):
         return words
 
 
-def _words_with_offsets(text):
-    """Split text on whitespace; return (word, start offset) pairs.
+def _words_with_utf16_ranges(text):
+    """Split text on whitespace; return (word, start, length) triples with
+    start and length measured in UTF-16 CODE UNITS, not Python code points.
 
-    The offsets are what let the backend ask the recognizer for the exact
-    rectangle of each word inside its line, so this must not use split(),
-    which throws the positions away.
+    The ranges are what let the backend ask the recognizer for the exact
+    rectangle of each word inside its line, and the recognizer's strings
+    are Foundation NSStrings, which NSRange indexes in UTF-16 code units.
+    A character outside the Basic Multilingual Plane - an emoji in a
+    recognized line, say - occupies ONE Python code point but TWO UTF-16
+    code units, so a Python enumerate() offset drifts by one for every
+    such character earlier in the line and the rectangle request would
+    land on the wrong characters. Counting code units here keeps the two
+    sides of the bridge indexing the same string the same way.
     """
-    words = []
-    start = None
-    for index, ch in enumerate(text):
+    ranges = []
+    word_chars = []
+    word_start = 0
+    position = 0
+    for ch in text:
         if ch.isspace():
-            if start is not None:
-                words.append((text[start:index], start))
-                start = None
-        elif start is None:
-            start = index
-    if start is not None:
-        words.append((text[start:], start))
-    return words
+            if word_chars:
+                ranges.append(("".join(word_chars), word_start,
+                               position - word_start))
+                word_chars = []
+        else:
+            if not word_chars:
+                word_start = position
+            word_chars.append(ch)
+        position += 2 if ord(ch) > 0xFFFF else 1
+    if word_chars:
+        ranges.append(("".join(word_chars), word_start, position - word_start))
+    return ranges
 
 
 class MacVisionBackend(OcrBackend):
@@ -212,6 +225,22 @@ class MacVisionBackend(OcrBackend):
         return matches
 
     def recognize(self, image, lang):
+        # The one exception boundary of this backend, mirroring the Windows
+        # one. The bridge underneath can raise its own exceptions - from
+        # the Objective-C side, from the binding, from Pillow - and every
+        # one of them is a broken instrument, not a crash: it must surface
+        # as the documented exit 2, not as a raw traceback. The deliberate
+        # ScrubError messages raised below pass through unchanged.
+        try:
+            return self._recognize(image, lang)
+        except ScrubError:
+            raise
+        except Exception as exc:
+            raise ScrubError(
+                "macOS Vision text recognition failed unexpectedly for "
+                "language '%s': %s: %s" % (lang, type(exc).__name__, exc))
+
+    def _recognize(self, image, lang):
         width, height = image.size
         vision = self._vision
 
@@ -248,9 +277,9 @@ class MacVisionBackend(OcrBackend):
                     "is a broken read." % index)
             candidate = candidates[0]
             text = str(candidate.string())
-            for word_text, offset in _words_with_offsets(text):
+            for word_text, start, length in _words_with_utf16_ranges(text):
                 box_observation, box_error = candidate.boundingBoxForRange_error_(
-                    (offset, len(word_text)), None)
+                    (start, length), None)
                 if box_observation is None:
                     raise ScrubError(
                         "Vision would not give a rectangle for word '%s' of "

--- a/tools/cc-scrub/src/ocr_backend.py
+++ b/tools/cc-scrub/src/ocr_backend.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+"""The one OCR seam for cc-scrub.
+
+Everything above this file is platform independent. Everything below it is
+the operating system's own text recognizer. There is exactly one way in:
+
+    backend = get_backend()
+    words = backend.recognize(pil_image, lang)
+
+`recognize` returns a flat list of word dictionaries, in reading order:
+
+    {"text": str, "x": float, "y": float, "w": float, "h": float, "line": int}
+
+`x`, `y`, `w`, `h` are pixels measured in the coordinate space of the image
+that was handed in, with the origin at the top left.
+
+`line` is the index of the recognized line the word came from. Words that
+share a `line` value are on one line, and the matcher above joins adjacent
+words within a line so a term split across two OCR words still matches. It
+is not optional and it is not cosmetic: a backend that gave every word a
+different `line` value would silently switch the joining off and start
+missing terms. Every recognizer worth using groups its output into lines
+already, so both backends can fill this in honestly.
+
+A backend also declares:
+
+    name                  a human name, used in error messages
+    max_image_dimension   the longest side the engine accepts, in pixels
+
+No backend may fall back to another, and no backend may substitute a
+different engine for the one it names. If the recognizer for this operating
+system is not usable, the backend raises ScrubError saying what is missing
+and how to fix it, and the run stops.
+"""
+
+import sys
+
+
+class ScrubError(Exception):
+    """A condition that must stop the run loudly.
+
+    It lives here because the OCR seam is the lowest layer of the tool and
+    raises it too; everything above imports it from this module.
+    """
+
+
+class OcrBackend(object):
+    """The interface every platform backend implements."""
+
+    name = "unnamed backend"
+    max_image_dimension = 10000
+
+    def recognize(self, image, lang):
+        """OCR a PIL image; return word dictionaries as described above."""
+        raise NotImplementedError
+
+
+class WindowsOcrBackend(OcrBackend):
+    """The OCR engine built into Windows, reached through the winocr wheel.
+
+    winocr is a pip wheel that wraps the Windows OCR engine through WinRT.
+    No external executable is installed, required or looked for - in
+    particular this tool never calls tesseract, even on a machine where one
+    happens to be present. It launches no subprocess at all.
+    """
+
+    name = "Windows OCR (winocr / WinRT)"
+
+    def __init__(self):
+        try:
+            import winocr
+            from winocr import OcrEngine
+        except ImportError as exc:
+            raise ScrubError(
+                "winocr is not installed (%s). Fix: python -m pip install "
+                "winocr. winocr is a pip wheel that wraps the OCR engine built "
+                "into Windows; there is no installer and no .exe to find."
+                % exc)
+        self._winocr = winocr
+        self._engine = OcrEngine
+        self.max_image_dimension = OcrEngine.max_image_dimension
+
+    def _languages(self):
+        return ", ".join(language.language_tag
+                         for language in
+                         self._engine.available_recognizer_languages)
+
+    def recognize(self, image, lang):
+        try:
+            result = self._winocr.recognize_pil_sync(image, lang)
+        except Exception as exc:
+            raise ScrubError(
+                "Windows OCR failed for language '%s': %s. Installed "
+                "recognizer languages: %s" % (lang, exc, self._languages()))
+
+        words = []
+        for index, line in enumerate(result["lines"]):
+            for word in line["words"]:
+                rect = word["bounding_rect"]
+                words.append({
+                    "text": word["text"],
+                    "x": float(rect["x"]),
+                    "y": float(rect["y"]),
+                    "w": float(rect["width"]),
+                    "h": float(rect["height"]),
+                    "line": index,
+                })
+        return words
+
+
+class MacVisionBackend(OcrBackend):
+    """Apple's Vision text recognizer. NOT IMPLEMENTED YET.
+
+    The macOS backend is deliberately present and deliberately loud. It is
+    not a stub that returns nothing - a backend that returned an empty word
+    list would look exactly like a clean screenshot, which is the one
+    failure this tool must never produce.
+    """
+
+    name = "macOS Vision text recognizer"
+
+    def __init__(self):
+        raise ScrubError(
+            "the macOS OCR backend is not implemented yet. cc-scrub needs a "
+            "MacVisionBackend that recognises text with Apple's Vision "
+            "framework (VNRecognizeTextRequest, accurate recognition level) "
+            "through a pip-installable binding, and returns one dictionary "
+            "per word with keys text, x, y, w, h in top-left pixel "
+            "coordinates of the image it was handed, plus 'line' set to the "
+            "index of the recognised line the word came from. It must also "
+            "set max_image_dimension to the engine's real limit. Until that "
+            "exists, run cc-scrub on Windows.")
+
+
+def get_backend():
+    """Return the OCR backend for this operating system, or fail loudly.
+
+    Platform detection only. There is no probing, no trying one engine and
+    then another, and no silent substitution: an operating system whose
+    recognizer this tool cannot drive is an error, not a degraded mode.
+    """
+    if sys.platform.startswith("win"):
+        return WindowsOcrBackend()
+    if sys.platform == "darwin":
+        return MacVisionBackend()
+    raise ScrubError(
+        "cc-scrub has no OCR backend for platform '%s'. The recognizer is the "
+        "operating system's own; the supported systems are Windows and "
+        "macOS. There is no portable fallback engine and none will be added."
+        % sys.platform)

--- a/tools/cc-scrub/terms.example.txt
+++ b/tools/cc-scrub/terms.example.txt
@@ -1,0 +1,19 @@
+# cc-scrub denylist - EXAMPLE ONLY.
+#
+# Copy this file to terms.txt beside it and put your own terms in that copy.
+# terms.txt is listed in this folder's .gitignore and must never be
+# committed: a real denylist is a list of the exact strings you are trying
+# to keep out of public screenshots, so committing it publishes them.
+#
+# One term per line. '#' starts a comment. Matching is case-insensitive and
+# by substring, so 'myorg' also hits 'myorg/secret-repo'. Punctuation and
+# spaces are ignored on both sides, so a term split across OCR words still
+# matches.
+#
+# Keep terms specific. Glyph folding (on by default) deliberately
+# over-matches, so a two or three character term will hit far more than you
+# intended.
+
+example@example.com
+myorg/secret-repo
+internal-hostname.local

--- a/tools/cc-scrub/tests/__init__.py
+++ b/tools/cc-scrub/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for cc-scrub."""

--- a/tools/cc-scrub/tests/test_cc_scrub.py
+++ b/tools/cc-scrub/tests/test_cc_scrub.py
@@ -25,11 +25,11 @@ from src import cli
 from src.ocr_backend import ScrubError
 
 
-# The platforms that have a working OCR backend today. macOS joins this
-# tuple when MacVisionBackend is implemented. It is a list of platforms and
-# NOT a probe of whether OCR happens to work: on a supported platform a
-# missing or broken engine must fail these tests, not quietly skip them.
-SUPPORTED_PLATFORMS = ("win32",)
+# The platforms that have a working OCR backend today. It is a list of
+# platforms and NOT a probe of whether OCR happens to work: on a supported
+# platform a missing or broken engine must fail these tests, not quietly
+# skip them.
+SUPPORTED_PLATFORMS = ("win32", "darwin")
 
 requires_ocr = pytest.mark.skipif(
     sys.platform not in SUPPORTED_PLATFORMS,
@@ -158,21 +158,28 @@ def test_check_only_finds_small_grey_ui_text_only_after_upscaling(
 @requires_ocr
 def test_glyph_confusion_is_caught_by_folding_and_missed_without_it(
         samples, terms_file, capsys):
-    """The host name comes back with its leading l-shaped glyph as a t.
+    """The host name must match with folding on, whatever the engine read.
 
-    Folded, it matches; unfolded, it does not. That pair is the whole
-    argument for glyph folding, so both halves are asserted here.
+    On Windows the recognizer returns the leading l-shaped glyph as a t, so
+    the second half of this test demonstrates the miss: unfolded, the term
+    is not found. Vision on macOS reads this sample cleanly at every scale,
+    so the miss cannot be demonstrated there and that half is asserted on
+    Windows only. The fold-versus-miss property itself is proven
+    deterministically on every platform by the controlled test backend,
+    which feeds the matcher a synthetic misread; this test is the live
+    engine smoke pass on top of that.
     """
     folded_code, folded = run(capsys, samples / "sample-glyph.png",
                               "--check-only", "--terms-file", terms_file)
     assert folded_code == 1
     assert "term='%s'" % gen_samples.TERM_HOST in folded
 
-    exact_code, exact = run(capsys, samples / "sample-glyph.png",
-                            "--check-only", "--no-fold",
-                            "--terms-file", terms_file)
-    assert exact_code == 0
-    assert "HITS: 0" in exact
+    if sys.platform == "win32":
+        exact_code, exact = run(capsys, samples / "sample-glyph.png",
+                                "--check-only", "--no-fold",
+                                "--terms-file", terms_file)
+        assert exact_code == 0
+        assert "HITS: 0" in exact
 
 
 # ------------------------------------------------------------------ scrub pass

--- a/tools/cc-scrub/tests/test_cc_scrub.py
+++ b/tools/cc-scrub/tests/test_cc_scrub.py
@@ -463,14 +463,32 @@ def test_an_image_too_big_for_the_engine_is_refused_before_it_is_read(
 # The input-overwrite guard is a FILESYSTEM question, not an OCR one, so all
 # three arms are driven with the scripted backend: coupling them to a real
 # recognizer would make them skip on a platform where the guard itself works
-# perfectly well. Only the case-alias arm carries a platform marker, because
-# only that arm's premise - two spellings naming one file - is a property of
-# the filesystem the test happens to be running on. Hard links and
-# os.path.samefile work on Windows and on macOS alike.
-case_insensitive_filesystem_only = pytest.mark.skipif(
-    sys.platform != "win32",
-    reason="this arm needs a case-insensitive filesystem; Windows always is, "
-           "a POSIX host may not be")
+# perfectly well. Hard links and os.path.samefile work on Windows and on
+# macOS alike, so the hard-link arm is gated on nothing.
+#
+# Some arms do need a volume on which two spellings name one file. That is a
+# property of the VOLUME THE TEST WRITES TO, and it is measured there.
+#
+# It must not be keyed on sys.platform, and this file has already made that
+# mistake once: a marker reading `sys.platform != "win32"` skipped four arms
+# on a Mac whose volume is case-insensitive and would have run every one of
+# them, while its reason string said "a POSIX host may not be" and then
+# assumed it was not. The guard those arms cover is the one protecting the
+# only unredacted copy of the input, so it stood unproved there for a reason
+# that was not true - a skip that reads like a pass, which is the same defect
+# these tests exist to catch, one layer down.
+#
+# It also cannot be a marker at all. pytest.mark.skipif is evaluated at
+# collection time, when tmp_path does not exist yet, so a marker could only
+# ever probe some other directory than the one under test. The probe
+# therefore happens inside the test, on its own directory, using the same
+# instrument the tool itself uses.
+def require_case_insensitive(directory):
+    """Skip only on a measured answer from the volume under test."""
+    if not cli.directory_is_case_insensitive(str(directory)):
+        pytest.skip("this arm needs a volume on which two spellings name one "
+                    "file; %s is case-sensitive (measured, not assumed)"
+                    % directory)
 
 
 def test_refuses_to_overwrite_the_input_image(blank_image, terms_file, capsys,
@@ -483,7 +501,6 @@ def test_refuses_to_overwrite_the_input_image(blank_image, terms_file, capsys,
     assert "refusing to overwrite the input image" in out
 
 
-@case_insensitive_filesystem_only
 def test_refuses_to_overwrite_the_input_addressed_in_a_different_case(
         blank_image, terms_file, capsys, monkeypatch):
     """The same file spelled in another case is still the same file.
@@ -491,6 +508,7 @@ def test_refuses_to_overwrite_the_input_addressed_in_a_different_case(
     A string comparison of absolute paths says these two are different and
     would let the scrub overwrite the only unredacted copy of the input.
     """
+    require_case_insensitive(blank_image.parent)
     alias = blank_image.parent / blank_image.name.upper()
 
     # The premise, asserted rather than assumed.
@@ -609,7 +627,6 @@ def test_two_inputs_that_would_share_one_output_are_refused(tmp_path, capsys,
     assert "shot-scrubbed.png" in out
 
 
-@case_insensitive_filesystem_only
 def test_two_inputs_whose_stems_differ_only_in_case_are_refused(
         tmp_path, capsys, terms_file):
     """Shot.png and shot.jpg want Shot-scrubbed.png and shot-scrubbed.png.
@@ -618,6 +635,7 @@ def test_two_inputs_whose_stems_differ_only_in_case_are_refused(
     """
     work = tmp_path / "case-collide"
     work.mkdir()
+    require_case_insensitive(work)
     Image.new("RGB", (60, 40), (255, 255, 255)).save(str(work / "Shot.png"))
     Image.new("RGB", (60, 40), (255, 255, 255)).save(str(work / "shot.jpg"))
 
@@ -626,7 +644,6 @@ def test_two_inputs_whose_stems_differ_only_in_case_are_refused(
     assert "would both be written to" in out
 
 
-@case_insensitive_filesystem_only
 def test_collision_detection_does_not_depend_on_the_host_normcase(
         tmp_path, capsys, terms_file, monkeypatch):
     """The exact defect: normcase is the HOST's rule, not the volume's.
@@ -638,10 +655,12 @@ def test_collision_detection_does_not_depend_on_the_host_normcase(
     be found anyway, because the answer must come from the destination
     directory rather than from the path module.
     """
-    monkeypatch.setattr(os.path, "normcase", lambda path: path)
-
     work = tmp_path / "normcase-collide"
     work.mkdir()
+    require_case_insensitive(work)
+
+    monkeypatch.setattr(os.path, "normcase", lambda path: path)
+
     Image.new("RGB", (60, 40), (255, 255, 255)).save(str(work / "Shot.png"))
     Image.new("RGB", (60, 40), (255, 255, 255)).save(str(work / "shot.jpg"))
 
@@ -650,10 +669,20 @@ def test_collision_detection_does_not_depend_on_the_host_normcase(
     assert "would both be written to" in out
 
 
-@case_insensitive_filesystem_only
 def test_the_case_probe_answers_from_the_filesystem_and_cleans_up(tmp_path):
+    """The instrument, checked against an independent observation.
+
+    No skip and no platform anywhere in here: on any volume the probe's
+    verdict has to match what that directory actually does with two
+    spellings of one name, so the test writes a witness file and looks.
+    """
+    witness = tmp_path / "Witness.txt"
+    witness.write_text("x", encoding="utf-8")
+    observed = os.path.exists(str(tmp_path / "witness.txt"))
+    witness.unlink()
+
     before = sorted(os.listdir(str(tmp_path)))
-    assert cli.directory_is_case_insensitive(str(tmp_path)) is True
+    assert cli.directory_is_case_insensitive(str(tmp_path)) == observed
     assert sorted(os.listdir(str(tmp_path))) == before, "the probe was left behind"
 
 
@@ -769,9 +798,7 @@ def test_gather_inputs_rejects_a_missing_path(tmp_path):
 
 
 def test_is_same_file_sees_through_a_case_variant_of_an_existing_path(tmp_path):
-    if sys.platform != "win32":
-        pytest.skip("case-insensitive path aliasing is a Windows filesystem "
-                    "property")
+    require_case_insensitive(tmp_path)
     real = tmp_path / "shot.png"
     real.write_bytes(b"x")
     alias = tmp_path / "SHOT.PNG"

--- a/tools/cc-scrub/tests/test_cc_scrub.py
+++ b/tools/cc-scrub/tests/test_cc_scrub.py
@@ -38,7 +38,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import gen_samples
 from src import cli
-from src.ocr_backend import ScrubError
+from src.ocr_backend import ScrubError, _words_with_utf16_ranges
 
 
 # The platforms that have a working OCR backend today. It is a list of
@@ -550,6 +550,30 @@ def test_bad_scales_are_a_usage_error(samples, terms_file, capsys):
 
 
 # --------------------------------------------------------------- unit coverage
+
+def test_word_ranges_count_utf16_code_units_not_code_points():
+    """The macOS backend hands these ranges to NSRange, which indexes
+    NSStrings in UTF-16 code units. A character outside the Basic
+    Multilingual Plane is one Python code point but two UTF-16 units, so
+    counting code points would shift every later word's range by one per
+    such character and the recognizer would return a neighbouring word's
+    rectangle. The grinning-face character below is exactly that case.
+    """
+    text = "\U0001F600 secret word"
+    assert _words_with_utf16_ranges(text) == [
+        ("\U0001F600", 0, 2),   # two code units, one code point
+        ("secret", 3, 6),        # starts at 3, not the code-point offset 2
+        ("word", 10, 4),
+    ]
+
+
+def test_word_ranges_match_code_points_for_plain_text():
+    # Inside the Basic Multilingual Plane the two counts agree, so this
+    # pins the ordinary case the OCR engines actually produce.
+    assert _words_with_utf16_ranges("re po myorg") == [
+        ("re", 0, 2), ("po", 3, 2), ("myorg", 6, 5)]
+    assert _words_with_utf16_ranges("  padded  ") == [("padded", 2, 6)]
+    assert _words_with_utf16_ranges("") == []
 
 def test_a_denylist_term_that_can_never_match_is_refused(
         samples, tmp_path, capsys):

--- a/tools/cc-scrub/tests/test_cc_scrub.py
+++ b/tools/cc-scrub/tests/test_cc_scrub.py
@@ -686,21 +686,130 @@ def test_the_case_probe_answers_from_the_filesystem_and_cleans_up(tmp_path):
     assert sorted(os.listdir(str(tmp_path))) == before, "the probe was left behind"
 
 
+def _explode_on(monkeypatch, name, matches, error):
+    """Make one os call fail for the paths `matches` selects, and no others.
+
+    Injection is the only way to reach these arms. A permission error, an I/O
+    error or a race cannot be arranged on demand on a working filesystem, and
+    they are exactly the inputs that decide whether a guard fails open.
+    """
+    original = getattr(os, name)
+
+    def exploding(path, *args, **kwargs):
+        try:
+            text = str(path)
+        except Exception:
+            text = ""
+        if matches(text):
+            raise error
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, name, exploding)
+
+
 def _explode_on_the_probe(monkeypatch, name, error):
-    """Make one os call fail for the case probe only, and nothing else.
+    """Fail one os call for the case probe only.
 
     The probe's own name is mixed case and the readback looks it up with the
     case swapped, so the match has to be case-insensitive to catch both
     spellings.
     """
-    original = getattr(os, name)
+    _explode_on(monkeypatch, name,
+                lambda text: "ccscrubcase" in text.lower(), error)
 
-    def exploding(path, *args, **kwargs):
-        if "ccscrubcase" in str(path).lower():
-            raise error
-        return original(path, *args, **kwargs)
 
-    monkeypatch.setattr(os, name, exploding)
+def _explode_on_path(monkeypatch, name, target, error):
+    _explode_on(monkeypatch, name, lambda text: text == str(target), error)
+
+
+DENIED = PermissionError(13, "permission denied")
+
+
+# ------------------------------ an error is never a boolean that permits
+
+def test_is_same_file_refuses_when_it_cannot_tell_whether_a_path_exists(
+        tmp_path, monkeypatch):
+    """The guard on the ONLY unredacted copy of the input.
+
+    os.path.exists returns False for every error, and False here falls
+    through to the canonical comparison - which on a case-insensitive POSIX
+    volume is the identity function and answers "different files". An
+    unreadable destination would therefore have switched off the one check
+    standing between a run and the original image.
+    """
+    first = tmp_path / "input.png"
+    first.write_bytes(b"x")
+    second = tmp_path / "output.png"
+    _explode_on_path(monkeypatch, "stat", second, DENIED)
+
+    with pytest.raises(ScrubError) as caught:
+        cli.is_same_file(str(second), str(first))
+    assert "Refusing to guess" in str(caught.value)
+
+
+def test_an_unreadable_output_path_stops_the_run_instead_of_publishing_over_it(
+        blank_image, terms_file, tmp_path, capsys, monkeypatch):
+    """The existing-output refusal, reached through an error.
+
+    An errored exists() answered False, the refusal never fired, and the run
+    published over an output that may already have passed verification -
+    which is precisely the harm that refusal exists to stop.
+    """
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    destination = out_dir / "input-scrubbed.png"
+    destination.write_bytes(b"an earlier, verified output")
+    before = destination.read_bytes()
+
+    _explode_on_path(monkeypatch, "stat", destination, DENIED)
+    backend = ScriptedBackend([HIT_WORDS, CLEAN_WORDS])
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", out_dir,
+                             "--scales", "1", "--terms-file", terms_file)
+    assert code == 2
+    assert "Refusing to guess" in out
+    assert destination.read_bytes() == before, "the earlier output was replaced"
+
+
+def test_an_unreadable_terms_file_is_reported_as_unreadable_not_as_missing(
+        blank_image, tmp_path, capsys, monkeypatch):
+    """A fail-CLOSED site, but the reason it gives must still be true.
+
+    os.path.isfile answering False for a permission error made the tool say
+    "terms file not found" about a file that is right there. The run stopped
+    either way, so nothing was permitted - but a wrong reason sends someone
+    looking for the wrong problem.
+    """
+    terms = tmp_path / "terms.txt"
+    terms.write_text("alpha\n", encoding="utf-8")
+    _explode_on_path(monkeypatch, "stat", terms, DENIED)
+
+    code, out = run(capsys, blank_image, "--check-only", "--terms-file", terms)
+    assert code == 2
+    assert "Refusing to guess" in out
+    assert "terms file not found" not in out
+
+
+def test_a_candidate_that_cannot_be_removed_warns_and_never_masks_the_failure(
+        blank_image, terms_file, tmp_path, capsys, monkeypatch):
+    """Cleanup is the one place a failure must NOT become the outcome.
+
+    An exception is usually in flight here - the verify failure that stopped
+    the publish - and raising from the finally would replace the real reason
+    with a housekeeping complaint. So the candidate's removal is attempted,
+    a failure is reported loudly, and nothing is gated on it.
+    """
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    _explode_on(monkeypatch, "remove", lambda text: text.endswith(".tmp"), DENIED)
+
+    backend = ScriptedBackend([HIT_WORDS, HIT_WORDS])
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", out_dir,
+                             "--scales", "1", "--terms-file", terms_file)
+    assert code == 1, "the verify failure must survive the cleanup failure"
+    assert "VERIFY FAILED" in out
+    assert "could not remove the unpublished candidate" in out
 
 
 def test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer(

--- a/tools/cc-scrub/tests/test_cc_scrub.py
+++ b/tools/cc-scrub/tests/test_cc_scrub.py
@@ -11,10 +11,12 @@ Run from this tool's directory:
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -58,6 +60,61 @@ def run(capsys, *argv):
     code = cli.main([str(a) for a in argv])
     captured = capsys.readouterr()
     return code, captured.out + captured.err
+
+
+def word(text, x, y, w, h, line=0):
+    """One word in the shape the OCR seam contract requires."""
+    return {"text": text, "x": float(x), "y": float(y),
+            "w": float(w), "h": float(h), "line": line}
+
+
+class ScriptedBackend(object):
+    """A deliberate test double implementing the OCR seam contract exactly.
+
+    This is test tooling, not a runtime fallback. It is never reachable from
+    get_backend(), it never ships, and nothing in the tool can select it - a
+    test must hand it in.
+
+    It exists because the verify pass's failure arms cannot be reached with a
+    real recognizer. There is no screenshot that makes an engine read zero
+    words from a file it has just read words from, and none that reliably
+    leaves a redacted term readable. Those two arms are exactly the ones that
+    must never rot, so they get a backend whose every read is written down
+    here in the test.
+    """
+
+    name = "scripted test backend"
+
+    def __init__(self, reads, max_image_dimension=10000):
+        self.reads = list(reads)
+        self.max_image_dimension = max_image_dimension
+        self.calls = []
+
+    def recognize(self, image, lang):
+        self.calls.append((image.size, lang))
+        if not self.reads:
+            raise AssertionError(
+                "the scripted backend was asked for read %d but only %d were "
+                "scripted" % (len(self.calls), len(self.calls) - 1))
+        return self.reads.pop(0)
+
+
+@pytest.fixture
+def blank_image(tmp_path):
+    """An input file for the scripted tests. Its pixels are never read."""
+    path = tmp_path / "input.png"
+    Image.new("RGB", (200, 100), (250, 250, 250)).save(path)
+    return path
+
+
+def run_scripted(capsys, monkeypatch, backend, *argv):
+    """Run the tool against a scripted backend instead of the real engine."""
+    monkeypatch.setattr(cli, "get_backend", lambda: backend)
+    return run(capsys, *argv)
+
+
+def temp_files_in(directory):
+    return [name for name in os.listdir(str(directory)) if name.endswith(".tmp")]
 
 
 # --------------------------------------------------------------- sample shape
@@ -139,11 +196,19 @@ def test_scrub_redacts_and_the_verify_pass_proves_it(
     assert written.read_bytes() != (samples / name).read_bytes()
 
     # The pass condition is a presence and is asserted as one: hits found,
-    # regions redacted, words read back out of the file on disk.
+    # regions redacted, and a word count read back out of the file on disk
+    # that is checked as a NUMBER. Asserting that the string "read 0 words"
+    # is absent would pass just as happily if the line were missing
+    # altogether, which is the failure it was supposed to catch.
     assert "VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR " \
            "read " in out
     assert "and 0 denylist hit(s) remain." in out
-    assert "verify OCR read 0 words" not in out
+    match = re.search(r"verify OCR read (\d+) words in the output", out)
+    assert match, out
+    assert int(match.group(1)) > 0
+
+    # Publishing is atomic: the candidate is gone, the output is there.
+    assert temp_files_in(out_dir) == []
 
 
 @requires_ocr
@@ -173,12 +238,21 @@ def test_a_directory_run_skips_files_already_scrubbed(
     code, out = run(capsys, work, "--terms-file", terms_file)
     assert code == 0
     assert "images     : 2" in out
+    first = (work / "sample-normal-scrubbed.png").read_bytes()
 
-    # Second run sees the two outputs beside the inputs and must still pick
-    # up exactly the two inputs.
+    # The second run still picks up exactly the two inputs - the outputs are
+    # skipped by their suffix - but it now refuses to replace an output that
+    # has already been verified.
     code, out = run(capsys, work, "--terms-file", terms_file)
+    assert code == 2
+    assert "already exists" in out
+    assert (work / "sample-normal-scrubbed.png").read_bytes() == first
+
+    # --force is how you say you meant it.
+    code, out = run(capsys, work, "--force", "--terms-file", terms_file)
     assert code == 0
     assert "images     : 2" in out
+    assert temp_files_in(work) == []
 
 
 # -------------------------------------------------------- the broken instrument
@@ -193,6 +267,122 @@ def test_an_image_with_no_text_is_a_broken_read_not_a_clean_image(
     assert "Refusing to call this scrubbed." in out
 
 
+# ------------------------------------------ the verify pass, both failure arms
+
+HIT_WORDS = [word("repo", 10, 20, 30, 10, line=0),
+             word("myorg/secret-repo", 45, 20, 100, 10, line=0),
+             word("elsewhere", 10, 45, 60, 10, line=1)]
+CLEAN_WORDS = [word("repo", 10, 20, 30, 10, line=0),
+               word("elsewhere", 10, 45, 60, 10, line=1)]
+
+
+def test_a_verify_read_of_zero_words_publishes_nothing_and_exits_two(
+        blank_image, terms_file, tmp_path, capsys, monkeypatch):
+    """A verify instrument that reads nothing proves nothing."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    backend = ScriptedBackend([HIT_WORDS, []])
+
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", out_dir,
+                             "--scales", "1", "--terms-file", terms_file)
+    assert code == 2
+    assert "verify OCR read ZERO words from the candidate" in out
+    assert "nothing was published" in out
+    assert os.listdir(str(out_dir)) == [], "an unverified file was left behind"
+
+
+def test_a_term_surviving_in_the_output_exits_one_and_publishes_nothing(
+        blank_image, terms_file, tmp_path, capsys, monkeypatch):
+    """The redaction did not work, so the candidate must not be published.
+
+    A previously verified output is sitting at the destination. It must come
+    through byte for byte, because a run that fails is not allowed to destroy
+    a result that passed.
+    """
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    existing = out_dir / "input-scrubbed.png"
+    existing.write_bytes(b"an earlier, verified output")
+    before = existing.read_bytes()
+
+    backend = ScriptedBackend([HIT_WORDS, HIT_WORDS])
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", out_dir, "--force",
+                             "--scales", "1", "--terms-file", terms_file)
+    assert code == 1
+    assert "VERIFY FAILED" in out
+    assert "NOT PUBLISHED" in out
+    assert existing.read_bytes() == before, "the earlier output was destroyed"
+    assert temp_files_in(out_dir) == [], "a candidate file was left behind"
+
+
+def test_a_passing_scripted_run_publishes_the_candidate(
+        blank_image, terms_file, tmp_path, capsys, monkeypatch):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    backend = ScriptedBackend([HIT_WORDS, CLEAN_WORDS])
+
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", out_dir,
+                             "--scales", "1", "--terms-file", terms_file)
+    assert code == 0
+    assert "VERIFY PASSED" in out
+    assert (out_dir / "input-scrubbed.png").is_file()
+    assert temp_files_in(out_dir) == []
+
+
+# ------------------------------------------- joining and coordinate mapping
+
+def test_a_term_split_across_adjacent_words_on_one_line_is_joined():
+    """Three OCR words, one term, one rectangle spanning all three."""
+    backend = ScriptedBackend([[
+        word("myorg", 10, 20, 40, 10, line=0),
+        word("/secret", 55, 20, 50, 10, line=0),
+        word("-repo", 110, 20, 35, 10, line=0),
+        word("elsewhere", 10, 60, 60, 10, line=1),
+    ]])
+    ocr_pass = cli.ocr_image(Image.new("RGB", (300, 100)), 1, "en", backend)
+    assert len(ocr_pass.lines) == 2
+
+    hits = cli.find_hits(ocr_pass, ["myorg/secret-repo"], True)
+    assert len(hits) == 1
+    assert hits[0].box == (10.0, 20.0, 145.0, 30.0)
+
+
+def test_a_term_split_across_two_lines_is_not_joined():
+    """The documented limit, held down by a test so it cannot drift."""
+    backend = ScriptedBackend([[
+        word("myorg", 10, 20, 40, 10, line=0),
+        word("/secret-repo", 10, 40, 80, 10, line=1),
+    ]])
+    ocr_pass = cli.ocr_image(Image.new("RGB", (300, 100)), 1, "en", backend)
+    assert cli.find_hits(ocr_pass, ["myorg/secret-repo"], True) == []
+
+
+def test_a_scaled_read_maps_back_to_native_coordinates_exactly():
+    """The engine sees the enlarged image; every rectangle divides back down."""
+    backend = ScriptedBackend([[word("secret", 31, 62, 91, 25, line=0)]])
+    ocr_pass = cli.ocr_image(Image.new("RGB", (100, 50)), 3, "en", backend)
+
+    assert backend.calls[0][0] == (300, 150), "the engine was not handed 3x"
+    (text, box), = ocr_pass.lines[0]
+    assert text == "secret"
+    assert box == (31 / 3.0, 62 / 3.0, 91 / 3.0, 25 / 3.0)
+
+
+def test_an_image_too_big_for_the_engine_is_refused_before_it_is_read(
+        blank_image, terms_file, capsys, monkeypatch):
+    """Refused off the header, at scale 1, without touching the engine."""
+    backend = ScriptedBackend([], max_image_dimension=150)
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "--check-only",
+                             "--scales", "1", "--terms-file", terms_file)
+    assert code == 2
+    assert "over the scripted test backend limit of 150 px" in out
+    assert backend.calls == [], "the engine was called on an oversized image"
+
+
 # ------------------------------------------------------------- usage and rules
 
 @requires_ocr
@@ -203,6 +393,60 @@ def test_refuses_to_overwrite_the_input_image(samples, terms_file, tmp_path,
     code, out = run(capsys, target, "-o", target, "--terms-file", terms_file)
     assert code == 2
     assert "refusing to overwrite the input image" in out
+
+
+# Path aliasing is a filesystem property, not an OCR one. This skip is keyed
+# to the platform whose filesystem is case-insensitive by default, never to a
+# probe of whether the alias happened to resolve - and the test asserts its
+# own premise, so if the alias ever stops naming the same file the test fails
+# instead of quietly proving nothing.
+windows_paths_only = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="case-insensitive path aliasing is a Windows filesystem property")
+
+
+@requires_ocr
+@windows_paths_only
+def test_refuses_to_overwrite_the_input_addressed_in_a_different_case(
+        samples, terms_file, tmp_path, capsys):
+    """The same file spelled in another case is still the same file.
+
+    A string comparison of absolute paths says these two are different and
+    would let the scrub overwrite the only unredacted copy of the input.
+    """
+    target = tmp_path / "sample-normal.png"
+    target.write_bytes((samples / "sample-normal.png").read_bytes())
+    alias = tmp_path / "SAMPLE-NORMAL.PNG"
+
+    # The premise, asserted rather than assumed.
+    assert os.path.abspath(str(target)) != os.path.abspath(str(alias))
+    assert os.path.exists(str(alias))
+    assert os.path.samefile(str(target), str(alias))
+
+    before = target.read_bytes()
+    code, out = run(capsys, target, "-o", alias, "--terms-file", terms_file)
+    assert code == 2
+    assert "refusing to overwrite the input image" in out
+    assert target.read_bytes() == before, "the input image was modified"
+
+
+@requires_ocr
+@windows_paths_only
+def test_refuses_to_overwrite_the_input_reached_through_a_hard_link(
+        samples, terms_file, tmp_path, capsys):
+    """A hard link is a second name for one file, not a second file."""
+    target = tmp_path / "sample-normal.png"
+    target.write_bytes((samples / "sample-normal.png").read_bytes())
+    link = tmp_path / "link-to-sample.png"
+    os.link(str(target), str(link))
+
+    assert os.path.samefile(str(target), str(link))
+
+    before = target.read_bytes()
+    code, out = run(capsys, target, "-o", link, "--terms-file", terms_file)
+    assert code == 2
+    assert "refusing to overwrite the input image" in out
+    assert target.read_bytes() == before, "the input image was modified"
 
 
 def test_a_missing_terms_file_names_the_example_to_copy(samples, capsys):
@@ -227,16 +471,90 @@ def test_bad_scales_are_a_usage_error(samples, terms_file, capsys):
 
 # --------------------------------------------------------------- unit coverage
 
+def test_a_denylist_term_that_can_never_match_is_refused(
+        samples, tmp_path, capsys):
+    """A term counted in the banner but skipped in the matcher is a lie."""
+    path = tmp_path / "terms.txt"
+    path.write_text("example@example.com\n...\n", encoding="utf-8")
+    code, out = run(capsys, samples / "sample-normal.png", "--check-only",
+                    "--terms-file", path)
+    assert code == 2
+    assert "nothing left to match on after normalisation" in out
+    assert "'...'" in out
+
+
+def test_term_validation_follows_the_normalisation_actually_in_force():
+    # '!!!' folds onto 'lll' and can match; with --no-fold it is punctuation
+    # and cannot. The verdict has to follow the setting, not a guess.
+    cli.validate_terms(["!!!"], True)
+    with pytest.raises(ScrubError):
+        cli.validate_terms(["!!!"], False)
+
+
+def test_two_inputs_that_would_share_one_output_are_refused(tmp_path, capsys,
+                                                            terms_file):
+    """shot.png and shot.jpg both want shot-scrubbed.png."""
+    work = tmp_path / "collide"
+    work.mkdir()
+    Image.new("RGB", (60, 40), (255, 255, 255)).save(str(work / "shot.png"))
+    Image.new("RGB", (60, 40), (255, 255, 255)).save(str(work / "shot.jpg"))
+
+    code, out = run(capsys, work, "--terms-file", terms_file)
+    assert code == 2
+    assert "would both be written to" in out
+    assert "shot-scrubbed.png" in out
+
+
+def test_an_output_directory_that_cannot_be_created_exits_two(
+        blank_image, terms_file, tmp_path, capsys):
+    """Output I/O answers with exit 2, not a raw traceback."""
+    blocker = tmp_path / "a-file"
+    blocker.write_text("not a directory", encoding="utf-8")
+    code, out = run(capsys, blank_image, "-o", blocker / "sub" / "out.png",
+                    "--terms-file", terms_file)
+    assert code == 2
+    assert "cannot create the output directory" in out
+
+
+def test_pad_box_grows_outwards_to_whole_pixels():
+    # Rounding the far edges instead of ceiling them used to return
+    # (10, 20, 40, 30) here, losing the last column and the last row of the
+    # region - a strip of readable text left behind at --pad 0.
+    assert cli._pad_box((10.2, 20.9, 40.1, 30.4), 0, (100, 100)) == (10, 20, 41, 31)
+
+
+def test_pad_box_pads_and_clamps_to_the_image():
+    assert cli._pad_box((1.5, 1.5, 98.5, 98.5), 4, (100, 100)) == (0, 0, 100, 100)
+
+
 def test_normalise_drops_punctuation_and_case():
     assert cli.normalise("Example@Example.COM", fold=False) == "exampleexamplecom"
 
 
-def test_normalise_folds_the_glyph_classes():
-    # i, 1, t, j, ! and | all fold onto l, which is what lets a misread
-    # host name still match its term.
-    assert cli.normalise("tnternal", fold=True) == cli.normalise("internal", fold=True)
-    assert cli.normalise("O0", fold=True) == "oo"
-    assert cli.normalise("tnternal", fold=False) != cli.normalise("internal", fold=False)
+def test_normalise_folds_every_advertised_glyph_class():
+    """All six classes, every member - including the two that were dead.
+
+    '!' and '|' are not alphanumeric. While the alphanumeric filter ran
+    before the fold, they were discarded rather than folded, so two of the
+    six advertised folds did nothing at all and an engine reading 'internal'
+    as '!nternal' produced a false negative. Asserting only the 'l'/'t' pair
+    and 'O0', as this test once did, could not see that.
+    """
+    for target, members in cli._FOLD_CLASSES:
+        for member in members:
+            assert cli.normalise(member, fold=True) == target, (
+                "'%s' does not fold onto '%s'" % (member, target))
+
+    # The two that were silently dropped, stated as their own case.
+    assert cli.normalise("!nternal", fold=True) == cli.normalise("internal",
+                                                                 fold=True)
+    assert cli.normalise("|nternal", fold=True) == cli.normalise("internal",
+                                                                 fold=True)
+
+    # Folding off means an exact normalised match, and punctuation is gone.
+    assert cli.normalise("tnternal", fold=False) != cli.normalise("internal",
+                                                                  fold=False)
+    assert cli.normalise("!nternal", fold=False) == "nternal"
 
 
 def test_parse_scales_sorts_and_deduplicates():
@@ -289,6 +607,34 @@ def test_gather_inputs_skips_already_scrubbed_files(tmp_path):
 def test_gather_inputs_rejects_a_missing_path(tmp_path):
     with pytest.raises(ScrubError):
         cli.gather_inputs(str(tmp_path / "nowhere"))
+
+
+def test_is_same_file_sees_through_a_case_variant_of_an_existing_path(tmp_path):
+    if sys.platform != "win32":
+        pytest.skip("case-insensitive path aliasing is a Windows filesystem "
+                    "property")
+    real = tmp_path / "shot.png"
+    real.write_bytes(b"x")
+    alias = tmp_path / "SHOT.PNG"
+    assert os.path.abspath(str(real)) != os.path.abspath(str(alias))
+    assert cli.is_same_file(str(real), str(alias))
+
+
+def test_is_same_file_compares_canonically_when_the_target_is_not_created_yet(
+        tmp_path):
+    # The destination branch: nothing exists at either path, so the operating
+    # system cannot be asked and the canonical spellings decide.
+    missing = tmp_path / "sub" / ".." / "later.png"
+    assert not os.path.exists(str(missing))
+    assert cli.is_same_file(str(missing), str(tmp_path / "later.png"))
+
+
+def test_is_same_file_says_no_to_two_genuinely_different_files(tmp_path):
+    one = tmp_path / "one.png"
+    two = tmp_path / "two.png"
+    one.write_bytes(b"x")
+    two.write_bytes(b"x")
+    assert not cli.is_same_file(str(one), str(two))
 
 
 def test_output_path_defaults_to_the_scrubbed_name_beside_the_input(tmp_path):

--- a/tools/cc-scrub/tests/test_cc_scrub.py
+++ b/tools/cc-scrub/tests/test_cc_scrub.py
@@ -357,6 +357,32 @@ def test_a_passing_scripted_run_publishes_the_candidate(
 
 # ------------------------------------------- joining and coordinate mapping
 
+def test_folding_finds_a_misread_term_and_no_fold_misses_it():
+    """The fold-versus-miss property, proved without a real engine.
+
+    The live-engine test above can only demonstrate the miss where the
+    recognizer actually misreads the sample, which is a property of that
+    engine on that platform - Vision reads the same sample cleanly, so the
+    second half is asserted on Windows only there. The property itself is not
+    platform specific, so it is proved here instead, deterministically and
+    everywhere, by feeding the matcher the misread directly: the engine
+    returned the leading 'i' of 'internal' as a 't'.
+
+    Folded, the term is found. Unfolded, it is not. That pair is the whole
+    argument for glyph folding and it must be held down on every platform,
+    not only on the one whose engine happens to make the mistake.
+    """
+    misread = "https:/ftnternal-hostname.local/status/session"
+    backend = ScriptedBackend([[word(misread, 10, 20, 300, 12, line=0)]])
+    ocr_pass = cli.ocr_image(Image.new("RGB", (400, 60)), 1, "en", backend)
+
+    folded = cli.find_hits(ocr_pass, [gen_samples.TERM_HOST], True)
+    assert len(folded) == 1
+    assert folded[0].box == (10.0, 20.0, 310.0, 32.0)
+
+    assert cli.find_hits(ocr_pass, [gen_samples.TERM_HOST], False) == []
+
+
 def test_a_term_split_across_adjacent_words_on_one_line_is_joined():
     """Three OCR words, one term, one rectangle spanning all three."""
     backend = ScriptedBackend([[

--- a/tools/cc-scrub/tests/test_cc_scrub.py
+++ b/tools/cc-scrub/tests/test_cc_scrub.py
@@ -27,6 +27,7 @@ Run from this tool's directory:
 """
 
 import os
+import pathlib
 import re
 import sys
 from pathlib import Path
@@ -725,6 +726,60 @@ def _explode_on_path(monkeypatch, name, target, error):
 DENIED = PermissionError(13, "permission denied")
 
 
+# ------------------------------- the redaction modes, at the pixel level
+
+CORNERS = ((0, 0), (19, 0), (0, 19), (19, 19))
+
+
+def _image_with_planted_corners():
+    image = Image.new("RGB", (20, 20), (255, 255, 255))
+    for xy in CORNERS:
+        image.putpixel(xy, (0, 0, 0))
+    return image
+
+
+def test_patch_covers_the_whole_rectangle_including_its_corners():
+    """--patch is documented as leaving no signal from the covered pixels.
+
+    It was drawn with rounded_rectangle, so the corners were never painted
+    and the mode advertised as the safe one was the only one that provably
+    left ORIGINAL pixels inside the hit rectangle. --pad 0 removes the
+    margin that was hiding it.
+    """
+    image = _image_with_planted_corners()
+    hit = cli.Hit("term", (0.0, 0.0, 20.0, 20.0), 1, "line")
+    out = cli.redact(image, [hit], 0, "patch")
+
+    survivors = [xy for xy in CORNERS if out.getpixel(xy) == (0, 0, 0)]
+    assert survivors == [], "original pixels survived at %s" % (survivors,)
+
+
+def test_blur_covers_the_whole_rectangle_including_its_corners():
+    image = _image_with_planted_corners()
+    hit = cli.Hit("term", (0.0, 0.0, 20.0, 20.0), 1, "line")
+    out = cli.redact(image, [hit], 0, "blur")
+
+    survivors = [xy for xy in CORNERS if out.getpixel(xy) == (0, 0, 0)]
+    assert survivors == [], "original pixels survived at %s" % (survivors,)
+
+
+def test_patch_leaves_one_flat_colour_with_no_original_pixel_anywhere():
+    """The stronger statement --patch actually makes: nothing gets through.
+
+    Every pixel of the box is the same colour afterwards, so no signal from
+    what was underneath survives anywhere in it - not merely at the corners.
+    """
+    image = Image.new("RGB", (16, 12), (255, 255, 255))
+    for x in range(16):
+        for y in range(12):
+            image.putpixel((x, y), (x * 15 % 256, y * 20 % 256, 7))
+    hit = cli.Hit("term", (0.0, 0.0, 16.0, 12.0), 1, "line")
+    out = cli.redact(image, [hit], 0, "patch")
+
+    seen = set(out.getpixel((x, y)) for x in range(16) for y in range(12))
+    assert len(seen) == 1, "patch left %d distinct colours in the box" % len(seen)
+
+
 # ------------------------------ an error is never a boolean that permits
 
 def test_is_same_file_refuses_when_it_cannot_tell_whether_a_path_exists(
@@ -790,6 +845,140 @@ def test_an_unreadable_terms_file_is_reported_as_unreadable_not_as_missing(
     assert "terms file not found" not in out
 
 
+def _symlinks_available(directory):
+    """Measured, not assumed: can this process make a symbolic link here?
+
+    Windows needs a privilege or developer mode for this, and macOS does
+    not. The answer is a real capability of this machine, so it is tested
+    rather than inferred from sys.platform - and when it is absent the skip
+    says so with the error the operating system gave.
+    """
+    probe = os.path.join(str(directory), "cc-scrub-symlink-probe")
+    try:
+        os.symlink(os.path.join(str(directory), "no-such-target"), probe)
+    except OSError as exc:
+        return str(exc)
+    os.remove(probe)
+    return None
+
+
+def test_a_dangling_symlink_at_the_destination_is_still_something_to_refuse(
+        blank_image, terms_file, tmp_path, capsys, monkeypatch):
+    """A directory ENTRY exists even when what it points at does not.
+
+    Classification - is this a file, is it a directory - wants a following
+    stat. The existing-output refusal wants to know whether writing would
+    clobber a name, and that is an lstat question. Following stat answered
+    "absent" for a dangling symlink, so a scrub with no --force replaced the
+    link and reported success.
+    """
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    unavailable = _symlinks_available(out_dir)
+    if unavailable is not None:
+        pytest.skip("this machine cannot create symbolic links here: %s"
+                    % unavailable)
+
+    destination = out_dir / "input-scrubbed.png"
+    os.symlink(str(out_dir / "no-such-target.png"), str(destination))
+    assert os.path.lexists(str(destination))
+    assert not os.path.exists(str(destination))
+
+    backend = ScriptedBackend([HIT_WORDS, CLEAN_WORDS])
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", out_dir,
+                             "--scales", "1", "--terms-file", terms_file)
+    assert code == 2
+    assert "already exists" in out
+    assert os.path.lexists(str(destination)), "the symlink was replaced"
+
+
+class BackendThatCreatesAFileMidRun(ScriptedBackend):
+    """Drops a competing file in during the verify read.
+
+    That is the exact window the existing-output check cannot cover: the
+    check runs before the candidate is written, the publish runs after the
+    candidate is verified, and anything can happen in between.
+    """
+
+    def __init__(self, reads, path, content):
+        ScriptedBackend.__init__(self, reads)
+        self._path = path
+        self._content = content
+
+    def recognize(self, image, lang):
+        result = ScriptedBackend.recognize(self, image, lang)
+        if len(self.calls) == 2:
+            pathlib.Path(self._path).write_bytes(self._content)
+        return result
+
+
+def test_a_competing_output_appearing_after_the_check_is_not_clobbered(
+        blank_image, terms_file, tmp_path, capsys, monkeypatch):
+    """Time of check is not time of use.
+
+    A correct answer at inspection time does not make the caller safe. The
+    publish itself has to be the no-clobber operation, or the window between
+    them is a hole the size of a whole verification pass.
+    """
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    destination = out_dir / "input-scrubbed.png"
+    competitor = b"a verified output that arrived while we were verifying"
+
+    backend = BackendThatCreatesAFileMidRun(
+        [HIT_WORDS, CLEAN_WORDS], str(destination), competitor)
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", out_dir,
+                             "--scales", "1", "--terms-file", terms_file)
+    assert code == 2
+    assert destination.read_bytes() == competitor, "the competitor was replaced"
+
+
+def test_force_still_replaces_a_competing_output(
+        blank_image, terms_file, tmp_path, capsys, monkeypatch):
+    """--force means what it says, including through that same window."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    destination = out_dir / "input-scrubbed.png"
+
+    backend = BackendThatCreatesAFileMidRun(
+        [HIT_WORDS, CLEAN_WORDS], str(destination), b"whatever was there")
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", out_dir, "--force",
+                             "--scales", "1", "--terms-file", terms_file)
+    assert code == 0
+    assert "VERIFY PASSED" in out
+    assert destination.read_bytes() != b"whatever was there"
+    assert temp_files_in(out_dir) == []
+
+
+def test_a_terms_file_that_cannot_be_decoded_is_exit_two_not_a_traceback(
+        blank_image, tmp_path, capsys):
+    """The guard has to be on the ACTION, not on a preliminary check.
+
+    load_terms asked whether the path is a regular file and then opened it
+    outside any boundary, so invalid UTF-8 escaped as a raw
+    UnicodeDecodeError instead of the documented exit 2 - and so did a
+    permission change between the stat and the open.
+    """
+    terms = tmp_path / "terms.txt"
+    terms.write_bytes(b"alpha\n\xff\xfe not utf-8 at all\n")
+    code, out = run(capsys, blank_image, "--check-only", "--terms-file", terms)
+    assert code == 2
+    assert "cannot read the terms file" in out
+
+
+def test_the_megapixel_message_never_rounds_back_onto_the_limit():
+    """A just-over value printed as the limit itself reads as nonsense."""
+    backend = ScriptedBackend([], max_image_dimension=1000000)
+    with pytest.raises(ScrubError) as caught:
+        cli.check_scales_fit((20000, 9601), [1], backend, "image", 192)
+    message = str(caught.value)
+    assert "192,020,000 pixels" in message
+    assert "192.0 megapixels, over the 192 megapixel budget" not in message
+
+
 def test_a_candidate_that_cannot_be_removed_warns_and_never_masks_the_failure(
         blank_image, terms_file, tmp_path, capsys, monkeypatch):
     """Cleanup is the one place a failure must NOT become the outcome.
@@ -810,6 +999,10 @@ def test_a_candidate_that_cannot_be_removed_warns_and_never_masks_the_failure(
     assert code == 1, "the verify failure must survive the cleanup failure"
     assert "VERIFY FAILED" in out
     assert "could not remove the unpublished candidate" in out
+    # Deliberate, and pinned rather than implied: the candidate is left
+    # behind. It can still contain readable denylisted text, which is why
+    # the warning names it and the README calls the cleanup best effort.
+    assert temp_files_in(out_dir) != [], "the candidate should still be there"
 
 
 def test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer(
@@ -884,13 +1077,20 @@ def test_the_megapixel_budget_is_decimal_megapixels_not_mebipixels():
 
     # The PRINTED figure is pinned, not just the direction, because a fix
     # can reach the comparison and miss the message. 900x260 at scale 8 is
-    # 7200x2080, which is 14,976,000 pixels: 15.0 true megapixels, and 14.3
-    # if the unit were mebipixels. This is the same arithmetic the proof
+    # 7200x2080, which is 14,976,000 pixels: 14.976 true megapixels, and
+    # 14.3 if the unit were mebipixels. This is the same arithmetic the proof
     # transcript prints.
+    #
+    # This used to pin the string "15.0 megapixels". The count is identical -
+    # the rendering changed, because printing one decimal let a value just
+    # over the cap print AS the cap. The exact count now leads and the
+    # megapixel figure carries three decimals.
     with pytest.raises(ScrubError) as caught:
         cli.check_scales_fit((900, 260), [8], backend, "image", 1)
-    assert "15.0 megapixels" in str(caught.value)
-    assert "14.3" not in str(caught.value)
+    message = str(caught.value)
+    assert "14,976,000 pixels" in message
+    assert "14.976 megapixels" in message
+    assert "14.3 " not in message
 
 
 def test_the_case_probe_refuses_to_guess_when_it_cannot_be_created(tmp_path):

--- a/tools/cc-scrub/tests/test_cc_scrub.py
+++ b/tools/cc-scrub/tests/test_cc_scrub.py
@@ -1,0 +1,299 @@
+"""Tests for cc-scrub.
+
+The OCR tests run the tool end to end over the synthetic samples that
+gen_samples.py draws - there is no mocked recognizer anywhere, because a
+mocked one would prove nothing about the engine this tool actually depends
+on.
+
+Run from this tool's directory:
+
+    python -m pytest tests/ -q
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import gen_samples
+from src import cli
+from src.ocr_backend import ScrubError
+
+
+# The platforms that have a working OCR backend today. macOS joins this
+# tuple when MacVisionBackend is implemented. It is a list of platforms and
+# NOT a probe of whether OCR happens to work: on a supported platform a
+# missing or broken engine must fail these tests, not quietly skip them.
+SUPPORTED_PLATFORMS = ("win32",)
+
+requires_ocr = pytest.mark.skipif(
+    sys.platform not in SUPPORTED_PLATFORMS,
+    reason="cc-scrub has no OCR backend for %s yet" % sys.platform)
+
+
+TERMS = [gen_samples.TERM_EMAIL, gen_samples.TERM_REPO, gen_samples.TERM_HOST]
+
+
+@pytest.fixture(scope="session")
+def samples(tmp_path_factory):
+    """Draw the four samples once and hand back the directory."""
+    out = tmp_path_factory.mktemp("samples")
+    gen_samples.generate(str(out))
+    return out
+
+
+@pytest.fixture(scope="session")
+def terms_file(tmp_path_factory):
+    path = tmp_path_factory.mktemp("terms") / "terms.txt"
+    path.write_text("# test denylist\n" + "\n".join(TERMS) + "\n",
+                    encoding="utf-8")
+    return path
+
+
+def run(capsys, *argv):
+    """Run the tool, return (exit code, everything it printed)."""
+    code = cli.main([str(a) for a in argv])
+    captured = capsys.readouterr()
+    return code, captured.out + captured.err
+
+
+# --------------------------------------------------------------- sample shape
+
+def test_generator_writes_all_four_samples(samples):
+    for name in gen_samples.SAMPLE_NAMES:
+        assert (samples / name).is_file(), "%s was not generated" % name
+
+
+# ------------------------------------------------------------- check-only pass
+
+@requires_ocr
+def test_check_only_finds_the_planted_email_with_coordinates(
+        samples, terms_file, capsys):
+    code, out = run(capsys, samples / "sample-normal.png",
+                    "--check-only", "--terms-file", terms_file)
+    assert code == 1
+    assert "HITS: 1" in out
+    assert "term='%s'" % gen_samples.TERM_EMAIL in out
+    assert "rect=(x=" in out
+    assert "CHECK-ONLY: 1 hit(s) present, image NOT modified." in out
+
+
+@requires_ocr
+def test_check_only_finds_small_grey_ui_text_only_after_upscaling(
+        samples, terms_file, capsys):
+    """The 10 px line is the reason multi-scale exists.
+
+    The recognizer cannot resolve it at native resolution, so the hit must
+    carry scales above 1. If this ever passes with 'scales=1' the sample has
+    drifted and stopped testing what it is for.
+    """
+    code, out = run(capsys, samples / "sample-small-ui.png",
+                    "--check-only", "--terms-file", terms_file)
+    assert code == 1
+    assert "term='%s'" % gen_samples.TERM_REPO in out
+    scales = out.split("scales=")[1].split(" ")[0]
+    assert scales != "1", "the small grey line resolved at scale 1: %s" % scales
+
+
+@requires_ocr
+def test_glyph_confusion_is_caught_by_folding_and_missed_without_it(
+        samples, terms_file, capsys):
+    """The host name comes back with its leading l-shaped glyph as a t.
+
+    Folded, it matches; unfolded, it does not. That pair is the whole
+    argument for glyph folding, so both halves are asserted here.
+    """
+    folded_code, folded = run(capsys, samples / "sample-glyph.png",
+                              "--check-only", "--terms-file", terms_file)
+    assert folded_code == 1
+    assert "term='%s'" % gen_samples.TERM_HOST in folded
+
+    exact_code, exact = run(capsys, samples / "sample-glyph.png",
+                            "--check-only", "--no-fold",
+                            "--terms-file", terms_file)
+    assert exact_code == 0
+    assert "HITS: 0" in exact
+
+
+# ------------------------------------------------------------------ scrub pass
+
+@requires_ocr
+@pytest.mark.parametrize("name,term", [
+    ("sample-normal.png", gen_samples.TERM_EMAIL),
+    ("sample-small-ui.png", gen_samples.TERM_REPO),
+    ("sample-glyph.png", gen_samples.TERM_HOST),
+])
+def test_scrub_redacts_and_the_verify_pass_proves_it(
+        samples, terms_file, tmp_path, capsys, name, term):
+    out_dir = tmp_path / name.replace(".png", "")
+    out_dir.mkdir()
+    code, out = run(capsys, samples / name, "-o", out_dir,
+                    "--terms-file", terms_file)
+    assert code == 0, out
+
+    written = out_dir / name.replace(".png", "-scrubbed.png")
+    assert written.is_file()
+    assert written.read_bytes() != (samples / name).read_bytes()
+
+    # The pass condition is a presence and is asserted as one: hits found,
+    # regions redacted, words read back out of the file on disk.
+    assert "VERIFY PASSED: 1 hit(s) found, 1 region(s) redacted, verify OCR " \
+           "read " in out
+    assert "and 0 denylist hit(s) remain." in out
+    assert "verify OCR read 0 words" not in out
+
+
+@requires_ocr
+def test_the_scrubbed_output_is_clean_when_checked_again(
+        samples, terms_file, tmp_path, capsys):
+    out_dir = tmp_path / "recheck"
+    out_dir.mkdir()
+    code, _ = run(capsys, samples / "sample-normal.png", "-o", out_dir,
+                  "--terms-file", terms_file)
+    assert code == 0
+
+    written = out_dir / "sample-normal-scrubbed.png"
+    code, out = run(capsys, written, "--check-only", "--terms-file", terms_file)
+    assert code == 0
+    assert "HITS: 0" in out
+    assert "CHECK-ONLY: no hits against 3 terms over " in out
+
+
+@requires_ocr
+def test_a_directory_run_skips_files_already_scrubbed(
+        samples, terms_file, tmp_path, capsys):
+    work = tmp_path / "dir-run"
+    work.mkdir()
+    for name in ("sample-normal.png", "sample-small-ui.png"):
+        (work / name).write_bytes((samples / name).read_bytes())
+
+    code, out = run(capsys, work, "--terms-file", terms_file)
+    assert code == 0
+    assert "images     : 2" in out
+
+    # Second run sees the two outputs beside the inputs and must still pick
+    # up exactly the two inputs.
+    code, out = run(capsys, work, "--terms-file", terms_file)
+    assert code == 0
+    assert "images     : 2" in out
+
+
+# -------------------------------------------------------- the broken instrument
+
+@requires_ocr
+def test_an_image_with_no_text_is_a_broken_read_not_a_clean_image(
+        samples, terms_file, capsys):
+    code, out = run(capsys, samples / "sample-notext.png",
+                    "--check-only", "--terms-file", terms_file)
+    assert code == 2
+    assert "OCR read ZERO words" in out
+    assert "Refusing to call this scrubbed." in out
+
+
+# ------------------------------------------------------------- usage and rules
+
+@requires_ocr
+def test_refuses_to_overwrite_the_input_image(samples, terms_file, tmp_path,
+                                              capsys):
+    target = tmp_path / "sample-normal.png"
+    target.write_bytes((samples / "sample-normal.png").read_bytes())
+    code, out = run(capsys, target, "-o", target, "--terms-file", terms_file)
+    assert code == 2
+    assert "refusing to overwrite the input image" in out
+
+
+def test_a_missing_terms_file_names_the_example_to_copy(samples, capsys):
+    code, out = run(capsys, samples / "sample-normal.png", "--check-only",
+                    "--terms-file", samples / "nope.txt")
+    assert code == 2
+    assert "terms file not found" in out
+    assert "terms.example.txt" in out
+
+
+def test_the_shipped_example_denylist_parses(capsys):
+    terms = cli.load_terms(cli.EXAMPLE_TERMS_FILE)
+    assert terms == TERMS
+
+
+def test_bad_scales_are_a_usage_error(samples, terms_file, capsys):
+    code, out = run(capsys, samples / "sample-normal.png", "--check-only",
+                    "--terms-file", terms_file, "--scales", "0")
+    assert code == 2
+    assert "--scales takes positive whole numbers" in out
+
+
+# --------------------------------------------------------------- unit coverage
+
+def test_normalise_drops_punctuation_and_case():
+    assert cli.normalise("Example@Example.COM", fold=False) == "exampleexamplecom"
+
+
+def test_normalise_folds_the_glyph_classes():
+    # i, 1, t, j, ! and | all fold onto l, which is what lets a misread
+    # host name still match its term.
+    assert cli.normalise("tnternal", fold=True) == cli.normalise("internal", fold=True)
+    assert cli.normalise("O0", fold=True) == "oo"
+    assert cli.normalise("tnternal", fold=False) != cli.normalise("internal", fold=False)
+
+
+def test_parse_scales_sorts_and_deduplicates():
+    assert cli.parse_scales("3,1,2,1") == [1, 2, 3]
+
+
+def test_parse_scales_rejects_rubbish():
+    with pytest.raises(ScrubError):
+        cli.parse_scales("two")
+    with pytest.raises(ScrubError):
+        cli.parse_scales("")
+
+
+def test_load_terms_ignores_comments_and_blank_lines(tmp_path):
+    path = tmp_path / "t.txt"
+    path.write_text("# a comment\n\nalpha\nbeta # trailing\n", encoding="utf-8")
+    assert cli.load_terms(str(path)) == ["alpha", "beta"]
+
+
+def test_load_terms_rejects_an_empty_denylist(tmp_path):
+    path = tmp_path / "t.txt"
+    path.write_text("# nothing but comments\n", encoding="utf-8")
+    with pytest.raises(ScrubError):
+        cli.load_terms(str(path))
+
+
+def test_merge_hits_unions_overlapping_rectangles_of_one_term():
+    a = cli.Hit("x", (10.0, 10.0, 50.0, 30.0), 1, "line one")
+    b = cli.Hit("x", (40.0, 12.0, 90.0, 32.0), 2, "line one longer")
+    merged = cli.merge_hits([a, b])
+    assert len(merged) == 1
+    assert merged[0].box == (10.0, 10.0, 90.0, 32.0)
+    assert merged[0].scales == [1, 2]
+
+
+def test_merge_hits_keeps_different_terms_apart():
+    a = cli.Hit("x", (10.0, 10.0, 50.0, 30.0), 1, "line")
+    b = cli.Hit("y", (10.0, 10.0, 50.0, 30.0), 1, "line")
+    assert len(cli.merge_hits([a, b])) == 2
+
+
+def test_gather_inputs_skips_already_scrubbed_files(tmp_path):
+    (tmp_path / "one.png").write_bytes(b"")
+    (tmp_path / "one-scrubbed.png").write_bytes(b"")
+    (tmp_path / "notes.txt").write_text("x", encoding="utf-8")
+    found = [os.path.basename(p) for p in cli.gather_inputs(str(tmp_path))]
+    assert found == ["one.png"]
+
+
+def test_gather_inputs_rejects_a_missing_path(tmp_path):
+    with pytest.raises(ScrubError):
+        cli.gather_inputs(str(tmp_path / "nowhere"))
+
+
+def test_output_path_defaults_to_the_scrubbed_name_beside_the_input(tmp_path):
+    source = tmp_path / "shot.png"
+    source.write_bytes(b"")
+    out = cli.output_path_for(str(source), None, False)
+    assert os.path.basename(out) == "shot-scrubbed.png"
+    assert os.path.dirname(out) == str(tmp_path)

--- a/tools/cc-scrub/tests/test_cc_scrub.py
+++ b/tools/cc-scrub/tests/test_cc_scrub.py
@@ -686,6 +686,104 @@ def test_the_case_probe_answers_from_the_filesystem_and_cleans_up(tmp_path):
     assert sorted(os.listdir(str(tmp_path))) == before, "the probe was left behind"
 
 
+def _explode_on_the_probe(monkeypatch, name, error):
+    """Make one os call fail for the case probe only, and nothing else.
+
+    The probe's own name is mixed case and the readback looks it up with the
+    case swapped, so the match has to be case-insensitive to catch both
+    spellings.
+    """
+    original = getattr(os, name)
+
+    def exploding(path, *args, **kwargs):
+        if "ccscrubcase" in str(path).lower():
+            raise error
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, name, exploding)
+
+
+def test_a_probe_readback_error_is_an_error_not_a_case_sensitive_answer(
+        tmp_path, monkeypatch):
+    """The fail-open case: an unreadable probe must not answer 'sensitive'.
+
+    os.path.exists swallows OSError and returns False, so a permission
+    error, an I/O error or a race used to be classified as case-sensitive -
+    which is the answer that switches the output-collision check OFF and
+    lets one result overwrite another. Only a genuine not-found means
+    case-sensitive; every other error is exit 2.
+    """
+    _explode_on_the_probe(monkeypatch, "stat",
+                          PermissionError(13, "permission denied"))
+    with pytest.raises(ScrubError) as caught:
+        cli.directory_is_case_insensitive(str(tmp_path))
+    assert "Refusing to guess" in str(caught.value)
+
+
+def test_a_probe_that_cannot_be_removed_is_an_error_not_a_warning(
+        tmp_path, monkeypatch):
+    """A verdict returned after a failed cleanup is a verdict from a
+    directory that is not behaving as the check assumes."""
+    _explode_on_the_probe(monkeypatch, "remove",
+                          PermissionError(13, "permission denied"))
+    with pytest.raises(ScrubError) as caught:
+        cli.directory_is_case_insensitive(str(tmp_path))
+    assert "could not be removed" in str(caught.value)
+
+
+def test_a_genuinely_missing_swapped_name_is_the_case_sensitive_answer(
+        tmp_path, monkeypatch):
+    """FileNotFoundError is the one error that IS an answer.
+
+    Everything else is an instrument failure, but a swapped name that
+    honestly is not there is exactly what a case-sensitive volume looks
+    like, so it must come back False rather than raise.
+    """
+    _explode_on_the_probe(monkeypatch, "stat",
+                          FileNotFoundError(2, "no such file"))
+    assert cli.directory_is_case_insensitive(str(tmp_path)) is False
+
+
+def test_the_megapixel_budget_is_decimal_megapixels_not_mebipixels():
+    """The number is pinned, not the direction.
+
+    --max-megapixels 1 must mean 1,000,000 pixels. Read as mebipixels it
+    meant 1,048,576, so a documented 192 megapixel ceiling actually admitted
+    201,326,592 pixels - a true 200 megapixel image passing under a 192
+    megapixel limit.
+    """
+    backend = ScriptedBackend([], max_image_dimension=100000)
+
+    # Exactly one million pixels is inside a one megapixel budget.
+    cli.check_scales_fit((1000, 1000), [1], backend, "image", 1)
+
+    # A thousand more is not.
+    with pytest.raises(ScrubError) as caught:
+        cli.check_scales_fit((1000, 1001), [1], backend, "image", 1)
+    assert "over the 1 megapixel budget" in str(caught.value)
+
+    # 1024x1024 is 1,048,576 pixels. Under the mebipixel reading that was
+    # exactly at the limit and passed; it is over a decimal megapixel.
+    with pytest.raises(ScrubError):
+        cli.check_scales_fit((1024, 1024), [1], backend, "image", 1)
+
+    # And the scaled arithmetic is decimal too: 500x500 at scale 2 is one
+    # million pixels exactly.
+    cli.check_scales_fit((500, 500), [2], backend, "image", 1)
+    with pytest.raises(ScrubError):
+        cli.check_scales_fit((500, 501), [2], backend, "image", 1)
+
+    # The PRINTED figure is pinned, not just the direction, because a fix
+    # can reach the comparison and miss the message. 900x260 at scale 8 is
+    # 7200x2080, which is 14,976,000 pixels: 15.0 true megapixels, and 14.3
+    # if the unit were mebipixels. This is the same arithmetic the proof
+    # transcript prints.
+    with pytest.raises(ScrubError) as caught:
+        cli.check_scales_fit((900, 260), [8], backend, "image", 1)
+    assert "15.0 megapixels" in str(caught.value)
+    assert "14.3" not in str(caught.value)
+
+
 def test_the_case_probe_refuses_to_guess_when_it_cannot_be_created(tmp_path):
     missing = tmp_path / "no-such-directory"
     with pytest.raises(ScrubError) as caught:

--- a/tools/cc-scrub/tests/test_cc_scrub.py
+++ b/tools/cc-scrub/tests/test_cc_scrub.py
@@ -1,9 +1,25 @@
 """Tests for cc-scrub.
 
-The OCR tests run the tool end to end over the synthetic samples that
-gen_samples.py draws - there is no mocked recognizer anywhere, because a
-mocked one would prove nothing about the engine this tool actually depends
-on.
+Two kinds of test, on purpose.
+
+The INTEGRATION tests run the tool end to end over the synthetic samples
+that gen_samples.py draws, against the REAL recognizer for this platform.
+They are what proves the tool works with the engine it actually depends on,
+and they skip by platform name where no backend exists yet - never by
+probing whether OCR happens to work, so a broken install on a supported
+platform fails them instead of quietly passing.
+
+The CONTROLLED tests drive a ScriptedBackend: a deliberate test double
+implementing the OCR seam contract, unreachable from get_backend() and never
+shipped. It exists because parts of the tool cannot be reached with a real
+engine at all - no screenshot makes a recognizer read zero words from a file
+it has just read words from, and none reliably leaves a redacted term
+readable - and those are precisely the arms that must never rot. It also
+lets the coordinate mapping and the word joining be asserted as exact
+numbers rather than inferred from a hit count.
+
+Neither kind substitutes for the other, and the double never stands in for
+the engine in a test about the engine.
 
 Run from this tool's directory:
 
@@ -378,6 +394,32 @@ def test_a_scaled_read_maps_back_to_native_coordinates_exactly():
     assert box == (31 / 3.0, 62 / 3.0, 91 / 3.0, 25 / 3.0)
 
 
+def test_a_read_over_the_megapixel_budget_is_refused_before_it_is_attempted(
+        blank_image, terms_file, capsys, monkeypatch):
+    """Passing the side limit says nothing about the allocation.
+
+    200x100 at scale 20 is 4000x2000 - well inside a 10000 px side limit, and
+    8 megapixels, which is over a 1 megapixel budget. The engine must never
+    be reached and the resize must never be attempted.
+    """
+    backend = ScriptedBackend([], max_image_dimension=10000)
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "--check-only", "--scales", "20",
+                             "--max-megapixels", "1",
+                             "--terms-file", terms_file)
+    assert code == 2
+    assert "over the 1 megapixel budget for one read" in out
+    assert backend.calls == [], "the engine was called on an oversized read"
+
+
+def test_the_megapixel_budget_must_be_at_least_one(blank_image, terms_file,
+                                                   capsys):
+    code, out = run(capsys, blank_image, "--check-only",
+                    "--max-megapixels", "0", "--terms-file", terms_file)
+    assert code == 2
+    assert "--max-megapixels must be at least 1" in out
+
+
 def test_an_image_too_big_for_the_engine_is_refused_before_it_is_read(
         blank_image, terms_file, capsys, monkeypatch):
     """Refused off the header, at scale 1, without touching the engine."""
@@ -392,68 +434,73 @@ def test_an_image_too_big_for_the_engine_is_refused_before_it_is_read(
 
 # ------------------------------------------------------------- usage and rules
 
-@requires_ocr
-def test_refuses_to_overwrite_the_input_image(samples, terms_file, tmp_path,
-                                              capsys):
-    target = tmp_path / "sample-normal.png"
-    target.write_bytes((samples / "sample-normal.png").read_bytes())
-    code, out = run(capsys, target, "-o", target, "--terms-file", terms_file)
+# The input-overwrite guard is a FILESYSTEM question, not an OCR one, so all
+# three arms are driven with the scripted backend: coupling them to a real
+# recognizer would make them skip on a platform where the guard itself works
+# perfectly well. Only the case-alias arm carries a platform marker, because
+# only that arm's premise - two spellings naming one file - is a property of
+# the filesystem the test happens to be running on. Hard links and
+# os.path.samefile work on Windows and on macOS alike.
+case_insensitive_filesystem_only = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="this arm needs a case-insensitive filesystem; Windows always is, "
+           "a POSIX host may not be")
+
+
+def test_refuses_to_overwrite_the_input_image(blank_image, terms_file, capsys,
+                                              monkeypatch):
+    backend = ScriptedBackend([HIT_WORDS])
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", blank_image,
+                             "--scales", "1", "--terms-file", terms_file)
     assert code == 2
     assert "refusing to overwrite the input image" in out
 
 
-# Path aliasing is a filesystem property, not an OCR one. This skip is keyed
-# to the platform whose filesystem is case-insensitive by default, never to a
-# probe of whether the alias happened to resolve - and the test asserts its
-# own premise, so if the alias ever stops naming the same file the test fails
-# instead of quietly proving nothing.
-windows_paths_only = pytest.mark.skipif(
-    sys.platform != "win32",
-    reason="case-insensitive path aliasing is a Windows filesystem property")
-
-
-@requires_ocr
-@windows_paths_only
+@case_insensitive_filesystem_only
 def test_refuses_to_overwrite_the_input_addressed_in_a_different_case(
-        samples, terms_file, tmp_path, capsys):
+        blank_image, terms_file, capsys, monkeypatch):
     """The same file spelled in another case is still the same file.
 
     A string comparison of absolute paths says these two are different and
     would let the scrub overwrite the only unredacted copy of the input.
     """
-    target = tmp_path / "sample-normal.png"
-    target.write_bytes((samples / "sample-normal.png").read_bytes())
-    alias = tmp_path / "SAMPLE-NORMAL.PNG"
+    alias = blank_image.parent / blank_image.name.upper()
 
     # The premise, asserted rather than assumed.
-    assert os.path.abspath(str(target)) != os.path.abspath(str(alias))
+    assert os.path.abspath(str(blank_image)) != os.path.abspath(str(alias))
     assert os.path.exists(str(alias))
-    assert os.path.samefile(str(target), str(alias))
+    assert os.path.samefile(str(blank_image), str(alias))
 
-    before = target.read_bytes()
-    code, out = run(capsys, target, "-o", alias, "--terms-file", terms_file)
+    before = blank_image.read_bytes()
+    backend = ScriptedBackend([HIT_WORDS])
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", alias, "--force",
+                             "--scales", "1", "--terms-file", terms_file)
     assert code == 2
     assert "refusing to overwrite the input image" in out
-    assert target.read_bytes() == before, "the input image was modified"
+    assert blank_image.read_bytes() == before, "the input image was modified"
 
 
-@requires_ocr
-@windows_paths_only
 def test_refuses_to_overwrite_the_input_reached_through_a_hard_link(
-        samples, terms_file, tmp_path, capsys):
-    """A hard link is a second name for one file, not a second file."""
-    target = tmp_path / "sample-normal.png"
-    target.write_bytes((samples / "sample-normal.png").read_bytes())
-    link = tmp_path / "link-to-sample.png"
-    os.link(str(target), str(link))
+        blank_image, terms_file, tmp_path, capsys, monkeypatch):
+    """A hard link is a second name for one file, not a second file.
 
-    assert os.path.samefile(str(target), str(link))
+    No platform marker: os.link and os.path.samefile both work on Windows and
+    on macOS, so this arm must run on both.
+    """
+    link = tmp_path / "link-to-input.png"
+    os.link(str(blank_image), str(link))
+    assert os.path.samefile(str(blank_image), str(link))
 
-    before = target.read_bytes()
-    code, out = run(capsys, target, "-o", link, "--terms-file", terms_file)
+    before = blank_image.read_bytes()
+    backend = ScriptedBackend([HIT_WORDS])
+    code, out = run_scripted(capsys, monkeypatch, backend,
+                             blank_image, "-o", link, "--force",
+                             "--scales", "1", "--terms-file", terms_file)
     assert code == 2
     assert "refusing to overwrite the input image" in out
-    assert target.read_bytes() == before, "the input image was modified"
+    assert blank_image.read_bytes() == before, "the input image was modified"
 
 
 def test_a_missing_terms_file_names_the_example_to_copy(samples, capsys):
@@ -510,6 +557,61 @@ def test_two_inputs_that_would_share_one_output_are_refused(tmp_path, capsys,
     assert code == 2
     assert "would both be written to" in out
     assert "shot-scrubbed.png" in out
+
+
+@case_insensitive_filesystem_only
+def test_two_inputs_whose_stems_differ_only_in_case_are_refused(
+        tmp_path, capsys, terms_file):
+    """Shot.png and shot.jpg want Shot-scrubbed.png and shot-scrubbed.png.
+
+    Those two names are one file wherever the volume is case-insensitive.
+    """
+    work = tmp_path / "case-collide"
+    work.mkdir()
+    Image.new("RGB", (60, 40), (255, 255, 255)).save(str(work / "Shot.png"))
+    Image.new("RGB", (60, 40), (255, 255, 255)).save(str(work / "shot.jpg"))
+
+    code, out = run(capsys, work, "--terms-file", terms_file)
+    assert code == 2
+    assert "would both be written to" in out
+
+
+@case_insensitive_filesystem_only
+def test_collision_detection_does_not_depend_on_the_host_normcase(
+        tmp_path, capsys, terms_file, monkeypatch):
+    """The exact defect: normcase is the HOST's rule, not the volume's.
+
+    os.path.normcase lower-cases on Windows and is the identity function on
+    POSIX, so a lexical comparison built on it stops detecting anything on a
+    case-insensitive volume under a POSIX host - which is a normal Mac. This
+    test makes normcase the identity function and requires the collision to
+    be found anyway, because the answer must come from the destination
+    directory rather than from the path module.
+    """
+    monkeypatch.setattr(os.path, "normcase", lambda path: path)
+
+    work = tmp_path / "normcase-collide"
+    work.mkdir()
+    Image.new("RGB", (60, 40), (255, 255, 255)).save(str(work / "Shot.png"))
+    Image.new("RGB", (60, 40), (255, 255, 255)).save(str(work / "shot.jpg"))
+
+    code, out = run(capsys, work, "--terms-file", terms_file)
+    assert code == 2
+    assert "would both be written to" in out
+
+
+@case_insensitive_filesystem_only
+def test_the_case_probe_answers_from_the_filesystem_and_cleans_up(tmp_path):
+    before = sorted(os.listdir(str(tmp_path)))
+    assert cli.directory_is_case_insensitive(str(tmp_path)) is True
+    assert sorted(os.listdir(str(tmp_path))) == before, "the probe was left behind"
+
+
+def test_the_case_probe_refuses_to_guess_when_it_cannot_be_created(tmp_path):
+    missing = tmp_path / "no-such-directory"
+    with pytest.raises(ScrubError) as caught:
+        cli.directory_is_case_insensitive(str(missing))
+    assert "Refusing to guess" in str(caught.value)
 
 
 def test_an_output_directory_that_cannot_be_created_exits_two(

--- a/tools/registry.json
+++ b/tools/registry.json
@@ -169,6 +169,14 @@
       "requirements": ["Windows", ".NET runtime", "OPENAI_API_KEY"]
     },
     {
+      "name": "cc-scrub",
+      "category": "media",
+      "type": "python",
+      "description": "Find denylisted text in screenshots with the operating system's own OCR engine and destroy it",
+      "built": false,
+      "requirements": []
+    },
+    {
       "name": "cc-image",
       "category": "media",
       "type": "python",


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1881.

Adds `cc-scrub`, a screenshot scrubber. It finds denylisted text in an image
with the operating system's own text recognizer, destroys it, and then proves
the redaction worked by reading the result back.

## Why

A screenshot going into a public video, a documentation page or a website has
to be checked for anything that should not be public. Doing that by eye does
not scale and it fails silently - the one you miss is the one that ships.

## What it does

- Reads the image at several scales (default 1, 2, 3) and unions the hits.
  Small grey interface text near 10 pixels is unreadable at native size, so a
  single read is not enough. This is a union, not a fallback chain: different
  scales misread the same text in different ways.
- Joins each recognised line back into one string, with a map to the word each
  character came from, so a term split across adjacent words still matches.
- Normalises both sides and folds characters that share a shape, because small
  anti-aliased text provokes exactly those confusions.
- Blurs (or patches) the covering rectangles, writes the result to a temporary
  candidate, reads that candidate back, and publishes it only if no denylisted
  term survives. A failed verification publishes nothing.
- Exit codes: 0 done and proved, 1 a term is still readable, 2 broken
  instrument or usage error. There is no fallback anywhere; it fails loudly.

Pure Python. Every dependency is a pip wheel, no external executable is
installed or looked for, and it launches no subprocess.

All platform-specific code sits behind one seam, `src/ocr_backend.py`:
`WindowsOcrBackend` on the engine built into Windows via the `winocr` wheel,
`MacVisionBackend` on Apple's Vision text recognizer via pyobjc. Everything
above the seam is platform independent and does not know which engine
answered.

## What the verify pass does and does not prove

The verification is performed by the same recognizer that found the text, so
a pass proves the term is no longer readable *by that engine at those scales*.
It is not a proof that no trace survives.

`--blur` mosaics the region and blurs it: the original pixel values are not
present in the output, but a low-frequency average of the covered region
remains, and recovering text from a mosaic is a documented attack. `--patch`
paints an opaque fill and is the only mode that leaves no signal from the
covered pixels. The README says so plainly, and the default remains `--blur`
as a judgement about the common case, not a claim that the two modes are
equally strong.

## Safety

The tool refuses to write over the input image, refuses to replace an existing
output unless `--force` is passed, and refuses a run where two inputs would
collide on one output name - all decided before any image is read.

Those guards ask the filesystem rather than comparing path strings, because a
different letter case, a hard link or a symbolic link all compare unequal as
text while naming one file. The output-collision check probes the destination
directory directly to find out whether it treats two spellings as one file.

The real denylist (`terms.txt`) is not committed: it is a list of the exact
strings you are keeping out of public screenshots, so committing it would
publish them. `terms.example.txt` ships instead, with deliberately fake
entries.

## Proof

Both backends were proved by a clean install into a fresh virtual environment,
with the full transcript recorded in the tool folder: `PROOF-windows.md` and
`PROOF-macos.md`. Each was regenerated - never hand-edited - whenever the code
beneath it changed, and each runs its suite step with skips printed and their
reasons recorded.

The suite is 60 tests and runs with zero skips on Windows and zero on a
default macOS volume. It exercises the failure arms as well as the success
ones: a verification that reads zero words, a term surviving into the output,
an existing output preserved byte-for-byte when a run fails, and injected
permission and I/O errors on every path that decides whether a write is
allowed.

## Review

Four rounds by a separate reviewer; 21 findings, all resolved.

Round 1 raised ten against the Windows backend, three of them blockers: an
overwrite guard defeated by a case-variant path, an output written before it
was verified, and two of the six advertised glyph folds being dead code.

Round 2 raised eight more, including two the first round could not have seen:
the output-collision preflight was keyed on the host's lexical path rules, so
on a case-insensitive macOS volume two inputs could still land on one output;
and NSRange indices were computed in Unicode code points where Foundation
counts UTF-16 code units.

Round 3 raised three, two of them blockers: the directory probe still failed
open, because `os.path.exists` returns False for every error and False is the
answer that switches collision detection off; and `--max-megapixels` was
implemented in mebipixels, so a documented 192 megapixel ceiling actually
admitted 201,326,592 pixels and a genuine 200 megapixel image passed.

Round 4 confirmed the result.

Four defects were found only because a claim was checked against the artifact
behind it rather than against the report of it:

- A round-1 ruling stated the fold-versus-miss property was proved on every
  platform by a controlled test backend. That test did not exist, so on macOS
  nothing held the property down at all.
- A round-2 fix was reported complete when the marker in question had been
  renamed while its condition still read `sys.platform != "win32"`. Four
  filesystem-dependent arms were skipping on a volume that satisfied their
  premise, leaving the guard that protects the only unredacted copy of the
  input unproved on macOS for a reason that was not true.
- The verify-pass documentation asserted that what is inside the rectangle is
  destroyed and the information is gone. That is false as an absolute for a
  mosaic, and it is the sentence a user leans on when deciding to publish.
- The reviewer found one fail-open call site. A sweep for the pattern rather
  than the instance found six, across `is_same_file`, the existing-output
  refusal, `load_terms`, `gather_inputs` and `output_path_for`. All now route
  through one helper that treats exactly two errors as answers - a genuine
  absence - and raises on everything else.

Both proof transcripts now print skips with their reasons, because a skip
nobody prints reads exactly like a pass.

## One thing to know before changing the case probe

`directory_is_case_insensitive` reads `FileNotFoundError` on the swapped name
as its case-sensitive answer. That conversion relaxes the collision keying, so
it is the one a future change could widen without noticing, and the only thing
standing on it is a single test:
`test_a_genuinely_missing_swapped_name_is_the_case_sensitive_answer`.

## Follow-ups, deliberately not in this change

Both are tracked on thefrederiksen/devthrottle_internal#1881.

**Packaging.** `cc-scrub` is in `tools/registry.json` but is not packaged: no
`ship` flag, no build script, no PyInstaller specification, and it is not in
the Python tools list in `scripts/build-all-tools.ps1`. Packaging is a pipeline
change outside the tool folder and it needs `winocr` proved under PyInstaller
first, which nobody has tested.

**Reproducible proofs.** The two proof transcripts are committed and readable,
but the scripts that generate them are not, so nobody else can regenerate one.
A build-time check that fails when the transcript's summary quotes a figure the
recorded output does not contain exists, and works, but it lives outside the
repository for the same reason. Committing the proof driver and builder would
make both the transcripts reproducible and that guard durable.
