### PR TITLE
Turn push, phase 3b: waiting for a spoken answer watches the stored conversation

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/WaitForSpokenReplyTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WaitForSpokenReplyTests.cs
@@ -1,0 +1,207 @@
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Phase 3b of the turn-push mission: waiting for the answer to a SPOKEN question.
+///
+/// This used to poll the transcript down the tunnel every 750 milliseconds for up to three minutes - one
+/// command per poll, each making the owning Director open and parse the whole transcript file on the user's
+/// disk, all so the Gateway could notice a reply it is now simply handed. It watches the stored conversation
+/// instead.
+///
+/// The giving-up signal changed with it, which is the part worth pinning. The old loop counted forty
+/// consecutive FAILED READS to guess the Director had gone - a proxy for something it could not see, built
+/// on a failure mode that no longer exists. It now asks the question it actually means: can a reply still
+/// arrive at all? Every test below is written to FAIL if that logic regresses, not merely to pass.
+/// </summary>
+public sealed class WaitForSpokenReplyTests
+{
+    private static readonly TimeSpan Poll = TimeSpan.FromMilliseconds(5);
+    private static readonly TimeSpan Settle = TimeSpan.FromMilliseconds(30);
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    private static List<TurnWidgetDto> Convo(params (string Kind, string Content)[] widgets) =>
+        widgets.Select(w => new TurnWidgetDto { Kind = w.Kind, Content = w.Content }).ToList();
+
+    private static Task<string?> Wait(Func<IReadOnlyList<TurnWidgetDto>?> read, Func<Task<bool>> reachable, int? before = 1,
+        TimeSpan? timeout = null)
+        => GatewayWingmanVoiceEndpoint.WaitForReplyAsync(read, reachable, "sid-1", before, CancellationToken.None,
+            timeout: timeout ?? Timeout, pollEvery: Poll, settleFor: Settle);
+
+    [Fact]
+    public async Task AReplyThatArrivesAndSettles_IsTheAnswer()
+    {
+        var conversation = Convo(("UserMessage", "the question"));
+        var reply = await Wait(() =>
+        {
+            if (conversation.Count == 1) conversation.Add(new TurnWidgetDto { Kind = "Text", Content = "the answer" });
+            return conversation;
+        }, () => Task.FromResult(true));
+
+        Assert.Equal("the answer", reply);
+    }
+
+    [Fact]
+    public async Task AConversationStillGrowing_IsNotAnsweredUntilItStops()
+    {
+        // The agent is still writing. Answering the first thing that appears would read half a turn aloud.
+        var conversation = Convo(("UserMessage", "the question"));
+        var grows = 0;
+        var reply = await Wait(() =>
+        {
+            if (grows++ < 5) conversation.Add(new TurnWidgetDto { Kind = "Text", Content = "part " + grows });
+            return conversation;
+        }, () => Task.FromResult(true));
+
+        Assert.Equal("part 5", reply);   // the last one, after it stopped growing - never "part 1"
+    }
+
+    [Fact]
+    public async Task NothingStoredForAWhile_IsNotAFailure_HoweverLongItLasts()
+    {
+        // The old loop gave up after forty consecutive unreadable polls. A store read cannot fail - it just
+        // has nothing yet - so there is nothing to count, and a session whose push is slow must not be
+        // abandoned. Deliberately more than forty polls, so the old heuristic would have failed this test.
+        var polls = 0;
+        var reachabilityChecks = 0;
+        var reply = await Wait(() =>
+        {
+            polls++;
+            return polls <= 60 ? null : Convo(("UserMessage", "the question"), ("Text", "arrived very late"));
+        }, () => { reachabilityChecks++; return Task.FromResult(true); });
+
+        Assert.True(polls > 60, $"the wait must have kept polling past the old forty-failure limit, saw {polls}");
+        Assert.True(reachabilityChecks > 0, "and it should have been asking whether a reply could still arrive");
+        Assert.Equal("arrived very late", reply);
+    }
+
+    [Fact]
+    public async Task WhenTheOwningComputerGoesAway_TheWaitEndsEarly_RatherThanSittingOutTheTimeout()
+    {
+        // No reply is coming, and ten seconds of silence tells the person nothing. Asserted on the number of
+        // checks rather than only on elapsed time, so this cannot pass by being slow.
+        var checks = 0;
+        var reply = await Wait(() => Convo(("UserMessage", "the question")), () => { checks++; return Task.FromResult(false); });
+
+        Assert.Null(reply);
+        Assert.Equal(2, checks);   // one negative is a blip; the second consecutive one ends it
+    }
+
+    [Fact]
+    public async Task OneBlipOfUnreachability_DoesNotEndTheWait()
+    {
+        // A reconnect blip must not abandon a session that is still working on the answer.
+        var checks = 0;
+        var polls = 0;
+        var reply = await Wait(() =>
+        {
+            polls++;
+            return polls < 40 ? Convo(("UserMessage", "the question"))
+                              : Convo(("UserMessage", "the question"), ("Text", "worth waiting for"));
+        }, () => { checks++; return Task.FromResult(checks != 1); });   // the first check says unreachable
+
+        Assert.Equal("worth waiting for", reply);
+    }
+
+    [Fact]
+    public async Task AReplyStoredAsTheComputerGoesAway_IsStillAnswered()
+    {
+        // The finished turn can land in the moment between the read and the reachability answer. Discarding
+        // it would lose an answer the person is waiting to hear, for a computer whose job is already done.
+        var stored = false;
+        var reply = await Wait(() => stored
+                ? Convo(("UserMessage", "the question"), ("Text", "landed at the last moment"))
+                : Convo(("UserMessage", "the question")),
+            () => { stored = true; return Task.FromResult(false); });
+
+        Assert.Equal("landed at the last moment", reply);
+    }
+
+    [Fact]
+    public async Task AReplyAlreadyInHand_NeverSpendsAReachabilityCheck()
+    {
+        // While an answer is settling, whether the machine is reachable is beside the point - the words are
+        // already here. Settling deliberately outlasts the ten-poll check interval, so a regression that
+        // checked anyway would be caught.
+        var checks = 0;
+        var conversation = Convo(("UserMessage", "the question"), ("Text", "the answer"));
+
+        var reply = await GatewayWingmanVoiceEndpoint.WaitForReplyAsync(
+            () => conversation, () => { checks++; return Task.FromResult(false); },
+            "sid-1", 1, CancellationToken.None,
+            timeout: Timeout, pollEvery: Poll, settleFor: TimeSpan.FromMilliseconds(200));
+
+        Assert.Equal("the answer", reply);
+        Assert.Equal(0, checks);
+    }
+
+    [Fact]
+    public async Task AFailingReachabilityCheck_IsNotEvidenceTheComputerIsGone()
+    {
+        // The check throwing is the absence of evidence, not evidence of absence - and it runs inside a
+        // request, so an escaping exception would answer a spoken question with a server error.
+        var polls = 0;
+        var reply = await Wait(() =>
+        {
+            polls++;
+            return polls < 40 ? Convo(("UserMessage", "the question"))
+                              : Convo(("UserMessage", "the question"), ("Text", "still got there"));
+        }, () => throw new InvalidOperationException("the reachability lookup blew up"));
+
+        Assert.Equal("still got there", reply);
+    }
+
+    [Fact]
+    public async Task OnlyRepliesAFTERTheQuestion_Count()
+    {
+        // The snapshot taken before sending is what "new" means. Without it the wait would answer instantly
+        // with whatever the agent said last time, and the person would hear a reply to their previous
+        // question (issue #366). The old reply sits exactly ON the boundary, so an off-by-one would return it.
+        var conversation = Convo(("Text", "an answer from before"));
+        var polls = 0;
+        var reply = await Wait(() =>
+        {
+            if (polls++ == 3) conversation.Add(new TurnWidgetDto { Kind = "Text", Content = "the new answer" });
+            return conversation;
+        }, () => Task.FromResult(true), before: 1);
+
+        Assert.Equal("the new answer", reply);
+    }
+
+    [Fact]
+    public async Task WithNoBaseline_TheFirstConversationSeenBecomesIt_SoAnOldReplyIsNeverReadAloud()
+    {
+        // Nothing was stored when the question was sent, and the whole history - including an OLD agent
+        // reply - arrives a moment later. Treating "nothing stored" as a baseline of zero would hand that old
+        // reply back as the answer to the question just asked: a confident answer to a question the person
+        // did not ask, which is issue #366 returning by a new route.
+        var arrived = false;
+        var answered = false;
+        var reply = await Wait(() =>
+        {
+            if (!arrived) { arrived = true; return null; }
+            if (!answered)
+            {
+                answered = true;
+                return Convo(("Text", "an answer from LAST time"), ("UserMessage", "the new question"));
+            }
+            return Convo(("Text", "an answer from LAST time"), ("UserMessage", "the new question"), ("Text", "the genuinely new answer"));
+        }, () => Task.FromResult(true), before: null);
+
+        Assert.Equal("the genuinely new answer", reply);
+    }
+
+    [Fact]
+    public async Task WithNoBaseline_AndNothingNewEverArriving_NothingIsInvented()
+    {
+        // The other half of the same rule: if only the old conversation ever shows up, the honest answer is
+        // no answer. Hearing nothing is recoverable; hearing the wrong answer confidently is not.
+        var reply = await Wait(() => Convo(("Text", "an answer from LAST time")),
+            () => Task.FromResult(true), before: null, timeout: TimeSpan.FromMilliseconds(300));
+
+        Assert.Null(reply);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -594,16 +594,25 @@ internal static class GatewayWingmanVoiceEndpoint
             // for the wingman so it can resolve references in the agent's reply. The current question
             // is appended below; BuildRecentContext is called on the pre-send snapshot so it
             // excludes the new turn and includes only what came before.
-            var snapshotWidgets = (await route.GetTurnsAsync(sid, ct))?.Widgets
-                ?? new List<TurnWidgetDto>();
-            var widgetsBefore = snapshotWidgets.Count;
+            var snapshot = conversationReader?.Invoke(reqTenant.Value, sid)?.Widgets;
+            var snapshotWidgets = snapshot ?? new List<TurnWidgetDto>();
+            // NULL MEANS "NO BASELINE", NOT "ZERO". If nothing is stored for this session yet, treating the
+            // baseline as zero would let the whole conversation arrive a moment later and hand back an OLD
+            // agent reply as the answer to the question just asked - which is issue #366 returning by a new
+            // route, and is the worst thing this path can do: the person hears a confident answer to a
+            // question they did not ask. The wait adopts its baseline from the first conversation it
+            // actually sees instead (found in review).
+            int? widgetsBefore = snapshot?.Count;
             var priorContext = WingmanTranslator.BuildRecentContext(snapshotWidgets);
 
             var (ok, _, sendErr) = await route.PostPromptAsync(sid, new PromptRequest { Text = req.Text, AppendEnter = true }, ct);
             if (!ok)
                 return Results.Json(new { error = "send failed: " + sendErr }, statusCode: StatusCodes.Status502BadGateway);
 
-            var reply = await WaitForReplyAsync(route, sid, widgetsBefore, ct);
+            var reply = await WaitForReplyAsync(
+                () => conversationReader?.Invoke(reqTenant.Value, sid)?.Widgets,
+                async () => await ResolveRouteAsync(reqTenant.Value, sid) is not null,
+                sid, widgetsBefore, ct);
             if (string.IsNullOrWhiteSpace(reply))
                 return Results.Json(new { error = "the agent did not produce a reply in time" }, statusCode: StatusCodes.Status504GatewayTimeout);
 
@@ -1232,65 +1241,116 @@ internal static class GatewayWingmanVoiceEndpoint
     /// <summary>How long the reply transcript must stop growing before we treat the turn as done.</summary>
     private static readonly TimeSpan ReplyStable = TimeSpan.FromSeconds(2.0);
 
+    /// <summary>How often the wait re-checks that the owning computer is still reachable. Every poll would
+    /// be wasteful and every never would be blind; this is roughly every eight seconds.</summary>
+    private const int ReachabilityCheckEveryPolls = 10;
+
     /// <summary>
-    /// Wait for the agent's reply by polling the TRANSCRIPT (not the fragile live session-state
-    /// read across the gateway-to-Director hop): once a new Text widget appears beyond
-    /// <paramref name="widgetsBefore"/> and stops growing for <see cref="ReplyStable"/>, that is the
-    /// reply. Transient null/hiccup reads from the Director are tolerated (we just keep polling) so a
-    /// busy Director mid-turn never makes us give up early - the only way out without a reply is the
-    /// full <see cref="TurnTimeout"/>. Returns the reply text, or null if none landed in time.
+    /// Wait for the agent's reply to a spoken question by watching the Gateway's own STORED conversation
+    /// (the turn-push mission, phase 3b): once a new agent text appears beyond <paramref name="widgetsBefore"/>
+    /// and the conversation stops growing for <see cref="ReplyStable"/>, that is the reply.
+    ///
+    /// This used to poll the TRANSCRIPT down the tunnel, at 750 milliseconds, for up to three minutes - one
+    /// command per poll, each making the owning Director open and parse the whole transcript file on the
+    /// user's disk, all so the Gateway could notice a reply it is now simply handed. The Director pushes
+    /// each finished turn, so the words arrive here on their own.
+    ///
+    /// THE GIVING-UP SIGNAL CHANGED, and it is better. The old loop counted forty consecutive FAILED READS
+    /// to guess the Director was gone - a proxy for something it could not see, using a failure mode that no
+    /// longer exists (a store read cannot fail; it just has nothing yet). So the wait now asks the question
+    /// it actually means: is the owning computer still reachable? If it is not, no reply is coming and
+    /// saying so at once beats waiting out three minutes of silence. If it is, the wait keeps waiting -
+    /// a long turn is a long turn, and giving up on a session that is still working was never the intent.
+    ///
+    /// Returns the reply text, or null if none landed in time.
     /// </summary>
-    private static async Task<string?> WaitForReplyAsync(
-        SessionVerbClient route, string sid, int widgetsBefore, CancellationToken ct)
+    /// <param name="timeout">How long to wait in all. Injected so the wait's own behaviour can be tested in
+    /// milliseconds instead of the three minutes a real spoken turn is allowed.</param>
+    /// <param name="pollEvery">How often to look. Injected for the same reason.</param>
+    /// <param name="settleFor">How long the conversation must stop growing before a reply counts as
+    /// finished. Injected for the same reason.</param>
+    internal static async Task<string?> WaitForReplyAsync(
+        Func<IReadOnlyList<TurnWidgetDto>?> readStoredConversation,
+        Func<Task<bool>> ownerReachableAsync,
+        string sid, int? widgetsBefore, CancellationToken ct,
+        TimeSpan? timeout = null, TimeSpan? pollEvery = null, TimeSpan? settleFor = null)
     {
-        var deadline = DateTime.UtcNow + TurnTimeout;
+        var turnTimeout = timeout ?? TurnTimeout;
+        var pollInterval = pollEvery ?? PollInterval;
+        var replyStable = settleFor ?? ReplyStable;
+        var deadline = DateTime.UtcNow + turnTimeout;
+        var baseline = widgetsBefore;
         string? reply = null;
         var stableCount = -1;
         var stableSince = DateTime.MinValue;
-        var consecutiveNulls = 0;
+        var polls = 0;
+        var unreachableInARow = 0;
         while (DateTime.UtcNow < deadline)
         {
-            try { await Task.Delay(PollInterval, ct); } catch (OperationCanceledException) { return reply; }
+            try { await Task.Delay(pollInterval, ct); } catch (OperationCanceledException) { return reply; }
 
-            TurnsResponse? turns;
-            try { turns = await route.GetTurnsAsync(sid, ct); }
-            catch { turns = null; }
-
-            var widgets = turns?.Widgets;
-            if (widgets is null)
+            var widgets = readStoredConversation() ?? Array.Empty<TurnWidgetDto>();
+            if (baseline is null)
             {
-                // A transient gateway->Director hiccup (the Director is busy running the turn). Do
-                // NOT give up - keep polling. Only a long run of failures (the Director is truly
-                // gone) ends it, and even then we fall through to the deadline.
-                consecutiveNulls++;
-                if (consecutiveNulls > 40) { FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: director unreachable for replies"); break; }
+                // No baseline could be taken before the question was sent, because nothing was stored for
+                // this session then. The first conversation we actually see becomes the baseline, so only
+                // what arrives AFTER it can be the answer. Waiting one more poll costs a moment; the
+                // alternative is reading out an answer to a question the person did not ask.
+                if (widgets.Count == 0) continue;
+                baseline = widgets.Count;
+                FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: no conversation was stored when the question was sent, so the first one seen ({baseline} widget(s)) is the baseline for the reply");
                 continue;
             }
-            consecutiveNulls = 0;
 
-            var lastText = widgets.Skip(widgetsBefore).LastOrDefault(w => w.Kind == "Text");
+            var lastText = widgets.Skip(baseline.Value).LastOrDefault(w => w.Kind == "Text");
             if (lastText is not null && !string.IsNullOrWhiteSpace(lastText.Content))
             {
                 reply = lastText.Content;
+                unreachableInARow = 0;
                 if (widgets.Count != stableCount) { stableCount = widgets.Count; stableSince = DateTime.UtcNow; }
-                else if (DateTime.UtcNow - stableSince >= ReplyStable)
+                else if (DateTime.UtcNow - stableSince >= replyStable)
                 {
-                    FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: reply read, len={reply.Length}");
+                    FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: reply read from the stored conversation, len={reply.Length}");
                     return reply;
                 }
+                continue;   // a reply is in hand and settling; do not spend a reachability check on it
             }
+
+            // No reply yet. Ask, occasionally, whether one can still arrive at all.
+            if (++polls % ReachabilityCheckEveryPolls != 0) continue;
+
+            bool reachable;
+            try { reachable = await ownerReachableAsync(); }
+            catch (OperationCanceledException) { return reply; }
+            catch (Exception ex)
+            {
+                // The check itself failed. That is not evidence the computer is gone - it is the absence of
+                // evidence either way - so it must never end the wait. Contained here because this runs
+                // inside a request: an escaping exception would answer the person's spoken question with a
+                // server error (found in review).
+                FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: could not check whether the owning computer is reachable ({ex.Message}); continuing to wait");
+                continue;
+            }
+            if (reachable) { unreachableInARow = 0; continue; }
+
+            // ONE unreachable answer is not enough. A reconnect blip would end the wait on a session that is
+            // still working, and worse, the finished turn may have been stored in the moment between the read
+            // above and this answer - so re-read before believing it, and require a second consecutive
+            // negative before giving up (found in review).
+            var lateWidgets = readStoredConversation() ?? Array.Empty<TurnWidgetDto>();
+            var lateText = lateWidgets.Skip(baseline.Value).LastOrDefault(w => w.Kind == "Text");
+            if (lateText is not null && !string.IsNullOrWhiteSpace(lateText.Content))
+            {
+                FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: the reply landed as the owning computer went away - answering with it rather than discarding it");
+                return lateText.Content;
+            }
+            if (++unreachableInARow < 2) continue;
+
+            FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: the owning computer is no longer reachable, so no reply is coming - ending the wait rather than sitting out the timeout");
+            break;
         }
         FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: returning {(reply is null ? "NO reply" : "last reply len=" + reply.Length)} after wait");
         return reply;
-    }
-
-    private static async Task<string?> ReadNewReplyAsync(
-        SessionVerbClient route, string sid, int widgetsBefore, CancellationToken ct)
-    {
-        var turns = await route.GetTurnsAsync(sid, ct);
-        if (turns?.Widgets is null) return null;
-        var last = turns.Widgets.Skip(widgetsBefore).LastOrDefault(w => w.Kind == "Text");
-        return last?.Content;
     }
 }
 


### PR DESCRIPTION
Phase 3b of thefrederiksen/devthrottle_internal#1882. After a person asks a session a question by voice, the Gateway waits for the answer. That wait was the last thing polling the tunnel. **No transcript read of any kind is left anywhere in the voice surface.**

## What it was

Every 750 milliseconds, for up to three minutes, one command down the tunnel - each making the owning Director open and parse the whole transcript file on the user's disk - so the Gateway could notice a reply it is now simply handed.

## The giving-up signal changed, and it is better

The old loop counted forty consecutive **failed reads** to guess the Director had gone: a proxy for something it could not see, built on a failure mode that no longer exists, because a store read does not fail - it just has nothing yet.

The wait now asks the question that heuristic stood in for: can a reply still arrive at all? It asks occasionally, never while an answer is already settling, and never believes a single negative. One blip must not abandon a session that is still working, and the finished turn can land in the very moment the connection drops - so it re-reads before giving up, and answers with what it finds.

## The baseline can be unknown, and pretending otherwise was the worst bug here

The wait only counts replies arriving after a snapshot taken when the question was sent. If nothing is stored at that moment, treating the baseline as zero would let the whole history arrive a moment later and hand back an **old** reply as the answer - a confident answer to a question the person did not ask, which is issue #366 returning by a new route. An absent snapshot is now admitted as absent, and the first conversation actually seen becomes the baseline. If only the old conversation ever appears, the honest answer is no answer.

## Proof

Eleven tests on a wait that had none - it was a private helper polling a live tunnel and could not be driven. They are written to fail on regression, not merely to pass:

- a reply that arrives and settles; one still growing is not answered early
- nothing stored for **more than sixty polls** is not a failure (the old forty-failure heuristic would have failed this test)
- an unreachable computer ends the wait, asserted on the number of checks rather than on elapsed time
- one blip of unreachability does not end it; a reply stored as the computer goes away is still answered
- a reply in hand never spends a reachability check at all
- a failing reachability check is not evidence the computer is gone, and cannot escape into the request
- only replies after the question count, with the old reply sitting exactly on the boundary so an off-by-one would return it
- with no baseline, the first conversation seen becomes it, and nothing is invented if only the old conversation appears

**Mutation-checked:** the no-baseline rule was changed to adopt zero, and the suite caught it. A dead helper with no callers was deleted rather than converted.

Local gate green, nine suites.

## Reviews

One Codex pass, all findings fixed here: the race between reading an empty store and an unreachable answer; a single transient negative ending the wait; the reachability check able to throw into the request or ignore cancellation; the snapshot-index risk above; and five specific ways the first draft of the tests failed to discriminate.

## Not proven

No live run with a real phone and a real session.
