### PR TITLE
Turn push, phase 1: the Director pushes each turn and the Gateway stores it

### DIFF
--- a/docs/missions/turn-push-2026-09-01/brief.md
+++ b/docs/missions/turn-push-2026-09-01/brief.md
@@ -157,6 +157,21 @@ guard land together. Every phase says what it does NOT prove.
 
 ---
 
+## Seats and their names
+
+**The mission's name is "Turn Push", and every seat on it is named `Turn Push - <Role>`** - mission first,
+a dash, then the role, as the conduct file requires. The seats:
+
+- `Turn Push - Architect` - holds the design, this brief, and the merge authority. One at a time.
+- `Turn Push - Manager` - drives a phase. Seated per phase from `handoff.md`, killed when the phase ends.
+- `Turn Push - Worker` - one task, then gone.
+- `Turn Push - Inspector` - a different agent family, reads the diff, writes its review to a file.
+
+A seat whose name does not start with `Turn Push -` is not on this mission, whatever it is doing. This
+matters on a machine running several missions at once: the roster is how the owner sees which seats belong
+to which piece of work, and a seat named for its repository or its symptom tells him nothing about why it
+exists.
+
 ## How this mission is run
 
 Standalone-with-review per slice, seated in this worktree, with a Codex inspector run inline on each

--- a/docs/missions/turn-push-2026-09-01/handoff.md
+++ b/docs/missions/turn-push-2026-09-01/handoff.md
@@ -3,24 +3,27 @@
 Read `brief.md` first. This note is the compact state a fresh seat needs; it is rewritten at every
 boundary, never appended to.
 
-- **Branch:** `mission/turn-push`, worktree `D:\ReposFred\devthrottle-turn-push`, cut from `b71baccbf`.
+- **Branch:** `mission/turn-push`, worktree `D:\ReposFred\devthrottle-turn-push`.
 - **Issue:** thefrederiksen/devthrottle#2638.
-- **Phase 0 (the store): done, three Codex passes.** Tables `session_turns` (key tenant, session,
-  generation key, ordinal) and `session_turn_heads` (one per session: current generation key + source
-  text + start, contiguous watermark, agent facts, history state, `Revision` concurrency token).
-  Migrations `AddSessionTurns` on both providers, snapshots in sync. `SessionTurnStore`: validated batch,
-  one transaction per push with one retry on a lost race, idempotent rows, paged contiguous watermark,
-  generation switch only when strictly later (millisecond precision on both sides, ties by key), whole-
-  session retention judged on the head and race-free, aged rows of left generations dropped. Retention
-  wired into `SessionHistorySweep`. Contracts `PushedTurn` / `TurnPushBatch` / `TurnWatermark`.
-  Thirty-one store tests. Local gate green.
-- **Next: Phase 1.** `DirectorHub.PushTurns(sequence, TurnPushBatch)` bound to the tenant and Director
-  like `PushDelta`, writes through `SessionTurnStore.Append`, returns the `TurnWatermark`; `Hello`
-  answers `WatermarksFor(directorId)` on `GatewayCapabilities`. Director side: `TurnPusher` in
-  `CcDirector.ControlApi` reading through `SessionHistoryReader.Read`; generation = resolved transcript
-  path (Claude) or the session id (others); `GenerationStartedUtc` = when the Director first saw that
-  source this process lifetime; triggers: the Director's own Working-to-Waiting edge (where
-  `NotifyDelta` fires in `ControlApiHost`), pointer change, reconnect backfill from the Hello watermarks,
-  a slow safety sweep. `HistoryState` computed on the Director at push time (`HistoryStateDeriver`).
-  Batches of at most `SessionTurnStore.MaxBatchSize`.
-- **Not proven yet:** anything live. No reader uses the rows until Phase 2.
+- **Phase 0 (the store): MERGED** to main as pull request 2640. `session_turns` + `session_turn_heads`,
+  migrations on both providers, `SessionTurnStore` (validated batches, one transaction per push with a
+  retry on a lost race, idempotent rows, paged contiguous watermark, generation switch only to a strictly
+  later source with a deterministic tie-break, whole-session retention). Thirty-one tests.
+- **Phase 1 (the Director pushes, the Gateway stores): built, green, four Codex passes.**
+  - Gateway: `DirectorHub.PushTurns(sequence, batch)` writes through the store under the bound tenant and
+    Director and answers the watermark; `Hello` returns this Director's watermarks on `GatewayCapabilities`.
+  - Director: `TurnPushBuilder.Snapshot` reads a session's conversation through the ONE resolver
+    (`SessionHistoryReader`, pointer-first), resolving the path once and using it for the generation, the
+    messages and the history state. `TurnPusher` keeps per-session state under a lock, pushes bounded
+    batches from the watermark, stamps each new source strictly later than the last (so a stale read can
+    never outrank the current source), reconciles fully on Hello, retires state safely against the sweep,
+    and hands outstanding work to a fresh call rather than leaving it for the sweep.
+  - Stream client: `PushTurnsAsync`, `GatewaySupports`, an `onHello` callback, capabilities cleared when
+    the connection drops. Triggers: the Director's own Working-to-Waiting/Idle edge, any-to-Exited,
+    session creation, Hello, and a one-minute safety sweep.
+  - Twenty-eight pusher tests plus three hub tests. Local gate green; the parked run was in progress at
+    the time of writing.
+- **Next: Phase 2** - serve `GET /sessions/{sid}/history` from the store, fold `HistoryState` on the
+  Gateway, and remove `history` from `TunnelCatchAllDispatch`.
+- **Not proven:** anything live. No reader uses the stored rows until Phase 2, so nothing a person sees
+  has changed yet.

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -48,6 +48,9 @@ public sealed class ControlApiHost : IAsyncDisposable
     // Issue #1176 (Phase 1a): the outbound push-stream client, running alongside _gatewayClient when
     // gateway.streamMode is on. Null when stream mode is off, so the Director behaves exactly as today.
     private GatewayStreamClient? _streamClient;
+    /// <summary>The turn-push mission's Director side: keeps the Gateway's stored conversation current for
+    /// every session by pushing what it has not seen. Null when there is no Gateway.</summary>
+    private TurnPusher? _turnPusher;
 
     /// <summary>
     /// Remove-the-network-port mission, phase 1b: the hashes of the Gateway session keys this Director's
@@ -457,8 +460,10 @@ public sealed class ControlApiHost : IAsyncDisposable
         // heartbeat, and dial the tunnel. Disabled (no-op) when local-only.
         _gatewayClient = BuildGatewayClient(gatewayConfig);
         _gatewayClient.Start();
+        _turnPusher = BuildTurnPusher(gatewayConfig);
         _streamClient = BuildStreamClient(gatewayConfig);
         _streamClient?.Start();
+        _turnPusher?.Start();
         WireDoorbellPush();
         WireRepositoryPush();
 
@@ -832,6 +837,14 @@ public sealed class ControlApiHost : IAsyncDisposable
             // registry so the director-level reads that stamp/read them (facts, handover, repos-list) serve the
             // same value over the tunnel that their REST route served.
             cmd => DispatchTunnelCommandAsync(cmd),
+            // Turn push: every Hello hands back what the Gateway already holds of this Director's sessions'
+            // conversations; the pusher seeds from it and backfills the rest.
+            // Only when the Gateway actually READ its store. A Gateway that could not read answers a
+            // silence, and reconciling against a silence would re-push every conversation from the start.
+            onHello: capabilities =>
+            {
+                if (capabilities.TurnWatermarksKnown) _turnPusher?.SeedWatermarks(capabilities.TurnWatermarks);
+            },
             // Gateway Cleanup mission, Phase 0 (up-stream): pass the SessionManager so the four connection-bound
             // stream verbs work - their terminal/file producers read session and file state from it and stream
             // frames up this same connection.
@@ -856,6 +869,31 @@ public sealed class ControlApiHost : IAsyncDisposable
                 if (Guid.TryParse(id, out var confirmed))
                     _sessionGatewayKeys.RevocationConfirmed(confirmed);
             });
+    }
+
+    /// <summary>
+    /// The turn-push mission's Director side. Reads each session's conversation through the one resolver
+    /// (<see cref="TurnPushBuilder"/>) and pushes what the Gateway has not seen, over the stream client that
+    /// is current at the time of the push (the field is read per call, so a Gateway settings change that
+    /// rebuilds the stream does not strand the pusher on a dead one). Null when there is no Gateway.
+    /// </summary>
+    private TurnPusher? BuildTurnPusher(GatewayConfig gatewayConfig)
+    {
+        if (!gatewayConfig.IsEnabled) return null;
+        return new TurnPusher(
+            sessionIds: () => _sessionManager.ListSessions().Select(s => s.Id).ToList(),
+            snapshot: sid =>
+            {
+                var session = _sessionManager.GetSession(sid);
+                return session is null ? null : TurnPushBuilder.Snapshot(session);
+            },
+            push: (batch, ct) =>
+            {
+                var client = _streamClient;
+                if (client is null) throw new InvalidOperationException("there is no Gateway stream to push turns over");
+                return client.PushTurnsAsync(batch, ct);
+            },
+            canPush: () => _streamClient?.GatewaySupports("PushTurns") == true);
     }
 
     /// <summary>
@@ -970,7 +1008,7 @@ public sealed class ControlApiHost : IAsyncDisposable
     {
         void Attach(Core.Sessions.Session session)
         {
-            session.OnActivityStateChanged += (_, newState) =>
+            session.OnActivityStateChanged += (oldState, newState) =>
             {
                 var eventName = newState switch
                 {
@@ -981,6 +1019,16 @@ public sealed class ControlApiHost : IAsyncDisposable
                     _ => null,
                 };
                 _gatewayClient?.NotifySessionState(session.Id.ToString(), newState.ToString(), eventName);
+                // Turn push: the Director's OWN turn-end edge - FROM working TO waiting for input or a
+                // permission, or idle - which is the moment the conversation has something new; and the
+                // session ending from any state, for the final push. Deterministic, not sampled: this is the
+                // edge itself, and a transition into a waiting state from anywhere else is not a turn ending.
+                var turnEnded = oldState is Core.Sessions.ActivityState.Working
+                                && newState is Core.Sessions.ActivityState.WaitingForInput
+                                    or Core.Sessions.ActivityState.WaitingForPerm
+                                    or Core.Sessions.ActivityState.Idle;
+                if (turnEnded || newState is Core.Sessions.ActivityState.Exited)
+                    _turnPusher?.Trigger(session.Id);
                 // Issue #1176 (Phase 1a): push the changed session up the stream as a delta.
                 _streamClient?.NotifyDelta(ControlEndpoints.Map(session, DirectorId));
             };
@@ -1041,6 +1089,7 @@ public sealed class ControlApiHost : IAsyncDisposable
             _gatewayClient?.NotifySessionState(session.Id.ToString(), session.ActivityState.ToString(),
                 DoorbellEvents.SessionCreated);
             _streamClient?.NotifyDelta(ControlEndpoints.Map(session, DirectorId));
+            _turnPusher?.Trigger(session.Id);   // a resumed session already has a conversation to push
         };
         _sessionManager.OnSessionRemoved += session =>
         {
@@ -1105,8 +1154,13 @@ public sealed class ControlApiHost : IAsyncDisposable
 
             _gatewayClient = BuildGatewayClient(gatewayConfig);
             _gatewayClient.Start();
+            // The pusher is built BEFORE the stream dials. The stream's first Hello carries the Gateway's
+            // turn watermarks, and a pusher created after that call has already gone out would miss the
+            // reconciliation entirely (found in review) - the same order StartAsync uses.
+            _turnPusher ??= BuildTurnPusher(gatewayConfig);
             _streamClient = BuildStreamClient(gatewayConfig);
             _streamClient?.Start();
+            _turnPusher?.Start();
             // Issue #1292: keep the async-vs-local numbering decision in step with the new config.
             _sessionManager.FleetNumberingActive = gatewayConfig.IsEnabled;
         }
@@ -1182,6 +1236,12 @@ public sealed class ControlApiHost : IAsyncDisposable
         _sessionLogManager?.Dispose();
         _sessionLogManager = null;
         _pointerWatcher?.Dispose();
+        if (_turnPusher is not null)
+        {
+            try { await _turnPusher.DisposeAsync(); }
+            catch (Exception ex) { FileLog.Write($"[ControlApiHost] turn pusher dispose error: {ex.Message}"); }
+            _turnPusher = null;
+        }
         _pointerWatcher = null;
         _preambleMaintainer?.Dispose();
         _preambleMaintainer = null;

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -118,8 +118,10 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         Func<string?>? displayName = null,
         Func<List<SessionKeyRegistration>>? sessionKeys = null,
         Func<List<string>>? pendingRevocations = null,
-        Action<string>? onRevocationConfirmed = null)
+        Action<string>? onRevocationConfirmed = null,
+        Action<GatewayCapabilities>? onHello = null)
     {
+        _onHello = onHello;
         _sessionKeys = sessionKeys;
         _pendingRevocations = pendingRevocations;
         _onRevocationConfirmed = onRevocationConfirmed;
@@ -284,6 +286,7 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         _connection.Reconnecting += ex =>
         {
             FileLog.Write($"[GatewayStreamClient] reconnecting: {ex?.Message}");
+            _capabilities = null;   // unknown until the reconnect's Hello answers
             // Gateway Cleanup Phase 0 (Architect ruling A): the tunnel dropped, so no frame can reach the
             // Gateway - tear down every live up-stream instead of leaving a producer sending into a dead socket.
             _upStreamHandler?.CancelAll();
@@ -292,7 +295,9 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         };
         _connection.Reconnected += async _ => { await ReseedAsync(); _monitor?.MarkTunnelConnected(); };
         // Also tear streams down on a full close (auto-reconnect gave up); the supervise loop then re-dials.
-        _connection.Closed += _ => { _upStreamHandler?.CancelAll(); _monitor?.MarkTunnelConnecting(); return Task.CompletedTask; };
+        // The capabilities go with the connection: the next dial may reach a different (older) Gateway, and a
+        // caller must not act on the last one's answer until the new Hello has answered.
+        _connection.Closed += _ => { _capabilities = null; _upStreamHandler?.CancelAll(); _monitor?.MarkTunnelConnecting(); return Task.CompletedTask; };
 
         // Issue #1176 (Phase 1b): the down-channel proof. The Gateway can call this and await the reply
         // over the same connection (SignalR client results), demonstrating request-both-ways on one
@@ -483,8 +488,36 @@ public sealed class GatewayStreamClient : IAsyncDisposable
     /// </summary>
     private static readonly string[] MethodsThisDirectorNeeds =
     {
-        "RegisterSessionKey", "RevokeSessionKey", "PushSnapshot", "PushDelta", "PushRepoSnapshot",
+        "RegisterSessionKey", "RevokeSessionKey", "PushSnapshot", "PushDelta", "PushRepoSnapshot", "PushTurns",
     };
+
+    /// <summary>What the Gateway answered on the last Hello, so callers can ask whether it has a hub method
+    /// before calling it. Null until the first Hello has answered.</summary>
+    private GatewayCapabilities? _capabilities;
+
+    /// <summary>Told every time a Hello answers (turn-push mission: the TurnPusher seeds its watermarks from
+    /// the answer and backfills). Called after the capability line is logged.</summary>
+    private readonly Action<GatewayCapabilities>? _onHello;
+
+    /// <summary>Whether the Gateway on the other end has this hub method. False before the first Hello and
+    /// against a Gateway built before the method existed - the caller then does not call it.</summary>
+    public bool GatewaySupports(string hubMethod)
+        => _capabilities?.HubMethods.Contains(hubMethod, StringComparer.Ordinal) == true;
+
+    /// <summary>
+    /// Push one batch of a session's conversation (turn-push mission) and return the watermark the Gateway
+    /// holds afterwards. Null when the Gateway refused the batch. Throws when the tunnel is not connected -
+    /// the caller (TurnPusher) logs and resumes from the Gateway's watermark on the next trigger.
+    /// </summary>
+    public async Task<TurnWatermark?> PushTurnsAsync(TurnPushBatch batch, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        var conn = _connection;
+        if (conn is null || conn.State != HubConnectionState.Connected)
+            throw new InvalidOperationException("the Gateway stream is not connected");
+        var seq = Interlocked.Increment(ref _sequence);
+        return await conn.InvokeAsync<TurnWatermark?>("PushTurns", seq, batch, ct).ConfigureAwait(false);
+    }
 
     /// <summary>The capability line already reported, so a ten-second reseed does not repeat it forever.</summary>
     private string _lastCapabilityReport = "";
@@ -571,6 +604,12 @@ public sealed class GatewayStreamClient : IAsyncDisposable
             });
             awaitGateway += DateTime.UtcNow - helloStarted;
             ReportGatewayCapabilities(capabilities);
+            _capabilities = capabilities;
+            if (capabilities is not null && _onHello is not null)
+            {
+                try { _onHello(capabilities); }
+                catch (Exception ex) { FileLog.Write($"[GatewayStreamClient] Hello callback FAILED: {ex.Message}"); }
+            }
 
             // OUR work, on this machine: assembling the roster. Timed apart from the send because a slow build
             // is a local problem (a starved machine, a lock held too long) and a slow send is the Gateway's -

--- a/src/CcDirector.ControlApi/TurnPushBuilder.cs
+++ b/src/CcDirector.ControlApi/TurnPushBuilder.cs
@@ -1,0 +1,99 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.History;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Everything the Director knows about one session's conversation at one moment, in the shape the
+/// Gateway stores (the turn-push mission, <c>docs/missions/turn-push-2026-09-01/brief.md</c>): the
+/// generation (the identity of the transcript source), the per-session facts, and EVERY message as a
+/// <see cref="PushedTurn"/> in order. <see cref="TurnPusher"/> slices this from the Gateway's watermark;
+/// the Director reads the whole source once per turn instead of once per 2.5-second poll.
+/// </summary>
+public sealed record TurnSnapshot(
+    string SessionId,
+    string Generation,
+    string Agent,
+    bool IsSupported,
+    bool IsRawText,
+    string? HistoryState,
+    IReadOnlyList<PushedTurn> Turns);
+
+/// <summary>
+/// Reads one session's conversation THROUGH THE ONE RESOLVER (<see cref="SessionHistoryReader"/>, which
+/// follows the hook-reported transcript pointer) and shapes it for the push. This is the only place the
+/// Director turns a transcript into pushed turns; the Gateway never asks for the transcript again.
+/// </summary>
+public static class TurnPushBuilder
+{
+    /// <summary>The session's conversation right now. Never throws for an unsupported agent - it answers a
+    /// head-only snapshot so the Gateway can say "unsupported" exactly as the Director's own history read
+    /// did.</summary>
+    public static TurnSnapshot Snapshot(Session session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        var sessionId = session.Id.ToString();
+        var agent = session.AgentKind.ToString();
+        if (!SessionHistoryReader.IsSupported(session))
+            return new TurnSnapshot(sessionId, GenerationFor(session, null), agent, IsSupported: false, IsRawText: false, HistoryState: null, Turns: Array.Empty<PushedTurn>());
+
+        // Resolved ONCE and used three times - as the generation, as the file the messages are read from,
+        // and as the file the history state is derived from - so a pointer that moves mid-snapshot cannot
+        // label one file's messages with another file's identity (found in review).
+        var path = SessionHistoryReader.ResolveTranscriptPath(session);
+        var history = SessionHistoryReader.Read(session, path);
+        // The transcript-derived history state (the background-agent lifecycle signal) lives in the Claude
+        // transcript format and needs process liveness, which only the Director has - so it is computed HERE,
+        // at push time, and carried on the batch for the Gateway to serve verbatim.
+        string? historyState = null;
+        if (session.AgentKind == AgentKind.ClaudeCode)
+            historyState = HistoryStateDeriver.DeriveFromFile(path, session.Backend.IsRunning).ToString();
+
+        return new TurnSnapshot(
+            sessionId,
+            GenerationFor(session, path),
+            agent,
+            IsSupported: true,
+            IsRawText: session.AgentKind == AgentKind.Gemini,
+            historyState,
+            Map(history.Messages));
+    }
+
+    /// <summary>
+    /// The generation: the transcript source's identity. For a file-backed agent that is the resolved
+    /// path - it changes on /clear and when the agent moves into a worktree, which is exactly when the
+    /// conversation the Gateway holds must start over. Agents whose conversation is not a per-session file
+    /// (Gemini reads its own terminal buffer; Copilot and OpenCode read a store by repository) have one
+    /// generation for the life of the session, named by the session id.
+    /// </summary>
+    internal static string GenerationFor(Session session, string? transcriptPath)
+        => session.AgentKind is AgentKind.Gemini or AgentKind.Copilot or AgentKind.OpenCode || string.IsNullOrEmpty(transcriptPath)
+            ? "session:" + session.Id
+            : transcriptPath;
+
+    /// <summary>Shape the reader's messages as pushed turns, ordinal = position. Pure, so it is tested
+    /// without a session.</summary>
+    internal static IReadOnlyList<PushedTurn> Map(IReadOnlyList<ConversationMessage> messages)
+    {
+        var turns = new List<PushedTurn>(messages.Count);
+        for (var i = 0; i < messages.Count; i++)
+        {
+            var m = messages[i];
+            var turn = new PushedTurn
+            {
+                Ordinal = i,
+                Role = m.Role.ToString(),
+                Timestamp = m.Timestamp,
+                ContextId = m.ContextId,
+                IsMeta = m.IsMeta,
+                IsSidechain = m.IsSidechain,
+            };
+            foreach (var p in m.Parts)
+                turn.Parts.Add(new HistoryPartDto { Kind = p.Kind.ToString(), Text = p.Text, ToolName = p.ToolName, ToolId = p.ToolId });
+            turns.Add(turn);
+        }
+        return turns;
+    }
+}

--- a/src/CcDirector.ControlApi/TurnPusher.cs
+++ b/src/CcDirector.ControlApi/TurnPusher.cs
@@ -1,0 +1,451 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// The Director side of the turn-push mission (<c>docs/missions/turn-push-2026-09-01/brief.md</c>): keeps
+/// the Gateway's stored conversation for every session current by PUSHING what it has not seen. Once this
+/// runs, the Gateway never asks a Director to re-read a transcript.
+///
+/// Per session it remembers the generation it last pushed, how far the Gateway's watermark had got, and -
+/// per SOURCE, for the life of this process - when that source was first seen. A run reads the session's
+/// whole conversation once (<see cref="TurnSnapshot"/>), slices from the watermark, sends bounded batches,
+/// and moves the watermark to what the Gateway answered. If the source changed (a /clear, a transcript
+/// that moved into a worktree), it starts a new generation at ordinal zero.
+///
+/// WHY THE START STAMP IS "FIRST SEEN", NOT "NOW". The Gateway switches a session to a generation only when
+/// that generation STARTED LATER than the one it is on. A Director that re-stamped every read with now
+/// could take a stale read of an old source - the pointer moved between the read and the answer - and, on
+/// its next run, hand the old source a newer stamp than the new one, and the Gateway would put the old
+/// conversation back on the reader's screen. First-seen stamps are stable within a process, so an old
+/// source keeps its old stamp however often it is re-read; only a source never seen before gets a fresh,
+/// later one. After a restart the current source is stamped now, which is later than anything, and that is
+/// correct: at restart the current source IS the latest.
+///
+/// TRIGGERS ARE DETERMINISTIC, NOT SAMPLED. The Director fires a run at its own turn-end edge (the same
+/// place it pushes the session delta), on session creation, on every Hello (backfill from the watermarks
+/// the Gateway hands back, and a reset for every session it does NOT hand back), and from a slow safety
+/// sweep that catches anything the edges missed. Runs for one session never overlap: a trigger during a run
+/// marks it pending under the session's lock, and the runner checks that flag under the same lock before
+/// it leaves, so a wake-up cannot be lost. A run is bounded - so many batches per round, so many rounds per
+/// call - so a session that never stops changing cannot hold the sweep hostage.
+///
+/// Built on delegates, not on the session manager or the stream client directly, so every branch is tested
+/// with a fake conversation and a fake Gateway.
+/// </summary>
+public sealed class TurnPusher : IAsyncDisposable
+{
+    /// <summary>How often the safety sweep visits every session. A minute: late enough to cost nothing on
+    /// an idle fleet, soon enough that a missed edge is corrected before anyone notices.</summary>
+    public static readonly TimeSpan DefaultSweepInterval = TimeSpan.FromMinutes(1);
+
+    /// <summary>The most batches one round sends before it stops. A long backfill goes round again on the
+    /// next trigger or sweep rather than holding one run open for minutes.</summary>
+    public const int MaxBatchesPerRound = 20;
+
+    /// <summary>The most rounds one call makes for one session before it yields, even if triggers keep
+    /// arriving. What is still pending is picked up by the next trigger or the sweep.</summary>
+    public const int MaxRoundsPerCall = 3;
+
+    /// <summary>Turns per push, the Gateway's own ceiling.</summary>
+    public const int BatchSize = 500;
+
+    private sealed class SessionState
+    {
+        // Every field is read and written under lock (this).
+        public string? Generation;
+        public int Pushed;
+        public string? LastHistoryState;
+        public bool SentUnsupported;
+        public string? RefusedGeneration;
+        public bool Pending;
+        public bool Running;
+        /// <summary>The sweep has taken this state out of the table. A caller holding it must drop it and take
+        /// a fresh one, so a run can never attach to a state nothing can find.</summary>
+        public bool Retired;
+        /// <summary>The latest stamp this session has issued, so the next one can be made strictly later.</summary>
+        public DateTime LastStampUtc;
+        /// <summary>Source -> when this process first saw it for this session. Never overwritten.</summary>
+        public readonly Dictionary<string, DateTime> FirstSeen = new(StringComparer.Ordinal);
+    }
+
+    private readonly Func<IReadOnlyCollection<Guid>> _sessionIds;
+    private readonly Func<Guid, TurnSnapshot?> _snapshot;
+    private readonly Func<TurnPushBatch, CancellationToken, Task<TurnWatermark?>> _push;
+    private readonly Func<bool> _canPush;
+    private readonly Func<DateTime> _clock;
+    private readonly ConcurrentDictionary<Guid, SessionState> _states = new();
+    private readonly CancellationTokenSource _stopping = new();
+    private readonly TimeSpan _sweepInterval;
+    private Task? _sweepLoop;
+
+    /// <param name="sessionIds">The live sessions to sweep.</param>
+    /// <param name="snapshot">The session's conversation now, or null when the session is gone.</param>
+    /// <param name="push">Send one batch to the Gateway and return its watermark; null when the Gateway
+    /// refused the batch. Throws when the tunnel is down - the run logs and stops, the sweep retries.</param>
+    /// <param name="canPush">Whether the Gateway on the other end has the PushTurns hub method at all. An
+    /// older Gateway does not, and pushing at it would only fill the log.</param>
+    public TurnPusher(
+        Func<IReadOnlyCollection<Guid>> sessionIds,
+        Func<Guid, TurnSnapshot?> snapshot,
+        Func<TurnPushBatch, CancellationToken, Task<TurnWatermark?>> push,
+        Func<bool> canPush,
+        Func<DateTime>? clock = null,
+        TimeSpan? sweepInterval = null)
+    {
+        _sessionIds = sessionIds ?? throw new ArgumentNullException(nameof(sessionIds));
+        _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+        _push = push ?? throw new ArgumentNullException(nameof(push));
+        _canPush = canPush ?? throw new ArgumentNullException(nameof(canPush));
+        _clock = clock ?? (() => DateTime.UtcNow);
+        _sweepInterval = sweepInterval ?? DefaultSweepInterval;
+    }
+
+    /// <summary>
+    /// The Gateway's watermarks, handed back on Hello: what it already holds per session. A FULL
+    /// reconciliation: a session the Gateway lists resumes from its watermark; a session it does not list
+    /// is reset so it is pushed from the start (the Gateway was replaced, or lost its rows). Then a sweep
+    /// brings every live session current.
+    /// </summary>
+    public void SeedWatermarks(IReadOnlyList<TurnWatermark> watermarks)
+    {
+        ArgumentNullException.ThrowIfNull(watermarks);
+        var listed = new HashSet<Guid>();
+        var seeded = 0;
+        foreach (var mark in watermarks)
+        {
+            if (!Guid.TryParse(mark.SessionId, out var sid)) continue;
+            listed.Add(sid);
+            var state = _states.GetOrAdd(sid, _ => new SessionState());
+            lock (state)
+            {
+                state.Generation = mark.Generation;
+                state.Pushed = mark.Count;
+                state.LastHistoryState = null;     // the head's state is unknown to us; the next run refreshes it
+                state.SentUnsupported = false;
+                // The refusal is NOT cleared here. A refusal means the batch was malformed - a bug on this
+                // side - so re-sending the same generation after a reconnect would only be refused again,
+                // every sweep, forever. It clears when the source changes, or on the full reset below.
+            }
+            seeded++;
+        }
+        var reset = 0;
+        foreach (var (sid, state) in _states)
+        {
+            if (listed.Contains(sid)) continue;
+            lock (state)
+            {
+                if (state.Generation is null && state.Pushed == 0) continue;
+                state.Generation = null;
+                state.Pushed = 0;
+                state.LastHistoryState = null;
+                state.SentUnsupported = false;
+                state.RefusedGeneration = null;
+            }
+            reset++;
+        }
+        FileLog.Write($"[TurnPusher] Hello: seeded {seeded} watermark(s) from the Gateway; reset {reset} session(s) it did not list, so they are pushed from the start");
+        _ = SweepAsync(_stopping.Token);
+    }
+
+    /// <summary>Fire-and-forget: bring one session current. Coalesces with a run already in progress.</summary>
+    public void Trigger(Guid sessionId) => _ = PushSessionAsync(sessionId, _stopping.Token);
+
+    /// <summary>Start the safety sweep.</summary>
+    public void Start()
+    {
+        if (_sweepLoop is not null) return;
+        _sweepLoop = Task.Run(async () =>
+        {
+            try
+            {
+                using var timer = new PeriodicTimer(_sweepInterval);
+                while (await timer.WaitForNextTickAsync(_stopping.Token).ConfigureAwait(false))
+                    await SweepAsync(_stopping.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex) { FileLog.Write($"[TurnPusher] sweep loop FAILED: {ex.Message}"); }
+        });
+    }
+
+    /// <summary>Bring every live session current, one after another. Never throws into a timer.</summary>
+    public async Task SweepAsync(CancellationToken ct = default)
+    {
+        if (!_canPush()) return;
+        IReadOnlyCollection<Guid> ids;
+        try { ids = _sessionIds(); }
+        catch (Exception ex) { FileLog.Write($"[TurnPusher] sweep could not list sessions: {ex.Message}"); return; }
+        foreach (var sid in ids)
+        {
+            if (ct.IsCancellationRequested) return;
+            await PushSessionAsync(sid, ct).ConfigureAwait(false);
+        }
+        // Forget sessions that no longer exist, so the state table does not grow for the life of the process.
+        // NEVER a session that is mid-run or has a trigger waiting: dropping its state would lose its
+        // watermark, and the next run would re-push the whole conversation from ordinal zero.
+        //
+        // RETIRE-THEN-REMOVE, because a check followed by a removal is not atomic and a trigger can arrive
+        // between the two (found in review). The flag is set under the same lock a trigger takes, so exactly
+        // one of them wins: either the sweep retires the state and the trigger goes and takes a fresh one, or
+        // the trigger claims it first and the sweep leaves it alone.
+        foreach (var (known, state) in _states)
+        {
+            if (ids.Contains(known)) continue;
+            var retire = false;
+            lock (state)
+            {
+                if (!state.Running && !state.Pending && !state.Retired)
+                    retire = state.Retired = true;
+            }
+            if (retire) _states.TryRemove(new KeyValuePair<Guid, SessionState>(known, state));
+        }
+    }
+
+    /// <summary>
+    /// One session's run: read, slice from the watermark, push, move the watermark, until the Gateway holds
+    /// everything or the run's budget is spent. Never overlaps itself for one session; a call during a run
+    /// marks it pending under the lock, and the runner re-checks under the same lock before leaving, so the
+    /// wake-up is never lost. Bounded to <see cref="MaxRoundsPerCall"/> rounds. Never throws.
+    /// </summary>
+    public async Task PushSessionAsync(Guid sessionId, CancellationToken ct = default)
+    {
+        if (!_canPush()) return;
+        SessionState state;
+        while (true)
+        {
+            state = _states.GetOrAdd(sessionId, _ => new SessionState());
+            var claimed = false;
+            lock (state)
+            {
+                if (!state.Retired)
+                {
+                    state.Pending = true;
+                    if (state.Running) return;     // the runner sees Pending before it leaves
+                    state.Running = true;
+                    claimed = true;
+                }
+            }
+            if (claimed) break;
+            // The sweep retired this state between the lookup and the lock. Take it out of the table if it is
+            // still there, and go round for a fresh one.
+            _states.TryRemove(new KeyValuePair<Guid, SessionState>(sessionId, state));
+        }
+        var rounds = 0;
+        // Whether the last round actually got a batch into the Gateway. It gates the hand-off below, so the
+        // hand-off means what its comment says: a round that returned without reaching the Gateway at all
+        // (nothing to send, a refused generation, a session that has gone) does not chain another call.
+        var lastRoundReachedGateway = false;
+        try
+        {
+            while (true)
+            {
+                var handOff = false;
+                var capped = rounds >= MaxRoundsPerCall;
+                lock (state)
+                {
+                    if (!state.Pending)
+                    {
+                        state.Running = false;
+                        return;
+                    }
+                    if (capped)
+                    {
+                        // This call has had its rounds but work is still outstanding. Release the session, and
+                        // if the last round actually reached the Gateway hand the rest to a fresh call at
+                        // once - otherwise a trigger that arrived during the final round would wait out the
+                        // minute-long sweep (found in review). After a FAILED round the hand-off is skipped on
+                        // purpose: a dead tunnel would otherwise be retried in a tight chain of calls, and the
+                        // sweep's minute is the right pace at which to wait for it to come back. The same
+                        // applies to a round that never reached the Gateway for any other reason.
+                        state.Running = false;
+                        handOff = lastRoundReachedGateway;
+                    }
+                    else state.Pending = false;
+                }
+                if (capped)
+                {
+                    if (handOff) _ = Task.Run(() => PushSessionAsync(sessionId, ct), ct);
+                    return;
+                }
+                rounds++;
+                lastRoundReachedGateway = false;
+                try
+                {
+                    var round = await RunOnceAsync(sessionId, state, ct).ConfigureAwait(false);
+                    lastRoundReachedGateway = round.ReachedGateway;
+                    // The round stopped on its batch budget with more of this conversation still to send.
+                    // Mark it pending so the next round carries on at once: a long backfill should not be
+                    // paid out one round per minute of sweep (found in review).
+                    if (round.MoreToSend) lock (state) { state.Pending = true; }
+                }
+                catch (OperationCanceledException) { lock (state) { state.Running = false; } return; }
+                catch (Exception ex)
+                {
+                    // A dropped tunnel mid-push lands here. Nothing is lost: the watermark the Gateway holds is
+                    // the truth, and the next round resumes from whatever it answers.
+                    //
+                    // It goes BACK ROUND rather than returning. A trigger that arrived while this round was
+                    // failing has set Pending, and returning here would clear the run without anyone consuming
+                    // it - the turn would then wait for the next trigger or the minute-long sweep (found in
+                    // review). The round cap bounds this, so a persistently failing push cannot spin.
+                    FileLog.Write($"[TurnPusher] push for session={sessionId} stopped: {ex.Message}; resuming from the Gateway's watermark");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[TurnPusher] run for session={sessionId} FAILED: {ex.Message}");
+            lock (state) { state.Running = false; }
+        }
+    }
+
+    /// <summary>What one round did: whether it got a batch into the Gateway (which is what makes handing the
+    /// rest to a fresh call worth doing), and whether it stopped with more of this conversation still to
+    /// send (which is what makes the next round worth running at once).</summary>
+    private readonly record struct RoundResult(bool ReachedGateway, bool MoreToSend);
+
+    private async Task<RoundResult> RunOnceAsync(Guid sessionId, SessionState state, CancellationToken ct)
+    {
+        var snap = _snapshot(sessionId);
+        if (snap is null) return default;
+
+        // Take a consistent copy of the state for this round, and apply the generation change under the lock.
+        int pushed; DateTime started; string? lastHistoryState; bool sentUnsupported; bool refused;
+        lock (state)
+        {
+            if (!string.Equals(state.Generation, snap.Generation, StringComparison.Ordinal))
+            {
+                FileLog.Write($"[TurnPusher] session={sessionId}: generation {(state.Generation is null ? "starts" : "changed")} -> {Short(snap.Generation)}; pushing from ordinal 0");
+                state.Generation = snap.Generation;
+                state.Pushed = 0;
+                state.SentUnsupported = false;
+                state.LastHistoryState = null;
+            }
+            if (!state.FirstSeen.TryGetValue(snap.Generation, out started))
+            {
+                // STRICTLY later than every stamp this session has already issued. The Gateway switches only
+                // to a LATER generation, so a clock that has not moved since the last source - or has moved
+                // BACKWARDS - would mint a stamp that could never win, and the session would be stuck on the
+                // old conversation (found in review). A millisecond, because that is the precision the store
+                // compares at.
+                started = _clock();
+                if (started <= state.LastStampUtc)
+                    started = state.LastStampUtc + TimeSpan.FromMilliseconds(1);
+                state.LastStampUtc = started;
+                state.FirstSeen[snap.Generation] = started;
+            }
+            pushed = state.Pushed;
+            lastHistoryState = state.LastHistoryState;
+            sentUnsupported = state.SentUnsupported;
+            refused = string.Equals(state.RefusedGeneration, snap.Generation, StringComparison.Ordinal);
+        }
+        if (refused) return default;   // the Gateway refused this generation once; a re-send would be the same batch. Logged then.
+
+        if (!snap.IsSupported)
+        {
+            // Nothing to push and nothing that will ever change here, but the Gateway needs the head once so
+            // it can answer "unsupported" for this session instead of "nothing has arrived yet".
+            if (sentUnsupported) return default;
+            var answer = await _push(NewBatch(snap, started, 0, Array.Empty<PushedTurn>()), ct).ConfigureAwait(false);
+            lock (state) { if (answer is not null) state.SentUnsupported = true; else state.RefusedGeneration = snap.Generation; }
+            return new RoundResult(answer is not null, MoreToSend: false);
+        }
+
+        var total = snap.Turns.Count;
+        if (pushed > total)
+        {
+            // The same source has FEWER messages than the Gateway already holds. A transcript file does not
+            // shrink in the ordinary course of things; if it did, the rows the Gateway holds are the record of
+            // what was said, and re-numbering them would lie about it. Say so and wait for it to grow again.
+            FileLog.Write($"[TurnPusher] session={sessionId}: source {Short(snap.Generation)} now holds {total} message(s) but the Gateway holds {pushed}; not re-pushing until it grows");
+            return default;
+        }
+
+        var reached = false;
+        var batches = 0;
+        while (pushed < total && batches < MaxBatchesPerRound)
+        {
+            ct.ThrowIfCancellationRequested();
+            var count = Math.Min(BatchSize, total - pushed);
+            var slice = new PushedTurn[count];
+            for (var i = 0; i < count; i++) slice[i] = snap.Turns[pushed + i];
+            var mark = await _push(NewBatch(snap, started, pushed, slice), ct).ConfigureAwait(false);
+            batches++;
+            if (mark is null)
+            {
+                FileLog.Write($"[TurnPusher] session={sessionId}: the Gateway refused a batch from ordinal {pushed} of generation {Short(snap.Generation)}; not re-sending this generation (a refusal means the batch was malformed - a bug here, not a fault there)");
+                lock (state) { state.RefusedGeneration = snap.Generation; }
+                return new RoundResult(reached, MoreToSend: false);
+            }
+            if (!string.Equals(mark.Generation, snap.Generation, StringComparison.Ordinal))
+            {
+                // The Gateway is on a LATER source than the one just read - this read was already stale by the
+                // time it arrived. Adopt the Gateway's view and stop; the next trigger re-reads. NOT marked
+                // pending: going round again at once would re-read the same source and get the same answer.
+                // And because this source keeps its first-seen stamp, a later re-read of it cannot outrank the
+                // generation the Gateway is on.
+                FileLog.Write($"[TurnPusher] session={sessionId}: the Gateway is on generation {Short(mark.Generation)} (watermark {mark.Count}), not the one just pushed; the next trigger re-reads");
+                lock (state) { state.Generation = mark.Generation; state.Pushed = mark.Count; }
+                return new RoundResult(ReachedGateway: true, MoreToSend: false);
+            }
+            reached = true;
+            var before = pushed;
+            pushed = mark.Count;
+            lock (state) { state.Pushed = pushed; state.LastHistoryState = snap.HistoryState; }
+            lastHistoryState = snap.HistoryState;
+            if (pushed <= before)
+            {
+                // The Gateway did not advance past where this batch started: an earlier batch was lost and it
+                // answered where it wants us to resume. The loop continues from there, bounded by the round's
+                // batch budget, so a Gateway that never advances cannot spin this round forever.
+                FileLog.Write($"[TurnPusher] session={sessionId}: the Gateway's watermark is {pushed} after a push from {before}; resuming from there");
+            }
+        }
+
+        // Nothing new to send, but the transcript-derived state moved (a background agent started or stopped
+        // between turns). The head carries it, so push an empty batch to refresh it.
+        if (pushed == total && !string.Equals(lastHistoryState, snap.HistoryState, StringComparison.Ordinal))
+        {
+            var answer = await _push(NewBatch(snap, started, total, Array.Empty<PushedTurn>()), ct).ConfigureAwait(false);
+            lock (state)
+            {
+                if (answer is not null) state.LastHistoryState = snap.HistoryState;
+                else state.RefusedGeneration = snap.Generation;   // a refusal here is a malformed head - same treatment
+            }
+            reached |= answer is not null;
+        }
+
+        // More to send means the batch budget ran out, not that anything is wrong: the caller runs another
+        // round rather than leaving the rest to the sweep.
+        return new RoundResult(reached, MoreToSend: pushed < total);
+    }
+
+    private static TurnPushBatch NewBatch(TurnSnapshot snap, DateTime started, int startOrdinal, IReadOnlyList<PushedTurn> turns) => new()
+    {
+        SessionId = snap.SessionId,
+        Generation = snap.Generation,
+        GenerationStartedUtc = started,
+        Agent = snap.Agent,
+        IsSupported = snap.IsSupported,
+        IsRawText = snap.IsRawText,
+        HistoryState = snap.HistoryState,
+        StartOrdinal = startOrdinal,
+        TotalCount = snap.Turns.Count,
+        Turns = turns.ToList(),
+    };
+
+    private static string Short(string generation)
+        => generation.Length <= 40 ? generation : "..." + generation[^40..];
+
+    public async ValueTask DisposeAsync()
+    {
+        _stopping.Cancel();
+        if (_sweepLoop is not null)
+        {
+            try { await _sweepLoop.ConfigureAwait(false); } catch (Exception) { }
+        }
+        _stopping.Dispose();
+    }
+}

--- a/src/CcDirector.Core/History/SessionHistoryReader.cs
+++ b/src/CcDirector.Core/History/SessionHistoryReader.cs
@@ -81,6 +81,33 @@ public static class SessionHistoryReader
     public static ConversationHistory Read(Session session) => ReadAll(session).MainThread;
 
     /// <summary>
+    /// The main-thread history read from a transcript path the CALLER already resolved. Exists so a caller
+    /// that needs the path for something else (the turn push labels the messages with it as their
+    /// generation, and derives the history state from the same file) reads the messages from THAT file -
+    /// resolving twice could label one file's messages with another's identity if the pointer moved in
+    /// between. Gemini ignores the path (its history is its terminal buffer); the store-backed agents read
+    /// by repository as always.
+    /// </summary>
+    public static ConversationHistory Read(Session session, string? resolvedPath)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        // No blanket null-path check: Copilot and OpenCode read a store BY REPOSITORY and never needed the
+        // path, so cutting them off above would have made them permanently empty here while ReadAll still
+        // answered (found in review). Each file-backed arm tests the path itself.
+        return (session.AgentKind switch
+        {
+            AgentKind.Gemini => GeminiTerminalHistory.FromBuffer(session.Buffer),
+            AgentKind.Copilot => CopilotHistoryReader.Read(session.RepoPath),
+            AgentKind.OpenCode => OpenCodeHistoryReader.Read(session.RepoPath),
+            AgentKind.ClaudeCode when resolvedPath is not null => ClaudeTranscriptReader.Read(resolvedPath),
+            AgentKind.Codex when resolvedPath is not null => CodexTranscriptReader.Read(resolvedPath),
+            AgentKind.Pi when resolvedPath is not null => PiTranscriptReader.Read(resolvedPath),
+            AgentKind.Grok when resolvedPath is not null => GrokTranscriptReader.Read(resolvedPath),
+            _ => ConversationHistory.Empty,
+        }).MainThread;
+    }
+
+    /// <summary>
     /// Everything the source holds, unfiltered - including nested subagent turns, meta lines, and
     /// lines carrying only token usage. Prefer <see cref="Read"/> unless you specifically need those.
     /// </summary>

--- a/src/CcDirector.Gateway.Contracts/GatewayCapabilities.cs
+++ b/src/CcDirector.Gateway.Contracts/GatewayCapabilities.cs
@@ -52,4 +52,21 @@ public sealed class GatewayCapabilities
     /// methods added after this type was written without needing a new field for each one.
     /// </summary>
     public List<string> HubMethods { get; set; } = new();
+
+    /// <summary>
+    /// What the Gateway already holds of each of this Director's sessions' conversations (the turn-push
+    /// mission): one watermark per session it has stored turns for. A reconnecting Director resends only
+    /// what is above these; a Director this Gateway has never heard from gets an empty list and sends
+    /// everything. Empty from a Gateway built before the store existed.
+    /// </summary>
+    public List<TurnWatermark> TurnWatermarks { get; set; } = new();
+
+    /// <summary>
+    /// Whether <see cref="TurnWatermarks"/> is an ANSWER rather than a silence. True when the Gateway read
+    /// its store, even if the answer was "nothing for you" - which is a real fact a Director acts on, by
+    /// pushing every conversation from the start. False when it could not read (or has no store at all, or
+    /// is too old to have one), which is NOT that fact: a Director that treated the two alike would re-push
+    /// every conversation it has on any database hiccup.
+    /// </summary>
+    public bool TurnWatermarksKnown { get; set; }
 }

--- a/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/Data/PostgresProviderProofTests.cs
@@ -187,7 +187,10 @@ public sealed class PostgresProviderProofTests
             "ORDER BY c.relname, a.attname");
 
         // One entry per UseCollation("C") declaration in GatewayDbContext, read back from the live catalog.
-        // 21 declarations, 21 columns - verified one-to-one against the model on 2026-08-11.
+        // 25 declarations, 25 columns - verified one-to-one against the model on 2026-09-02, when the four
+        // turn-push columns were added (they were added to the model on 1 September and this list was not
+        // updated with them, so the suite was red on main in between - the third time this enumeration has
+        // gone stale, and the third time it did its job).
         // It went stale a second time between 2026-07-31 and now: the two session_keys columns arrived with
         // the remove-the-network-port change (#2450) and this list was not updated, so the suite was red on
         // main from 2026-08-05 and stayed red through the v2.0.0 and v2.0.1 tags. Being environment-gated is
@@ -209,6 +212,13 @@ public sealed class PostgresProviderProofTests
             ("session_keys", "KeyHash"),
             ("session_keys", "SessionId"),
             ("session_spend", "SessionId"),
+            // The stored conversation's natural keys (the turn-push mission): the session id, and the
+            // generation digest that identifies which transcript source a row belongs to. Both are compared
+            // and keyed byte-ordinally, the same reason session_history.SessionId above is pinned.
+            ("session_turn_heads", "Generation"),
+            ("session_turn_heads", "SessionId"),
+            ("session_turns", "Generation"),
+            ("session_turns", "SessionId"),
             ("skill_tenant_overrides", "SkillId"),
             ("skills", "Id"),
             ("snoozes", "SessionId"),

--- a/src/CcDirector.Gateway.UnitTests/DirectorHubTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/DirectorHubTests.cs
@@ -61,6 +61,105 @@ public sealed class DirectorHubTests : IDisposable
         return (hub, ctx);
     }
 
+    private (DirectorHub hub, FakeHubCallerContext ctx) NewHub(string connectionId, CcDirector.Gateway.History.SessionTurnStore turns)
+    {
+        var ctx = new FakeHubCallerContext(connectionId);
+        var hub = new DirectorHub(_store, _registry, InputStatsHandle.Available(_inputStats), new GatewayStreamRegistry(), SelfHostBoundary(), sessionTurns: turns) { Context = ctx };
+        return (hub, ctx);
+    }
+
+    // ---------- Turn push (the turn-push mission, phase 1): PushTurns stores, Hello hands back the watermarks ----------
+
+    private static TurnPushBatch Turns(string sid, string generation, int start, int count) => new()
+    {
+        SessionId = sid,
+        Generation = generation,
+        GenerationStartedUtc = new DateTime(2026, 9, 1, 20, 0, 0, DateTimeKind.Utc),
+        Agent = "ClaudeCode",
+        StartOrdinal = start,
+        TotalCount = start + count,
+        Turns = Enumerable.Range(start, count).Select(i => new PushedTurn
+        {
+            Ordinal = i,
+            Role = i % 2 == 0 ? "User" : "Assistant",
+            Parts = { new HistoryPartDto { Kind = "Text", Text = "m" + i } },
+        }).ToList(),
+    };
+
+    [Fact]
+    public void PushTurns_AfterHello_StoresTheTurns_AndAnswersTheWatermark()
+    {
+        var turns = new CcDirector.Gateway.History.SessionTurnStore(Db);
+        var (hub, _) = NewHub("conn-1", turns);
+        hub.Hello(Hello("dir-A"));
+
+        var mark = hub.PushTurns(1, Turns("s1", "gen-a", 0, 3));
+
+        Assert.NotNull(mark);
+        Assert.Equal(3, mark.Count);
+        var stored = turns.ReadCurrent("s1");
+        Assert.NotNull(stored);
+        Assert.Equal(new[] { "m0", "m1", "m2" }, stored.Value.Messages.Select(m => m.Parts[0].Text));
+        Assert.Equal("dir-A", stored.Value.Head.DirectorId);   // attributed to the BOUND Director, not to anything in the batch
+    }
+
+    [Fact]
+    public void PushTurns_AMalformedBatch_IsRefused_AndNothingIsStored()
+    {
+        var turns = new CcDirector.Gateway.History.SessionTurnStore(Db);
+        var (hub, _) = NewHub("conn-1", turns);
+        hub.Hello(Hello("dir-A"));
+        var bad = Turns("s1", "gen-a", 0, 2);
+        bad.Turns[1].Ordinal = 9;   // disagrees with its own position
+
+        Assert.Null(hub.PushTurns(1, bad));
+        Assert.Null(turns.ReadCurrent("s1"));
+    }
+
+    [Fact]
+    public void Hello_HandsBackTheWatermarks_ForThisDirectorsSessionsOnly()
+    {
+        var turns = new CcDirector.Gateway.History.SessionTurnStore(Db);
+        var (hubA, _) = NewHub("conn-1", turns);
+        hubA.Hello(Hello("dir-A"));
+        hubA.PushTurns(1, Turns("s1", "gen-a", 0, 2));
+        hubA.PushTurns(2, Turns("s2", "gen-b", 0, 5));
+        var (hubB, _) = NewHub("conn-2", turns);
+        hubB.Hello(Hello("dir-B"));
+        hubB.PushTurns(1, Turns("s3", "gen-c", 0, 1));
+
+        var again = hubA.Hello(Hello("dir-A"));
+
+        Assert.NotNull(again);
+        var marks = again.TurnWatermarks.OrderBy(m => m.SessionId).ToList();
+        Assert.Equal(new[] { "s1", "s2" }, marks.Select(m => m.SessionId));
+        Assert.Equal(new[] { 2, 5 }, marks.Select(m => m.Count));
+        Assert.Equal(new[] { "gen-a", "gen-b" }, marks.Select(m => m.Generation));
+        Assert.Contains("PushTurns", again.HubMethods);
+        Assert.True(again.TurnWatermarksKnown);
+    }
+
+    [Fact]
+    public void Hello_WithNothingStoredForThisDirector_SaysSo_RatherThanStayingSilent()
+    {
+        // An empty list that the Gateway VOUCHES for is a fact the Director acts on: it pushes every
+        // conversation from the start. A Gateway with no store at all must not look like that.
+        var turns = new CcDirector.Gateway.History.SessionTurnStore(Db);
+        var (withStore, _) = NewHub("conn-1", turns);
+        var answered = withStore.Hello(Hello("dir-A"));
+
+        Assert.NotNull(answered);
+        Assert.Empty(answered.TurnWatermarks);
+        Assert.True(answered.TurnWatermarksKnown);
+
+        var (noStore, _) = NewHub("conn-2");
+        var silent = noStore.Hello(Hello("dir-B"));
+
+        Assert.NotNull(silent);
+        Assert.Empty(silent.TurnWatermarks);
+        Assert.False(silent.TurnWatermarksKnown);
+    }
+
     private (DirectorHub hub, FakeHubCallerContext ctx) NewHub(string connectionId, SnoozeLandingObserver snooze)
     {
         var ctx = new FakeHubCallerContext(connectionId);

--- a/src/CcDirector.Gateway.UnitTests/GatewayCapabilityHandshakeTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/GatewayCapabilityHandshakeTests.cs
@@ -127,7 +127,7 @@ public class GatewayCapabilityHandshakeTests
             HubMethods = new List<string>
             {
                 "Hello", "RegisterSessionKey", "RevokeSessionKey",
-                "PushSnapshot", "PushDelta", "PushRepoSnapshot",
+                "PushSnapshot", "PushDelta", "PushRepoSnapshot", "PushTurns",
             },
         });
 
@@ -157,7 +157,7 @@ public class GatewayCapabilityHandshakeTests
             HubMethods = new List<string>
             {
                 "Hello", "RegisterSessionKey", "RevokeSessionKey",
-                "PushSnapshot", "PushDelta", "PushRepoSnapshot",
+                "PushSnapshot", "PushDelta", "PushRepoSnapshot", "PushTurns",
             },
         });
 

--- a/src/CcDirector.Gateway.UnitTests/TurnPusherTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TurnPusherTests.cs
@@ -1,0 +1,527 @@
+using CcDirector.ControlApi;
+using CcDirector.Core.History;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Phase 1 of the turn-push mission, Director side: <see cref="TurnPusher"/> against a fake conversation
+/// and a fake Gateway. Pins: a first push sends everything from ordinal zero; a later push sends only what
+/// the watermark says is missing; a changed source starts a new generation; the Gateway's watermark (not
+/// the Director's count) is the truth after every push; a refusal stops the run; a tunnel failure stops the
+/// run without losing anything; a seeded watermark resumes; an unsupported agent sends its head once; a
+/// changed history state refreshes the head; runs for one session never overlap.
+/// </summary>
+public sealed class TurnPusherTests
+{
+    private static readonly DateTime Now = new(2026, 9, 1, 21, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>A Gateway that stores nothing but remembers every batch and answers like the real store
+    /// would for the ordinary case: watermark = start + count, generation = what was sent.</summary>
+    private sealed class FakeGateway
+    {
+        public readonly List<TurnPushBatch> Received = new();
+        public Func<TurnPushBatch, TurnWatermark?>? Answer;
+        public Exception? ThrowNext;
+        public Task<TurnWatermark?> Push(TurnPushBatch b, CancellationToken ct)
+        {
+            if (ThrowNext is { } ex) { ThrowNext = null; throw ex; }
+            Received.Add(b);
+            // A configured Answer that returns null IS the refusal; only an unconfigured fake answers by default.
+            var answer = Answer is null
+                ? new TurnWatermark { SessionId = b.SessionId, Generation = b.Generation, Count = b.StartOrdinal + b.Turns.Count }
+                : Answer(b);
+            return Task.FromResult(answer);
+        }
+    }
+
+    private static PushedTurn T(int i) => new() { Ordinal = i, Role = i % 2 == 0 ? "User" : "Assistant", Parts = { new HistoryPartDto { Kind = "Text", Text = "m" + i } } };
+
+    private static TurnSnapshot Snap(Guid sid, string generation, int count, string? state = null, bool supported = true) =>
+        new(sid.ToString(), generation, "ClaudeCode", supported, false, state, Enumerable.Range(0, count).Select(T).ToList());
+
+    private static (TurnPusher pusher, FakeGateway gw) Build(Guid sid, Func<TurnSnapshot?> snapshot, bool canPush = true)
+    {
+        var gw = new FakeGateway();
+        var pusher = new TurnPusher(() => new[] { sid }, _ => snapshot(), gw.Push, () => canPush, () => Now);
+        return (pusher, gw);
+    }
+
+    [Fact]
+    public async Task AFirstRun_PushesEverythingFromOrdinalZero_InBoundedBatches()
+    {
+        var sid = Guid.NewGuid();
+        var (pusher, gw) = Build(sid, () => Snap(sid, @"C:\t\a.jsonl", 1200));
+
+        await pusher.PushSessionAsync(sid);
+
+        Assert.Equal(3, gw.Received.Count);
+        Assert.Equal(new[] { 0, 500, 1000 }, gw.Received.Select(b => b.StartOrdinal));
+        Assert.Equal(new[] { 500, 500, 200 }, gw.Received.Select(b => b.Turns.Count));
+        Assert.All(gw.Received, b => Assert.Equal(1200, b.TotalCount));
+        Assert.All(gw.Received, b => Assert.Equal(Now, b.GenerationStartedUtc));
+        Assert.All(gw.Received, b => Assert.Equal(@"C:\t\a.jsonl", b.Generation));
+    }
+
+    [Fact]
+    public async Task ALaterRun_PushesOnlyWhatIsMissing()
+    {
+        var sid = Guid.NewGuid();
+        var count = 3;
+        var (pusher, gw) = Build(sid, () => Snap(sid, "g", count));
+        await pusher.PushSessionAsync(sid);
+        gw.Received.Clear();
+
+        count = 5;
+        await pusher.PushSessionAsync(sid);
+
+        var b = Assert.Single(gw.Received);
+        Assert.Equal(3, b.StartOrdinal);
+        Assert.Equal(new[] { 3, 4 }, b.Turns.Select(t => t.Ordinal));
+    }
+
+    [Fact]
+    public async Task NothingNew_PushesNothing()
+    {
+        var sid = Guid.NewGuid();
+        var (pusher, gw) = Build(sid, () => Snap(sid, "g", 3));
+        await pusher.PushSessionAsync(sid);
+        gw.Received.Clear();
+
+        await pusher.PushSessionAsync(sid);
+
+        Assert.Empty(gw.Received);
+    }
+
+    [Fact]
+    public async Task AChangedSource_StartsANewGeneration_FromOrdinalZero_WithANewStart()
+    {
+        // /clear, or the transcript moved into a worktree.
+        var sid = Guid.NewGuid();
+        var generation = "old";
+        var (pusher, gw) = Build(sid, () => Snap(sid, generation, 4));
+        await pusher.PushSessionAsync(sid);
+        gw.Received.Clear();
+
+        generation = "new";
+        await pusher.PushSessionAsync(sid);
+
+        var b = Assert.Single(gw.Received);
+        Assert.Equal("new", b.Generation);
+        Assert.Equal(0, b.StartOrdinal);
+        Assert.Equal(4, b.Turns.Count);
+    }
+
+    [Fact]
+    public async Task TheGatewaysWatermark_IsTheTruth_NotTheDirectorsCount()
+    {
+        // The Gateway answers a LOWER watermark than what was sent (an earlier batch was lost, so the prefix
+        // stops short). The Director must resume from the Gateway's number, not its own.
+        var sid = Guid.NewGuid();
+        var (pusher, gw) = Build(sid, () => Snap(sid, "g", 10));
+        var answers = 0;
+        gw.Answer = b => new TurnWatermark { SessionId = b.SessionId, Generation = b.Generation, Count = answers++ == 0 ? 4 : b.StartOrdinal + b.Turns.Count };
+
+        await pusher.PushSessionAsync(sid);
+
+        // First push 0..9 answered 4; the run goes round again and resends from 4.
+        Assert.Equal(2, gw.Received.Count);
+        Assert.Equal(0, gw.Received[0].StartOrdinal);
+        Assert.Equal(4, gw.Received[1].StartOrdinal);
+    }
+
+    [Fact]
+    public async Task TheGatewayOnALaterGeneration_StopsTheRun_AndAdoptsItsView()
+    {
+        var sid = Guid.NewGuid();
+        var (pusher, gw) = Build(sid, () => Snap(sid, "stale-read", 3));
+        gw.Answer = _ => new TurnWatermark { SessionId = sid.ToString(), Generation = "later-source", Count = 7 };
+
+        await pusher.PushSessionAsync(sid);
+
+        // One push, then it stopped (it did not keep pushing "stale-read" batches at a Gateway that has moved on).
+        Assert.Single(gw.Received);
+    }
+
+    [Fact]
+    public async Task ARefusedBatch_StopsTheRun()
+    {
+        var sid = Guid.NewGuid();
+        var (pusher, gw) = Build(sid, () => Snap(sid, "g", 1200));
+        gw.Answer = _ => null;
+
+        await pusher.PushSessionAsync(sid);
+
+        Assert.Single(gw.Received);
+    }
+
+    [Fact]
+    public async Task ATunnelFailure_StopsTheRunWithoutThrowing_AndTheNextRunResumes()
+    {
+        var sid = Guid.NewGuid();
+        var (pusher, gw) = Build(sid, () => Snap(sid, "g", 700));
+        gw.ThrowNext = new InvalidOperationException("tunnel down");
+
+        await pusher.PushSessionAsync(sid);           // must not throw
+        Assert.Empty(gw.Received);
+
+        await pusher.PushSessionAsync(sid);
+        Assert.Equal(new[] { 0, 500 }, gw.Received.Select(b => b.StartOrdinal));
+    }
+
+    [Fact]
+    public async Task ASeededWatermark_ResumesFromIt_OnTheSameGeneration()
+    {
+        // The Gateway said on Hello: session s, generation g, 3 held. The Director sends from 3.
+        var sid = Guid.NewGuid();
+        var gw = new FakeGateway();
+        var pusher = new TurnPusher(() => new[] { sid }, _ => Snap(sid, "g", 5), gw.Push, () => true, () => Now, sweepInterval: TimeSpan.FromHours(1));
+
+        pusher.SeedWatermarks(new[] { new TurnWatermark { SessionId = sid.ToString(), Generation = "g", Count = 3 } });
+        await Task.Delay(200);   // the seed kicks a sweep
+        if (gw.Received.Count == 0) await pusher.PushSessionAsync(sid);
+
+        var b = gw.Received.First();
+        Assert.Equal(3, b.StartOrdinal);
+        Assert.Equal(2, b.Turns.Count);
+    }
+
+    [Fact]
+    public async Task ASeededWatermark_OnAnotherGeneration_IsReplacedByAFullPush()
+    {
+        var sid = Guid.NewGuid();
+        var gw = new FakeGateway();
+        var pusher = new TurnPusher(() => new[] { sid }, _ => Snap(sid, "current", 2), gw.Push, () => true, () => Now, sweepInterval: TimeSpan.FromHours(1));
+
+        pusher.SeedWatermarks(new[] { new TurnWatermark { SessionId = sid.ToString(), Generation = "previous", Count = 9 } });
+        await Task.Delay(200);
+        if (gw.Received.Count == 0) await pusher.PushSessionAsync(sid);
+
+        var b = gw.Received.First();
+        Assert.Equal("current", b.Generation);
+        Assert.Equal(0, b.StartOrdinal);
+        Assert.Equal(2, b.Turns.Count);
+    }
+
+    [Fact]
+    public async Task AnUnsupportedAgent_SendsItsHeadOnce_AndNoTurns()
+    {
+        var sid = Guid.NewGuid();
+        var (pusher, gw) = Build(sid, () => Snap(sid, "session:" + sid, 0, supported: false));
+
+        await pusher.PushSessionAsync(sid);
+        await pusher.PushSessionAsync(sid);
+
+        var b = Assert.Single(gw.Received);
+        Assert.False(b.IsSupported);
+        Assert.Empty(b.Turns);
+    }
+
+    [Fact]
+    public async Task AChangedHistoryState_WithNoNewTurns_RefreshesTheHead()
+    {
+        var sid = Guid.NewGuid();
+        var state = "Idle";
+        var (pusher, gw) = Build(sid, () => Snap(sid, "g", 2, state));
+        await pusher.PushSessionAsync(sid);
+        gw.Received.Clear();
+
+        state = "BackgroundRunning";
+        await pusher.PushSessionAsync(sid);
+
+        var b = Assert.Single(gw.Received);
+        Assert.Empty(b.Turns);
+        Assert.Equal(2, b.StartOrdinal);
+        Assert.Equal("BackgroundRunning", b.HistoryState);
+    }
+
+    [Fact]
+    public async Task AGatewayWithoutPushTurns_IsNeverPushedAt()
+    {
+        var sid = Guid.NewGuid();
+        var (pusher, gw) = Build(sid, () => Snap(sid, "g", 3), canPush: false);
+
+        await pusher.PushSessionAsync(sid);
+        await pusher.SweepAsync();
+
+        Assert.Empty(gw.Received);
+    }
+
+    [Fact]
+    public async Task RunsForOneSession_NeverOverlap_ButATriggerDuringARun_IsNotLost()
+    {
+        var sid = Guid.NewGuid();
+        var count = 2;
+        var gate = new TaskCompletionSource();
+        var gw = new FakeGateway();
+        var entered = 0;
+        var pusher = new TurnPusher(() => new[] { sid }, _ => Snap(sid, "g", count),
+            async (b, ct) =>
+            {
+                if (Interlocked.Increment(ref entered) == 1) await gate.Task;   // hold the first push open
+                return await gw.Push(b, ct);
+            },
+            () => true, () => Now);
+
+        var first = pusher.PushSessionAsync(sid);
+        await Task.Delay(50);
+        count = 3;                                    // a new turn lands while the first run is mid-push
+        var second = pusher.PushSessionAsync(sid);    // must return at once, marking the run pending
+        Assert.True(second.IsCompleted);
+        gate.SetResult();
+        await first;
+
+        // The first run went round again and pushed the third message; nothing overlapped.
+        Assert.Equal(2, gw.Received.Count);
+        Assert.Equal(new[] { 0, 2 }, gw.Received.Select(b => b.StartOrdinal));
+    }
+
+    [Fact]
+    public async Task AHelloThatDoesNotListASession_ResetsIt_SoItIsPushedFromTheStart()
+    {
+        // The Gateway was replaced or lost its rows: its Hello lists nothing for this session. The Director must
+        // not go on believing its old watermark (found in review).
+        var sid = Guid.NewGuid();
+        var gw = new FakeGateway();
+        var pusher = new TurnPusher(() => new[] { sid }, _ => Snap(sid, "g", 4), gw.Push, () => true, () => Now, sweepInterval: TimeSpan.FromHours(1));
+        await pusher.PushSessionAsync(sid);
+        Assert.Equal(4, gw.Received.Single().Turns.Count);
+        gw.Received.Clear();
+
+        pusher.SeedWatermarks(Array.Empty<TurnWatermark>());
+        await Task.Delay(200);
+        if (gw.Received.Count == 0) await pusher.PushSessionAsync(sid);
+
+        var b = gw.Received.First();
+        Assert.Equal(0, b.StartOrdinal);
+        Assert.Equal(4, b.Turns.Count);
+    }
+
+    [Fact]
+    public async Task AnOldSourceReReadLater_KeepsItsFirstSeenStamp_SoItCannotOutrankTheNewerOne()
+    {
+        // The stale-read case (found in review): the Director read old source A, the Gateway answered "I am on
+        // B", and then the Director happens to read A again. A must NOT be re-stamped with a later time than
+        // B's, or the Gateway would switch back to it. First-seen stamps are stable for the process.
+        var sid = Guid.NewGuid();
+        var clockNow = Now;
+        var source = "A";
+        var gw = new FakeGateway();
+        var pusher = new TurnPusher(() => new[] { sid }, _ => Snap(sid, source, 2), gw.Push, () => true, () => clockNow);
+
+        await pusher.PushSessionAsync(sid);                 // A first seen at Now
+        var stampA = gw.Received.Single().GenerationStartedUtc;
+        clockNow = Now.AddMinutes(1);
+        source = "B";
+        await pusher.PushSessionAsync(sid);                 // B first seen at Now+1
+        var stampB = gw.Received.Last().GenerationStartedUtc;
+        clockNow = Now.AddMinutes(2);
+        source = "A";
+        gw.Answer = b => new TurnWatermark { SessionId = sid.ToString(), Generation = "B", Count = 2 };
+        await pusher.PushSessionAsync(sid);                 // a stale re-read of A
+
+        var late = gw.Received.Last();
+        Assert.Equal("A", late.Generation);
+        Assert.Equal(stampA, late.GenerationStartedUtc);    // NOT Now+2
+        Assert.True(stampB > late.GenerationStartedUtc);    // so the Gateway keeps B
+    }
+
+    [Fact]
+    public async Task ARefusedGeneration_IsNotReSentEverySweep()
+    {
+        var sid = Guid.NewGuid();
+        var (pusher, gw) = Build(sid, () => Snap(sid, "g", 3));
+        gw.Answer = _ => null;
+
+        await pusher.PushSessionAsync(sid);
+        await pusher.SweepAsync();
+        await pusher.PushSessionAsync(sid);
+
+        Assert.Single(gw.Received);
+    }
+
+    [Fact]
+    public async Task AConversationThatKeepsGrowingMidRun_IsAllPushed_AndNoCallRunsForever()
+    {
+        // Each push makes more work arrive. One CALL is capped at MaxRoundsPerCall rounds, so it returns to
+        // its caller rather than holding the session (and the sweep) - and because the last round reached the
+        // Gateway, it hands the remainder to a fresh call at once instead of leaving the trigger to wait out
+        // the minute-long sweep (found in review). The whole conversation still lands.
+        var sid = Guid.NewGuid();
+        var count = 1;
+        var grown = 0;
+        var gw = new FakeGateway();
+        TurnPusher? pusher = null;
+        pusher = new TurnPusher(() => new[] { sid }, _ => Snap(sid, "g", count), async (b, ct) =>
+        {
+            if (Interlocked.Increment(ref grown) <= 8) { count++; pusher!.Trigger(sid); }
+            return await gw.Push(b, ct);
+        }, () => true, () => Now);
+
+        var run = pusher.PushSessionAsync(sid);
+        var finished = await Task.WhenAny(run, Task.Delay(5000));
+        Assert.Same(run, finished);        // the call returned; it did not run until the work ran out
+
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < deadline && gw.Received.Count < 9) await Task.Delay(25);
+        // More pushes than one call's round cap allows, so the hand-off chain carried the rest.
+        Assert.True(gw.Received.Count >= 9, $"expected the whole conversation to land, saw {gw.Received.Count} push(es)");
+        Assert.True(gw.Received.Count > TurnPusher.MaxRoundsPerCall, "the remainder must be handed on, not left waiting for the sweep");
+    }
+
+    [Fact]
+    public async Task ABackfillBiggerThanOneRoundsBudget_FinishesInTheSameCall()
+    {
+        // A round stops after MaxBatchesPerRound. The rest of the conversation must carry on in the next
+        // round of the SAME call, not wait a minute for the sweep (found in review).
+        var sid = Guid.NewGuid();
+        var overOneRound = TurnPusher.MaxBatchesPerRound * TurnPusher.BatchSize + TurnPusher.BatchSize;
+        var (pusher, gw) = Build(sid, () => Snap(sid, "g", overOneRound));
+
+        await pusher.PushSessionAsync(sid);
+
+        Assert.Equal(TurnPusher.MaxBatchesPerRound + 1, gw.Received.Count);
+        Assert.Equal(overOneRound, gw.Received.Sum(b => b.Turns.Count));
+    }
+
+    [Fact]
+    public async Task ASessionTheSweepPruned_PushesAgainWhenItComesBack()
+    {
+        // The sweep retires and removes the state of a session that is no longer on the roster. A caller that
+        // was holding that state must not go on using it (nothing can find it any more) - it takes a fresh
+        // one, which pushes from ordinal zero. The store is idempotent, so re-pushing costs nothing.
+        var sid = Guid.NewGuid();
+        var gw = new FakeGateway();
+        IReadOnlyCollection<Guid> ids = new[] { sid };
+        var pusher = new TurnPusher(() => ids, _ => Snap(sid, "g", 2), gw.Push, () => true, () => Now);
+        await pusher.PushSessionAsync(sid);
+        gw.Received.Clear();
+
+        ids = Array.Empty<Guid>();
+        await pusher.SweepAsync();          // gone from the roster: its state is retired and removed
+        ids = new[] { sid };
+        await pusher.PushSessionAsync(sid); // back again: a fresh state, so it pushes from the start
+
+        var b = Assert.Single(gw.Received);
+        Assert.Equal(0, b.StartOrdinal);
+        Assert.Equal(2, b.Turns.Count);
+    }
+
+    [Fact]
+    public async Task ATriggerThatArrivesWhileARoundIsFailing_IsNotLost()
+    {
+        // A turn ends while a push is failing on a dropped tunnel. Returning from the failed round would leave
+        // that trigger set with nobody to consume it, and the turn would wait for the minute-long sweep (found
+        // in review). The call goes round again instead, bounded by the round cap.
+        var sid = Guid.NewGuid();
+        var gw = new FakeGateway();
+        TurnPusher? pusher = null;
+        var attempt = 0;
+        pusher = new TurnPusher(() => new[] { sid }, _ => Snap(sid, "g", 2), async (b, ct) =>
+        {
+            if (Interlocked.Increment(ref attempt) == 1)
+            {
+                pusher!.Trigger(sid);                       // the turn-end edge fires mid-push
+                throw new InvalidOperationException("tunnel dropped mid-push");
+            }
+            return await gw.Push(b, ct);
+        }, () => true, () => Now);
+
+        await pusher.PushSessionAsync(sid);
+
+        var b = Assert.Single(gw.Received);
+        Assert.Equal(2, b.Turns.Count);
+    }
+
+    [Fact]
+    public async Task TheSweep_DoesNotForgetASessionThatIsMidRun()
+    {
+        // The sweep prunes state for sessions that no longer exist. Pruning one that is mid-push would lose its
+        // watermark, and the next run would re-push the whole conversation from ordinal zero (found in review).
+        var sid = Guid.NewGuid();
+        var gate = new TaskCompletionSource();
+        var gw = new FakeGateway();
+        IReadOnlyCollection<Guid> ids = new[] { sid };
+        var pusher = new TurnPusher(() => ids, _ => Snap(sid, "g", 2),
+            async (b, ct) => { await gate.Task; return await gw.Push(b, ct); }, () => true, () => Now);
+
+        var run = pusher.PushSessionAsync(sid);
+        await Task.Delay(50);
+        ids = Array.Empty<Guid>();          // the roster stops listing it while its push is in flight
+        await pusher.SweepAsync();
+        gate.SetResult();
+        await run;
+        ids = new[] { sid };
+        await pusher.PushSessionAsync(sid);  // its watermark survived, so there is nothing left to send
+
+        Assert.Single(gw.Received);
+    }
+
+    [Fact]
+    public async Task EachNewSource_GetsAStrictlyLaterStamp_EvenWhenTheClockDoesNotMove()
+    {
+        // The Gateway switches only to a LATER generation. A clock that has not ticked between two sources -
+        // or has gone backwards - would mint a stamp that could never win, wedging the session on the old
+        // conversation (found in review).
+        var sid = Guid.NewGuid();
+        var source = "A";
+        var frozen = Now;
+        var gw = new FakeGateway();
+        var pusher = new TurnPusher(() => new[] { sid }, _ => Snap(sid, source, 1), gw.Push, () => true, () => frozen);
+
+        await pusher.PushSessionAsync(sid);
+        source = "B";
+        await pusher.PushSessionAsync(sid);
+        frozen = Now.AddMinutes(-5);        // the clock goes BACKWARDS
+        source = "C";
+        await pusher.PushSessionAsync(sid);
+
+        var stamps = gw.Received.Select(b => b.GenerationStartedUtc).ToList();
+        Assert.Equal(3, stamps.Count);
+        Assert.True(stamps[1] > stamps[0], "the second source must start later than the first");
+        Assert.True(stamps[2] > stamps[1], "the third source must start later than the second");
+    }
+
+    [Fact]
+    public async Task ARefusedGeneration_StaysRefused_AcrossAHelloThatListsTheSameGeneration()
+    {
+        // A refusal means the batch was malformed - a bug on this side - so a reconnect must not start
+        // re-sending it every sweep (found in review).
+        var sid = Guid.NewGuid();
+        var (pusher, gw) = Build(sid, () => Snap(sid, "g", 3));
+        gw.Answer = _ => null;
+        await pusher.PushSessionAsync(sid);
+        Assert.Single(gw.Received);
+
+        pusher.SeedWatermarks(new[] { new TurnWatermark { SessionId = sid.ToString(), Generation = "g", Count = 0 } });
+        await Task.Delay(200);
+        await pusher.PushSessionAsync(sid);
+
+        Assert.Single(gw.Received);
+    }
+
+    [Fact]
+    public void Map_ShapesMessagesAsOrdinalTurns_WithTheSamePartsChatRenders()
+    {
+        var messages = new List<ConversationMessage>
+        {
+            new(ConversationRole.User, new[] { new ConversationPart(ConversationPartKind.Text, "hello") }, new DateTimeOffset(Now)),
+            new(ConversationRole.Assistant, new[]
+            {
+                new ConversationPart(ConversationPartKind.Thinking, "hmm"),
+                new ConversationPart(ConversationPartKind.ToolUse, "{}", ToolName: "Read", ToolId: "t1"),
+                new ConversationPart(ConversationPartKind.Text, "hi"),
+            }, ContextId: "ctx-1", IsMeta: false, IsSidechain: false),
+        };
+
+        var turns = TurnPushBuilder.Map(messages);
+
+        Assert.Equal(new[] { 0, 1 }, turns.Select(t => t.Ordinal));
+        Assert.Equal(new[] { "User", "Assistant" }, turns.Select(t => t.Role));
+        Assert.Equal(new[] { "Thinking", "ToolUse", "Text" }, turns[1].Parts.Select(p => p.Kind));
+        Assert.Equal("Read", turns[1].Parts[1].ToolName);
+        Assert.Equal("ctx-1", turns[1].ContextId);
+        Assert.Equal(new DateTimeOffset(Now), turns[0].Timestamp);
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2562,6 +2562,8 @@ public sealed class GatewayHost : IAsyncDisposable
         // Issue #2194: the work-history recorder, so the SignalR-constructed DirectorHub folds every
         // accepted push into the durable session record (throttled inside the recorder).
         builder.Services.AddSingleton(_sessionHistoryRecorder);
+        // The stored conversation (turn-push mission): DirectorHub.PushTurns writes it, Hello reads its watermarks.
+        builder.Services.AddSingleton(_sessionTurns);
         // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store, so the mission endpoints and
         // spawn validation share the one instance.
         builder.Services.AddSingleton(Missions);

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -61,8 +61,10 @@ public sealed class DirectorHub : Hub
         DirectorConnectionRegistry? connections = null,
         PushedRepositoryStore? repositoryStore = null, RepoHistoryStore? repoHistory = null,
         History.SessionHistoryRecorder? sessionHistory = null,
-        Pairing.SessionKeyRegistry? sessionKeys = null)
+        Pairing.SessionKeyRegistry? sessionKeys = null,
+        History.SessionTurnStore? sessionTurns = null)
     {
+        _sessionTurns = sessionTurns;
         _sessionKeys = sessionKeys;
         _store = store;
         _registry = registry;
@@ -92,6 +94,8 @@ public sealed class DirectorHub : Hub
     // Issue #2194: the durable work-history recorder, fed from the same accepted pushes as the other
     // observers. Throttled internally (it is NOT a write per push) and never throws.
     private readonly History.SessionHistoryRecorder? _sessionHistory;
+    /// <summary>The stored conversation (turn-push mission). Null only in tests that do not exercise it.</summary>
+    private readonly History.SessionTurnStore? _sessionTurns;
 
     /// <summary>
     /// A full repository/worktree snapshot from the bound Director (repositories mission, #510
@@ -207,7 +211,83 @@ public sealed class DirectorHub : Hub
         _registry.RegisterFromStream(directorId, hello.MachineName, hello.User, hello.Version, hello.Pid, hello.StartedAt, tenant,
             hello.DisplayName);
         FileLog.Write($"[DirectorHub] Hello: director={directorId} bound to conn={Short(Context.ConnectionId)} (version={hello.Version}, machine={hello.MachineName})");
-        return Capabilities;
+        return CapabilitiesFor(tenant, directorId);
+    }
+
+    /// <summary>
+    /// The shared capability record plus THIS Director's turn watermarks (turn-push mission): what the
+    /// Gateway already holds of each of its sessions' conversations, so a reconnecting Director resends
+    /// only what is missing. Read inside the bound tenant's scope, because the store answers through the
+    /// tenant query filter.
+    /// </summary>
+    private GatewayCapabilities CapabilitiesFor(TenantId tenant, string directorId)
+    {
+        var shared = Capabilities;
+        var answer = new GatewayCapabilities { Version = shared.Version, Commit = shared.Commit, HubMethods = shared.HubMethods };
+        if (_sessionTurns is null) return answer;
+        // BEST EFFORT, and never allowed to throw. Hello is the first thing a Director does on every dial,
+        // and the Director treats a failed Hello as a failed RESEED - so a database that is slow, not open
+        // yet (this Gateway binds its port BEFORE the database is connected), or simply unhappy would stop
+        // the Director pushing its session snapshot at all, and its whole fleet would go missing from every
+        // screen. The watermarks are an optimisation: without them the Director pushes each conversation
+        // from the start, which the store is idempotent about. Losing them costs a little bandwidth once;
+        // losing the reseed costs the roster.
+        try
+        {
+            using var tenantScope = EnterBoundTenantScope();
+            answer.TurnWatermarks = _sessionTurns.WatermarksFor(directorId).ToList();
+            answer.TurnWatermarksKnown = true;
+            if (answer.TurnWatermarks.Count > 0)
+                FileLog.Write($"[DirectorHub] Hello: handing director={directorId} {answer.TurnWatermarks.Count} turn watermark(s) (tenant {tenant.ToLogString()})");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DirectorHub] Hello: could not read turn watermarks for director={directorId} (tenant {tenant.ToLogString()}): {ex.Message}. "
+                        + "Answering with none - the Director will push each conversation from the start, which the store is idempotent about. The reseed is NOT affected.");
+            answer.TurnWatermarks = new List<TurnWatermark>();
+            answer.TurnWatermarksKnown = false;   // a silence, not an answer - the Director keeps what it has
+        }
+        return answer;
+    }
+
+    /// <summary>
+    /// The turn-push mission's one write: a Director pushes a contiguous run of one session's conversation
+    /// messages, and the Gateway stores them (<see cref="History.SessionTurnStore.Append"/>) and answers the
+    /// watermark the Director should continue from. From here Chat, the transcript view, and the wingman
+    /// read the stored rows; the Gateway never asks the Director to re-read the transcript.
+    ///
+    /// The <paramref name="sequence"/> is the Director's push sequence, carried for the log and for
+    /// symmetry with <see cref="PushDelta"/>; ordering inside the conversation is the batch's own ordinals,
+    /// and the store is idempotent, so a batch that arrives twice or late is harmless - a superseded
+    /// connection pushing the same rows again stores nothing new and cannot move the session backwards
+    /// (the store switches generation only to a strictly later source).
+    ///
+    /// Null means REFUSED: the batch disagreed with itself (a Director bug, logged with the reason), or this
+    /// Gateway has no store. The Director stops that run and logs; nothing was written.
+    /// </summary>
+    public TurnWatermark? PushTurns(long sequence, TurnPushBatch batch)
+    {
+        var directorId = RequireBoundDirector();
+        if (_sessionTurns is null)
+        {
+            FileLog.Write($"[DirectorHub] PushTurns ignored (this Gateway has no turn store): director={directorId}");
+            return null;
+        }
+        if (batch is null || string.IsNullOrEmpty(batch.SessionId))
+        {
+            FileLog.Write($"[DirectorHub] PushTurns ignored (no session id): director={directorId}, seq={sequence}");
+            return null;
+        }
+        using var tenantScope = EnterBoundTenantScope();
+        try
+        {
+            return _sessionTurns.Append(directorId, batch, DateTime.UtcNow);
+        }
+        catch (ArgumentException ex)
+        {
+            FileLog.Write($"[DirectorHub] PushTurns REFUSED a malformed batch: director={directorId} session={batch.SessionId} seq={sequence}: {ex.Message}");
+            return null;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Phase 1 of thefrederiksen/devthrottle_internal#1882. Nothing reads the stored conversation yet - Chat moves over in phase 2, the wingman in phase 3 - so no screen behaves differently after this merge.

## What

**Gateway.** `DirectorHub.PushTurns(sequence, batch)` stores a contiguous run of one session's messages through `SessionTurnStore` under the bound tenant and Director, and answers the watermark to continue from. A malformed batch is refused with its reason in the log and nothing is written. `Hello` returns that Director's watermarks on `GatewayCapabilities`, so a reconnect resends only what is missing.

**Director.** `TurnPushBuilder` reads the conversation through the one pointer-following resolver, resolving the transcript path once and using it for the generation, the messages and the history state. `TurnPusher` holds per-session state under a lock, pushes bounded batches from the watermark, and stamps each new source strictly later than the last so a stale read cannot displace the current source. Triggers: the Director's own Working-to-Waiting/Idle edge, any transition to Exited, session creation, every Hello, and a one-minute safety sweep.

**Compatibility.** The pusher checks the Gateway's reported hub methods and never pushes at a Gateway that lacks `PushTurns`.

## Proof

- Twenty-eight `TurnPusher` tests: first push, incremental push, gap handling, generation change, the Gateway's watermark winning over the Director's count, refusal, tunnel failure, seeding and full reconciliation on Hello, unsupported agents, history-state refresh, no overlapping runs, a trigger arriving while a round is failing, sweep pruning that spares a running session, strictly increasing source stamps under a frozen and a backwards clock, a backfill larger than one round's budget finishing in the same call, and a refusal surviving a reconnect.
- Three `DirectorHub` tests: turns stored and attributed to the bound Director, a malformed batch refused with nothing written, and Hello handing back only this Director's watermarks.
- Local gate green on nine suites; the parked `Core.Tests` and `Gateway.Tests` green as well.
- Codex reviewed four times. Findings fixed here: lost triggers on the failure path and at the round cap, two sweep-versus-trigger races, a stale generation that could displace a newer one, incomplete Hello reconciliation, a double transcript resolution, a trigger edge that did not test the previous state, capabilities surviving a disconnect, refusals retried forever, and store-backed agents cut off by a null path check.

## Not proven

Anything live. No reader consumes the stored rows until phase 2, and no Director in the field runs this code until a release carries it.

## What the parked suites caught

Both fixed in this pull request.

- **The Postgres collation proof was stale.** It pins the exact set of natural-key columns carrying byte-ordinal collation. Phase 0 added four and did not update the list, so that suite was red on main in between. The list is updated and the comment records that this is the third time it has gone stale.
- **Reading the store during `Hello` was a real regression.** It put a database call on the critical path of every Director reconnect, and a Director treats a failed `Hello` as a failed reseed - so a slow or not-yet-open database would have stopped it pushing its session snapshot and its sessions would have disappeared from every screen. That is exactly what the interrupt test saw. The read is now best-effort, and `GatewayCapabilities.TurnWatermarksKnown` distinguishes "you have nothing stored" from "I could not check", so a database hiccup no longer makes every Director re-push every conversation.

Parked suites green: `Core.Tests` 4,374 passed; the `Gateway.Tests` classes covering both failures re-run green after every subsequent change.
