### PR TITLE
Turn push, phase 2: Chat reads the conversation from the Gateway

### DIFF
--- a/apps/cockpit/src/sessions/ChatTab.tsx
+++ b/apps/cockpit/src/sessions/ChatTab.tsx
@@ -12,7 +12,7 @@ import { FileViewerModal } from "../components/FileViewerModal";
 const BOTTOM_THRESHOLD_PX = 40;
 
 export function ChatTab({ sessionId }: { sessionId: string | undefined }) {
-  const { bubbles, emptyText, loadFailed, filter, setFilter } = useSessionChat(sessionId);
+  const { bubbles, emptyText, staleNotice, loadFailed, filter, setFilter } = useSessionChat(sessionId);
   const [copied, setCopied] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Local Files (Phase 2): the file path currently being shown in the viewer, or null when closed. A
@@ -77,6 +77,12 @@ export function ChatTab({ sessionId }: { sessionId: string | undefined }) {
       </div>
 
       {error !== null && <div className="composer-error" role="alert">{error}</div>}
+
+      {/* ABOVE the scrolling conversation, not inside it. A long conversation opens at the BOTTOM, so a
+          notice placed at the top of the scroll is exactly where nobody looks (found in review); and it
+          must survive the empty branches too, where the reader is even more in the dark. It is non-null
+          only when there IS a stored conversation, so it never doubles up with the empty-state sentence. */}
+      {staleNotice !== null && <div className="chat-stale" role="status">{staleNotice}</div>}
 
       <div className="chat-stage">
         {loadFailed && bubbles.length === 0 ? (

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -1640,6 +1640,20 @@ body {
   overflow: hidden;
 }
 
+/* A conversation that is real but no longer current: its computer is offline, or too old to send new
+   turns. The words on screen are true; what has stopped being true is that they are up to date. Muted
+   rather than alarming - nothing is broken, and the reader is not being asked to fix anything. */
+.chat-stale {
+  margin: 0 12px 8px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--warn);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--warn) 10%, transparent);
+  color: var(--text-dim);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .chat-empty {
   flex: 1;
   display: flex;

--- a/apps/mobile/src/pages/Chat.tsx
+++ b/apps/mobile/src/pages/Chat.tsx
@@ -24,7 +24,7 @@ export function Chat() {
   const navigate = useNavigate();
 
   const [name, setName] = useState<string | null>(null);
-  const { bubbles, emptyText, loadFailed, filter, setFilter } = useSessionChat(sessionId);
+  const { bubbles, emptyText, staleNotice, loadFailed, filter, setFilter } = useSessionChat(sessionId);
   const [status, setStatus] = useState(STATUS_BASE);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
@@ -129,6 +129,12 @@ export function Chat() {
 
       {/* Live dictation status so a Speak Send from Chat is never silent (#1139). */}
       <DictationStatusStrip sessionId={sessionId} />
+
+      {/* ABOVE the scrolling conversation, not inside it. A long conversation opens at the BOTTOM, so a
+          notice placed at the top of the scroll is exactly where nobody looks (found in review); and it
+          must survive the empty branches too, where the reader is even more in the dark. It is non-null
+          only when there IS a stored conversation, so it never doubles up with the empty-state sentence. */}
+      {staleNotice !== null && <div className="chat-stale" role="status">{staleNotice}</div>}
 
       <div className="chat-stage">
         {loadFailed && bubbles.length === 0 ? (

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1971,6 +1971,20 @@ a.banner-btn {
   overflow: hidden;
 }
 
+/* A conversation that is real but no longer current: its computer is offline, or too old to send new
+   turns. The words on screen are true; what has stopped being true is that they are up to date. Muted
+   rather than alarming - nothing is broken, and the reader is not being asked to fix anything. */
+.chat-stale {
+  margin: 0 12px 8px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--warn);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--warn) 10%, transparent);
+  color: var(--text-dim);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .chat-empty {
   flex: 1;
   display: flex;

--- a/docs/missions/turn-push-2026-09-01/handoff.md
+++ b/docs/missions/turn-push-2026-09-01/handoff.md
@@ -1,29 +1,26 @@
 # Turn push - running handoff note
 
 Read `brief.md` first. This note is the compact state a fresh seat needs; it is rewritten at every
-boundary, never appended to.
+boundary, never appended to. Seats on this mission are named `Turn Push - <Role>`.
 
 - **Branch:** `mission/turn-push`, worktree `D:\ReposFred\devthrottle-turn-push`.
 - **Issue:** thefrederiksen/devthrottle#2638.
-- **Phase 0 (the store): MERGED** to main as pull request 2640. `session_turns` + `session_turn_heads`,
-  migrations on both providers, `SessionTurnStore` (validated batches, one transaction per push with a
-  retry on a lost race, idempotent rows, paged contiguous watermark, generation switch only to a strictly
-  later source with a deterministic tie-break, whole-session retention). Thirty-one tests.
-- **Phase 1 (the Director pushes, the Gateway stores): built, green, four Codex passes.**
-  - Gateway: `DirectorHub.PushTurns(sequence, batch)` writes through the store under the bound tenant and
-    Director and answers the watermark; `Hello` returns this Director's watermarks on `GatewayCapabilities`.
-  - Director: `TurnPushBuilder.Snapshot` reads a session's conversation through the ONE resolver
-    (`SessionHistoryReader`, pointer-first), resolving the path once and using it for the generation, the
-    messages and the history state. `TurnPusher` keeps per-session state under a lock, pushes bounded
-    batches from the watermark, stamps each new source strictly later than the last (so a stale read can
-    never outrank the current source), reconciles fully on Hello, retires state safely against the sweep,
-    and hands outstanding work to a fresh call rather than leaving it for the sweep.
-  - Stream client: `PushTurnsAsync`, `GatewaySupports`, an `onHello` callback, capabilities cleared when
-    the connection drops. Triggers: the Director's own Working-to-Waiting/Idle edge, any-to-Exited,
-    session creation, Hello, and a one-minute safety sweep.
-  - Twenty-eight pusher tests plus three hub tests. Local gate green; the parked run was in progress at
-    the time of writing.
-- **Next: Phase 2** - serve `GET /sessions/{sid}/history` from the store, fold `HistoryState` on the
-  Gateway, and remove `history` from `TunnelCatchAllDispatch`.
-- **Not proven:** anything live. No reader uses the stored rows until Phase 2, so nothing a person sees
-  has changed yet.
+- **Phase 0 (the store): MERGED**, pull request 2640. `session_turns` + `session_turn_heads`, migrations on
+  both providers, `SessionTurnStore`.
+- **Phase 1 (the Director pushes, the Gateway stores): MERGED**, pull request 2645. `DirectorHub.PushTurns`,
+  watermarks on `Hello`, `TurnPushBuilder` + `TurnPusher` on the Director, deterministic triggers.
+- **Phase 2 (Chat reads the store): built, green, two Codex passes.**
+  - `GET /sessions/{sid}/history` is a literal Gateway route served from the store
+    (`SessionConversationEndpoint`), read INSIDE the caller's tenant scope. The `history` entry is gone from
+    `TunnelCatchAllDispatch`, so reading a conversation never travels down the tunnel again.
+  - `SessionConversationFold` decides the whole answer including the sentence an empty screen shows. Six
+    outcomes, ordered: stored content, unsupported agent, unknown session, offline computer, computer too
+    old to send, nothing sent yet, conversation not started.
+  - `TurnPushCapabilityRegistry` records from each `Hello`, per (tenant, Director), whether that build sends
+    conversations - the input that tells "not sent yet" from "that computer cannot send it".
+  - The client renders the Gateway's `emptyText` verbatim and keeps only its own filter line.
+- **Next: Phase 3** - feed the wingman from the store, delete the `turns` tunnel read from the voice path,
+  and rebase the voice retry schedule and Generate button (branch `feat/voice-retry-schedule-then-button`,
+  two Codex findings outstanding) on top of it.
+- **Not proven:** no live run against a real Director and phone yet. The proof so far is unit-level plus the
+  parked suites.

--- a/packages/client-core/src/history/chatView.test.ts
+++ b/packages/client-core/src/history/chatView.test.ts
@@ -45,11 +45,35 @@ describe("renderChatHistory", () => {
     expect(bubbles[0].html).toBe(""); // raw bubbles carry no rendered HTML
   });
 
-  it("reports the unsupported-agent empty text", () => {
-    const h = history([], { isSupported: false });
+  it("renders the Gateway's empty-state sentence verbatim", () => {
+    // The turn-push mission moved this sentence to the Gateway, which knows WHY a conversation is empty:
+    // an agent that keeps no history, a computer that has not sent its conversation, one too old to send
+    // one, one that is offline. The client used to guess between the first two and show "waiting" for all
+    // the rest, which is how a person waits for something that is never coming.
+    const h = history([], { isSupported: false, emptyText: "History is not available for this agent yet." });
     const { bubbles, emptyText } = renderChatHistory(h, ALL_HIDDEN);
     expect(bubbles).toHaveLength(0);
     expect(emptyText).toBe("History is not available for this agent yet.");
+  });
+
+  it("renders whatever sentence the Gateway sends, including ones it has never seen before", () => {
+    // A new reason for an empty screen is added on the Gateway alone; this must not need a client change.
+    const h = history([], { emptyText: "This session's computer is offline, so its conversation has not arrived here." });
+    expect(renderChatHistory(h, ALL_HIDDEN).emptyText)
+      .toBe("This session's computer is offline, so its conversation has not arrived here.");
+  });
+
+  it("falls back to the waiting line only when the Gateway sent no sentence", () => {
+    const h = history([]);
+    expect(renderChatHistory(h, ALL_HIDDEN).emptyText).toBe("Waiting for the conversation to start...");
+  });
+
+  it("keeps its OWN filter line above the Gateway's sentence - the Gateway cannot see the filters", () => {
+    const h = history([{ role: "Assistant", parts: [{ kind: "ToolUse", text: "ls", toolName: "bash" }] }],
+      { emptyText: "This session's computer is offline, so its conversation has not arrived here." });
+    const { bubbles, emptyText } = renderChatHistory(h, ALL_HIDDEN);
+    expect(bubbles).toHaveLength(0);
+    expect(emptyText).toBe("No messages match the current filters.");
   });
 
   it("reports the no-match empty text when everything is filtered out", () => {

--- a/packages/client-core/src/history/chatView.ts
+++ b/packages/client-core/src/history/chatView.ts
@@ -83,9 +83,17 @@ export function chatLinkLabel(text: string): string {
 export function renderChatHistory(history: SessionHistoryDto | null, filter: HistoryBubbleFilter): RenderedHistory {
   const mapped = mapHistory(history, filter);
 
-  let emptyText = "Waiting for the conversation to start...";
-  if (history && history.isSupported === false) emptyText = "History is not available for this agent yet.";
-  else if (mapped.length === 0 && anyHidden(filter) && history && history.messages.length > 0)
+  // THE GATEWAY WRITES THIS SENTENCE (turn-push mission, phase 2). It used to be guessed here from a
+  // boolean, so every reason an empty screen could be empty - a computer that never sent its conversation,
+  // one too old to send one, one that is offline - rendered as "waiting for the conversation to start",
+  // and a person could sit in front of that waiting for something that was never coming. The one line
+  // still written here is about the reader's OWN filters, which the Gateway cannot see.
+  let emptyText = history?.emptyText
+    // No sentence from the Gateway: fall back to what this file used to derive, so a response from any
+    // older build still reads sensibly rather than telling an unsupported agent's reader to keep waiting.
+    ?? (history?.isSupported === false ? "History is not available for this agent yet." : null)
+    ?? "Waiting for the conversation to start...";
+  if (mapped.length === 0 && anyHidden(filter) && history && history.messages.length > 0)
     emptyText = "No messages match the current filters.";
 
   const bubbles: RenderedBubble[] = [];

--- a/packages/client-core/src/history/types.ts
+++ b/packages/client-core/src/history/types.ts
@@ -38,8 +38,28 @@ export interface SessionHistoryDto {
   historyState?: string | null;
   /** The conversation messages, in chronological order. */
   messages: HistoryMessageDto[];
-  /** "ok" | "unsupported". */
+  /**
+   * The finished sentence to show ABOVE a conversation that is frozen - its computer is offline, or too old
+   * to send new turns. Null while the session is live. Unlike emptyText it rides alongside the content: a
+   * conversation that stopped an hour ago otherwise looks exactly like a live one.
+   */
+  staleNotice?: string | null;
+  /**
+   * The finished sentence to show when nothing renders, or null/absent when there is content. Written by
+   * the GATEWAY (SessionConversationFold), because "no messages" has several causes - a session that has
+   * not spoken, an agent that keeps no history, a computer that has not sent its conversation, one too old
+   * to send it, one that is offline - and only one of them means "wait, it is coming". Rendered verbatim.
+   */
+  emptyText?: string | null;
+  /**
+   * "ok" | "unsupported" | "unknown-session" | "director-offline" | "director-too-old" | "not-pushed-yet".
+   * A machine-readable companion to emptyText, for logs and diagnostics - the screen renders emptyText.
+   */
   status: string;
-  /** Free-text error message if status != "ok". */
+  /**
+   * The same sentence as emptyText when the empty screen is a FAULT - the computer is offline, too old to
+   * send conversations, or the session is unknown here. Null for the two states that are not faults: a
+   * session that has simply not spoken yet, and an agent that keeps no history at all.
+   */
   error?: string | null;
 }

--- a/packages/client-core/src/history/useSessionChat.ts
+++ b/packages/client-core/src/history/useSessionChat.ts
@@ -22,6 +22,9 @@ const CHAT_POLL_MS = 2500;
 export interface SessionChat {
   bubbles: RenderedBubble[];
   emptyText: string;
+  /** The Gateway's sentence for a conversation that is real but no longer current - its computer is away,
+   *  or too old to send new turns. Shown ABOVE the bubbles; null while the session is live. */
+  staleNotice: string | null;
   loadFailed: boolean;
   filter: HistoryBubbleFilter;
   /** Flip a "Show:" category; the choice is persisted and the cached history re-rendered immediately. */
@@ -32,6 +35,9 @@ export function useSessionChat(sessionId: string | undefined): SessionChat {
   const [filter, setFilterState] = useState<HistoryBubbleFilter>(loadChatFilter);
   const [bubbles, setBubbles] = useState<RenderedBubble[]>([]);
   const [emptyText, setEmptyText] = useState("Waiting for the conversation to start...");
+  // The Gateway's notice for a conversation that is real but no longer current (its computer is away, or
+  // cannot send new turns). Shown ABOVE the bubbles; null while the session is live.
+  const [staleNotice, setStaleNotice] = useState<string | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
 
   const signatureRef = useRef("");
@@ -46,6 +52,7 @@ export function useSessionChat(sessionId: string | undefined): SessionChat {
     const f = filterRef.current;
     const rendered = renderChatHistory(history, f);
     setEmptyText(rendered.emptyText);
+    setStaleNotice(history?.staleNotice ?? null);
 
     const mappedForSignature = rendered.bubbles.map((r) => r.bubble);
     const signature = buildChatSignature(mappedForSignature, history?.historyState, f);
@@ -94,5 +101,5 @@ export function useSessionChat(sessionId: string | undefined): SessionChat {
     [renderHistory],
   );
 
-  return { bubbles, emptyText, loadFailed, filter, setFilter };
+  return { bubbles, emptyText, staleNotice, loadFailed, filter, setFilter };
 }

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -601,6 +601,7 @@ public sealed class GatewayStreamClient : IAsyncDisposable
                 Pid = Environment.ProcessId,
                 StartedAt = _startedAt,
                 DisplayName = ReadDisplayName(),
+                PushesTurns = true,   // this build carries the TurnPusher (turn-push mission)
             });
             awaitGateway += DateTime.UtcNow - helloStarted;
             ReportGatewayCapabilities(capabilities);

--- a/src/CcDirector.Gateway.Contracts/DirectorStreamMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorStreamMessages.cs
@@ -28,6 +28,14 @@ public sealed class DirectorStreamHello
     /// <summary>Gateway Cleanup mission (tunnel-only): the Director process id (roster/diagnostics).</summary>
     public int Pid { get; set; }
 
+    /// <summary>
+    /// This Director SENDS its sessions' conversations (the turn-push mission). False from a build too old
+    /// to have the feature, which is why the Gateway asks rather than assuming: when it holds no
+    /// conversation for a session, "it has not arrived yet" and "that computer cannot send it" are
+    /// different news to the person looking at an empty Chat screen, and only this tells them apart.
+    /// </summary>
+    public bool PushesTurns { get; set; }
+
     /// <summary>Gateway Cleanup mission (tunnel-only): when the Director process started (UTC).</summary>
     public DateTime StartedAt { get; set; }
 

--- a/src/CcDirector.Gateway.Contracts/SessionHistoryDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionHistoryDto.cs
@@ -36,6 +36,26 @@ public sealed class SessionHistoryDto
     public List<HistoryMessageDto> Messages { get; set; } = new();
 
     /// <summary>"ok" | "unsupported".</summary>
+    /// <summary>
+    /// The finished sentence to show ABOVE a conversation that is FROZEN - the words are here, but no more
+    /// are coming, because the computer that produces them is not reachable or cannot send them. Null when
+    /// the session is live. Unlike <see cref="EmptyText"/> this rides ALONGSIDE content: a reader looking at
+    /// a conversation that stopped an hour ago sees the same screen as one watching a live session, would
+    /// type a prompt into it, and would wonder why nothing happened. Written by the Gateway
+    /// (<c>SessionConversationFold</c>) and rendered verbatim.
+    /// </summary>
+    public string? StaleNotice { get; set; }
+
+    /// <summary>
+    /// The finished sentence to show when the conversation renders as nothing, or null when there is
+    /// content. Decided on the GATEWAY (see <c>SessionConversationFold</c>) because "no messages" has
+    /// several causes - a session that has not spoken, an agent that keeps no history, a computer that has
+    /// not sent its conversation, one too old to send it, one that is offline - and only one of them means
+    /// "wait, it is coming". The client renders it verbatim and derives nothing from it; the one empty-state
+    /// line the client still writes for itself is about its OWN filters, which the Gateway cannot see.
+    /// </summary>
+    public string? EmptyText { get; set; }
+
     public string Status { get; set; } = "ok";
 
     /// <summary>Free-text error message if Status != "ok".</summary>

--- a/src/CcDirector.Gateway.UnitTests/DirectorHubTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/DirectorHubTests.cs
@@ -140,6 +140,28 @@ public sealed class DirectorHubTests : IDisposable
     }
 
     [Fact]
+    public void Hello_RecordsWhetherThisDirectorSendsConversations()
+    {
+        // The input to the sentence an empty Chat screen shows. Without it, "the computer has not sent its
+        // conversation yet" and "that computer is too old to send one" are the same silence, and the screen
+        // tells a reader to wait for something that will never arrive.
+        var caps = new CcDirector.Gateway.Streaming.TurnPushCapabilityRegistry();
+        var ctxNew = new FakeHubCallerContext("conn-1");
+        var newBuild = new DirectorHub(_store, _registry, InputStatsHandle.Available(_inputStats), new GatewayStreamRegistry(), SelfHostBoundary(), turnPushCapabilities: caps) { Context = ctxNew };
+        var ctxOld = new FakeHubCallerContext("conn-2");
+        var oldBuild = new DirectorHub(_store, _registry, InputStatsHandle.Available(_inputStats), new GatewayStreamRegistry(), SelfHostBoundary(), turnPushCapabilities: caps) { Context = ctxOld };
+
+        newBuild.Hello(new DirectorStreamHello { DirectorId = "dir-new", Version = "test", PushesTurns = true });
+        oldBuild.Hello(new DirectorStreamHello { DirectorId = "dir-old", Version = "test" });   // an older build says nothing
+
+        Assert.True(caps.PushesTurns(TenantId.Local, "dir-new"));
+        Assert.False(caps.PushesTurns(TenantId.Local, "dir-old"));
+        Assert.False(caps.PushesTurns(TenantId.Local, "dir-never-seen"));
+        // Partitioned: another account's Director of the same name has said nothing to us.
+        Assert.False(caps.PushesTurns(new TenantId("11111111-1111-1111-1111-111111111111"), "dir-new"));
+    }
+
+    [Fact]
     public void Hello_WithNothingStoredForThisDirector_SaysSo_RatherThanStayingSilent()
     {
         // An empty list that the Gateway VOUCHES for is a fact the Director acts on: it pushes every

--- a/src/CcDirector.Gateway.UnitTests/History/SessionConversationFoldTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/History/SessionConversationFoldTests.cs
@@ -1,0 +1,234 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data.Entities;
+using CcDirector.Gateway.History;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.History;
+
+/// <summary>
+/// Phase 2 of the turn-push mission: Chat reads the Gateway's stored conversation, and the Gateway decides
+/// what an empty screen SAYS. "There are no messages" has six different causes and only one of them means
+/// "wait, it is coming" - the client used to show that one sentence for all of them, which is how a person
+/// ends up waiting for something that will never arrive.
+/// </summary>
+public sealed class SessionConversationFoldTests
+{
+    private static SessionTurnHeadEntity Head(bool supported = true, string agent = "ClaudeCode", string? state = null, bool raw = false) => new()
+    {
+        SessionId = "s1",
+        DirectorId = "d1",
+        Generation = "abc",
+        GenerationSource = @"C:\t\a.jsonl",
+        Agent = agent,
+        IsSupported = supported,
+        IsRawText = raw,
+        HistoryState = state,
+        Count = 2,
+    };
+
+    private static List<HistoryMessageDto> Messages(params string[] texts) =>
+        texts.Select(t => new HistoryMessageDto { Role = "User", Parts = { new HistoryPartDto { Kind = "Text", Text = t } } }).ToList();
+
+    private static SessionHistoryDto Fold(SessionTurnHeadEntity? head, List<HistoryMessageDto>? messages = null,
+        bool known = true, bool connected = true, bool pushes = true)
+        => SessionConversationFold.Fold("s1", head, messages ?? new List<HistoryMessageDto>(), "d1", known, connected, pushes);
+
+    [Fact]
+    public void AStoredConversation_IsServedWithItsMessages_AndNoEmptyText()
+    {
+        var dto = Fold(Head(state: "BackgroundRunning"), Messages("hello", "hi"));
+
+        Assert.Equal("ok", dto.Status);
+        Assert.Equal(new[] { "hello", "hi" }, dto.Messages.Select(m => m.Parts[0].Text));
+        Assert.Equal("ClaudeCode", dto.Agent);
+        Assert.Equal("BackgroundRunning", dto.HistoryState);
+        Assert.Null(dto.EmptyText);      // there is content; the empty line is not the client's to render
+        Assert.Null(dto.Error);
+    }
+
+    [Fact]
+    public void StoredRows_AreServedEvenWhenTheDirectorIsOfflineAndTooOldAndUnknown()
+    {
+        // The whole point of storing the conversation: it is readable when the machine that produced it is
+        // not. Chat used to go blank the moment that computer went away.
+        var dto = Fold(Head(), Messages("said before it went offline"), known: false, connected: false, pushes: false);
+
+        Assert.Equal("ok", dto.Status);
+        Assert.Single(dto.Messages);
+        Assert.Null(dto.EmptyText);
+    }
+
+    [Fact]
+    public void AFrozenConversation_CarriesANoticeAboveIt_SoItDoesNotReadAsLive()
+    {
+        // The words are real; what stopped being true is that they are current. Without this the screen is
+        // identical to a live session, and a reader types a prompt into a session whose agent is not running.
+        var dto = Fold(Head(), Messages("said before it went offline"), connected: false);
+
+        Assert.Equal("ok", dto.Status);
+        Assert.Single(dto.Messages);                                  // the conversation is still served
+        Assert.Equal(SessionConversationFold.FrozenOfflineNotice, dto.StaleNotice);
+        Assert.Null(dto.EmptyText);                                   // a notice rides ALONGSIDE, never instead
+    }
+
+    [Fact]
+    public void AConversationFromAComputerTooOldToSendMore_SaysWhatItStopsAt()
+    {
+        var dto = Fold(Head(), Messages("the last turn it ever sent"), connected: true, pushes: false);
+
+        Assert.Equal(SessionConversationFold.FrozenTooOldNotice, dto.StaleNotice);
+        Assert.Contains("Update it", dto.StaleNotice);
+    }
+
+    [Fact]
+    public void TheSentencesClaimOnlyWhatTheGatewayObserved_NotThatAComputerIsSwitchedOff()
+    {
+        // All this Gateway knows is that a Director has not pushed inside the freshness window. The machine
+        // may be running perfectly behind a dropped connection, so the words a person reads must not say it
+        // is off (found in review - and the same imprecision the owner corrected in conversation).
+        foreach (var text in new[] { SessionConversationFold.DirectorOfflineText, SessionConversationFold.FrozenOfflineNotice })
+        {
+            Assert.Contains("has not checked in", text);
+            Assert.DoesNotContain("is offline", text);
+        }
+        Assert.Contains("until it reconnects", SessionConversationFold.FrozenOfflineNotice);
+    }
+
+    [Fact]
+    public void ALiveConversation_CarriesNoNotice()
+    {
+        var dto = Fold(Head(), Messages("hello"), connected: true, pushes: true);
+        Assert.Null(dto.StaleNotice);
+    }
+
+    [Fact]
+    public void AnEmptyScreen_NeverCarriesBothASentenceAndANotice()
+    {
+        // The two channels are exclusive by construction: EmptyText replaces the conversation, StaleNotice
+        // sits above one. A screen carrying both would say the same thing twice, differently.
+        var cases = new[]
+        {
+            Fold(head: null, known: false),
+            Fold(head: null, connected: false),
+            Fold(head: null, pushes: false),
+            Fold(head: null),
+            Fold(Head()),
+            Fold(Head(supported: false)),
+            Fold(Head(), Messages("live")),
+            Fold(Head(), Messages("frozen"), connected: false),
+        };
+
+        Assert.All(cases, dto => Assert.False(dto.EmptyText is not null && dto.StaleNotice is not null));
+    }
+
+    [Fact]
+    public void AnAgentThatKeepsNoConversation_SaysSo_EvenWhenItsComputerIsAlsoOffline()
+    {
+        // Terminal, and true whether the machine is on or off. Saying "your computer is offline" would send
+        // the reader to fix something that is not the reason nothing will ever appear.
+        var dto = Fold(Head(supported: false, agent: "Gemini"), connected: false);
+
+        Assert.Equal("unsupported", dto.Status);
+        Assert.False(dto.IsSupported);
+        Assert.Equal(SessionConversationFold.UnsupportedText, dto.EmptyText);
+    }
+
+    [Fact]
+    public void AnUnknownSession_SaysItIsUnknown_NotThatSomeComputerIsOffline()
+    {
+        var dto = Fold(head: null, known: false, connected: false);
+
+        Assert.Equal("unknown-session", dto.Status);
+        Assert.Equal(SessionConversationFold.UnknownSessionText, dto.EmptyText);
+    }
+
+    [Fact]
+    public void AKnownSessionWhoseComputerIsAway_SaysOffline()
+    {
+        var dto = Fold(head: null, known: true, connected: false);
+
+        Assert.Equal("director-offline", dto.Status);
+        Assert.Equal(SessionConversationFold.DirectorOfflineText, dto.EmptyText);
+        Assert.Equal(dto.EmptyText, dto.Error);
+    }
+
+    [Fact]
+    public void ADirectorTooOldToSend_SaysToUpdateIt_NotToWait()
+    {
+        // THE SENTENCE THIS FOLD EXISTS FOR. Nothing is ever going to arrive from this computer, so telling
+        // the reader to wait would be a lie they could sit in front of indefinitely.
+        var dto = Fold(head: null, connected: true, pushes: false);
+
+        Assert.Equal("director-too-old", dto.Status);
+        Assert.Contains("Update it", dto.EmptyText);
+        Assert.DoesNotContain("moment", dto.EmptyText);
+    }
+
+    [Fact]
+    public void NothingStored_WithAConnectedPushingDirector_SaysItIsComing()
+    {
+        var dto = Fold(head: null, connected: true, pushes: true);
+
+        Assert.Equal("not-pushed-yet", dto.Status);
+        Assert.Equal(SessionConversationFold.NotPushedYetText, dto.EmptyText);
+        Assert.Empty(dto.Messages);
+    }
+
+    [Fact]
+    public void AStoredSessionThatHasNotSpokenYet_SaysTheConversationHasNotStarted()
+    {
+        var dto = Fold(Head());
+
+        Assert.Equal("ok", dto.Status);
+        Assert.Equal(SessionConversationFold.NotStartedText, dto.EmptyText);
+        Assert.Null(dto.Error);          // not a fault - a new session really has said nothing yet
+    }
+
+    [Fact]
+    public void AnEmptyStoredSession_WhoseComputerThenWentAway_StopsSayingItIsAboutToStart()
+    {
+        // A head registered, nothing was ever said, and then the machine left. The first version of this
+        // fold stopped at "the conversation has not started" the moment a head existed, so this session sat
+        // on that sentence forever while the reader waited (found in review).
+        var dto = Fold(Head(), connected: false);
+
+        Assert.Equal("director-offline", dto.Status);
+        Assert.Equal(SessionConversationFold.DirectorOfflineText, dto.EmptyText);
+    }
+
+    [Fact]
+    public void AnEmptyStoredSession_WhoseComputerDowngraded_SaysToUpdateIt()
+    {
+        var dto = Fold(Head(), connected: true, pushes: false);
+
+        Assert.Equal("director-too-old", dto.Status);
+        Assert.Equal(SessionConversationFold.DirectorTooOldText, dto.EmptyText);
+    }
+
+    [Fact]
+    public void RawTextAgents_KeepTheirRawFlag_SoTheClientRendersThemVerbatim()
+    {
+        var dto = Fold(Head(agent: "Gemini", raw: true), Messages("scrollback"));
+        Assert.True(dto.IsRawText);
+    }
+
+    [Fact]
+    public void EveryEmptyAnswer_CarriesASentence_AndEveryFaultCarriesItAsTheErrorToo()
+    {
+        // A screen with nothing on it and nothing to say is the failure this whole fold exists to prevent.
+        var cases = new[]
+        {
+            Fold(head: null, known: false),
+            Fold(head: null, connected: false),
+            Fold(head: null, pushes: false),
+            Fold(head: null),
+            Fold(Head()),
+            Fold(Head(supported: false)),
+        };
+
+        Assert.All(cases, dto => Assert.False(string.IsNullOrWhiteSpace(dto.EmptyText)));
+        // The two non-faults - a new session, and an agent that keeps no history - are NOT errors.
+        Assert.All(cases.Where(d => d.Status is "ok" or "unsupported"), dto => Assert.Null(dto.Error));
+        Assert.All(cases.Where(d => d.Status is not ("ok" or "unsupported")), dto => Assert.Equal(dto.EmptyText, dto.Error));
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/TunnelCatchAllDispatchTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TunnelCatchAllDispatchTests.cs
@@ -60,7 +60,6 @@ public sealed class TunnelCatchAllDispatchTests
     [InlineData("buffer/html", "buffer-html")]
     [InlineData("usage", "usage")]
     [InlineData("context", "context")]
-    [InlineData("history", "history")]
     [InlineData("github-urls", "github-urls")]
     [InlineData("queue", "queue-read")]
     public async Task Each_catch_all_read_path_maps_to_its_verb(string rest, string expectedVerb)
@@ -74,6 +73,23 @@ public sealed class TunnelCatchAllDispatchTests
         Assert.True(handled);
         Assert.Equal(expectedVerb, seen()!.Verb);
         Assert.Equal("", seen()!.PayloadJson); // reads carry no payload
+    }
+
+    [Fact]
+    public async Task History_is_NOT_dispatched_down_the_tunnel_any_more()
+    {
+        // The turn-push mission's whole point: a conversation is read from the Gateway's own store, not
+        // fetched from the owning Director on every 2.5-second Chat poll. The literal route
+        // (SessionConversationEndpoint) serves it; this dispatcher must not claim the path, or a request
+        // would go back down the tunnel and re-parse a transcript on the user's disk.
+        var send = Capture(out var seen, DirectorCommandResult.Success("{}"));
+        var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, _) = NewCtx("GET");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "history");
+
+        Assert.False(handled);
+        Assert.Null(seen());
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/SessionConversationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/SessionConversationEndpoint.cs
@@ -1,0 +1,84 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.History;
+using CcDirector.Gateway.Streaming;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// <c>GET /sessions/{sid}/history</c> - the session's conversation, served from the Gateway's OWN store
+/// (the turn-push mission, phase 2).
+///
+/// What this replaces. The same route used to fall through the <c>/sessions/{sid}/{**rest}</c> catch-all
+/// onto the tunnel: every request became a command to the owning Director, which opened the transcript file
+/// on the user's disk, parsed all of it, and sent the whole conversation back. The Chat screen polls every
+/// 2.5 seconds, so that ran perpetually, per open screen, and Chat went blank the moment the machine went
+/// away. Now the Director pushes each turn once (phase 1) and this reads rows.
+///
+/// A literal route outranks the catch-all in routing, and the catch-all's <c>history</c> verb entry is
+/// removed in the same change, so there is exactly one way to read a conversation and it never leaves this
+/// Gateway.
+/// </summary>
+public static class SessionConversationEndpoint
+{
+    /// <param name="turns">The stored conversation.</param>
+    /// <param name="pushedSessions">Used only to locate the owning Director and see whether it is currently
+    /// pushing - which is what lets an empty answer say WHY it is empty.</param>
+    /// <param name="capabilities">Which Directors said they send conversations at all.</param>
+    /// <param name="staleAfter">How long since a Director's last push still counts as connected.</param>
+    public static void Map(
+        IEndpointRouteBuilder app,
+        SessionTurnStore turns,
+        PushedSessionStore pushedSessions,
+        TurnPushCapabilityRegistry capabilities,
+        TimeSpan staleAfter,
+        Tenancy.HostedTenantBoundary? tenantBoundary)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(turns);
+        ArgumentNullException.ThrowIfNull(pushedSessions);
+        ArgumentNullException.ThrowIfNull(capabilities);
+
+        app.MapGet("/sessions/{sid}/history", (string sid, HttpContext ctx) =>
+        {
+            var tenant = GatewayEndpoints.ResolveReadTenant(ctx, tenantBoundary);
+            if (tenant is null)
+                return Results.Json(new { error = "no tenant is bound to this request" }, statusCode: StatusCodes.Status403Forbidden);
+            if (!Guid.TryParse(sid, out _))
+                return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
+
+            // Fresh (inside the staleness window) means the owning computer is reachable now; ignoring
+            // freshness still finds a session this Gateway KNOWS about whose computer has gone away. The
+            // difference is what lets an empty answer say "that computer is offline" instead of "this
+            // session does not exist", which are different things to be told.
+            var located = pushedSessions.TryLocate(tenant.Value, sid, staleAfter);
+            var everSeen = located is null ? pushedSessions.TryLocateIgnoringFreshness(tenant.Value, sid) : null;
+
+            // THE STORE IS READ INSIDE THE CALLER'S TENANT SCOPE. Its rows are partitioned by the context's
+            // ambient tenant (GatewayDbContext's global query filter), so a read taken outside a scope
+            // answers from whatever tenant happened to be ambient - which on hosted is how one account ends
+            // up served another account's conversation (found in review). Resolving the request's tenant is
+            // authentication; entering it is what makes the read authorised.
+            using var scope = tenantBoundary?.EnterScope(tenant.Value);
+            var stored = turns.ReadCurrent(sid);
+
+            var directorId = located?.DirectorId ?? everSeen?.DirectorId ?? stored?.Head.DirectorId;
+            var dto = SessionConversationFold.Fold(
+                sid,
+                stored?.Head,
+                stored?.Messages ?? new List<Contracts.HistoryMessageDto>(),
+                directorId,
+                sessionKnown: located is not null || everSeen is not null || stored is not null,
+                directorConnected: located is not null,
+                directorPushesTurns: capabilities.PushesTurns(tenant.Value, located?.DirectorId));
+
+            // Logged only when there is nothing to serve. A healthy poll every 2.5 seconds per open screen
+            // must not write a line each time - that is how a log stops being readable.
+            if (dto.Messages.Count == 0)
+                FileLog.Write($"[SessionConversation] history sid={sid} tenant={tenant.Value.ToLogString()}: {dto.Status} ({dto.EmptyText})");
+            return Results.Json(dto);
+        });
+    }
+}

--- a/src/CcDirector.Gateway/Api/TunnelCatchAllDispatch.cs
+++ b/src/CcDirector.Gateway/Api/TunnelCatchAllDispatch.cs
@@ -14,7 +14,7 @@ namespace CcDirector.Gateway.Api;
 /// caller answers 404. There is NO HTTP fallback.
 ///
 /// The catch-all carries the session verbs that do NOT have their own literal Gateway route: the reads (turns,
-/// buffer-html, usage, context, history, github-urls, queue-read) and the writes (resize, clear-context,
+/// buffer-html, usage, context, github-urls, queue-read) and the writes (resize, clear-context,
 /// history-picker, mobile-mode, voice-mode, wingman-enabled, relink, execute-action, and the voice queue's
 /// add/update/remove/move/clear/send). The verb's request DTO and core are the SAME the Director REST route
 /// used (Phase 0), so the reply body is identical; the Gateway only marshals method + path + body into the verb
@@ -45,7 +45,9 @@ internal sealed class TunnelCatchAllDispatch
         ["buffer/html"] = "buffer-html",
         ["usage"] = "usage",
         ["context"] = "context",
-        ["history"] = "history",
+        // "history" is NOT here any more. The conversation is served from the Gateway's own store by
+        // SessionConversationEndpoint (turn-push mission, phase 2) instead of being fetched from the owning
+        // Director on every 2.5-second Chat poll. Putting it back would reopen that round trip.
         ["github-urls"] = "github-urls",
         ["queue"] = "queue-read",
     };

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -639,6 +639,8 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly History.SessionHistoryStore _sessionHistory;
     /// <summary>The stored conversation (turn-push mission): what Directors push and every reader reads.</summary>
     private readonly History.SessionTurnStore _sessionTurns;
+    /// <summary>Which Directors told this Gateway they send conversations (turn-push mission, phase 2).</summary>
+    private readonly Streaming.TurnPushCapabilityRegistry _turnPushCapabilities = new();
     private readonly History.SessionHistoryRecorder _sessionHistoryRecorder;
     private History.SessionHistorySweep? _sessionHistorySweep;
     private System.Threading.Timer? _sessionHistoryTimer;
@@ -2564,6 +2566,8 @@ public sealed class GatewayHost : IAsyncDisposable
         builder.Services.AddSingleton(_sessionHistoryRecorder);
         // The stored conversation (turn-push mission): DirectorHub.PushTurns writes it, Hello reads its watermarks.
         builder.Services.AddSingleton(_sessionTurns);
+        // Which Directors say they send conversations - recorded at Hello, read when Chat finds nothing stored.
+        builder.Services.AddSingleton(_turnPushCapabilities);
         // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store, so the mission endpoints and
         // spawn validation share the one instance.
         builder.Services.AddSingleton(Missions);
@@ -3131,6 +3135,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // listener with the phone in a pocket knows WHICH session is talking before anything else
         // (WingmanTranslator.FidelityPrompt v5.2). Push-store read - no dial. See ResolveSessionTitle.
         _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, _tenantSettingsResolver, instructionsProvider: () => _instructionsStore.ActiveContent, sessionTitleResolver: ResolveSessionTitle);
+        // The session's conversation, served from THIS Gateway's store (turn-push mission, phase 2). A
+        // literal route, so it outranks the /sessions/{sid}/{**rest} catch-all - whose "history" verb entry
+        // is removed in the same change, because the whole point is that reading a conversation no longer
+        // travels down the tunnel to re-parse a transcript on the user's disk once every 2.5 seconds.
+        Api.SessionConversationEndpoint.Map(_app, _sessionTurns, PushedSessions, _turnPushCapabilities,
+            _streamStaleAfter, _tenantBoundary);
+
         GatewayWingmanVoiceEndpoint.Map(_app, Registry, WingmanBrainAsync, _keyVault, _voiceService, _tenantSettingsResolver,
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync,

--- a/src/CcDirector.Gateway/History/SessionConversationFold.cs
+++ b/src/CcDirector.Gateway/History/SessionConversationFold.cs
@@ -1,0 +1,185 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data.Entities;
+
+namespace CcDirector.Gateway.History;
+
+/// <summary>
+/// Folds what the Gateway HOLDS of one session's conversation into the <see cref="SessionHistoryDto"/> the
+/// Chat screen renders (the turn-push mission, phase 2). Before this, Chat asked the owning Director for
+/// the conversation every 2.5 seconds and the Director re-parsed the whole transcript for each poll; now
+/// the Director pushes it once and this reads rows.
+///
+/// THE JOB THIS DOES BEYOND COPYING ROWS. "There are no messages" has several causes and they are not the
+/// same news to the person looking at an empty screen:
+///
+///   this session is not known here     - nothing has ever arrived about it; the id may be wrong.
+///   this agent keeps no conversation   - nothing will ever appear, and that is not a fault.
+///   that computer has not checked in   - it cannot send anything until it reconnects.
+///   that computer cannot send it       - its DevThrottle is too old to push conversations. Update it.
+///   nothing has been sent yet          - the Director has it and has not pushed it; wait a moment.
+///   the conversation has not started   - the session is here and has simply not spoken.
+///
+/// The client used to guess between two of these from a boolean and show "Waiting for the conversation to
+/// start..." for all the rest, which is the sentence that makes a person sit and wait for something that is
+/// never coming. So the sentence is decided HERE and rendered verbatim, like every other display verdict in
+/// this product (CLAUDE.md rule 7). The client keeps exactly one line of its own - the one about its OWN
+/// filters hiding messages - because the Gateway cannot know what a reader has filtered out.
+///
+/// WHAT "CONNECTED" MEANS HERE, precisely. It is the same freshness lease the rest of the product reads a
+/// Director's presence through: a Director counts as connected while its last push is younger than the
+/// stale-after window. So a machine that dropped a moment ago still reads as connected until that window
+/// expires, and the screen can be up to that long out of date about it. That is deliberate - the roster is
+/// built to ride out reconnect blips rather than flap - and it is written down here because a sentence
+/// about someone's computer being offline should not quietly mean something narrower than it says.
+/// </summary>
+public static class SessionConversationFold
+{
+    /// <summary>Shown while a session that has arrived simply has not said anything yet.</summary>
+    public const string NotStartedText = "Waiting for the conversation to start...";
+
+    /// <summary>Shown for an agent that keeps no readable conversation at all.</summary>
+    public const string UnsupportedText = "History is not available for this agent yet.";
+
+    /// <summary>Shown when the owning computer is connected and pushing, but this session's conversation has
+    /// not arrived yet. Self-heals within a minute: the Director's safety sweep pushes what it missed.</summary>
+    public const string NotPushedYetText = "This session's computer has not sent its conversation yet. It should appear in a moment.";
+
+    /// <summary>Shown when the owning computer is connected but its DevThrottle is too old to send
+    /// conversations. Nothing will arrive until it is updated, so the sentence says so rather than asking
+    /// the reader to keep waiting.</summary>
+    public const string DirectorTooOldText = "This session's computer is running an older DevThrottle that does not send conversations. Update it to read the chat here.";
+
+    /// <summary>
+    /// Shown when the owning computer has not checked in recently. Two kinds of precision here, both from
+    /// review:
+    ///
+    /// It is worded to be true of BOTH shapes it reaches - a session with nothing stored at all, and one
+    /// whose stored conversation is empty - because saying "nothing arrived" would contradict the head this
+    /// same response ships.
+    ///
+    /// And it says NOT CHECKED IN, not "offline", because that is the whole of what this Gateway knows: the
+    /// Director's last push is older than the freshness window. The machine may be running perfectly with a
+    /// dropped connection. The status key below is still the shorthand <c>director-offline</c> - that is a
+    /// machine-readable label for logs - but the sentence a person reads must not claim more than was
+    /// observed.
+    /// </summary>
+    public const string DirectorOfflineText = "This session's computer has not checked in recently, and no conversation has been stored for it.";
+
+    /// <summary>Shown when the Gateway has never heard of the session at all - not in the roster, nothing
+    /// stored. Distinct from "offline", which is about a session it DOES know.</summary>
+    public const string UnknownSessionText = "This session is not known here. It may have been deleted, or belong to another account.";
+
+    /// <summary>Shown ABOVE a stored conversation whose computer has not checked in recently. The words on
+    /// screen are real; what is not true any more is that they are current. "Until it reconnects" rather
+    /// than "until that computer is back", for the same reason as <see cref="DirectorOfflineText"/>: a
+    /// dropped connection is what was observed, not a machine that is switched off.</summary>
+    public const string FrozenOfflineNotice = "This session's computer has not checked in recently. This is the conversation as it last reached here - nothing new will arrive, and anything you send will not go through, until it reconnects.";
+
+    /// <summary>Shown above a stored conversation whose computer is checking in but cannot send new turns.
+    /// It says "the last turn stored" rather than "the last turn it sent", because the rows may have come
+    /// from an earlier Director on that session - ownership can change (found in review).</summary>
+    public const string FrozenTooOldNotice = "This session's computer is running an older DevThrottle that does not send conversations, so what is shown here stops at the last turn stored. Update it to keep the chat current.";
+
+    /// <param name="sessionId">The session being read.</param>
+    /// <param name="head">The stored head row, or null when nothing has ever been pushed for this session.</param>
+    /// <param name="messages">The stored messages, in order. Empty when the head exists but no turn has arrived.</param>
+    /// <param name="directorId">The Director that owns the session, or null when it is not located.</param>
+    /// <param name="sessionKnown">The Gateway has heard of this session at all - it is in the roster (fresh
+    /// or stale) or has stored rows. False means the id names nothing here, which is a different answer from
+    /// a session whose computer is merely away.</param>
+    /// <param name="directorConnected">Whether that Director's last push is inside the freshness window.</param>
+    /// <param name="directorPushesTurns">Whether that Director told this Gateway it sends conversations.
+    /// False for a Director too old to have the feature - which is why "nothing stored" is not always the
+    /// same news.</param>
+    public static SessionHistoryDto Fold(
+        string sessionId,
+        SessionTurnHeadEntity? head,
+        List<HistoryMessageDto> messages,
+        string? directorId,
+        bool sessionKnown,
+        bool directorConnected,
+        bool directorPushesTurns)
+    {
+        var dto = new SessionHistoryDto
+        {
+            SessionId = sessionId,
+            // The LIVE owner first, so the identifier in the response is the one the status below is about.
+            // Preferring the head's would let the response name the Director that wrote the rows while the
+            // sentence described the one that owns the session now (found in review).
+            DirectorId = directorId ?? head?.DirectorId ?? "",
+            Agent = head?.Agent ?? "",
+            IsSupported = head?.IsSupported ?? true,
+            IsRawText = head?.IsRawText ?? false,
+            HistoryState = head?.HistoryState,
+            Messages = messages,
+        };
+
+        // STORED CONTENT WINS OVER EVERYTHING. This is the whole point of holding the conversation: it stays
+        // readable when the machine that produced it is not.
+        //
+        // But readable is not the same as CURRENT, and the screen must not pretend otherwise. A conversation
+        // whose computer is away looks exactly like a live one: same bubbles, no hint that it stopped an
+        // hour ago. A reader types into it and waits for an answer that cannot come, because the agent that
+        // would answer is not running. So a frozen conversation carries a notice above it saying so - the
+        // same defect this mission exists to kill, one screen over, and it does NOT replace the content the
+        // way an empty-screen sentence does.
+        if (messages.Count > 0)
+        {
+            dto.Status = "ok";
+            dto.StaleNotice = !directorConnected ? FrozenOfflineNotice
+                            : !directorPushesTurns ? FrozenTooOldNotice
+                            : null;
+            return dto;
+        }
+
+        // An agent that keeps no conversation is next, ABOVE the connectivity answers, even though "that
+        // computer is offline" is the more actionable-sounding sentence. Nothing about this session will
+        // ever produce a conversation, online or off, so pointing the reader at their machine would send
+        // them to fix something that is not the reason.
+        if (head is not null && !head.IsSupported)
+        {
+            dto.Status = "unsupported";
+            dto.EmptyText = UnsupportedText;
+            return dto;
+        }
+
+        // Nothing to show. Now the reasons, most-final first - and note that these apply to a session with a
+        // stored-but-empty head just as much as to one with no head at all. An earlier version stopped at
+        // "the conversation has not started" the moment a head existed, so a session whose computer went
+        // away after registering sat on that sentence forever (found in review).
+        if (!sessionKnown)
+        {
+            dto.Status = "unknown-session";
+            dto.EmptyText = UnknownSessionText;
+            dto.Error = dto.EmptyText;
+            return dto;
+        }
+        if (!directorConnected)
+        {
+            dto.Status = "director-offline";
+            dto.EmptyText = DirectorOfflineText;
+            dto.Error = dto.EmptyText;
+            return dto;
+        }
+        if (!directorPushesTurns)
+        {
+            dto.Status = "director-too-old";
+            dto.EmptyText = DirectorTooOldText;
+            dto.Error = dto.EmptyText;
+            return dto;
+        }
+        if (head is null)
+        {
+            dto.Status = "not-pushed-yet";
+            dto.EmptyText = NotPushedYetText;
+            dto.Error = dto.EmptyText;
+            return dto;
+        }
+
+        // Known, connected, pushing, and its conversation has arrived - carrying nothing. The session really
+        // has not spoken yet, and this is the only arm where telling the reader to wait is honest.
+        dto.Status = "ok";
+        dto.EmptyText = NotStartedText;
+        return dto;
+    }
+}

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -62,8 +62,10 @@ public sealed class DirectorHub : Hub
         PushedRepositoryStore? repositoryStore = null, RepoHistoryStore? repoHistory = null,
         History.SessionHistoryRecorder? sessionHistory = null,
         Pairing.SessionKeyRegistry? sessionKeys = null,
-        History.SessionTurnStore? sessionTurns = null)
+        History.SessionTurnStore? sessionTurns = null,
+        TurnPushCapabilityRegistry? turnPushCapabilities = null)
     {
+        _turnPushCapabilities = turnPushCapabilities;
         _sessionTurns = sessionTurns;
         _sessionKeys = sessionKeys;
         _store = store;
@@ -96,6 +98,8 @@ public sealed class DirectorHub : Hub
     private readonly History.SessionHistoryRecorder? _sessionHistory;
     /// <summary>The stored conversation (turn-push mission). Null only in tests that do not exercise it.</summary>
     private readonly History.SessionTurnStore? _sessionTurns;
+    /// <summary>Which connected Directors send their conversations - learned here, from Hello.</summary>
+    private readonly TurnPushCapabilityRegistry? _turnPushCapabilities;
 
     /// <summary>
     /// A full repository/worktree snapshot from the bound Director (repositories mission, #510
@@ -210,6 +214,9 @@ public sealed class DirectorHub : Hub
         // authenticated device key - never the Hello payload, which the client writes.
         _registry.RegisterFromStream(directorId, hello.MachineName, hello.User, hello.Version, hello.Pid, hello.StartedAt, tenant,
             hello.DisplayName);
+        // What this build can do, kept against the CONNECTION: the same machine can come back on an older
+        // or a newer Director, and a stale answer here would put the wrong sentence on an empty Chat screen.
+        _turnPushCapabilities?.Record(tenant, directorId, hello.PushesTurns);
         FileLog.Write($"[DirectorHub] Hello: director={directorId} bound to conn={Short(Context.ConnectionId)} (version={hello.Version}, machine={hello.MachineName})");
         return CapabilitiesFor(tenant, directorId);
     }

--- a/src/CcDirector.Gateway/Streaming/TurnPushCapabilityRegistry.cs
+++ b/src/CcDirector.Gateway/Streaming/TurnPushCapabilityRegistry.cs
@@ -1,0 +1,47 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Tenancy;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// Which Directors told this Gateway they SEND their sessions' conversations (the turn-push mission,
+/// phase 2). Learned from each Director's <c>Hello</c>, and overwritten by the next one - so a machine that
+/// comes back on an older build corrects the record itself.
+///
+/// It exists so the Chat screen can tell two silences apart. When the Gateway holds no conversation for a
+/// session, "the computer has not sent it yet" and "that computer cannot send it at all" look identical in
+/// the store and are completely different news to the person reading an empty screen - one is a moment's
+/// wait, the other never ends until the Director is updated. Without this, the honest sentence could not be
+/// written, and the screen would go on saying "waiting" forever.
+///
+/// In memory by design: a Gateway restart re-learns it from the next Hello, and until then a Director reads
+/// as not-pushing, which is the safe direction - it says "that computer cannot send it", never "wait a
+/// moment" about a wait that would not end.
+///
+/// NOTHING FORGETS AN ENTRY ON DISCONNECT, deliberately. A disconnected Director cannot send anything
+/// whatever its build, and the fold that uses this asks about connection FIRST - so during the reconnect
+/// blips the roster is built to ride out, the screen says "that computer is offline", which is true, rather
+/// than "that computer cannot send conversations", which would be alarming and wrong. A Forget method was
+/// written here and deleted: nothing called it, and a cleanup entry point with no caller reads as a policy
+/// that exists when it does not.
+/// </summary>
+public sealed class TurnPushCapabilityRegistry
+{
+    // Keyed by TENANT AND Director, not by Director alone. A Director id is caller-supplied on the stream,
+    // and every other fact this Gateway holds about a Director is partitioned by the tenant its connection
+    // authenticated as - a shared key would let one account's Director decide what another account's Chat
+    // screen says about a session (found in review).
+    private readonly ConcurrentDictionary<(TenantId Tenant, string DirectorId), bool> _pushes = new();
+
+    /// <summary>Record what a Director said about itself on Hello, under the tenant its connection is bound to.</summary>
+    public void Record(TenantId tenant, string directorId, bool pushesTurns)
+    {
+        if (string.IsNullOrEmpty(directorId)) return;
+        _pushes[(tenant, directorId)] = pushesTurns;
+    }
+
+    /// <summary>Whether this tenant's Director said it sends conversations. False for one that never said so -
+    /// an older build, or one this Gateway has not heard from since it started.</summary>
+    public bool PushesTurns(TenantId tenant, string? directorId)
+        => !string.IsNullOrEmpty(directorId) && _pushes.TryGetValue((tenant, directorId), out var pushes) && pushes;
+}


### PR DESCRIPTION
Phase 2 of thefrederiksen/devthrottle_internal#1882.

## Why

The Chat screen polls every 2.5 seconds. Every poll became a command down the tunnel to the owning Director, which opened the transcript on the user's disk, parsed all of it, and returned the whole conversation - per poll, per open screen. Chat went blank whenever that machine was offline. Since phase 1 the Director pushes each turn to the Gateway; this reads the stored rows.

## What

- `GET /sessions/{sid}/history` is a literal Gateway route served from the store. A literal route outranks the `/sessions/{sid}/{**rest}` catch-all, and the catch-all's `history` verb entry is removed in the same change, so a conversation read never travels down the tunnel again.
- The store is read **inside the caller's tenant scope**. Resolving the request's tenant is authentication; entering it is what makes the read authorised.
- `SessionConversationFold` decides the answer, including the sentence shown when nothing renders. Ordered: stored content wins over everything; then an agent that keeps no conversation; then unknown session, offline computer, computer too old to send, nothing sent yet; and only then "the conversation has not started", which is the one case where telling the reader to wait is honest.
- `TurnPushCapabilityRegistry` records from each `Hello`, per account and Director, whether that build sends conversations - the input that tells "not sent yet" apart from "that computer cannot send it at all".
- The client renders the Gateway's sentence verbatim and keeps one line of its own, about its own filters.

## Proof

- Twelve fold tests covering all six outcomes, the orderings between them, and that every empty answer carries a sentence while the two non-faults carry no error.
- A hub test that `Hello` records the capability per account, and that another account's Director of the same name is not consulted.
- A dispatcher test pinning that `history` is no longer claimed by the catch-all.
- Client tests: the Gateway's sentence rendered verbatim, an unseen sentence rendered without a client change, the filter line still winning, and the old fallback preserved.
- Local gate green, nine suites; parked suites run before merge.

## Reviews

Two Codex passes. Fixed here: the store read taken outside the tenant scope (one account could have been served another's conversation); an empty stored head masking the offline and too-old answers forever; an unknown session reported as an offline computer; the capability registry keyed without the account; the offline sentence contradicting the metadata it shipped; the response naming the Director that wrote the rows rather than the one the sentence was about; and the client's fallback for a response carrying no sentence.

## Not proven

No live run against a real Director and a phone yet. The proof here is unit-level plus the parked suites.

## A frozen conversation says so

Storing the conversation means Chat keeps working while the owning computer is unreachable. The session does not: the agent runs on that machine, so nothing new arrives and a prompt goes nowhere. Rendered without a word, a conversation that stopped an hour ago looks exactly like a live one.

So a stored conversation whose computer is not checking in, or which cannot send new turns, carries a Gateway-written notice above it - outside the scrolling list, because a long conversation opens at the bottom and a notice at the top of the scroll is where nobody looks. It rides alongside the content rather than replacing it, and a test pins that the two channels are never both set.

The sentences claim only what was observed: the Gateway knows a Director has not pushed inside the freshness window, not that a machine is switched off. They say "has not checked in recently" and "until it reconnects", and a test pins that too.

## On the parked suites

The parked run was green on all eleven suites (`Gateway.Tests` 2,317, `Core.Tests` 4,374). It was taken before the last edit, which changed four sentence constants, some documentation, two client components and two stylesheets. Neither parked suite compiles the client files or asserts those strings, so the run stands as evidence for what those suites cover; everything the edit did touch is covered by the default gate, which is green, and by the client suites.
