### PR TITLE
Turn push, phase 3a: the wingman narrates from the stored conversation

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/History/StoredConversationWidgetsTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/History/StoredConversationWidgetsTests.cs
@@ -1,0 +1,124 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.History;
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.History;
+
+/// <summary>
+/// Phase 3 of the turn-push mission: the wingman reads the Gateway's stored conversation instead of asking
+/// the owning Director to re-read the user's transcript. These pin the adapter that keeps the SHAPE the
+/// translator already reads, so the only thing this phase changes is where the words come from - if the
+/// narration ever comes out different, it is not because the widget list did.
+/// </summary>
+public sealed class StoredConversationWidgetsTests
+{
+    private static HistoryMessageDto Msg(string role, params (string Kind, string Text)[] parts) => new()
+    {
+        Role = role,
+        Parts = parts.Select(p => new HistoryPartDto { Kind = p.Kind, Text = p.Text }).ToList(),
+    };
+
+    [Fact]
+    public void AnAgentsText_IsTheKindTheNarrationReads_AndAPersonsIsNot()
+    {
+        var widgets = StoredConversationWidgets.From(new[]
+        {
+            Msg("User", ("Text", "do the thing")),
+            Msg("Assistant", ("Text", "done")),
+        });
+
+        Assert.Equal(new[] { "UserMessage", "Text" }, widgets.Select(w => w.Kind));
+        Assert.Equal("done", StoredConversationWidgets.LastAgentText(widgets));
+    }
+
+    [Fact]
+    public void ToolWorkAndThinking_KeepTheirOwnKinds_SoTheContextWindowReadsAsItDidBefore()
+    {
+        var widgets = StoredConversationWidgets.From(new[]
+        {
+            Msg("Assistant", ("Thinking", "considering"), ("ToolUse", "{\"path\":\"x\"}"), ("Text", "here it is")),
+        });
+
+        Assert.Equal(new[] { "Thinking", "ToolUse", "Text" }, widgets.Select(w => w.Kind));
+        Assert.Equal("here it is", StoredConversationWidgets.LastAgentText(widgets));
+    }
+
+    [Fact]
+    public void TheLastAgentText_IsTheLastOne_NotTheFirstOrThePersonsReply()
+    {
+        var widgets = StoredConversationWidgets.From(new[]
+        {
+            Msg("Assistant", ("Text", "first answer")),
+            Msg("User", ("Text", "and again")),
+            Msg("Assistant", ("Text", "second answer")),
+            Msg("User", ("Text", "thanks")),
+        });
+
+        Assert.Equal("second answer", StoredConversationWidgets.LastAgentText(widgets));
+    }
+
+    [Fact]
+    public void AConversationWithNoAgentText_HasNothingToReadAloud()
+    {
+        // A session waiting on a prompt, or one whose turn was all tool work. This is a fact about the
+        // conversation, not a failure to read it - the difference that took a session silent for 48 minutes.
+        var widgets = StoredConversationWidgets.From(new[]
+        {
+            Msg("User", ("Text", "do the thing")),
+            Msg("Assistant", ("ToolUse", "{}")),
+        });
+
+        Assert.Null(StoredConversationWidgets.LastAgentText(widgets));
+    }
+
+    [Fact]
+    public void OnlyAnAssistantsText_IsNarratable_SoAnUnknownRoleIsNeverReadAloudAsTheAgent()
+    {
+        // "Anything that is not the user is the agent" would make a system or tool role narratable if the
+        // stored role set ever grew, and what it would read aloud is text the person never heard the agent
+        // say (found in review). An unrecognised role keeps its own name: still context, never the reply.
+        var widgets = StoredConversationWidgets.From(new[]
+        {
+            Msg("Assistant", ("Text", "the real answer")),
+            Msg("System", ("Text", "internal housekeeping")),
+        });
+
+        Assert.Equal(new[] { "Text", "System" }, widgets.Select(w => w.Kind));
+        Assert.Equal("the real answer", StoredConversationWidgets.LastAgentText(widgets));
+    }
+
+    [Fact]
+    public void EmptyAndMissingPieces_AreDropped_RatherThanDilutingTheContext()
+    {
+        var widgets = StoredConversationWidgets.From(new[]
+        {
+            Msg("Assistant", ("Text", "   "), ("Text", "real")),
+            new HistoryMessageDto { Role = "Assistant", Parts = null! },
+        });
+
+        Assert.Single(widgets);
+        Assert.Equal("real", widgets[0].Content);
+        Assert.Empty(StoredConversationWidgets.From(null));
+    }
+
+    [Fact]
+    public void TheAdaptedWidgets_FeedTheSameRecentContextTheTranslatorAlreadyBuilds()
+    {
+        // The proof that the shape survived the move: the translator's own context builder, unchanged,
+        // reads these widgets and produces the conversation it always did.
+        var widgets = StoredConversationWidgets.From(new[]
+        {
+            Msg("User", ("Text", "what is the status")),
+            Msg("Assistant", ("Text", "one moment")),
+            Msg("User", ("Text", "any luck")),
+            Msg("Assistant", ("Text", "all done")),
+        });
+
+        var context = WingmanTranslator.BuildRecentContext(widgets);
+
+        Assert.Contains("You: what is the status", context);
+        Assert.Contains("Agent: one moment", context);
+        Assert.DoesNotContain("all done", context);   // the latest reply is what gets narrated, not context
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
@@ -56,13 +56,103 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         return Path.Combine(dir, "voice-sessions.json");
     }
 
-    private WingmanVoiceService NewService()
+    private WingmanVoiceService NewService(
+        Func<TenantId, string, CcDirector.Gateway.History.StoredConversation?>? conversationReader = null)
     {
         // The flag methods never touch the brain; a provider that throws proves that.
         Func<TenantId, WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
             (_, _, _) => throw new InvalidOperationException("brain must not be called for flag state");
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
-        return new WingmanVoiceService(brain, new KeyVault(vaultPath), Settings, TempPersist());
+        return new WingmanVoiceService(brain, new KeyVault(vaultPath), Settings, TempPersist(),
+            conversationReader: conversationReader);
+    }
+
+    /// <summary>
+    /// The conversation the Gateway has STORED for a session, in the widget shape the narration reads
+    /// (turn-push mission, phase 3). This is the seam that replaced the "turns" command the narration used
+    /// to send down the tunnel, so it is the seam every generation test now sets up.
+    ///
+    /// It is a small class rather than a bare lambda for two reasons that tests here depend on. It COUNTS
+    /// the reads, which is how a test can still prove the service looked at the conversation before deciding
+    /// to skip - the assertion that used to be made against the tunnel stub's hit counter. And the stored
+    /// value is settable, so one test can drive the sequence that actually happens in production: nothing
+    /// stored yet, then the Director pushes the turn, then the next sweep narrates it.
+    /// </summary>
+    private sealed class StoredConversationStub
+    {
+        private IReadOnlyList<CcDirector.Gateway.Contracts.TurnWidgetDto>? _widgets;
+        private int _reads;
+
+        private StoredConversationStub(IReadOnlyList<CcDirector.Gateway.Contracts.TurnWidgetDto>? widgets)
+            => _widgets = widgets;
+
+        /// <summary>How many times the service asked for this session's conversation.</summary>
+        public int Reads => _reads;
+
+        /// <summary>A conversation of the given widgets, in order, as (kind, content) pairs. "Text" is the
+        /// agent's own words - the last of those is what a narration is made from.</summary>
+        public static StoredConversationStub Of(params (string Kind, string Content)[] widgets)
+            => new(Build(widgets));
+
+        /// <summary>Nothing has been stored for this session yet - the Director has not pushed its turn.
+        /// This is a WAIT, not a failure, and the service must treat it as one.</summary>
+        public static StoredConversationStub NothingStored() => new(null);
+
+        /// <summary>An agent that keeps no readable conversation AT ALL. Terminal: no wait and no retry will
+        /// ever produce words to narrate, so the service must say so rather than wait quietly forever.</summary>
+        public static StoredConversationStub NoConversationEverKept() => new(Build(Array.Empty<(string, string)>())) { _supported = false };
+
+        /// <summary>The Director's push arrives: from now on the reader answers with these widgets.</summary>
+        public void Store(params (string Kind, string Content)[] widgets) => _widgets = Build(widgets);
+
+        private bool _supported = true;
+
+        /// <summary>The delegate the service is constructed with.</summary>
+        public Func<TenantId, string, CcDirector.Gateway.History.StoredConversation?> Reader
+            => (_, _) =>
+            {
+                Interlocked.Increment(ref _reads);
+                return _widgets is null
+                    ? null
+                    : new CcDirector.Gateway.History.StoredConversation(_supported, _widgets);
+            };
+
+        private static List<CcDirector.Gateway.Contracts.TurnWidgetDto> Build((string Kind, string Content)[] widgets)
+        {
+            var built = new List<CcDirector.Gateway.Contracts.TurnWidgetDto>();
+            foreach (var (kind, content) in widgets)
+                built.Add(new CcDirector.Gateway.Contracts.TurnWidgetDto { Kind = kind, Content = content });
+            return built;
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WhenTheAgentKeepsNoConversation_IsTerminal_AndStandsTheSweepDown()
+    {
+        // THE CAPABILITY THAT NEARLY WENT WITH THE TUNNEL READ. An agent with no conversation to read used to
+        // answer "unsupported" on the transcript read, which recorded a terminal verdict: the voice screen
+        // said "Voice unavailable" and the sweep stopped spending its small per-cycle budget on a session
+        // that could never produce a narration. Reading the store removed the failing read and, with it, the
+        // only producer of that verdict - such a session would have read as an ordinary quiet wait, forever,
+        // with nothing said anywhere. The Director already pushes the fact, so the store carries it.
+        var conversation = StoredConversationStub.NoConversationEverKept();
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-terminal-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1, 2, 3 }, persistPath, conversation.Reader);
+            var tunnel = new TunnelStub();
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(tunnel));
+
+            Assert.Equal(HostedAiState.Unavailable, svc.ReadFailedFor(TenantId.Local, "sid-1"));
+            Assert.True(svc.ShouldSkipSweep(TenantId.Local, "sid-1"));
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+            // And NOT the honest-but-wrong "waiting on a prompt" answer, which is what a reader would be told
+            // to keep waiting for.
+            Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch (IOException) { } }
     }
 
     [Fact]
@@ -238,26 +328,26 @@ public sealed class WingmanVoiceServiceTests : IDisposable
 
     // ---------- Re-narrate only when the reply actually changed (issue #1322, identity-aware) ----------
 
-    /// <summary>Gateway Cleanup mission (the cut): a tunnel-connected "Director" whose "turns" verb returns a
-    /// fixed JSON body and counts how many times it was read. GenerateAsync reads the session over the
-    /// TUNNEL-ONLY SessionVerbClient now (the HTTP fallback is gone), so this stub is the sendCommand the client
-    /// dispatches to - it proves whether GenerateAsync fetched and what it did with the result.</summary>
-    private sealed class TunnelReadStub
+    /// <summary>
+    /// A tunnel-connected "Director" that answers every verb successfully and counts how many commands it
+    /// was sent. GenerateAsync still reaches the owning Director over the TUNNEL-ONLY SessionVerbClient, so
+    /// this stub is the sendCommand the client dispatches to.
+    ///
+    /// It no longer serves a "turns" body. The narration used to fetch the session's conversation by sending
+    /// that verb down the tunnel; since the turn-push mission's third phase it reads the conversation the
+    /// Gateway has already stored, so the only thing left riding this transport during a generation is the
+    /// LIVE SCREEN read. A test that wants to say something about the conversation sets up a
+    /// <see cref="StoredConversationStub"/> instead, and its own read counter is the signal that used to be
+    /// read off this one.
+    /// </summary>
+    private sealed class TunnelStub
     {
-        private readonly string _turnsJson;
         private int _hits;
         public int Hits => _hits;
 
-        public TunnelReadStub(string turnsJson) => _turnsJson = turnsJson;
-
-        public CcDirector.Gateway.Api.DirectorCommandRouter.SendDirectorCommandAsync SendCommand => (_, command, _) =>
+        public CcDirector.Gateway.Api.DirectorCommandRouter.SendDirectorCommandAsync SendCommand => (_, _, _) =>
         {
-            if (string.Equals(command.Verb, "turns", StringComparison.Ordinal))
-            {
-                Interlocked.Increment(ref _hits);
-                return Task.FromResult<CcDirector.Gateway.Contracts.DirectorCommandResult?>(
-                    CcDirector.Gateway.Contracts.DirectorCommandResult.Success(_turnsJson));
-            }
+            Interlocked.Increment(ref _hits);
             return Task.FromResult<CcDirector.Gateway.Contracts.DirectorCommandResult?>(
                 CcDirector.Gateway.Contracts.DirectorCommandResult.Success());
         };
@@ -313,13 +403,14 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         // is stuck and generate does nothing". The model leg now mirrors the speech leg: a non-answer is
         // Retrying (calm "voice on its way", the sweep retries), never a silent failure and never
         // ServiceDown. Nothing plays, but the phone knows why - and it is one session's state, nobody else's.
-        var director = new TunnelReadStub("{\"widgets\":[{\"kind\":\"Text\",\"content\":\"the reply to narrate\"}]}");
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-modeltimeout-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
             var brain = new TimingOutBrain();
-            var svc = ServiceWithBrainAndTts(brain, new byte[] { 7, 7, 7 }, persistPath);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 7, 7, 7 }, persistPath, conversation.Reader);
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
@@ -351,13 +442,14 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         // The screenshot's session: waiting on a prompt/menu, so the latest turn has no Text widget. The
         // auto path must record the honest "nothing to narrate" fact (so the Voice screen says so), call
         // no model, produce no audio, and set NO failure reason - it is not a failure, it is just empty.
-        var director = new TunnelReadStub("{\"widgets\":[{\"kind\":\"ToolUse\",\"content\":\"running a tool\"}]}");
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("ToolUse", "running a tool"));
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-nothing-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
             var brain = new RecordingBrain();
-            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath, conversation.Reader);
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
@@ -373,13 +465,14 @@ public sealed class WingmanVoiceServiceTests : IDisposable
     public async Task GenerateAsync_WithTextWidget_ClearsStaleNothingToNarrate_AndNarrates()
     {
         // A text reply appeared: the auto path clears any stale "nothing to narrate" and makes the voice.
-        var director = new TunnelReadStub("{\"widgets\":[{\"kind\":\"Text\",\"content\":\"the reply to read\"}]}");
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to read"));
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-nowtext-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
             var brain = new RecordingBrain();
-            var svc = ServiceWithBrainAndTts(brain, new byte[] { 9, 9, 9 }, persistPath);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 9, 9, 9 }, persistPath, conversation.Reader);
             svc.SetNothingToNarrate(TenantId.Local, "sid-1", true);   // a stale marker from an earlier empty read
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
@@ -421,57 +514,71 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         Assert.False(svc.NothingToNarrateFor(TenantId.Local, "s"));
     }
 
-    // ---------- A FAILED turns read is not "nothing to say" (issue #2561) ----------
+    // ---------- A FAILED read is not "nothing to say" (issue #2561), and there is no read left to fail ----------
 
     /// <summary>
-    /// The turns verb reports a failed read as a SUCCESSFUL command result carrying an empty widget list and
-    /// a Status naming the real outcome. Before this fix nothing read that Status, so a missing transcript,
-    /// an unreadable transcript, a parse exception and an agent with no history provider were all recorded as
-    /// "nothing to narrate" - a NON-failure that is never retried and raises nothing anywhere. A Pi session
-    /// observed on 12 August sat silent for 48 minutes that way.
+    /// THE LESSON, KEPT: a failed read of a session's conversation must never be mistaken for "this session
+    /// has nothing to say". Getting that wrong is issue #2561 - a missing transcript, an unreadable one, a
+    /// parse exception and an agent with no history provider were all recorded as "nothing to narrate", a
+    /// non-failure that is never retried and raises nothing anywhere, and a Pi session observed on 12 August
+    /// sat silent for 48 minutes because of it.
     ///
-    /// Each of these statuses must record Retrying (so the voice sweep picks it up again and the screen says
-    /// something) and must NOT record nothing-to-narrate.
+    /// The lesson now holds STRUCTURALLY rather than by a check. The narration reads the conversation the
+    /// Gateway has already stored, so there is no tunnel read left to fail: the five statuses this test used
+    /// to enumerate one by one - no_transcript, no_jsonl, parse_error, empty_history and no_session_id - were
+    /// each a shape of a failed "turns" command, and not one of them can arise any more. There is nothing to
+    /// tell apart, so nothing to tell apart wrongly.
+    ///
+    /// What is left in that space is the one honest waiting state: nothing has been stored for this session
+    /// yet, because the Director has not pushed its turn. That is a WAIT, not a failure and not an attempt.
+    /// So the service must record NEITHER a read failure NOR nothing-to-narrate, must not call the model, and
+    /// must produce no audio - it simply comes back on the next sweep.
     /// </summary>
-    [Theory]
-    [InlineData("no_transcript")]
-    [InlineData("no_jsonl")]
-    [InlineData("parse_error")]
-    [InlineData("empty_history")]
-    [InlineData("no_session_id")]
-    public async Task GenerateAsync_WhenTurnsReadFailed_RecordsRetrying_NotNothingToNarrate(string status)
+    [Fact]
+    public async Task GenerateAsync_WhenNothingIsStoredYet_RecordsNeitherAReadFailureNorNothingToNarrate()
     {
-        // A failed read: the transport succeeded, so this is a success carrying no widgets - exactly the
-        // shape that used to be indistinguishable from a session waiting on a prompt.
-        var director = new TunnelReadStub($"{{\"status\":\"{status}\",\"error\":\"the read failed\",\"widgets\":[]}}");
-        var dir = Path.Combine(Path.GetTempPath(), "wmvs-readfail-" + Guid.NewGuid().ToString("N"));
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.NothingStored();
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-nostore-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
             var brain = new RecordingBrain();
-            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath, conversation.Reader);
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
-            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
-            Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));   // the lie this fix removes
-            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
-            Assert.Equal(0, brain.AskCount);                                  // nothing was read, so nothing to translate
+            Assert.True(conversation.Reads >= 1);                              // it did look for the words
+            Assert.Null(svc.ReadFailedFor(TenantId.Local, "sid-1"));           // ...and a wait is not a failed read
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));     // ...so the row carries no reason at all
+            Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));    // ...and it is NOT "nothing to say" either
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));               // nothing to play yet
+            Assert.Equal(0, brain.AskCount);                                   // and nothing to translate, so no spend
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
 
-    /// <summary>A tunnel read that does not answer at all (the owning Director is not connected) is the same
-    /// class of non-evidence and takes the same Retrying treatment - never "nothing to narrate".</summary>
+    /// <summary>
+    /// The owning Director being unreachable no longer silences the narration, which is the whole gain of
+    /// moving the conversation into the Gateway's own store. It used to be fatal: the conversation was
+    /// fetched by a command sent down the tunnel, so a Director that had dropped off produced no words, and
+    /// this test asserted the consolation prize - that the session at least said "voice on its way" instead
+    /// of the lie "nothing to narrate".
+    ///
+    /// Now the words are already here. The only thing the tunnel still carries during a generation is the
+    /// live screen read, which the narration explicitly does not depend on. So an unreachable Director costs
+    /// this session a screen verdict and nothing else: it still narrates, and it still records no failure.
+    /// </summary>
     [Fact]
-    public async Task GenerateAsync_WhenTurnsReadDoesNotAnswer_RecordsRetrying_NotNothingToNarrate()
+    public async Task GenerateAsync_WhenTheDirectorIsUnreachable_StillNarratesFromTheStoredConversation()
     {
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-readnull-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
             var brain = new RecordingBrain();
-            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath, conversation.Reader);
             // A null command result is what DirectorCommandRouter yields for an unreachable Director.
             CcDirector.Gateway.Api.DirectorCommandRouter.SendDirectorCommandAsync unreachable =
                 (_, _, _) => Task.FromResult<CcDirector.Gateway.Contracts.DirectorCommandResult?>(null);
@@ -481,28 +588,31 @@ public sealed class WingmanVoiceServiceTests : IDisposable
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", route, CancellationToken.None, showReadingWindow: true);
 
-            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
-            Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));
-            Assert.Equal(0, brain.AskCount);
+            Assert.Equal(1, brain.AskCount);                                   // it translated the stored reply
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));                // and there is something to play
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));     // no failure was recorded
+            Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));    // and never the old lie
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
 
     /// <summary>
-    /// The other direction, so the fix cannot be "record Retrying for everything": a read that SUCCEEDS and
-    /// genuinely contains no text reply is still the honest "nothing to narrate", and still raises no failure.
-    /// This is the state a session waiting on a prompt is actually in, and it must survive the change.
+    /// The other direction, so the fix cannot be "say nothing about everything": a conversation that IS
+    /// stored and genuinely contains no text reply is still the honest "nothing to narrate", and still raises
+    /// no failure. This is the state a session waiting on a prompt is actually in, and it must survive the
+    /// move of the conversation from a tunnel read into the Gateway's own store.
     /// </summary>
     [Fact]
     public async Task GenerateAsync_WhenReadSucceedsWithNoText_StillRecordsNothingToNarrate()
     {
-        var director = new TunnelReadStub("{\"status\":\"ok\",\"widgets\":[{\"kind\":\"ToolUse\",\"content\":\"running a tool\"}]}");
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("ToolUse", "running a tool"));
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-oknotext-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
             var brain = new RecordingBrain();
-            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath, conversation.Reader);
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
@@ -522,12 +632,13 @@ public sealed class WingmanVoiceServiceTests : IDisposable
     [Fact]
     public async Task GenerateAsync_WhenReadRecovers_ClearsTheReadFailureRetrying()
     {
-        var director = new TunnelReadStub("{\"status\":\"ok\",\"widgets\":[{\"kind\":\"ToolUse\",\"content\":\"running a tool\"}]}");
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("ToolUse", "running a tool"));
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-recover-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
-            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath);
+            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath, conversation.Reader);
             svc.NoteReadFailed(TenantId.Local, "sid-1", HostedAiState.Retrying);   // left behind by an earlier failed read
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
@@ -541,54 +652,80 @@ public sealed class WingmanVoiceServiceTests : IDisposable
 
 
     /// <summary>
-    /// "unsupported" is the one read failure that CANNOT recover: the agent exposes no conversation history
-    /// at all, so retrying can never produce one. It takes the terminal state instead, so the screen says
-    /// "Voice unavailable" rather than promising a narration that is not coming - and so the voice sweep can
-    /// leave it out of its three-per-cycle budget instead of letting it starve sessions that would produce
-    /// audio. Found in review: the first version of this fix retried it forever.
+    /// A session with nothing stored yet must stay IN the sweep, so it narrates the moment its words arrive.
+    ///
+    /// This is the successor to the old "unsupported" case. A tunnel read could answer that the agent exposed
+    /// no conversation history at all, which retrying could never fix, so it took a terminal state - partly so
+    /// the screen stopped promising a narration that was not coming, and partly so such sessions stopped
+    /// starving the sweep's three-generations-a-cycle budget. Neither pressure exists now: a read of the store
+    /// costs nothing and cannot fail, so a session waiting for its first push is simply cheap to ask again.
+    ///
+    /// What must therefore be true, and is what this test pins: the wait never stands the sweep down
+    /// (<see cref="WingmanVoiceService.ShouldSkipSweep"/> stays false), and the session narrates on the very
+    /// next attempt once the Director's push has landed. The alternative - recording something terminal on a
+    /// session that has merely not spoken yet - would be the permanent silence this whole change removes.
     /// </summary>
     [Fact]
-    public async Task GenerateAsync_WhenAgentHasNoConversationHistory_IsTerminal_NotRetriedForever()
+    public async Task GenerateAsync_WhenNothingIsStoredYet_DoesNotStandTheSweepDown_AndNarratesOnceTurnsArrive()
     {
-        var director = new TunnelReadStub("{\"status\":\"unsupported\",\"error\":\"no history provider\",\"widgets\":[]}");
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.NothingStored();
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-unsup-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
-            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath);
+            var brain = new RecordingBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath, conversation.Reader);
 
+            // The turn has ended but the Director has not pushed it yet - the sweep finds nothing to read.
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
-            Assert.Equal(HostedAiState.Unavailable, svc.ReadFailedFor(TenantId.Local, "sid-1"));
-            Assert.Equal(HostedAiState.Unavailable, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            Assert.False(svc.ShouldSkipSweep(TenantId.Local, "sid-1"));       // still in the sweep - this is what recovers it
+            Assert.Null(svc.ReadFailedFor(TenantId.Local, "sid-1"));          // nothing terminal, nothing retryable
             Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));
+            Assert.Equal(0, brain.AskCount);
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+
+            // The push lands, and the next sweep of the same session narrates it.
+            conversation.Store(("Text", "the reply the Director finally pushed"));
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(1, brain.AskCount);
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
 
     /// <summary>
-    /// A failed read must NEVER replace a standing account condition. "Add credit" is actionable and certain;
-    /// a failed transcript read is neither, and says nothing whatever about the account. The first version of
-    /// this fix wrote the read state into the SAME dictionary, so one unreachable tunnel downgraded
-    /// "Voice needs credit" to "voice on its way" - found in review.
+    /// A conversation that is not there yet must NEVER replace a standing account condition. "Add credit" is
+    /// actionable and certain; a session whose words have not been pushed yet says nothing whatever about the
+    /// account. An early version of the read-failure fix wrote the read's state into the SAME dictionary as
+    /// the account's, so one unreachable tunnel downgraded "Voice needs credit" to "voice on its way" - found
+    /// in review, and the reason the two facts are stored apart.
+    ///
+    /// The pressure is lower now, because a wait records nothing at all, which is the second assertion here.
+    /// The precedence still has to hold, though: whatever the narration path learns on a pass where it has no
+    /// words, the reader must still be told the one thing they can act on.
     /// </summary>
     [Fact]
-    public async Task GenerateAsync_WhenReadFails_DoesNotOverwriteAStandingAccountCondition()
+    public async Task GenerateAsync_WhenNothingIsStoredYet_DoesNotOverwriteAStandingAccountCondition()
     {
-        var director = new TunnelReadStub("{\"status\":\"no_transcript\",\"error\":\"not located\",\"widgets\":[]}");
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.NothingStored();
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-acct-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
-            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath);
+            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath, conversation.Reader);
             svc.NoteUnavailableForTest(TenantId.Local, "sid-1", HostedAiState.NeedsCredits);
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
             // The account condition still wins: it is the more actionable and the more certain of the two.
             Assert.Equal(HostedAiState.NeedsCredits, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
-            // ...and the read failure is still recorded, in its own store, so nothing is lost either.
-            Assert.Equal(HostedAiState.Retrying, svc.ReadFailedFor(TenantId.Local, "sid-1"));
+            // ...and the wait added nothing of its own to argue with it.
+            Assert.Null(svc.ReadFailedFor(TenantId.Local, "sid-1"));
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
@@ -601,12 +738,13 @@ public sealed class WingmanVoiceServiceTests : IDisposable
     [Fact]
     public async Task GenerateAsync_WhenReadRecovers_DoesNotEraseAModelLegRetrying()
     {
-        var director = new TunnelReadStub("{\"status\":\"ok\",\"widgets\":[{\"kind\":\"ToolUse\",\"content\":\"running a tool\"}]}");
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("ToolUse", "running a tool"));
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelretry-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
-            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath);
+            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath, conversation.Reader);
             svc.NoteRetrying(TenantId.Local, "sid-1");   // the MODEL leg's own state, on the shared map
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
@@ -684,34 +822,40 @@ public sealed class WingmanVoiceServiceTests : IDisposable
     }
 
     /// <summary>A voice service wired to a recording brain and a text-to-speech stub that returns
-    /// <paramref name="audio"/>, so the full turn-end path (fetch -> translate -> synthesize -> store)
-    /// runs without a live model or provider.</summary>
-    private WingmanVoiceService ServiceWithBrainAndTts(IAgentBrain brain, byte[] audio, string persistPath)
+    /// <paramref name="audio"/>, so the full turn-end path (read the stored conversation -> translate ->
+    /// synthesize -> store) runs without a live model or provider. <paramref name="conversationReader"/> is
+    /// what the narration reads its words from; leaving it null is the honest "this Gateway has stored
+    /// nothing" case, which is what the tests about waiting want.</summary>
+    private WingmanVoiceService ServiceWithBrainAndTts(IAgentBrain brain, byte[] audio, string persistPath,
+        Func<TenantId, string, CcDirector.Gateway.History.StoredConversation?>? conversationReader = null)
     {
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
         var vault = new KeyVault(vaultPath);
         vault.Set("OPENAI_API_KEY", "sk-test");
         vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test");
         var http = new HttpClient(new TtsStubHandler(HttpStatusCode.OK, "", audio));
-        return new WingmanVoiceService((_, _, _) => Task.FromResult(brain), vault, Settings, persistPath, ttsHttpClient: http);
+        return new WingmanVoiceService((_, _, _) => Task.FromResult(brain), vault, Settings, persistPath,
+            ttsHttpClient: http, conversationReader: conversationReader);
     }
 
     /// <summary>Like <see cref="ServiceWithBrainAndTts"/> but with a caller-supplied speech transport, so a
     /// test can drive the full GenerateAsync path (model translation + speech) against a stateful handler.</summary>
-    private WingmanVoiceService ServiceWithBrainAndHandler(IAgentBrain brain, HttpMessageHandler handler, string persistPath)
+    private WingmanVoiceService ServiceWithBrainAndHandler(IAgentBrain brain, HttpMessageHandler handler, string persistPath,
+        Func<TenantId, string, CcDirector.Gateway.History.StoredConversation?>? conversationReader = null)
     {
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
         var vault = new KeyVault(vaultPath);
         vault.Set("OPENAI_API_KEY", "sk-test");
         vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test");
         var http = new HttpClient(handler);
-        return new WingmanVoiceService((_, _, _) => Task.FromResult(brain), vault, Settings, persistPath, ttsHttpClient: http);
+        return new WingmanVoiceService((_, _, _) => Task.FromResult(brain), vault, Settings, persistPath,
+            ttsHttpClient: http, conversationReader: conversationReader);
     }
 
     /// <summary>Gateway Cleanup mission (the cut): GenerateAsync takes a tunnel-only SessionVerbClient. This
-    /// binds one to the stub's sendCommand so the "turns" read rides the tunnel (the HTTP fallback is gone);
-    /// the stub's Hits still counts the reads, the exact signal these tests assert.</summary>
-    private static CcDirector.Gateway.Api.SessionVerbClient RouteFor(TunnelReadStub stub) =>
+    /// binds one to the stub's sendCommand, which is now the transport for the LIVE SCREEN read alone - the
+    /// conversation itself comes from the stored-conversation reader, not from the tunnel.</summary>
+    private static CcDirector.Gateway.Api.SessionVerbClient RouteFor(TunnelStub stub) =>
         new(new CcDirector.Gateway.Contracts.DirectorDto { DirectorId = "d1", ControlEndpoint = "http://tunnel-only" },
             stub.SendCommand);
 
@@ -722,13 +866,14 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         // differs from the one already narrated, the turn-end MUST regenerate - even though a cached clip
         // exists. The old guard skipped here whenever the Working transition was missed, leaving the
         // phone replaying a stale interim narration while the history had moved on to the real answer.
-        var director = new TunnelReadStub("{\"widgets\":[{\"kind\":\"Text\",\"content\":\"the NEW final answer\"}]}");
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the NEW final answer"));
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-regen-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
             var brain = new RecordingBrain();
-            var svc = ServiceWithBrainAndTts(brain, new byte[] { 4, 4, 4 }, persistPath);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 4, 4, 4 }, persistPath, conversation.Reader);
             svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "old spoken", "the OLD interim reply", new byte[] { 1, 2, 3 });
             Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
 
@@ -746,22 +891,23 @@ public sealed class WingmanVoiceServiceTests : IDisposable
     public async Task GenerateAsync_WhenCurrentReplyMatchesCache_SkipsQuietly()
     {
         // Issue #1322 preserved: when the CURRENT last reply is the EXACT one already narrated, the
-        // turn-end fetches to compare but does NOT regenerate - it never calls the brain, never re-mints
-        // audio, and never flips the session yellow, so a client mid-play is not disturbed.
-        var director = new TunnelReadStub("{\"widgets\":[{\"kind\":\"Text\",\"content\":\"the same reply\"}]}");
+        // turn-end reads the conversation to compare but does NOT regenerate - it never calls the brain,
+        // never re-mints audio, and never flips the session yellow, so a client mid-play is not disturbed.
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the same reply"));
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-same-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
             var brain = new RecordingBrain();
-            var svc = ServiceWithBrainAndTts(brain, new byte[] { 9, 9 }, persistPath);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 9, 9 }, persistPath, conversation.Reader);
             svc.StoreReadyAudioForTest(TenantId.Local, "sid-1", "old spoken", "the same reply", new byte[] { 1, 2, 3 });
             Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
             Assert.Equal(0, brain.AskCount);              // never regenerated
-            Assert.True(director.Hits >= 1);              // but it DID fetch to compare (identity-aware, not blind)
+            Assert.True(conversation.Reads >= 1);         // but it DID read the conversation to compare (identity-aware, not blind)
             Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));           // the existing clip is untouched
             Assert.False(svc.IsGenerating(TenantId.Local, "sid-1"));      // and it never flipped the session yellow
             Assert.Equal(new byte[] { 1, 2, 3 }, svc.GetAudio(TenantId.Local, "sid-1"));   // same original audio, not re-minted
@@ -1193,13 +1339,14 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         // new code there is no gate, so BOTH reach the provider and BOTH get audio. The probe is held
         // in-flight (the handler blocks), so the skip - if the gate still existed - is observed
         // deterministically, not on a timer.
-        var director = new TunnelReadStub("{\"widgets\":[{\"kind\":\"Text\",\"content\":\"the reply to narrate\"}]}");
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
         var dir = Path.Combine(Path.GetTempPath(), "wmvs-nogate-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
             var handler = new FirstFails5xxThenBlockingSuccessHandler(new byte[] { 5, 5, 5 });
-            var svc = ServiceWithBrainAndHandler(new RecordingBrain(), handler, persistPath);
+            var svc = ServiceWithBrainAndHandler(new RecordingBrain(), handler, persistPath, conversation.Reader);
 
             // A fails 5xx first - on the OLD code this armed the shared cooldown before B/C ever ask.
             await svc.GenerateAsync(TenantId.Local, "sid-A", RouteFor(director), CancellationToken.None, showReadingWindow: false);

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -130,6 +130,10 @@ internal static class GatewayWingmanVoiceEndpoint
         // in a defaulted position: a forgotten boundary must be a compile error, never a silent default.
         // Self-host callers construct it over the SingleTenantContext.
         Tenancy.HostedTenantBoundary tenantBoundary,
+        // One session's stored conversation as the widget list the wingman reads (turn-push mission, phase 3).
+        // Null answers "nothing stored yet", which is a wait rather than a failure. The caller enters the
+        // tenant's scope and hands over the finished list.
+        Func<TenantId, string, History.StoredConversation?>? conversationReader = null,
         Streaming.PushedSessionStore? pushedSessions = null,
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null,
         SessionOwnerCache? owners = null,
@@ -716,45 +720,51 @@ internal static class GatewayWingmanVoiceEndpoint
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
 
+            // NO LONGER 404 WHEN THE DIRECTOR IS UNREACHABLE. This route reads the conversation from the
+            // Gateway's own store, so a stored conversation can be narrated whether or not the machine that
+            // produced it is currently reachable - refusing here would have kept the old dependency alive in
+            // the one place a person presses a button to escape it (found in review). The route is resolved
+            // only so a session this Gateway has never heard of is still an honest 404.
             var route = await ResolveRouteAsync(reqTenant.Value, sid);
-            if (route is null)
-                return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
-
-            var turns = await route.GetTurnsAsync(sid, ct);
 
             voice.Mark(reqTenant.Value, sid);   // opening voice on a session makes it a voice session (kept fresh on turn-end)
 
-            // A FAILED READ IS NOT "NOTHING TO SUMMARIZE" (issue #2561). GetTurnsAsync answers null when the
-            // tunnel call failed, and otherwise carries the real outcome in Status - a failed read arrives as
-            // a SUCCESS with an empty widget list, because the transport worked even though the read did not.
+            // THE CONVERSATION COMES FROM THE GATEWAY'S OWN STORE (turn-push mission, phase 3). This route is
+            // the button a person presses when a narration has not appeared, so what it can honestly say
+            // matters more here than anywhere: it used to send a command down the tunnel asking the Director
+            // to re-read the transcript, and a failed read there arrived as a SUCCESS with no widgets, which
+            // is how this route came to tell people "this session has not produced anything to summarize yet"
+            // about sessions that had said plenty (issue #2561).
             //
-            // Reading only the widgets makes this route tell the person "this session has not produced
-            // anything to summarize yet" - a confident, wrong sentence about their own session - and record
-            // the never-retried "nothing to narrate" fact behind it. It is the same mistake the automatic
-            // path made, and on THIS route it is the one the owner presses a button to see. The honest answer
-            // is the one the model-leg timeout below already gives: say it is still coming, record Retrying so
-            // the screen says so, and let the voice sweep try again.
-            if (turns is null || !string.Equals(turns.Status, "ok", StringComparison.OrdinalIgnoreCase))
+            // There is no read to fail any more. Either the words are stored or they have not arrived yet,
+            // and the second is a wait on the Director rather than anything voice can fix by trying harder.
+            var stored = conversationReader?.Invoke(reqTenant.Value, sid);
+            if (stored is null && route is null)
+                return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
+            if (stored is { IsSupported: false })
             {
-                // "unsupported" is TERMINAL - this agent exposes no conversation history at all, so no amount
-                // of retrying will produce one and saying "it will keep trying" would be the same lie in a new
-                // costume. Everything else here can become readable on a later pass. Recorded through
-                // NoteReadFailed, into the read's own store, so it can never overwrite a standing account
-                // condition (see TenantVoiceState.ReadFailed).
-                var terminal = string.Equals(turns?.Status, "unsupported", StringComparison.OrdinalIgnoreCase);
-                voice.NoteReadFailed(reqTenant.Value, sid, terminal ? HostedAiState.Unavailable : HostedAiState.Retrying);
-                FileLog.Write(
-                    $"[GatewayWingmanVoice] explain sid={sid}: turns read FAILED "
-                    + $"(status={turns?.Status ?? "(no answer)"} error={turns?.Error ?? "(none)"}) "
-                    + $"- {(terminal ? "TERMINAL" : "Retrying")}; NOT reported as nothing-to-summarize (issue #2561).");
+                // Terminal, and the person pressed a button to find out: say the thing that is true rather
+                // than promising another try that cannot help.
+                voice.NoteReadFailed(reqTenant.Value, sid, HostedAiState.Unavailable);
+                FileLog.Write($"[GatewayWingmanVoice] explain sid={sid}: this agent keeps no conversation that can be read - TERMINAL.");
                 return Results.Json(new
                 {
                     reply = "",
-                    spoken = terminal
-                        ? "This agent does not keep a conversation I can read back to you."
-                        : "I could not read this session's conversation just now - it will keep trying.",
+                    spoken = "This agent does not keep a conversation I can read back to you.",
                     replySeconds = 0.0,
-                    retrying = !terminal,
+                    retrying = false,
+                });
+            }
+            var widgets = stored?.Widgets;
+            if (widgets is null)
+            {
+                FileLog.Write($"[GatewayWingmanVoice] explain sid={sid}: no conversation stored yet - the Director has not pushed it. Not a read failure, and not a statement about the session.");
+                return Results.Json(new
+                {
+                    reply = "",
+                    spoken = "This session's conversation has not reached here yet. It should arrive in a moment.",
+                    replySeconds = 0.0,
+                    retrying = true,
                 });
             }
 
@@ -765,8 +775,7 @@ internal static class GatewayWingmanVoiceEndpoint
             // fact is cleared - the model and speech states clear where they were set.
             voice.ClearReadFailed(reqTenant.Value, sid);
 
-            var widgets = turns.Widgets ?? new List<TurnWidgetDto>();
-            var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;
+            var lastReply = History.StoredConversationWidgets.LastAgentText(widgets);
             // Recent conversation so the wingman can give context to a short/terse reply.
             var recentContext = WingmanTranslator.BuildRecentContext(widgets);
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2052,6 +2052,26 @@ public sealed class GatewayHost : IAsyncDisposable
             ? PushedSessions.TryLocate(tenant, sessionId, staleAfter)
             : null;
 
+    /// <summary>
+    /// One session's stored conversation, as the widget list the wingman reads. Null means nothing has been
+    /// stored for it yet - which the narration path treats as "wait", not as a failure, and never as an
+    /// attempt against the turn's retry budget.
+    ///
+    /// The tenant scope is entered HERE, synchronously, and the finished list is handed over. Narration runs
+    /// fire-and-forget from a sweep, and an ambient scope does not survive into an asynchronous
+    /// continuation - which is how a read ends up answering for the wrong account.
+    /// </summary>
+    private History.StoredConversation? ReadStoredConversation(TenantId tenant, string sessionId)
+    {
+        if (!tenant.IsValid || string.IsNullOrEmpty(sessionId)) return null;
+        using var scope = _tenantBoundary?.EnterScope(tenant);
+        var stored = _sessionTurns.ReadCurrent(sessionId);
+        if (stored is null) return null;
+        return new History.StoredConversation(
+            stored.Value.Head.IsSupported,
+            History.StoredConversationWidgets.From(stored.Value.Messages));
+    }
+
     private string? ResolveSessionTitle(TenantId tenant, string sessionId)
     {
         if (!tenant.IsValid)
@@ -2395,7 +2415,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // sessionTitleResolver: the wingman opens every narration with the session's title, so a
         // listener with the phone in a pocket knows WHICH session is talking before anything else
         // (WingmanTranslator.FidelityPrompt v5.2). Push-store read - no dial. See ResolveSessionTitle.
-        _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, _tenantSettingsResolver, instructionsProvider: () => _instructionsStore.ActiveContent, sessionTitleResolver: ResolveSessionTitle);
+        _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, _tenantSettingsResolver,
+            instructionsProvider: () => _instructionsStore.ActiveContent,
+            sessionTitleResolver: ResolveSessionTitle,
+            // The narration's words now come from the Gateway's own store (turn-push mission, phase 3), not
+            // from a tunnel command asking the Director to re-read the user's transcript. See
+            // ReadStoredConversation for why the tenant scope is entered there rather than inside the service.
+            conversationReader: ReadStoredConversation);
 
         // The session supervisor (issue #915). It hangs off the SAME turn-end boundary as the voice refresh
         // below, deliberately: that event is the only thing that can wake it, so a Working session is out of
@@ -3138,7 +3164,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // sessionTitleResolver: the wingman opens every narration with the session's title, so a
         // listener with the phone in a pocket knows WHICH session is talking before anything else
         // (WingmanTranslator.FidelityPrompt v5.2). Push-store read - no dial. See ResolveSessionTitle.
-        _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, _tenantSettingsResolver, instructionsProvider: () => _instructionsStore.ActiveContent, sessionTitleResolver: ResolveSessionTitle);
+        _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, _tenantSettingsResolver,
+            instructionsProvider: () => _instructionsStore.ActiveContent,
+            sessionTitleResolver: ResolveSessionTitle,
+            // The narration's words now come from the Gateway's own store (turn-push mission, phase 3), not
+            // from a tunnel command asking the Director to re-read the user's transcript. See
+            // ReadStoredConversation for why the tenant scope is entered there rather than inside the service.
+            conversationReader: ReadStoredConversation);
         // The session's conversation, served from THIS Gateway's store (turn-push mission, phase 2). A
         // literal route, so it outranks the /sessions/{sid}/{**rest} catch-all - whose "history" verb entry
         // is removed in the same change, because the whole point is that reading a conversation no longer
@@ -3147,6 +3179,9 @@ public sealed class GatewayHost : IAsyncDisposable
             _streamStaleAfter, _tenantBoundary);
 
         GatewayWingmanVoiceEndpoint.Map(_app, Registry, WingmanBrainAsync, _keyVault, _voiceService, _tenantSettingsResolver,
+            // The manual "generate the narration now" route reads the stored conversation too, through the
+            // same reader the automatic path uses - one source for both, which is the point of the mission.
+            conversationReader: ReadStoredConversation,
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync,
             owners: SessionOwners,

--- a/src/CcDirector.Gateway/History/StoredConversationWidgets.cs
+++ b/src/CcDirector.Gateway/History/StoredConversationWidgets.cs
@@ -1,0 +1,97 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.History;
+
+/// <summary>
+/// One session's stored conversation as the narration path sees it: whether this agent keeps a readable
+/// conversation at all, and the words if it does.
+///
+/// The flag is here because losing it lost a capability. When the narration read the transcript down the
+/// tunnel, an agent with no history provider answered "unsupported", and that recorded a TERMINAL verdict -
+/// the voice screen said so, and the sweep stopped spending its small per-cycle budget on a session that
+/// could never produce a narration. Reading the store instead removed the failing read and, with it, the
+/// only producer of that verdict: such a session would have gone back to reading as an ordinary quiet wait,
+/// forever, with nothing said on any screen. That is the exact shape of the silence issue #2561 was filed
+/// about, arriving from the other direction. The Director already pushes the fact, so it is carried here.
+/// </summary>
+/// <param name="IsSupported">This agent keeps a conversation that can be read. False is terminal: no amount
+/// of waiting or retrying will produce words to narrate.</param>
+/// <param name="Widgets">The conversation, in the shape the wingman already reads. Empty is ordinary - a
+/// session that has not spoken yet.</param>
+public readonly record struct StoredConversation(bool IsSupported, IReadOnlyList<TurnWidgetDto> Widgets);
+
+/// <summary>
+/// Turns the Gateway's STORED conversation into the widget list the wingman already reads (the turn-push
+/// mission, phase 3).
+///
+/// Why an adapter rather than a new shape. The narration path reads a conversation through
+/// <c>WingmanTranslator.BuildRecentContext</c> and by taking the last agent text - both written against
+/// <see cref="TurnWidgetDto"/>, both well exercised, and neither having anything to do with where the
+/// conversation came from. Changing the SOURCE from a tunnel read of the user's transcript to a read of
+/// stored rows is the whole point of this phase; changing the shape the translator sees at the same time
+/// would mean the narration could come out different and nobody could say which change did it. So the
+/// shape is preserved exactly and only the source moves.
+///
+/// The mapping is the one the Director's own widget builder made from the same messages: an agent's text
+/// is <c>Text</c> (the narration reads the last of these), a person's text is <c>UserMessage</c>, and
+/// everything else is labelled with its own kind, which is all <c>BuildRecentContext</c> asks of it.
+/// </summary>
+public static class StoredConversationWidgets
+{
+    /// <summary>The kind a widget carries for an assistant's spoken-aloud text - what the narration reads.</summary>
+    public const string AgentTextKind = "Text";
+
+    /// <summary>The kind a widget carries for something the person typed or said.</summary>
+    public const string UserTextKind = "UserMessage";
+
+    public static List<TurnWidgetDto> From(IReadOnlyList<HistoryMessageDto>? messages)
+    {
+        var widgets = new List<TurnWidgetDto>();
+        if (messages is null) return widgets;
+        foreach (var message in messages)
+        {
+            if (message?.Parts is null) continue;
+            // Text becomes the NARRATABLE kind only for an assistant. The stored role comes from
+            // ConversationRole, which today has exactly User and Assistant - but "anything that is not the
+            // user is the agent" would quietly make a system or tool role narratable if that enum ever
+            // grows, and the thing it would narrate is text the person never heard the agent say (found in
+            // review). An unrecognised role keeps its own name as the widget kind: it still reaches the
+            // context window, and it can never be picked as the reply to read aloud.
+            var isAssistant = string.Equals(message.Role, "Assistant", StringComparison.OrdinalIgnoreCase);
+            var isUser = string.Equals(message.Role, "User", StringComparison.OrdinalIgnoreCase);
+            foreach (var part in message.Parts)
+            {
+                if (part is null) continue;
+                var text = part.Text ?? "";
+                // A part with no text carries nothing the wingman can use, and an empty widget only dilutes
+                // the recent-context window that the narration's quality depends on.
+                if (text.Trim().Length == 0) continue;
+                var kind = !string.Equals(part.Kind, "Text", StringComparison.Ordinal) ? part.Kind ?? ""
+                         : isAssistant ? AgentTextKind
+                         : isUser ? UserTextKind
+                         : string.IsNullOrEmpty(message.Role) ? "UnknownRole" : message.Role;
+                widgets.Add(new TurnWidgetDto
+                {
+                    Kind = kind,
+                    Content = text,
+                    Header = part.ToolName ?? "",
+                    ToolUseId = part.ToolId ?? "",
+                });
+            }
+        }
+        return widgets;
+    }
+
+    /// <summary>The agent's most recent spoken text - what a narration is made from - or null when the
+    /// conversation holds none. A conversation whose last word is the person's, or which is all tool work,
+    /// genuinely has nothing to read aloud, and that is a fact about the conversation rather than a
+    /// failure to read it.</summary>
+    public static string? LastAgentText(IReadOnlyList<TurnWidgetDto>? widgets)
+    {
+        if (widgets is null) return null;
+        for (var i = widgets.Count - 1; i >= 0; i--)
+            if (string.Equals(widgets[i].Kind, AgentTextKind, StringComparison.Ordinal))
+                return widgets[i].Content;
+        return null;
+    }
+}

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -130,6 +130,13 @@ public sealed class WingmanVoiceService
     private readonly string _baseDir;
     private readonly HttpClient? _ttsHttp;   // test seam for TtsAsync (issue #939); the shared static when null
     private readonly Func<TenantId, string, string?>? _sessionTitleResolver;   // tenant + sid -> session title, spoken first
+    /// <summary>Reads one session's stored conversation as the widget list the wingman already understands
+    /// (turn-push mission, phase 3). Null answers "nothing stored for this session yet" - which is not a
+    /// failure. Supplied by the host, which owns entering the tenant's scope before touching the store; this
+    /// service is handed the finished answer so an asynchronous continuation can never read it under the
+    /// wrong account. Null delegate leaves narration with nothing to read, which is what a Gateway with no
+    /// store would honestly be.</summary>
+    private readonly Func<TenantId, string, History.StoredConversation?>? _conversationReader;
 
     /// <summary>
     /// True only for the EXACT form <see cref="Tenancy.TenantRegistry"/> mints: a canonical lowercase GUID.
@@ -327,8 +334,10 @@ public sealed class WingmanVoiceService
         string? persistPath = null,
         Func<string>? instructionsProvider = null,
         HttpClient? ttsHttpClient = null,
-        Func<TenantId, string, string?>? sessionTitleResolver = null)
+        Func<TenantId, string, string?>? sessionTitleResolver = null,
+        Func<TenantId, string, History.StoredConversation?>? conversationReader = null)
     {
+        _conversationReader = conversationReader;
         _vault = vault ?? throw new ArgumentNullException(nameof(vault));
         _tenantSettings = tenantSettings ?? throw new ArgumentNullException(nameof(tenantSettings));
         // The account's spoken language comes from the same per-tenant resolver this service already
@@ -959,56 +968,51 @@ public sealed class WingmanVoiceService
     private async Task<bool> GenerateOnceAsync(TenantId tenant, string sid, SessionVerbClient route, CancellationToken ct, bool showReadingWindow)
     {
         var state = StateFor(tenant);
-        var turns = await route.GetTurnsAsync(sid, ct);
-        // A FAILED READ IS NOT "NOTHING TO SAY". This is the whole of issue #2561, and it is why sessions
-        // went permanently silent with no error raised anywhere.
+
+        // THE CONVERSATION COMES FROM THE GATEWAY'S OWN STORE (turn-push mission, phase 3), not from a
+        // command sent down the tunnel asking the owning Director to re-read the user's transcript.
         //
-        // GetTurnsAsync answers null when the tunnel call failed (the owning Director is not connected), and
-        // otherwise hands back a TurnsResponse whose Status carries the REAL outcome - "ok", or one of
-        // "unsupported" / "no_session_id" / "no_jsonl" / "no_transcript" / "parse_error". Every one of those
-        // failures arrives as a SUCCESSFUL command result with an EMPTY widget list, because the transport
-        // worked even though the read did not.
+        // What that removes is an entire class of failure that this method used to have to reason about.
+        // A tunnel read answered null when the Director was not connected, and otherwise carried a status -
+        // "no_jsonl", "no_transcript", "parse_error", "unsupported" - each arriving as a SUCCESSFUL command
+        // with an empty widget list, because the transport worked even though the read did not. Telling
+        // those apart from "this session is waiting on a prompt" was issue #2561, and getting it wrong is
+        // what left a session silent for forty-eight minutes with nothing raised anywhere. It is also what
+        // left session 111 silent for hours on 1 September: the Director was looking for a transcript that
+        // had moved, and answered no_jsonl to every attempt.
         //
-        // This method used to read the widgets and nothing else. So a missing transcript, an unreadable
-        // transcript, a parse exception and an agent with no history provider all looked identical to a
-        // session that was simply waiting on a prompt - and were recorded as NothingToNarrate, which is a
-        // NON-failure that is never retried and produces no log line, no Retrying state, and no error on any
-        // screen. Observed 12 August: a Pi session sat silent for 48 minutes while the roster showed it
-        // "Preparing voice".
+        // None of that can happen here. A read of the store answers one of exactly two things: rows, or
+        // nothing stored yet. There is no transport to fail, no file to be missing, no parse to go wrong.
+        // The narration path therefore has ONE remaining reason to retry - the model or the speech service
+        // did not answer - which is the whole promise of this mission.
         //
-        // The correct treatment is the one the MODEL leg already applies a few dozen lines below (see
-        // IsModelDidNotAnswer): a read that did not answer is evidence about the READ, not about the
-        // conversation, so it is recorded as a read failure and picked up again by the voice sweep.
-        //
-        // NOT EVERY FAILED READ IS RETRYABLE, and the difference is recorded rather than flattened (found in
-        // review). "unsupported" means this agent exposes no conversation history AT ALL - retrying cannot
-        // change that, and telling the owner "voice on its way" forever would be the same lie in a new
-        // costume. It takes the terminal HostedAiState.Unavailable, which folds to a plain "Voice
-        // unavailable". Everything else here CAN become readable on a later pass - the tunnel comes back, the
-        // transcript appears once the agent writes its first turn, a half-written line finishes - so those
-        // stay Retrying.
-        //
-        // The state is recorded through NoteReadFailed, into the read's OWN store, never over the account /
-        // provider state - see TenantVoiceState.ReadFailed for why writing it into Unavailable was wrong in
-        // both directions.
-        if (turns is null)
+        // NOTHING STORED IS NOT A FAILURE AND NOT AN ATTEMPT. The words have not reached the Gateway yet;
+        // the Director will push them, and the Chat screen already says so in its own words. Recording a
+        // failure here would burn this turn's retry budget on a wait that has nothing to do with voice.
+        var stored = _conversationReader?.Invoke(tenant, sid);
+        if (stored is null)
         {
-            NoteReadFailed(tenant, sid, HostedAiState.Retrying);
-            FileLog.Write(
-                $"[WingmanVoiceService] turns read did not answer for sid={sid} (owning Director not connected) "
-                + "- Retrying; the voice sweep picks it up again. NOT recorded as nothing-to-narrate (issue #2561).");
+            // Clear any standing "nothing to read aloud" first. That sentence means the session is parked on
+            // a prompt with no reply to narrate; it does NOT mean "we do not have the words yet". Leaving it
+            // up while the push is in flight tells the reader the conversation is empty when it is merely
+            // late - a small version of the exact confusion this mission exists to remove (found in review).
+            // Nothing here stands the sweep down: ShouldSkipSweep keys on a terminal read verdict only.
+            SetNothingToNarrate(tenant, sid, false);
+            FileLog.Write($"[WingmanVoiceService] no conversation stored yet for sid={sid} - nothing to narrate from, and not counted as an attempt; the Director pushes it and the sweep comes back");
             return false;
         }
-        if (!string.Equals(turns.Status, "ok", StringComparison.OrdinalIgnoreCase))
+        // THE ONE TERMINAL ANSWER LEFT. This agent keeps no readable conversation at all, so no amount of
+        // waiting or retrying produces words to narrate. It is recorded as the terminal verdict so the voice
+        // screen says "Voice unavailable" instead of an endless quiet wait, and so the sweep stops spending
+        // its small per-cycle budget on a session that can never answer. Losing the tunnel read all but lost
+        // this - see StoredConversation for why the flag is carried.
+        if (!stored.Value.IsSupported)
         {
-            var terminal = string.Equals(turns.Status, "unsupported", StringComparison.OrdinalIgnoreCase);
-            NoteReadFailed(tenant, sid, terminal ? HostedAiState.Unavailable : HostedAiState.Retrying);
-            FileLog.Write(
-                $"[WingmanVoiceService] turns read FAILED for sid={sid}: status={turns.Status} "
-                + $"error={turns.Error ?? "(none)"} - {(terminal ? "TERMINAL (this agent exposes no conversation history)" : "Retrying; the voice sweep picks it up again")}. "
-                + "NOT recorded as nothing-to-narrate (issue #2561).");
+            NoteReadFailed(tenant, sid, HostedAiState.Unavailable);
+            FileLog.Write($"[WingmanVoiceService] sid={sid}: this agent keeps no conversation that can be read - TERMINAL, so the screen says so and the sweep stands down until the verdict is revalidated");
             return false;
         }
+        var widgets = stored.Value.Widgets;
         // The read answered, so whatever the last failed read recorded is over. Cleared HERE, before the
         // reply check, because VoiceDisplayFold consults the unavailable state BEFORE nothingToNarrate - a
         // stale read failure would mask the honest "nothing to read aloud" verdict on the very next pass.
@@ -1018,8 +1022,7 @@ public sealed class WingmanVoiceService
         // new turn). An earlier version of this line cleared any Retrying in the shared Unavailable map and
         // therefore erased model-leg and speech-leg states it had not established.
         ClearReadFailed(tenant, sid);
-        var widgets = turns.Widgets ?? new List<TurnWidgetDto>();
-        var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;
+        var lastReply = History.StoredConversationWidgets.LastAgentText(widgets);
         if (string.IsNullOrWhiteSpace(lastReply))
         {
             // The read SUCCEEDED and there is no text reply in it - the session is waiting on a prompt /


### PR DESCRIPTION
Phase 3a of thefrederiksen/devthrottle_internal#1882. The wingman - the thing that writes a turn's spoken narration - now reads the conversation the Gateway already stores, instead of asking the owning Director to re-read the transcript on the user's disk. Both narration paths move together: the automatic one at turn-end, and the "Generate narration now" button.

## Why this is the heart of the mission

The old path sent a command down the tunnel. A failed read came back looking like a *success* with no words in it: `no_jsonl`, `no_transcript`, `parse_error`, `unsupported` all arrived as a successful command with an empty widget list, because the transport worked even though the read did not. Telling those apart from "this session is waiting on a prompt" is issue thefrederiksen/devthrottle_internal#1838, and getting it wrong left a session silent for forty-eight minutes with nothing raised anywhere. It is also what left session 111 silent for hours on 1 September: the Director was looking for a transcript that had moved into a worktree, and answered `no_jsonl` to every attempt for the life of the session.

There is no read to fail any more.

## The three answers

- **Nothing stored yet** is a WAIT. The words have not arrived; the Director will push them. It is deliberately **not counted as a narration attempt** - burning a turn's retry budget on a wait that has nothing to do with voice is how a retry limit stops meaning anything. It also clears any standing "nothing to read aloud", because "we do not have the words yet" is not "there is nothing to say".
- **An agent that keeps no readable conversation** is TERMINAL and says so. That verdict used to come from the tunnel read answering `unsupported`; removing the read removed its only producer, which would have left those sessions reading as an endless quiet wait with nothing said on any screen - the shape of thefrederiksen/devthrottle_internal#1838 arriving from the other direction. The Director already pushes the fact, so `StoredConversation` carries it.
- **Otherwise, the words**, adapted into the exact widget shape the translator already reads, so if a narration ever comes out different it is not because the shape changed.

Pressing the button no longer needs the Director to be reachable. The conversation is here; refusing to narrate it because the machine that produced it is away would have kept the old dependency alive in the one place a person presses a button to escape it.

## Proof

- Seven adapter tests, including that only an assistant's text is narratable (an unknown role keeps its own name: still context, never the reply) and that the adapted widgets feed the translator's own unchanged context builder.
- The voice service suite reworked onto the new source. Notably: an unreachable Director now costs a session its screen verdict and nothing else - it still translates and still has playable audio; nothing stored yet keeps the session in the sweep and narrates once the push lands; an agent that keeps no conversation records the terminal verdict and stands the sweep down.
- Local gate green, nine suites.

## Reviews

One Codex pass, three findings, all fixed here: a stale "nothing to read aloud" left standing during the wait; the button still refusing when the Director was unreachable; and the adapter treating any non-user role as the agent, which would have made a system or tool role narratable if the stored role set ever grew.

## Not proven

No live run. The voice-turn wait loop still polls the tunnel and moves in the next slice, as do the retry schedule and the Generate button behaviour.
