### PR TITLE
Fix red main: the parked voice tests watch the store, not a tunnel read that no longer exists

### DIFF
--- a/src/CcDirector.Gateway.Tests/TurnEndWatcherTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/TurnEndWatcherTenantIsolationTests.cs
@@ -101,6 +101,13 @@ public sealed class TurnEndWatcherTenantIsolationTests : IAsyncLifetime
     {
         var watcher = _gateway.TurnEndWatcherForTest!;
 
+        // The narration reads the Gateway's STORE now, not a "turns" command on the tunnel (turn-push
+        // mission), so each tenant's words are seeded into its own partition and the tunnel command this
+        // waits for is the LIVE SCREEN read the narration still makes. Same routing, same tenant resolution,
+        // same proof - and seeding BOTH tenants under the shared id is itself part of the point.
+        _gateway.SeedStoredConversationForTest(TenantA, "dir-a", SharedSid, ("User", "ask A"), ("Assistant", "A answered"));
+        _gateway.SeedStoredConversationForTest(TenantB, "dir-b", SharedSid, ("User", "ask B"), ("Assistant", "B answered"));
+
         // The interleaving that a bare-sid key gets wrong. Tenant A starts working; tenant B (same id) also
         // works then ENDS its turn first - writing "WaitingForInput" into the shared key. Then tenant A ends
         // its own turn. With a per-tenant key each transition is A's or B's alone; with a bare key A's real
@@ -111,11 +118,11 @@ public sealed class TurnEndWatcherTenantIsolationTests : IAsyncLifetime
         watcher.Observe(TenantA, SharedSid, "WaitingForInput", "dir-a");   // A turn end -> refresh dir-A
 
         // POSITIVE CONTROL: B's turn end reached its own Director, so the watcher is live and the harness works.
-        Assert.NotNull(await WaitForVerb(_seenByB, "turns", SharedSid));
+        Assert.NotNull(await WaitForVerb(_seenByB, "screen-grid", SharedSid));
 
         // THE PARTITION PROOF: A's turn end reached dir-A too - it was NOT suppressed by B sharing the id. A
-        // bare-sid key reddens exactly here (A's transition is swallowed, dir-A sees no "turns" read).
-        Assert.NotNull(await WaitForVerb(_seenByA, "turns", SharedSid));
+        // bare-sid key reddens exactly here (A's transition is swallowed, dir-A sees no narration read).
+        Assert.NotNull(await WaitForVerb(_seenByA, "screen-grid", SharedSid));
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/VoiceServingLoopIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceServingLoopIsolationTests.cs
@@ -110,16 +110,24 @@ public sealed class VoiceServingLoopIsolationTests : IAsyncLifetime
     [Fact]
     public async Task Voice_sweep_reaches_only_the_owning_tenants_director()
     {
+        // The narration reads the Gateway's STORE now, not a "turns" command on the tunnel (turn-push
+        // mission), so B's words are seeded here and the tunnel command this waits for is the LIVE SCREEN
+        // read the narration still makes - same routing, same tenant resolution, same proof.
+        _gateway.SeedStoredConversationForTest(TenantB, "dir-b", SessB, ("User", "do the thing"), ("Assistant", "it is done"));
+
         // The REAL idle voice sweep - the production timer callback, not a helper.
         await _gateway.SweepVoiceSessionsAsync();
 
         // POSITIVE CONTROL FIRST: the sweep's tunnel read for B's marked voice session reached dir-B. If this
         // did not hold the absence assertion below would pass vacuously in a sweep that did nothing.
-        Assert.NotNull(await WaitForVerb(_seenByB, "turns", SessB));
+        Assert.NotNull(await WaitForVerb(_seenByB, "screen-grid", SessB));
 
         // ABSENCE: dir-A was never asked to read B's session, and TenantA's own pass (its session is not a
-        // voice session) issued no voice read at all - so dir-A saw no "turns" command whatsoever.
-        Assert.DoesNotContain(_seenByA, c => c.Verb == "turns");
+        // voice session) issued no voice read at all - so dir-A saw no live-screen read whatsoever. Scoped to
+        // the VOICE read on purpose: dir-A does receive ordinary traffic for its OWN session (its role and
+        // display state), and asserting it saw nothing at all would fail on work that is none of this test's
+        // business.
+        Assert.DoesNotContain(_seenByA, c => c.Verb == "screen-grid");
     }
 
     [Fact]
@@ -128,14 +136,18 @@ public sealed class VoiceServingLoopIsolationTests : IAsyncLifetime
         // Drive a REAL Working -> Waiting transition for B's session on dir-B through the live watcher, which
         // fires the production onSessionWorking (clear) then onTurnEnd (refresh) callbacks. Both resolve the
         // owning tenant from the director id the signal carries.
+        // The narration reads the Gateway's STORE now, not a "turns" command on the tunnel (turn-push
+        // mission). So the session's words are seeded here, and the tunnel command this waits for is the
+        // LIVE SCREEN read the narration still makes - same routing, same tenant resolution, same proof.
+        _gateway.SeedStoredConversationForTest(TenantB, "dir-b", SessB, ("User", "do the thing"), ("Assistant", "it is done"));
         _gateway.TurnEndWatcherForTest!.Observe(TenantB, SessB, "Working", "dir-b");
         _gateway.TurnEndWatcherForTest!.Observe(TenantB, SessB, "WaitingForInput", "dir-b");
 
         // POSITIVE CONTROL FIRST: the turn-end refresh's tunnel read for B's session reached dir-B.
-        Assert.NotNull(await WaitForVerb(_seenByB, "turns", SessB));
+        Assert.NotNull(await WaitForVerb(_seenByB, "screen-grid", SessB));
 
-        // ABSENCE: dir-A was never asked to read B's session.
-        Assert.DoesNotContain(_seenByA, c => c.Verb == "turns" && c.SessionId == SessB);
+        // ABSENCE: dir-A was never asked anything about B's session.
+        Assert.DoesNotContain(_seenByA, c => c.SessionId == SessB);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
@@ -185,6 +185,16 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
 
     // ===================== The one thing allowed: type on a confident plain-text composer ===============
 
+    /// <summary>Accept the prompt AND put the agent's reply into the Gateway's store, which is what the
+    /// owning Director's push does the moment the turn ends. The voice-turn wait watches the store, so this
+    /// is what lets it find an answer instead of waiting out its deadline.</summary>
+    private DirectorCommandResult SeedReplyThenOk(string sid, string reply)
+    {
+        _gateway.SeedStoredConversationForTest(CcDirector.Core.Tenancy.TenantId.Local, DirectorId, sid,
+            new[] { ("User", "the spoken question"), ("Assistant", reply) });
+        return Ok(new PromptResponse { Accepted = true });
+    }
+
     [Fact]
     public async Task VoiceTurn_ConfidentPlainTextComposer_TypesTheSpokenAnswer()
     {
@@ -195,15 +205,11 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         _dispatch = cmd => cmd.Verb switch
         {
             "screen-grid" => Ok(ComposerGrid(sid)),   // both the classify and the pre-send re-confirm see it
-            "turns" => Ok(new TurnsResponse
-            {
-                SessionId = sid,
-                Status = "ok",
-                Widgets = promptSent
-                    ? new List<TurnWidgetDto> { new() { Kind = "Text", Content = "Added the retry." } }
-                    : new List<TurnWidgetDto>(),
-            }),
-            "prompt" => Mark(ref promptSent, Ok(new PromptResponse { Accepted = true })),
+            // The reply arrives the way it does in production now (turn-push mission): the Director PUSHES it
+            // once the turn ends and the Gateway reads its own store. There is no "turns" command any more,
+            // so seeding the store as the prompt lands is what stands in for that push - and without it the
+            // wait for the answer sits out its full deadline.
+            "prompt" => Mark(ref promptSent, SeedReplyThenOk(sid, "Added the retry.")),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
 
@@ -235,15 +241,11 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
                 IsAlternateScreen = false,
                 HasGrid = true,
             }),
-            "turns" => Ok(new TurnsResponse
-            {
-                SessionId = sid,
-                Status = "ok",
-                Widgets = promptSent
-                    ? new List<TurnWidgetDto> { new() { Kind = "Text", Content = "Running." } }
-                    : new List<TurnWidgetDto>(),
-            }),
-            "prompt" => Mark(ref promptSent, Ok(new PromptResponse { Accepted = true })),
+            // The reply arrives the way it does in production now (turn-push mission): the Director PUSHES it
+            // once the turn ends and the Gateway reads its own store. There is no "turns" command any more,
+            // so seeding the store as the prompt lands is what stands in for that push - and without it the
+            // wait for the answer sits out its full deadline.
+            "prompt" => Mark(ref promptSent, SeedReplyThenOk(sid, "Running.")),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -803,6 +803,35 @@ public sealed class GatewayHost : IAsyncDisposable
     /// re-implementation. Null until StartAsync builds it.</summary>
     internal TurnEndWatcher? TurnEndWatcherForTest => _turnEndWatcher;
 
+    /// <summary>
+    /// Put a conversation into this Gateway's store for one session, as the owning Director's push would
+    /// (turn-push mission). Tests need it because the narration path reads the STORE now: before the mission
+    /// they supplied a session's words by answering a "turns" command on the tunnel, and there is no such
+    /// command any more. Enters the tenant's scope itself, so a test cannot seed one account's conversation
+    /// into another's partition by forgetting to.
+    /// </summary>
+    internal void SeedStoredConversationForTest(TenantId tenant, string directorId, string sessionId,
+        params (string Role, string Text)[] messages)
+    {
+        using var scope = _tenantBoundary?.EnterScope(tenant);
+        var batch = new Contracts.TurnPushBatch
+        {
+            SessionId = sessionId,
+            Generation = "seeded:" + sessionId,
+            GenerationStartedUtc = DateTime.UtcNow,
+            Agent = "ClaudeCode",
+            StartOrdinal = 0,
+            TotalCount = messages.Length,
+            Turns = messages.Select((m, i) => new Contracts.PushedTurn
+            {
+                Ordinal = i,
+                Role = m.Role,
+                Parts = { new Contracts.HistoryPartDto { Kind = "Text", Text = m.Text } },
+            }).ToList(),
+        };
+        _sessionTurns.Append(directorId, batch, DateTime.UtcNow);
+    }
+
     /// <summary>Test-only: the session supervisor (issue #915), so a test can drive a real Working -&gt; idle
     /// transition into the REAL engine. Null until StartAsync builds it.</summary>
     internal Supervision.SessionSupervisor? SessionSupervisorForTest => _sessionSupervisor;


### PR DESCRIPTION
**Main is red and this makes it green.** The five failures come from the turn-push mission's phase 3a (#2648) and persisted through 3b (#2649). They are blocking a production deploy during a live incident.

## How this got in

I merged phases 3a, 3b and 3c on the default local gate alone. The suite that covers this work - `Gateway.Tests` - is parked, so it never ran. The rule is to run the parked suites before merging when a change touches them, and this change touched them squarely. That is on me.

## One root cause, and it is test-side

Those tests supplied a session's words by answering a `turns` command on the tunnel, and proved tenant isolation by watching for that command to reach the right Director. Phase 3a deleted that command: the narration reads the Gateway's own stored conversation now. So the tests' **subject is intact and their observable is gone**.

The subject is worth keeping - three of the five are tenant-isolation proofs, one of them the case where two accounts use the same session id. So:

- The words are seeded into the store, per tenant, through a host seam that **enters the tenant's scope itself** rather than trusting a test to remember to.
- The command they wait for is the **live-screen read the narration still makes**, which travels the same route through the same tenant resolution. Same proof, current observable.
- The absence assertions stay **scoped to the voice read**. A Director does receive ordinary traffic for its own sessions - its role, its display state - and asserting it saw nothing at all fails on work that is none of these tests' business. I made that mistake first and the suite caught it.

## The two live-screen proofs were not failing an assertion

With nothing ever landing in the store, the wait for the spoken answer sat out its full three-minute deadline. They now seed the reply as the prompt lands, which is exactly what the owning Director's push does when a turn ends.

## Proof

The five named tests green. The **whole** `Gateway.Tests` suite run before merge, because I do not otherwise know that 3a and 3b broke only these five - that is the same gap that produced this red in the first place.

No production code changed except the addition of the test seam.
