### PR TITLE
fix(deploy): the subsystem proof was silent on exactly the deploys that needed it

### DIFF
--- a/.github/workflows/deploy-hosted-gateway.yml
+++ b/.github/workflows/deploy-hosted-gateway.yml
@@ -866,11 +866,26 @@ jobs:
       # regression that dropped the block. Treating that as "nothing to check" would make this step
       # certify precisely the deploys it cannot see into, which is the failure it exists to remove.
       - name: Prove every subsystem came up
-        # Same guard the poller uses: only assert against production when a swap actually put the new
-        # image there. A refused or failed deploy leaves the OLD image serving, and holding that to this
-        # contract would report a three-minute subsystem failure for a run that deliberately changed
-        # nothing.
-        if: needs.deploy.outputs.readiness_outcome == 'healthy'
+        # `always()` IS LOAD-BEARING HERE - WITHOUT IT THIS STEP IS SILENT ON EXACTLY THE DEPLOYS THAT
+        # NEED IT.
+        #
+        # A step whose `if:` does not mention always()/failure() is implicitly ANDed with success(), so a
+        # bare condition here means "...and every earlier step passed". The step above measures the
+        # outage and FAILS the run when it exceeds the budget. So the first time this check mattered -
+        # run 33666956643, the deploy of the incident fix itself - the outage step failed at 36.4s and
+        # this step was SKIPPED. A troubled deploy is the one where "did the pages actually come up?" is
+        # worth asking, and it was the one case that could not ask it.
+        #
+        # That is a check whose pass condition was an absence: nothing failed here, because nothing ran
+        # here, and the run's own summary showed no subsystem complaint. The step exists because a green
+        # signal over a dead page cost four and a half hours on 2 September 2026; shipping it in a form
+        # that goes quiet whenever anything else is wrong would have reproduced that fault inside its own
+        # fix.
+        #
+        # The rest of the guard is unchanged and is a real exclusion, not a convenience: readiness_outcome
+        # is 'healthy' only when a swap actually put the new image into production. A refused deploy
+        # (wrong ref, failed checks) leaves the OLD image serving and must not be held to this contract.
+        if: always() && needs.deploy.outputs.readiness_outcome == 'healthy'
         run: |
           deadline=$(( $(date +%s) + 180 ))
           last=""


### PR DESCRIPTION
The post-swap subsystem proof only ran when every earlier step had already passed, so it went silent on exactly the deploys worth asking about.

## What happened

A step whose `if:` does not mention `always()` or `failure()` is implicitly ANDed with `success()`. The step immediately before this one measures the external outage and **fails the run** when it exceeds the budget.

So on run **33666956643** - the deploy of the statistics-store fix itself, the first deploy ever to carry this check - the outage step failed at 36.4s and `Prove every subsystem came up` was **skipped**:

```
Watch production past the swap and measure the true outage: failure
Prove every subsystem came up: skipped
```

A deploy that is already in trouble is the one where "did the pages actually come up?" is worth asking. It was the one case that could not ask it.

## Why this is the same defect it was written to prevent

The check's pass condition had quietly become an **absence**: the run summary showed no subsystem complaint, because nothing ran, not because nothing was wrong. That is the shape of the incident it was added for - a green signal over a dead page, which cost four and a half hours on 2026-09-02. Shipping the fix in a form that goes quiet whenever anything else is wrong reproduced the fault inside its own remedy.

## The change

`always() &&` in front of the existing condition. One line, plus the reasoning recorded next to it so the next edit does not undo it.

The rest of the guard is unchanged and is a genuine exclusion, not a convenience: `readiness_outcome` is `'healthy'` only when a swap actually put the new image into production, so a refused deploy (wrong ref, failed checks) leaves the OLD image serving and is still correctly not held to this contract.

## Verification

Production was checked by hand while this was unguarded, so we know what the skipped step would have said:

```
GET /healthz  -> {"commit":"fac79fb","subsystems":{"statistics":"available"}, ...}
GET /stats/data -> 200
```

It would have passed. The defect is that it could not have failed.

## Not addressed here

That deploy's 36.4s external outage (budget 10s, healthy norm 6.6-8.9s) is a separate, known problem - `site_state_left_running: no`, `time_to_healthy: 32s`, the second-container-startup shape already documented in CLAUDE.md and issues thefrederiksen/devthrottle_internal#1766/#2585. It is not caused by this change and is not fixed by it.
