### PR TITLE
fix(gateway): an unreachable statistics store retries itself, and a deploy proves the pages came up

### DIFF
--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -842,6 +842,76 @@ jobs:
           fi
           echo "Production stayed available for the full ${WATCH_SECONDS}s window past the swap."
 
+      # PROVE THE PAGES WORK, NOT JUST THAT THE PROCESS ANSWERS.
+      #
+      # Everything above this point measures ONE thing: is there a Gateway on the other end of the port,
+      # serving the commit we shipped. On 2 September 2026 the answer was yes for the whole watch window
+      # and the release was still broken - Your Throttle answered 503 to every request for hours and the
+      # owner's turns went unrecorded, because the container's statistics store lost a race for a database
+      # connection while production and staging were both up, and nothing retried it. A green deploy and a
+      # dead page, with no contradiction anywhere in this file, because nothing here had ever asked.
+      #
+      # /healthz now reports each subsystem that can be down on its own while the process serves. This step
+      # asserts every one of them is up. It POLLS rather than asking once, because a subsystem is allowed
+      # to come up after the port does - the statistics store publishes late by design, and now retries
+      # itself back after a failure - so a single read right after a swap would fail a release that was
+      # about to be fine.
+      #
+      # IT FAILS THE RUN AND DOES NOT ROLL BACK. A subsystem that is down does not make the new image worse
+      # than the old one, and the swap-back would ship the same code; what it needs is to be seen. The
+      # failure is what makes it impossible to walk away from a deploy that left a page dead.
+      #
+      # AN ABSENT BLOCK IS A FAILURE, NOT A PASS. A missing `subsystems` object means the Gateway serving
+      # production does not report readiness at all - an image older than this contract, or a wiring
+      # regression that dropped the block. Treating that as "nothing to check" would make this step
+      # certify precisely the deploys it cannot see into, which is the failure it exists to remove.
+      - name: Prove every subsystem came up
+        # Same guard the poller uses: only assert against production when a swap actually put the new
+        # image there. A refused or failed deploy leaves the OLD image serving, and holding that to this
+        # contract would report a three-minute subsystem failure for a run that deliberately changed
+        # nothing.
+        if: needs.deploy.outputs.readiness_outcome == 'healthy'
+        run: |
+          deadline=$(( $(date +%s) + 180 ))
+          last=""
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            body=$(curl -s -m 10 "${GATEWAY_URL}/healthz" 2>/dev/null || echo '')
+            # Every subsystem value, one per line, as "name=state". Empty when the block is absent.
+            last=$(printf '%s' "$body" | jq -r '.subsystems // {} | to_entries[] | "\(.key)=\(.value)"' 2>/dev/null || echo '')
+            down=$(printf '%s\n' "$last" | grep -v '=available$' | grep -v '^$' || true)
+            if [ -n "$last" ] && [ -z "$down" ]; then
+              echo "Every subsystem reports available:"
+              printf '%s\n' "$last" | sed 's/^/  /'
+              exit 0
+            fi
+            if [ -z "$last" ]; then
+              echo "production /healthz carries no subsystems block yet (waiting)"
+            else
+              echo "subsystem(s) not available yet: $(printf '%s' "$down" | tr '\n' ' ')"
+            fi
+            sleep 5
+          done
+
+          echo ""
+          if [ -z "$last" ]; then
+            echo "ERROR: production /healthz reports NO subsystem readiness at all after 180s."
+            echo "       Either the image serving production predates this contract, or the wiring that"
+            echo "       builds the block was dropped. This step cannot certify a deploy it cannot see"
+            echo "       into, so it fails rather than passing on an absence."
+          else
+            echo "ERROR: production is serving, but a subsystem behind the pages never came up:"
+            printf '%s\n' "$last" | sed 's/^/  /'
+            echo ""
+            echo "       The Gateway is healthy and its pages are NOT. This is the 2 September 2026 shape:"
+            echo "       a green deploy over a dead page. Read the Gateway log for the named reason (it is"
+            echo "       not on /healthz on purpose - the reason names the database host and that endpoint"
+            echo "       is public), and check the authenticated feed for the page in question."
+            echo ""
+            echo "       A statistics store that could not be reached now retries itself, so re-check"
+            echo "       before doing anything: it may have come back on its own since this ran."
+          fi
+          exit 1
+
       # Does this deploy carry a schema change to the LIVE Supabase Postgres? Diff the Postgres migration set
       # (the one Database.Migrate() applies on hosted) between the outgoing live commit and the shipped one.
       # "unknown" (never a guess) when the outgoing commit is not readable - the image predated the .commit

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -639,6 +639,7 @@ function statusSentence(status: number, what?: string): string {
 
 type GatewayErrorBody = {
   error?: unknown;
+  reason?: unknown;
   detail?: unknown;
   message?: unknown;
   code?: unknown;
@@ -655,6 +656,15 @@ function stringFromErrorBody(body: unknown): string | undefined {
     const code = typeof nested.code === "string" ? nested.code : undefined;
     return [message, code].filter(Boolean).join(" ") || undefined;
   }
+  // `reason` is the availability surfaces' spelling: the statistics feed answers
+  // `{ available: false, reason }` on 503, and the Gateway writes a full operator-facing sentence into it.
+  // It was NOT read here, and the cost was an incident (devthrottle_internal, 2 September 2026). With no
+  // reason found, a 503 falls through to the unreachable-status branch in gatewayErrorMessage and Your
+  // Throttle rendered "Can't reach the Gateway - retrying." for hours - pointing at a dead Gateway that was
+  // healthy the whole time and serving every other page, while the true sentence ("the statistics store
+  // could not be reached") sat unread in the body. A reason the server took the trouble to write must never
+  // lose to a sentence we invent from a status number.
+  if (typeof b.reason === "string") return b.reason;
   if (typeof b.detail === "string") return b.detail;
   if (typeof b.message === "string") return b.message;
   if (typeof b.code === "string") return b.code;

--- a/packages/client-core/src/api/reasonBodyIsRead.test.ts
+++ b/packages/client-core/src/api/reasonBodyIsRead.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { GatewayError, GATEWAY_UNREACHABLE_MESSAGE, gatewayErrorMessage } from "./client";
+
+// A SERVER REASON MUST NEVER LOSE TO A SENTENCE WE INVENT FROM A STATUS NUMBER.
+//
+// The Gateway's availability surfaces answer `{ available: false, reason }` - the statistics feed at
+// GET /stats/data is the one this file was written for. `reason` was not among the keys the client read a
+// failure sentence out of (it read error / detail / message / code), so the server's own explanation was
+// parsed into nothing, and a 503 with no reason falls through to the "never reached a healthy backend"
+// branch.
+//
+// The cost was an incident (devthrottle_internal, 2 September 2026). The Gateway was healthy and serving
+// every other page; its statistics store had lost a database connection during a deploy and said exactly
+// that, in a full sentence, in the body. Your Throttle displayed "Can't reach the Gateway - retrying." for
+// two hours. The one line that would have named the real fault was on the wire the whole time, and the
+// investigation it misdirected started at the Gateway's health and the deploy pipeline instead.
+//
+// These tests pin the fix at the level that matters - what a person reads on the page - rather than at the
+// parser, so a later refactor that keeps a `reason` key working but stops surfacing it still fails here.
+describe("a 503 carrying the server's own reason", () => {
+  const REASON =
+    "The hosted statistics store is unavailable (unreachable): The statistics store " +
+    "(postgres) failed after the startup deadline (NpgsqlException). The Gateway is retrying it.";
+
+  const from503 = async (body: unknown) =>
+    GatewayError.from(
+      new Response(JSON.stringify(body), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      }),
+      "load your throttle",
+    );
+
+  it("shows the server's reason instead of the generic unreachable line", async () => {
+    const err = await from503({ available: false, reason: REASON });
+
+    expect(err.serverReason).toBe(REASON);
+    expect(gatewayErrorMessage(err)).toContain("statistics store");
+    expect(gatewayErrorMessage(err)).not.toBe(GATEWAY_UNREACHABLE_MESSAGE);
+  });
+
+  it("does not tell the user to try again when the Gateway is already retrying for them", async () => {
+    // The retry hint is advice to do something. When the server has said it is retrying by itself, that
+    // advice is wrong - and two sentences that contradict each other about who acts next are worse than
+    // either alone.
+    const msg = gatewayErrorMessage(await from503({ available: false, reason: REASON }));
+
+    expect(msg).toBe(REASON);
+    expect(msg).not.toContain("Try again.");
+  });
+
+  // THE NEGATIVE CONTROL. Without this, the tests above would still pass against a build that had simply
+  // stopped collapsing 503s at all - which would break every background poll that legitimately relies on
+  // the shared line. The collapse is correct; reading the reason first is what was missing.
+  it("still collapses a 503 that carries NO reason to the shared unreachable line", async () => {
+    const err = await from503({ available: false });
+
+    expect(err.serverReason).toBeUndefined();
+    expect(gatewayErrorMessage(err)).toBe(GATEWAY_UNREACHABLE_MESSAGE);
+  });
+
+  it("still prefers `error` when a body carries one, so no existing surface changes", async () => {
+    const err = await from503({ error: "the usual shape", reason: "the availability shape" });
+
+    expect(err.serverReason).toBe("the usual shape");
+  });
+});

--- a/src/CcDirector.Gateway.Contracts/HealthDto.cs
+++ b/src/CcDirector.Gateway.Contracts/HealthDto.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace CcDirector.Gateway.Contracts;
 
 /// <summary>
@@ -38,6 +40,30 @@ public sealed class HealthDto
     /// </summary>
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     public string? Commit { get; set; }
+
+    /// <summary>
+    /// Per-SUBSYSTEM readiness: one entry per part of the Gateway that can be down on its own while the
+    /// process serves, each either "available" or "unavailable". NULL when the responder computes none, in
+    /// which case it is omitted rather than serialized as an empty object claiming everything is fine.
+    ///
+    /// WHY A LIVENESS PROBE CARRIES THIS. "The Gateway is up" and "the Gateway's pages work" are different
+    /// statements, and on 2 September 2026 the difference cost hours: the deploy's own health poll saw a
+    /// sustained 200 carrying the new commit and called the release good, while Your Throttle answered 503
+    /// to every request and the owner's turns went unrecorded. Nothing in the pipeline was WRONG - it
+    /// checked what it checked. It simply had no way to ask whether the parts behind the pages had come up,
+    /// because the process reported one status for the whole of itself.
+    ///
+    /// So a subsystem that fails without taking the process down has to say so where the deploy can read
+    /// it. The deploy asserts every entry here is "available" after the swap; see the "Prove every
+    /// subsystem came up" step in deploy-hosted-gateway.yml.
+    ///
+    /// STATUS WORDS ONLY, AND DELIBERATELY NOTHING MORE. This endpoint is PUBLIC and unauthenticated. The
+    /// reason a subsystem is down is a full operator sentence that names the database host, so it belongs
+    /// on the authenticated feed and in the Gateway log - never here. A caller who can read this learns
+    /// that statistics are down, which is a fact about our service, and nothing about our infrastructure.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Subsystems { get; set; }
 
     public DateTime ServerTime { get; set; } = DateTime.UtcNow;
 

--- a/src/CcDirector.Gateway.Tests/HealthzSubsystemReadinessTests.cs
+++ b/src/CcDirector.Gateway.Tests/HealthzSubsystemReadinessTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// <c>/healthz</c> REPORTS EACH SUBSYSTEM, so a deploy can tell "the process answers" apart from "the
+/// pages work".
+///
+/// WHY THIS EXISTS. On 2 September 2026 a deploy went green and the release was broken. Production served
+/// a sustained 200 on this endpoint carrying the commit that had just shipped - which is everything the
+/// pipeline knew how to ask - while Your Throttle answered 503 to every request and the owner's turns went
+/// unrecorded for hours. The container's statistics store had lost a race for a database connection during
+/// the four minutes production and staging both ran, and nothing retried it.
+///
+/// NOTHING IN THE PIPELINE WAS WRONG, and that is the point worth keeping. It checked what it checked. The
+/// Gateway reported ONE status for the whole of itself, so there was no question the deploy could have
+/// asked that would have caught this. A subsystem that is designed to fail on its own without stopping the
+/// process has to be able to SAY so somewhere the deploy reads, or it is by construction invisible to
+/// every check that will ever be written.
+///
+/// THE TESTS ARE PAIRED, because "the block says available" proves nothing on its own - it is exactly what
+/// a hard-coded string would say. So the same probe is run against a Gateway whose statistics store CANNOT
+/// open, and the block has to say the opposite. A build that stopped computing this and answered
+/// "available" always would pass the first test and fail the second.
+///
+/// AND THE REASON IS NOT ON IT. This endpoint is public and unauthenticated; the reason a subsystem is
+/// down is a full operator sentence that names the database host. Status words only.
+///
+/// The assembly runs sequentially (TestParallelization), so setting environment variables here is safe.
+/// </summary>
+public sealed class HealthzSubsystemReadinessTests
+{
+    private const string Token = "test-token-subsystems";
+
+    private readonly ITestOutputHelper _out;
+
+    public HealthzSubsystemReadinessTests(ITestOutputHelper output) => _out = output;
+
+    [Fact]
+    public async Task A_healthy_statistics_store_reports_available()
+    {
+        var dir = TempDir();
+        var (health, raw) = await ProbeHealthz(Path.Combine(dir, "gateway-stats.db"));
+
+        Assert.NotNull(health.Subsystems);
+        Assert.True(health.Subsystems!.ContainsKey("statistics"),
+            "the readiness block must name the statistics subsystem - the deploy step keys off it");
+        Assert.Equal("available", health.Subsystems["statistics"]);
+        _out.WriteLine(raw);
+    }
+
+    /// <summary>
+    /// THE OTHER HALF. A statistics store that cannot be opened - a directory sits where its file belongs,
+    /// which is a real provider failure rather than a fabricated one - and the Gateway still serves. That
+    /// is deliberate and unchanged: statistics are a failure domain of their own. What changed is that the
+    /// probe now SAYS so, which is the difference between the deploy on 2 September passing and failing.
+    /// </summary>
+    [Fact]
+    public async Task A_statistics_store_that_cannot_open_reports_unavailable_while_the_Gateway_still_serves()
+    {
+        var dir = TempDir();
+        var obstructed = Path.Combine(dir, "gateway-stats.db");
+        Directory.CreateDirectory(obstructed);   // a directory where the database file belongs
+
+        var (health, raw) = await ProbeHealthz(obstructed);
+
+        // The Gateway is up. That is the whole trap: this is a 200, and it always was.
+        Assert.Equal("ok", health.Status);
+
+        Assert.NotNull(health.Subsystems);
+        Assert.Equal("unavailable", health.Subsystems!["statistics"]);
+        _out.WriteLine(raw);
+    }
+
+    /// <summary>
+    /// PUBLIC ENDPOINT, SO STATUS WORDS ONLY. The store's own reason is a sentence naming the database host
+    /// and the connection's target; it belongs in the Gateway log and on the authenticated feed. An
+    /// anonymous caller learns that our statistics are down - a fact about our service - and nothing about
+    /// where our data lives.
+    /// </summary>
+    [Fact]
+    public async Task The_readiness_block_never_carries_the_reason_or_the_database_target()
+    {
+        var dir = TempDir();
+        var obstructed = Path.Combine(dir, "gateway-stats.db");
+        Directory.CreateDirectory(obstructed);
+
+        var (_, raw) = await ProbeHealthz(obstructed);
+
+        foreach (var leak in new[] { "gateway-stats.db", "Host=", "postgres", "Sqlite", "Exception", dir })
+            Assert.DoesNotContain(leak, raw, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string TempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-hz-subsys-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static async Task<(HealthDto Health, string RawJson)> ProbeHealthz(string inputStatsPath)
+    {
+        var instancesDir = Path.Combine(Path.GetTempPath(), "cc-hz-subsys-i-" + Guid.NewGuid().ToString("N"));
+        var gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token,
+            authEnabled: true,
+            instancesDirectory: instancesDir,
+            workListsPath: Path.Combine(instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(instancesDir, "snooze", "snooze.json"),
+            inputStatsPath: inputStatsPath,
+            streamMode: true);
+        try
+        {
+            await gateway.StartAsync();
+
+            // NO credential: /healthz is public, and that is exactly why the reason is not on it.
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{gateway.Port}/") };
+            var resp = await http.GetAsync("healthz");
+            resp.EnsureSuccessStatusCode();
+            var raw = await resp.Content.ReadAsStringAsync();
+            var dto = System.Text.Json.JsonSerializer.Deserialize<HealthDto>(raw,
+                          new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web))
+                      ?? throw new InvalidOperationException("healthz returned no body");
+            return (dto, raw);
+        }
+        finally
+        {
+            await gateway.StopAsync();
+            // Deliberately NOT deleting instancesDir - see HealthzTenantLeakTests for why a delete here can
+            // crash the whole test process via a late FileSystemWatcher event. The OS reclaims the temp dir.
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TurnEndWatcherTenantIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/TurnEndWatcherTenantIsolationTests.cs
@@ -101,6 +101,13 @@ public sealed class TurnEndWatcherTenantIsolationTests : IAsyncLifetime
     {
         var watcher = _gateway.TurnEndWatcherForTest!;
 
+        // The narration reads the Gateway's STORE now, not a "turns" command on the tunnel (turn-push
+        // mission), so each tenant's words are seeded into its own partition and the tunnel command this
+        // waits for is the LIVE SCREEN read the narration still makes. Same routing, same tenant resolution,
+        // same proof - and seeding BOTH tenants under the shared id is itself part of the point.
+        _gateway.SeedStoredConversationForTest(TenantA, "dir-a", SharedSid, ("User", "ask A"), ("Assistant", "A answered"));
+        _gateway.SeedStoredConversationForTest(TenantB, "dir-b", SharedSid, ("User", "ask B"), ("Assistant", "B answered"));
+
         // The interleaving that a bare-sid key gets wrong. Tenant A starts working; tenant B (same id) also
         // works then ENDS its turn first - writing "WaitingForInput" into the shared key. Then tenant A ends
         // its own turn. With a per-tenant key each transition is A's or B's alone; with a bare key A's real
@@ -111,11 +118,11 @@ public sealed class TurnEndWatcherTenantIsolationTests : IAsyncLifetime
         watcher.Observe(TenantA, SharedSid, "WaitingForInput", "dir-a");   // A turn end -> refresh dir-A
 
         // POSITIVE CONTROL: B's turn end reached its own Director, so the watcher is live and the harness works.
-        Assert.NotNull(await WaitForVerb(_seenByB, "turns", SharedSid));
+        Assert.NotNull(await WaitForVerb(_seenByB, "screen-grid", SharedSid));
 
         // THE PARTITION PROOF: A's turn end reached dir-A too - it was NOT suppressed by B sharing the id. A
-        // bare-sid key reddens exactly here (A's transition is swallowed, dir-A sees no "turns" read).
-        Assert.NotNull(await WaitForVerb(_seenByA, "turns", SharedSid));
+        // bare-sid key reddens exactly here (A's transition is swallowed, dir-A sees no narration read).
+        Assert.NotNull(await WaitForVerb(_seenByA, "screen-grid", SharedSid));
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/VoiceServingLoopIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceServingLoopIsolationTests.cs
@@ -110,16 +110,24 @@ public sealed class VoiceServingLoopIsolationTests : IAsyncLifetime
     [Fact]
     public async Task Voice_sweep_reaches_only_the_owning_tenants_director()
     {
+        // The narration reads the Gateway's STORE now, not a "turns" command on the tunnel (turn-push
+        // mission), so B's words are seeded here and the tunnel command this waits for is the LIVE SCREEN
+        // read the narration still makes - same routing, same tenant resolution, same proof.
+        _gateway.SeedStoredConversationForTest(TenantB, "dir-b", SessB, ("User", "do the thing"), ("Assistant", "it is done"));
+
         // The REAL idle voice sweep - the production timer callback, not a helper.
         await _gateway.SweepVoiceSessionsAsync();
 
         // POSITIVE CONTROL FIRST: the sweep's tunnel read for B's marked voice session reached dir-B. If this
         // did not hold the absence assertion below would pass vacuously in a sweep that did nothing.
-        Assert.NotNull(await WaitForVerb(_seenByB, "turns", SessB));
+        Assert.NotNull(await WaitForVerb(_seenByB, "screen-grid", SessB));
 
         // ABSENCE: dir-A was never asked to read B's session, and TenantA's own pass (its session is not a
-        // voice session) issued no voice read at all - so dir-A saw no "turns" command whatsoever.
-        Assert.DoesNotContain(_seenByA, c => c.Verb == "turns");
+        // voice session) issued no voice read at all - so dir-A saw no live-screen read whatsoever. Scoped to
+        // the VOICE read on purpose: dir-A does receive ordinary traffic for its OWN session (its role and
+        // display state), and asserting it saw nothing at all would fail on work that is none of this test's
+        // business.
+        Assert.DoesNotContain(_seenByA, c => c.Verb == "screen-grid");
     }
 
     [Fact]
@@ -128,14 +136,18 @@ public sealed class VoiceServingLoopIsolationTests : IAsyncLifetime
         // Drive a REAL Working -> Waiting transition for B's session on dir-B through the live watcher, which
         // fires the production onSessionWorking (clear) then onTurnEnd (refresh) callbacks. Both resolve the
         // owning tenant from the director id the signal carries.
+        // The narration reads the Gateway's STORE now, not a "turns" command on the tunnel (turn-push
+        // mission). So the session's words are seeded here, and the tunnel command this waits for is the
+        // LIVE SCREEN read the narration still makes - same routing, same tenant resolution, same proof.
+        _gateway.SeedStoredConversationForTest(TenantB, "dir-b", SessB, ("User", "do the thing"), ("Assistant", "it is done"));
         _gateway.TurnEndWatcherForTest!.Observe(TenantB, SessB, "Working", "dir-b");
         _gateway.TurnEndWatcherForTest!.Observe(TenantB, SessB, "WaitingForInput", "dir-b");
 
         // POSITIVE CONTROL FIRST: the turn-end refresh's tunnel read for B's session reached dir-B.
-        Assert.NotNull(await WaitForVerb(_seenByB, "turns", SessB));
+        Assert.NotNull(await WaitForVerb(_seenByB, "screen-grid", SessB));
 
-        // ABSENCE: dir-A was never asked to read B's session.
-        Assert.DoesNotContain(_seenByA, c => c.Verb == "turns" && c.SessionId == SessB);
+        // ABSENCE: dir-A was never asked anything about B's session.
+        Assert.DoesNotContain(_seenByA, c => c.SessionId == SessB);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceTurnLiveScreenProofTests.cs
@@ -185,6 +185,16 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
 
     // ===================== The one thing allowed: type on a confident plain-text composer ===============
 
+    /// <summary>Accept the prompt AND put the agent's reply into the Gateway's store, which is what the
+    /// owning Director's push does the moment the turn ends. The voice-turn wait watches the store, so this
+    /// is what lets it find an answer instead of waiting out its deadline.</summary>
+    private DirectorCommandResult SeedReplyThenOk(string sid, string reply)
+    {
+        _gateway.SeedStoredConversationForTest(CcDirector.Core.Tenancy.TenantId.Local, DirectorId, sid,
+            new[] { ("User", "the spoken question"), ("Assistant", reply) });
+        return Ok(new PromptResponse { Accepted = true });
+    }
+
     [Fact]
     public async Task VoiceTurn_ConfidentPlainTextComposer_TypesTheSpokenAnswer()
     {
@@ -195,15 +205,11 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
         _dispatch = cmd => cmd.Verb switch
         {
             "screen-grid" => Ok(ComposerGrid(sid)),   // both the classify and the pre-send re-confirm see it
-            "turns" => Ok(new TurnsResponse
-            {
-                SessionId = sid,
-                Status = "ok",
-                Widgets = promptSent
-                    ? new List<TurnWidgetDto> { new() { Kind = "Text", Content = "Added the retry." } }
-                    : new List<TurnWidgetDto>(),
-            }),
-            "prompt" => Mark(ref promptSent, Ok(new PromptResponse { Accepted = true })),
+            // The reply arrives the way it does in production now (turn-push mission): the Director PUSHES it
+            // once the turn ends and the Gateway reads its own store. There is no "turns" command any more,
+            // so seeding the store as the prompt lands is what stands in for that push - and without it the
+            // wait for the answer sits out its full deadline.
+            "prompt" => Mark(ref promptSent, SeedReplyThenOk(sid, "Added the retry.")),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
 
@@ -235,15 +241,11 @@ public sealed class WingmanVoiceTurnLiveScreenProofTests : IAsyncLifetime
                 IsAlternateScreen = false,
                 HasGrid = true,
             }),
-            "turns" => Ok(new TurnsResponse
-            {
-                SessionId = sid,
-                Status = "ok",
-                Widgets = promptSent
-                    ? new List<TurnWidgetDto> { new() { Kind = "Text", Content = "Running." } }
-                    : new List<TurnWidgetDto>(),
-            }),
-            "prompt" => Mark(ref promptSent, Ok(new PromptResponse { Accepted = true })),
+            // The reply arrives the way it does in production now (turn-push mission): the Director PUSHES it
+            // once the turn ends and the Gateway reads its own store. There is no "turns" command any more,
+            // so seeding the store as the prompt lands is what stands in for that push - and without it the
+            // wait for the answer sits out its full deadline.
+            "prompt" => Mark(ref promptSent, SeedReplyThenOk(sid, "Running.")),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
 

--- a/src/CcDirector.Gateway.UnitTests/StatsStoreReopensAfterAnUnreachableStoreTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/StatsStoreReopensAfterAnUnreachableStoreTests.cs
@@ -1,0 +1,196 @@
+using CcDirector.Gateway.Stats.Data;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// A STATISTICS STORE THAT COULD NOT BE REACHED COMES BACK ON ITS OWN.
+///
+/// THE INCIDENT THIS FILE IS THE PROOF FOR (devthrottle_internal, 2 September 2026). A deploy ran
+/// production and staging together for four minutes. Each container opens its own connection pool, the
+/// pooler refused the incoming container's statistics connection, and the open failed. Nothing retried it.
+/// Your Throttle answered 503 to every request for the next two hours and every turn the owner drove went
+/// unrecorded - against a database that was healthy the whole time, serving the roster from the other pool
+/// in the same process, and which answered the very next connection anybody made to it.
+///
+/// The store already had a promise for a SLOW database: the open outlives the startup deadline and
+/// publishes when it finishes, so a slow store costs the first seconds of one boot instead of everything
+/// after it. It had no promise at all for an UNREACHABLE one. That asymmetry is the whole defect, and
+/// nothing in the suite could see it, because every fixture here either opens successfully or fails
+/// against a fault that never clears - and a store that never retries and a store that retries into a
+/// permanent fault are indistinguishable when the fault is permanent.
+///
+/// SO THE FAULT HERE CLEARS. That is the one thing this file does that no other test in the suite does.
+/// The store is pointed at a SQLite path that CANNOT be opened - a directory sits where the database file
+/// belongs, which is a genuine "unable to open database file" from the provider and not a fabricated
+/// failure. The store is asserted unavailable. Then the obstruction is REMOVED and nothing else happens:
+/// no restart, no second construction, no call of any kind. The store has to notice by itself.
+///
+/// A NEGATIVE CONTROL RIDES ALONG, because "it became available" would also pass against a store that was
+/// never really broken: <see cref="AnObstructedStore_IsUnavailableToBeginWith"/> holds the obstruction in
+/// place and asserts the store stays unavailable and names UNREACHABLE. Delete the reopen and the first
+/// test fails while the control still passes - which is the shape that tells you the first test is
+/// measuring the reopen and not the weather.
+/// </summary>
+public sealed class StatsStoreReopensAfterAnUnreachableStoreTests : IDisposable
+{
+    /// <summary>
+    /// How long a test will wait for the reopen. Comfortably past the FIRST backoff step and no further:
+    /// the claim under test is that the store retries promptly, and a generous window would let a fix that
+    /// only retried once a minute pass a test whose comment says "promptly".
+    /// </summary>
+    private static readonly TimeSpan Patience = GatewayStatsStore.ReopenBackoff[0] + TimeSpan.FromSeconds(20);
+
+    private readonly ITestOutputHelper _out;
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-stats-reopen-" + Guid.NewGuid().ToString("N"));
+
+    public StatsStoreReopensAfterAnUnreachableStoreTests(ITestOutputHelper output)
+    {
+        _out = output;
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    private string SqlitePath => Path.Combine(_dir, "gateway-stats.db");
+
+    /// <summary>
+    /// Put a DIRECTORY where the database file belongs. SQLite cannot open it, and the failure is the real
+    /// provider error an operator would see rather than a stub throwing on our behalf.
+    /// </summary>
+    private void Obstruct() => Directory.CreateDirectory(SqlitePath);
+
+    private void ClearTheObstruction() => Directory.Delete(SqlitePath, recursive: true);
+
+    private StatsConnectionChoice SelfHostChoice() =>
+        StatsConnectionSelection.Resolve(
+            statsOverride: null, gatewayConnection: null, hosted: false, sqlitePath: SqlitePath);
+
+    // ============================================================ the negative control, first
+
+    /// <summary>
+    /// THE CONTROL. While the obstruction is in place the store is unavailable, and it says UNREACHABLE -
+    /// a database problem, not a missing setting and not our own bug. Without this arm, the reopen test
+    /// below could pass against a store that opened fine on the first attempt and never retried anything.
+    /// </summary>
+    [Fact]
+    public void AnObstructedStore_IsUnavailableToBeginWith()
+    {
+        Obstruct();
+
+        using var store = new GatewayStatsStore(SelfHostChoice());
+
+        Assert.False(store.Availability.IsAvailable);
+        Assert.Null(store.Factory);
+        Assert.Equal(StatsStoreUnavailableReason.Unreachable, store.Availability.Reason);
+        _out.WriteLine($"obstructed: {store.Availability.ReasonCode}: {store.Availability.Detail}");
+
+        // AND IT STAYS THAT WAY WHILE THE FAULT STAYS. The retry must not invent a store out of a fault
+        // that has not cleared, which is the one way a "it comes back" fix could be worse than no fix.
+        Thread.Sleep(Patience);
+        Assert.False(store.Availability.IsAvailable);
+        Assert.Null(store.Factory);
+    }
+
+    // ============================================================ the claim
+
+    /// <summary>
+    /// THE CLAIM. The obstruction is removed and NOTHING ELSE HAPPENS - no restart, no reconstruction, not
+    /// one call into the store. It has to come back by itself, which is exactly what production could not
+    /// do on 2 September 2026.
+    /// </summary>
+    [Fact]
+    public void WhenTheFaultClears_TheStoreReopensItself_WithNoRestartAndNoCall()
+    {
+        Obstruct();
+
+        using var store = new GatewayStatsStore(SelfHostChoice());
+        Assert.False(store.Availability.IsAvailable);   // the precondition, not the claim
+
+        ClearTheObstruction();
+
+        var deadline = DateTime.UtcNow + Patience;
+        while (DateTime.UtcNow < deadline && !store.Availability.IsAvailable)
+            Thread.Sleep(250);
+
+        Assert.True(
+            store.Availability.IsAvailable,
+            "the statistics store did not reopen itself after the fault cleared - this is the 2 September " +
+            $"2026 defect: {store.Availability.ReasonCode}: {store.Availability.Detail}");
+        Assert.NotNull(store.Factory);
+        Assert.Equal(StatsStoreUnavailableReason.None, store.Availability.Reason);
+
+        // AND IT IS A USABLE STORE, not merely a flag that flipped. A reopen that published an availability
+        // without a working context would read as fixed on every surface and record nothing, which is the
+        // half-state this whole area keeps producing.
+        using var context = store.CreateContext();
+        Assert.True(context.Database.CanConnect());
+        _out.WriteLine("reopened and served a working context");
+    }
+
+    // ============================================================ what must NOT be retried
+
+    /// <summary>
+    /// A store with NOTHING CONFIGURED is not retried, because there is nothing to retry: no setting names
+    /// a database, and asking again produces no connection string. It must stay unavailable, keep saying so
+    /// with its own distinct reason, and never quietly become available.
+    ///
+    /// This matters beyond tidiness. NOT CONFIGURED and UNREACHABLE are the two states an operator acts on
+    /// differently - one is a setting to fix, the other is a database to wait for - and a retry that
+    /// treated them alike would put the wrong advice on the surface for the one that needs a human.
+    /// </summary>
+    [Fact]
+    public void AStoreWithNothingConfigured_IsNotRetried()
+    {
+        var blank = StatsConnectionSelection.Resolve(
+            statsOverride: "", gatewayConnection: null, hosted: true, sqlitePath: SqlitePath);
+
+        using var store = new GatewayStatsStore(blank);
+
+        Assert.False(store.Availability.IsAvailable);
+        Assert.Equal(StatsStoreUnavailableReason.NotConfigured, store.Availability.Reason);
+
+        Thread.Sleep(Patience);
+
+        Assert.False(store.Availability.IsAvailable);
+        Assert.Equal(StatsStoreUnavailableReason.NotConfigured, store.Availability.Reason);
+        _out.WriteLine($"not configured, and left alone: {store.Availability.ReasonCode}");
+    }
+
+    // ============================================================ the schedule itself
+
+    /// <summary>
+    /// THE BACKOFF NEVER STOPS. The last entry repeats for the life of the process, so this asserts the
+    /// SHAPE that makes that safe rather than the numbers, which will move: it starts quickly, it never
+    /// goes backwards, and it settles somewhere a permanent poll is affordable.
+    ///
+    /// The claim being defended is that the loop has no give-up. A fix that retried five times and stopped
+    /// would satisfy every other test in this file - the fault always clears within the first attempt or
+    /// two here - and would reintroduce the incident for any outage longer than the schedule.
+    /// </summary>
+    [Fact]
+    public void TheBackoff_StartsQuickly_NeverGoesBackwards_AndSettlesSomewhereAffordable()
+    {
+        var schedule = GatewayStatsStore.ReopenBackoff;
+
+        Assert.NotEmpty(schedule);
+        Assert.True(
+            schedule[0] <= TimeSpan.FromSeconds(10),
+            $"the first retry is {schedule[0]}, too slow for a pooler that refused one connection");
+
+        for (var i = 1; i < schedule.Count; i++)
+            Assert.True(
+                schedule[i] >= schedule[i - 1],
+                $"the backoff goes backwards at step {i}: {schedule[i - 1]} then {schedule[i]}");
+
+        // The steady state, which repeats forever. Slow enough to be free, fast enough that a database
+        // coming back is noticed in about a minute rather than an hour.
+        var steady = schedule[^1];
+        Assert.InRange(steady, TimeSpan.FromSeconds(30), TimeSpan.FromMinutes(5));
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -196,7 +196,14 @@ internal static class GatewayEndpoints
         // runs before the listener binds and the database is opened AFTER it, so the value is not known
         // here. Null means "assume ready", which is what every self-host and test caller wants.
         Func<bool>? databaseReady = null,
-        History.KnownRepositoryStore? knownRepositories = null)
+        History.KnownRepositoryStore? knownRepositories = null,
+        // Per-subsystem readiness for /healthz: the parts of the Gateway that can be down on their own
+        // while the process serves normally. A delegate, not a snapshot, for the same reason databaseReady
+        // above is one - the statistics store is allowed to come up (and now to come BACK) long after Map
+        // ran, and a value read here would freeze the answer at startup. Null computes none, which OMITS
+        // the block; that is what every self-host and test caller gets, and it is honest: a responder that
+        // was given nothing to report must not report that everything is fine. See HealthDto.Subsystems.
+        Func<IReadOnlyDictionary<string, string>>? subsystems = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -586,6 +593,7 @@ internal static class GatewayEndpoints
                     Status = "starting",
                     Version = version,
                     Commit = Environment.GetEnvironmentVariable("COCKPIT_COMMIT"),
+                    Subsystems = subsystems?.Invoke(),
                     ServerTime = DateTime.UtcNow,
                 }, statusCode: StatusCodes.Status503ServiceUnavailable);
             }
@@ -622,6 +630,7 @@ internal static class GatewayEndpoints
                     Status = "ok",
                     Version = version,
                     Commit = commit,
+                    Subsystems = subsystems?.Invoke(),
                     ServerTime = DateTime.UtcNow,
                 });
             }
@@ -644,6 +653,7 @@ internal static class GatewayEndpoints
                 Sessions = totalSessions,
                 Version = version,
                 Commit = commit,
+                Subsystems = subsystems?.Invoke(),
                 ServerTime = DateTime.UtcNow,
             });
         });

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2904,6 +2904,16 @@ public sealed class GatewayHost : IAsyncDisposable
             gatewayPort: () => Port,
             // Not-ready until the database is open - see the /healthz handler.
             databaseReady: () => _gatewayDb.IsOpen,
+            // Per-subsystem readiness on /healthz, so a deploy can tell "the process is up" apart from
+            // "the pages work". Statistics is the one subsystem that is designed to fail on its own without
+            // stopping the Gateway, so it is the one that can be silently down after a green deploy - which
+            // is exactly what happened on 2 September 2026. Asked on every request, never cached: the store
+            // can come up late and can now come BACK on its own. Status words only; the reason names the
+            // database host and this endpoint is public. See HealthDto.Subsystems.
+            subsystems: () => new Dictionary<string, string>
+            {
+                ["statistics"] = InputStatsHandle.IsAvailable ? "available" : "unavailable",
+            },
             knownRepositories: _knownRepositories,
             // Store injection points: hand the phone-recorder ingest (RecordingEndpoints) the host's single
             // key vault + transcription history + audio archive, so it stops newing its own copies.

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -803,6 +803,35 @@ public sealed class GatewayHost : IAsyncDisposable
     /// re-implementation. Null until StartAsync builds it.</summary>
     internal TurnEndWatcher? TurnEndWatcherForTest => _turnEndWatcher;
 
+    /// <summary>
+    /// Put a conversation into this Gateway's store for one session, as the owning Director's push would
+    /// (turn-push mission). Tests need it because the narration path reads the STORE now: before the mission
+    /// they supplied a session's words by answering a "turns" command on the tunnel, and there is no such
+    /// command any more. Enters the tenant's scope itself, so a test cannot seed one account's conversation
+    /// into another's partition by forgetting to.
+    /// </summary>
+    internal void SeedStoredConversationForTest(TenantId tenant, string directorId, string sessionId,
+        params (string Role, string Text)[] messages)
+    {
+        using var scope = _tenantBoundary?.EnterScope(tenant);
+        var batch = new Contracts.TurnPushBatch
+        {
+            SessionId = sessionId,
+            Generation = "seeded:" + sessionId,
+            GenerationStartedUtc = DateTime.UtcNow,
+            Agent = "ClaudeCode",
+            StartOrdinal = 0,
+            TotalCount = messages.Length,
+            Turns = messages.Select((m, i) => new Contracts.PushedTurn
+            {
+                Ordinal = i,
+                Role = m.Role,
+                Parts = { new Contracts.HistoryPartDto { Kind = "Text", Text = m.Text } },
+            }).ToList(),
+        };
+        _sessionTurns.Append(directorId, batch, DateTime.UtcNow);
+    }
+
     /// <summary>Test-only: the session supervisor (issue #915), so a test can drive a real Working -&gt; idle
     /// transition into the REAL engine. Null until StartAsync builds it.</summary>
     internal Supervision.SessionSupervisor? SessionSupervisorForTest => _sessionSupervisor;

--- a/src/CcDirector.Gateway/Stats/Data/GatewayStatsStore.cs
+++ b/src/CcDirector.Gateway/Stats/Data/GatewayStatsStore.cs
@@ -102,12 +102,50 @@ public sealed class GatewayStatsStore : IDisposable
     /// </summary>
     public static readonly TimeSpan OpenDeadline = TimeSpan.FromSeconds(8);
 
+    /// <summary>
+    /// How long to wait before each successive attempt to reopen a store that COULD NOT BE REACHED, with the
+    /// last value repeating for as long as the process runs.
+    ///
+    /// WHY THIS EXISTS. The open used to happen exactly once. A store that was merely SLOW was covered - the
+    /// attempt outlives the startup deadline and publishes when it finishes - but a store that was briefly
+    /// UNREACHABLE was not: the failure latched, and statistics stayed dead for the life of the container
+    /// with no retry anywhere. That is not a theoretical gap. On 2 September 2026 a deploy ran production and
+    /// staging together for four minutes; each container opens its own pool, the pooler refused the incoming
+    /// container's statistics connection, and Your Throttle answered 503 for hours while every turn the owner
+    /// drove went unrecorded - on a database that was healthy the whole time and answered on the next
+    /// connection anyone made to it.
+    ///
+    /// A TRANSIENT FAILURE MUST NOT BE PERMANENT, and one reachability test is not evidence about the next
+    /// minute. So a store that could not be reached is retried until it can be, and the surface comes back on
+    /// its own with no restart - the same promise the late arrival already makes for a slow store, kept for an
+    /// unreachable one too.
+    ///
+    /// BACKED OFF, AND THEN STEADY RATHER THAN STOPPED. The early attempts are close together because the
+    /// common case is a pooler that refused one connection during a deploy and will accept the next one
+    /// seconds later. It settles at one attempt a minute and stays there: a database can come back at any
+    /// hour, an attempt is a single connection that costs nothing measurable beside the roster traffic
+    /// already flowing, and a store that gives up after N tries is the same permanent failure this exists to
+    /// remove, just with a longer fuse. Nothing here retries a store that is UNCONFIGURED, one that failed
+    /// inside our OWN code, or one whose adoption verdict says this build cannot use it - see
+    /// <see cref="ScheduleReopen"/> for why each of those is a different answer, not a slower one.
+    /// </summary>
+    internal static readonly IReadOnlyList<TimeSpan> ReopenBackoff = new[]
+    {
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromSeconds(10),
+        TimeSpan.FromSeconds(20),
+        TimeSpan.FromSeconds(40),
+        TimeSpan.FromSeconds(60),
+    };
+
     private readonly StatsFailureCounters _health = new(ObserverName);
     private readonly object _gate = new();
+    private readonly CancellationTokenSource _stop = new();
     private ServiceProvider? _provider;
     private StatsStoreAvailability _availability;
     private IDbContextFactory<GatewayStatsDbContext>? _factory;
     private bool _disposed;
+    private bool _reopening;
 
     /// <summary>
     /// What the statistics surface should say about itself. Folded once, here.
@@ -306,8 +344,9 @@ public sealed class GatewayStatsStore : IDisposable
             var detail = theirs
                 ? $"The statistics database ({choice.Target}) could not be opened or migrated " +
                   $"({ex.GetType().Name}). The settings name a database, so this is a database or network " +
-                  "problem rather than a missing setting. Statistics are unavailable; the Gateway is serving " +
-                  "normally and the rest of it is unaffected."
+                  "problem rather than a missing setting. The Gateway is retrying it until it answers, so " +
+                  "the statistics surface will come up on its own with no restart needed. The Gateway is " +
+                  "serving normally and the rest of it is unaffected."
                 : "Statistics are unavailable because something in DevThrottle's own code failed while " +
                   $"opening the statistics store ({ex.GetType().Name}). This is a fault in DevThrottle, NOT " +
                   "a problem with your database, your network or your settings - checking those will not " +
@@ -318,6 +357,11 @@ public sealed class GatewayStatsStore : IDisposable
                 theirs ? StatsStoreUnavailableReason.Unreachable : StatsStoreUnavailableReason.InternalError,
                 detail, choice.Source, choice.Target);
             _health.RecordFailure(detail);
+
+            // THEIRS IS RETRIED, OURS IS NOT. A database or network that refused this connection may accept
+            // the next one; a fault in our own code throws identically every time, and looping on it would
+            // bury the report that gets it fixed. See ScheduleReopen.
+            if (theirs) ScheduleReopen(choice);
 
             // The STACK is logged for our own faults and not for theirs. For a storage failure the type and
             // the redacted target are the whole diagnosis and a stack is noise; for a fault in our code the
@@ -397,13 +441,149 @@ public sealed class GatewayStatsStore : IDisposable
             late.Dispose();
 
             var detail = prepared?.Detail ??
-                $"The statistics store ({choice.Target}) failed after the startup deadline ({failure}).";
+                $"The statistics store ({choice.Target}) failed after the startup deadline ({failure}). " +
+                "The Gateway is retrying it until it answers, and the statistics surface will come up on " +
+                "its own with no restart needed.";
             var reason = prepared?.Reason ?? StatsStoreUnavailableReason.Unreachable;
             _availability = Unavailable(reason, detail, choice.Source, choice.Target);
             _health.RecordFailure(detail);
 
             FileLog.Write(
                 $"[GatewayStatsStore] Late arrival FAILED (CONTAINED): {_availability.ReasonCode}: {detail}");
+
+            // A THROW is a reachability failure and is retried; an adoption VERDICT is not. prepared is null
+            // exactly when the attempt faulted, which is the case this incident came from.
+            if (prepared is null) ScheduleReopen(choice);
+        }
+    }
+
+    /// <summary>
+    /// Start retrying an open that failed because the store COULD NOT BE REACHED, until it can be.
+    ///
+    /// ONLY UNREACHABLE IS RETRIED, and the three states this deliberately excludes are excluded because
+    /// retrying them is not a slower version of the right answer, it is the wrong answer repeated:
+    ///
+    ///  - NOT CONFIGURED. No setting names a database. There is nothing to connect to, and a thousand
+    ///    attempts do not produce a connection string. The operator has to set it, and the log already
+    ///    names the variable.
+    ///  - INTERNAL ERROR. Something in OUR code threw while opening the store. A defect is not a timing
+    ///    artefact; it will throw again on every attempt, and turning it into a permanent background loop
+    ///    buries the one report that would get it fixed.
+    ///  - AN ADOPTION VERDICT. The store was reached and interrogated, and this build says it cannot use
+    ///    what it found. That is a considered answer about the store's CONTENTS, and it does not change
+    ///    because we ask a second time.
+    ///
+    /// At most ONE loop ever runs, and it is the only thing other than the constructor and the late arrival
+    /// that may make the store available. It ends on success or on Dispose - never on a retry count; see
+    /// <see cref="ReopenBackoff"/> for why stopping would reintroduce exactly the failure it exists to fix.
+    /// </summary>
+    /// <param name="choice">The chosen connection to keep trying. The same one the failed attempt used - a
+    /// reopen never re-resolves the configuration, so it cannot quietly start using a different database
+    /// than the one the operator's log says the Gateway chose.</param>
+    private void ScheduleReopen(StatsConnectionChoice choice)
+    {
+        // Called from inside the lock on the late-arrival path and from outside it in the constructor, so it
+        // takes the lock itself and tolerates already holding it (a Monitor is re-entrant per thread).
+        lock (_gate)
+        {
+            if (_disposed || _reopening || _factory is not null) return;
+            _reopening = true;
+        }
+
+        FileLog.Write(
+            $"[GatewayStatsStore] Reopen SCHEDULED: source={choice.Source} target={choice.Target}. The store " +
+            "could not be reached, so it will be retried until it answers. No restart is needed.");
+
+        _ = Task.Run(() => ReopenLoop(choice));
+    }
+
+    /// <summary>
+    /// The reopen loop. Waits, opens, and publishes the first attempt that succeeds.
+    ///
+    /// It runs on a thread pool thread for the life of the process, so EVERY attempt is contained: a throw
+    /// escaping here would be an unobserved task exception and would end the loop silently, which is the
+    /// failure mode this whole type exists to prevent. Nothing it catches leaves.
+    /// </summary>
+    private async Task ReopenLoop(StatsConnectionChoice choice)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            var wait = ReopenBackoff[Math.Min(attempt, ReopenBackoff.Count - 1)];
+            try
+            {
+                await Task.Delay(wait, _stop.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;   // Disposed. There is nothing left to publish into.
+            }
+
+            ServiceProvider? provider = null;
+            try
+            {
+                provider = BuildProvider(choice);
+                var factory = provider.GetRequiredService<IDbContextFactory<GatewayStatsDbContext>>();
+
+                // NOT bounded on the clock here, and that is the difference from the constructor. The startup
+                // deadline exists because the platform is waiting on the port bind; nothing is waiting on
+                // this. A slow attempt takes as long as it takes, and the next one starts after it.
+                var prepared = await Task.Run(() => OpenAndMigrate(factory, choice)).ConfigureAwait(false);
+
+                if (!prepared.IsUsable)
+                {
+                    // The store answered, with a verdict. That is not a reachability failure, and asking a
+                    // second time asks the same question - so the loop ends with the verdict on the surface.
+                    provider.Dispose();
+                    lock (_gate)
+                    {
+                        _reopening = false;
+                        if (_disposed) return;
+                        _availability = Unavailable(
+                            prepared.Reason, prepared.Detail, choice.Source, choice.Target);
+                        _health.RecordFailure(prepared.Detail);
+                    }
+
+                    FileLog.Write(
+                        "[GatewayStatsStore] Reopen STOPPED: the store answered and this build cannot use it " +
+                        $"({prepared.Reason}): {prepared.Detail}");
+                    return;
+                }
+
+                lock (_gate)
+                {
+                    if (_disposed)
+                    {
+                        provider.Dispose();
+                        return;
+                    }
+
+                    _provider = provider;
+                    _factory = factory;
+                    _availability = new StatsStoreAvailability(
+                        IsAvailable: true,
+                        Reason: StatsStoreUnavailableReason.None,
+                        ReasonCode: "available",
+                        Detail: choice.Detail,
+                        Source: choice.Source,
+                        Target: choice.Target);
+                    _reopening = false;
+                }
+
+                FileLog.Write(
+                    $"[GatewayStatsStore] REOPENED on attempt {attempt + 1}: the statistics store is now " +
+                    $"AVAILABLE ({choice.Target}). No restart was needed.");
+                return;
+            }
+            catch (Exception ex)
+            {
+                // Contained, exactly as the constructor's boundary is. The exception MESSAGE is never used -
+                // a provider echoes a malformed connection string back in it - so the type and the already
+                // redacted target are what gets logged, and the loop waits and tries again.
+                provider?.Dispose();
+                FileLog.Write(
+                    $"[GatewayStatsStore] Reopen attempt {attempt + 1} FAILED (CONTAINED): " +
+                    $"target={choice.Target}: {ex.GetType().Name}. Waiting and retrying.");
+            }
         }
     }
 
@@ -861,6 +1041,7 @@ public sealed class GatewayStatsStore : IDisposable
         {
             if (_disposed) return;
             _disposed = true;
+            _stop.Cancel();
             _provider?.Dispose();
             _provider = null;
             _factory = null;
@@ -872,6 +1053,9 @@ public sealed class GatewayStatsStore : IDisposable
         // it is process-wide and has no business being held under this store's gate.
         if (availability.Source == StatsConnectionSource.SqliteFile)
             SqliteConnection.ClearAllPools();
+
+        // Outside the lock, and after the cancel above has already stopped the reopen loop from publishing.
+        _stop.Dispose();
         FileLog.Write($"[GatewayStatsStore] Dispose: closed {availability.Target}");
     }
 }


### PR DESCRIPTION
## The incident

Your Throttle answered HTTP 503 for two hours today on a Gateway that was healthy and serving every other page, and every turn driven in that window went unrecorded. Recording stopped dead at 14:04 UTC, straight from the statistics database:

```
12:00 UTC   18 turns
13:00 UTC   18
14:00 UTC    3     <- the deploy swapped at 14:04
15:00 UTC    -     nothing, on a busy fleet
```

Nobody shipped a bad change. Deploy run 33638580309 swapped commit 731ccb7 into production correctly and production came up serving it. Three separate things then had to be true for the page to stay dark, and all three are fixed here.

## 1. The store gave up, and nothing ever tried again

A deploy runs production and staging together for a few minutes, and each container opens its own connection pool. The pooler refused the incoming container's *statistics* connection - the second pool in the process, separate from the main one. The store opened exactly once at boot, latched `unavailable` when that attempt failed, and there was no retry path anywhere in `Stats/`. It stayed that way for the life of the container, against a database that was healthy throughout, serving the roster from the other pool in the same process, and which answered the very next connection anyone made to it.

The asymmetry is the defect. The store already kept a promise for a **slow** database: the open outlives the startup deadline on purpose and publishes when it finishes, so a slow store costs the first seconds of one boot instead of everything after it. It had no promise at all for an **unreachable** one.

It now retries on a backoff that starts at five seconds, settles at once a minute, and never stops - so the surface comes back on its own with no restart. **Only UNREACHABLE is retried.** Not a missing setting (there is nothing to connect to), not a fault in our own code (it will throw identically every time, and looping on it buries the report that gets it fixed), and not an adoption verdict (a considered answer about the store's contents, which does not change because we ask twice).

## 2. The message pointed at the wrong thing

The Gateway wrote a true, operator-facing sentence into the 503 body's `reason`. The client read `error`, `detail`, `message` and `code` - not `reason`. With no reason found, a 503 falls into the "never reached a healthy backend" branch, so the page rendered:

> Can't reach the Gateway - retrying.

on a Gateway that was answering everything else. That sentence sent the investigation to the Gateway's health and the deploy pipeline instead of to the statistics store, and it is most of why this took as long as it did. The client reads `reason` now. The collapse for a body that genuinely carries no reason is unchanged, and is asserted.

## 3. The deploy could not have caught it

The pipeline saw a sustained 200 carrying the commit it had just shipped and called the release good. That is everything it knew how to ask, because the Gateway reported **one status for the whole of itself** - so no check anyone could have written would have seen this.

`/healthz` now carries per-subsystem readiness, and the watch job asserts every subsystem is available after the swap. Status words only (`available` / `unavailable`): this endpoint is public and the reason names the database host, so the detail stays on the authenticated feed and in the log. It **polls** rather than asking once, because a subsystem is allowed to come up after the port does. An absent block **fails** the step rather than passing it, so it cannot certify a deploy it cannot see into.

## Proof

Each claim has a negative control, because "it works now" passes against a test that was never able to fail.

| Test | Claim | Control |
|---|---|---|
| `StatsStoreReopensAfterAnUnreachableStoreTests` | a fault that **clears** - no existing fixture had one, which is why nothing could see this | with the reopen disabled only the claim fails; all three controls still pass |
| `reasonBodyIsRead.test.ts` | pinned at what a person reads on the page, not at the parser | with the parser line removed the two claims fail and the two controls pass |
| `HealthzSubsystemReadinessTests` | `available` **and** `unavailable` both asserted | plus: the reason never reaches the public probe |

Local, on this branch: `Gateway.UnitTests` 3235 passed, `client-core` 979 passed, the three new `Gateway.Tests` passed.

## Note on CI

Branched off `e5578b8`, which is red for five pre-existing `Gateway.Tests` failures from the turn-push work (tenant isolation and the two live-screen voice proofs). Those are being fixed on `fix/turn-push-parked-suite` and are unrelated to this change. This branch rebases onto main once that lands, and the green run after the rebase is the one that counts.
