### PR TITLE
fix(gateway): the wingman says which computer to update instead of waiting for a conversation that is never coming

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/VoiceDisplayFoldTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceDisplayFoldTests.cs
@@ -183,4 +183,100 @@ public sealed class VoiceDisplayFoldTests
         Assert.Equal("serviceDown", d.Kind);
         Assert.Null(d.VoiceFallbackNotice);
     }
+
+    // ------------------------------------------------------------------------------------------------
+    // "That computer cannot send its conversation" (2026-09-02). The Gateway knew this the whole time -
+    // Chat was already saying it in plain English - while the voice path said "Voice did not arrive after
+    // 22m" and the colour fold held those sessions yellow. These pin the SENTENCE the reader gets, not
+    // just the branch taken, because the sentence is what was wrong.
+    // ------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void DirectorCannotSend_SaysUpdateThatComputer_AndOffersNoDeadEndButton()
+    {
+        var d = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: null, nothingToNarrate: false, directorCannotSendConversation: true);
+        Assert.Equal("directorTooOld", d.Kind);
+        Assert.Equal("red", d.Tone);
+        Assert.Equal("Update DevThrottle", d.Label);
+        // The WORDS, verbatim. A test that only pinned the Kind would have passed while the screen said
+        // anything at all, including the "be patient" sentence this whole arm exists to stop.
+        Assert.Equal(VoiceDisplayFold.DirectorTooOldText, d.Message);
+        Assert.Contains("Update it", d.Message);
+        Assert.False(d.CanGenerate);   // the action is on the other machine
+        Assert.False(d.CanPlay);
+    }
+
+    [Fact]
+    public void DirectorCannotSend_ReplacesTheGaveUpSentence_THE_2026_09_02_DEFECT()
+    {
+        // The exact shape of the incident: voice on, no audio, and a wait long past the give-up boundary.
+        // Before this arm the reader was told "Voice did not arrive after 22m" - a symptom, and a promise
+        // that the Gateway was still trying at something that could never work.
+        var waitingSince = new DateTime(2026, 9, 2, 18, 35, 0, DateTimeKind.Utc);
+        var now = waitingSince.AddMinutes(22);
+
+        var before = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: null, nothingToNarrate: false, waitingSince: waitingSince, utcNow: now,
+            directorCannotSendConversation: false);
+        Assert.Equal("gaveUp", before.Kind);                         // NEGATIVE CONTROL: this is what it used to say
+        Assert.Contains("did not arrive", before.Label);
+
+        var after = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: null, nothingToNarrate: false, waitingSince: waitingSince, utcNow: now,
+            directorCannotSendConversation: true);
+        Assert.Equal("directorTooOld", after.Kind);
+        Assert.Equal(VoiceDisplayFold.DirectorTooOldText, after.Message);
+        Assert.DoesNotContain("did not arrive", after.Label);
+        Assert.DoesNotContain("still trying", after.Message);        // no promise it cannot keep
+    }
+
+    [Fact]
+    public void DirectorCannotSend_BeatsNothingToNarrate_BecauseNobodyReadTheConversation()
+    {
+        // "This session is waiting for you on a prompt" is a claim about a conversation this Gateway has
+        // never seen. It must not be made on a session whose words never arrived.
+        var d = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: null, nothingToNarrate: true, directorCannotSendConversation: true);
+        Assert.Equal("directorTooOld", d.Kind);
+    }
+
+    [Theory]
+    [InlineData(HostedAiState.NeedsCredits)]
+    [InlineData(HostedAiState.NeedsKey)]
+    [InlineData(HostedAiState.SubscriptionRequired)]
+    [InlineData(HostedAiState.ServiceDown)]
+    public void AccountAndServiceConditions_StillOutrank_DirectorCannotSend(HostedAiState state)
+    {
+        // The deliberate ordering, asserted so it cannot drift: an account-level condition is what the rest
+        // of the product is already telling this member, and it is answered by a real call-to-action. The
+        // too-old machine is the narrower fact and waits its turn.
+        var d = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: state, nothingToNarrate: false, directorCannotSendConversation: true);
+        Assert.NotEqual("directorTooOld", d.Kind);
+    }
+
+    [Fact]
+    public void PlayableAudio_AndAWorkingAgent_BothStillWin_OverDirectorCannotSend()
+    {
+        // A clip in hand is never hidden behind a verdict about the machine that produced it, and a session
+        // mid-turn says so. Both sit above every reason arm; this pins that the new one did not jump them.
+        var ready = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: true, generating: false,
+            unavailable: null, nothingToNarrate: false, directorCannotSendConversation: true);
+        Assert.Equal("ready", ready.Kind);
+        Assert.True(ready.CanPlay);
+
+        var working = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: true, hasAudio: false, generating: false,
+            unavailable: null, nothingToNarrate: false, directorCannotSendConversation: true);
+        Assert.Equal("working", working.Kind);
+    }
+
+    [Fact]
+    public void VoiceOff_SaysNothingAboutAnybodysBuild()
+    {
+        var d = VoiceDisplayFold.Fold(voiceMode: false, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: null, nothingToNarrate: false, directorCannotSendConversation: true);
+        Assert.Equal("off", d.Kind);
+    }
+
 }

--- a/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
@@ -552,6 +552,9 @@ public sealed class WingmanVoiceServiceTests : IDisposable
             Assert.Null(svc.ReadFailedFor(TenantId.Local, "sid-1"));           // ...and a wait is not a failed read
             Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));     // ...so the row carries no reason at all
             Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));    // ...and it is NOT "nothing to say" either
+            // NEGATIVE CONTROL for the too-old arm below: a Director that CAN send simply has not sent
+            // yet, and nothing here may accuse its machine of being out of date.
+            Assert.False(svc.DirectorCannotSendConversationFor(TenantId.Local, "sid-1"));
             Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));               // nothing to play yet
             Assert.Equal(0, brain.AskCount);                                   // and nothing to translate, so no spend
         }
@@ -827,7 +830,8 @@ public sealed class WingmanVoiceServiceTests : IDisposable
     /// what the narration reads its words from; leaving it null is the honest "this Gateway has stored
     /// nothing" case, which is what the tests about waiting want.</summary>
     private WingmanVoiceService ServiceWithBrainAndTts(IAgentBrain brain, byte[] audio, string persistPath,
-        Func<TenantId, string, CcDirector.Gateway.History.StoredConversation?>? conversationReader = null)
+        Func<TenantId, string, CcDirector.Gateway.History.StoredConversation?>? conversationReader = null,
+        Func<TenantId, string, bool>? directorCannotSendConversation = null)
     {
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
         var vault = new KeyVault(vaultPath);
@@ -835,7 +839,8 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test");
         var http = new HttpClient(new TtsStubHandler(HttpStatusCode.OK, "", audio));
         return new WingmanVoiceService((_, _, _) => Task.FromResult(brain), vault, Settings, persistPath,
-            ttsHttpClient: http, conversationReader: conversationReader);
+            ttsHttpClient: http, conversationReader: conversationReader,
+            directorCannotSendConversation: directorCannotSendConversation);
     }
 
     /// <summary>Like <see cref="ServiceWithBrainAndTts"/> but with a caller-supplied speech transport, so a
@@ -1455,4 +1460,82 @@ public sealed class WingmanVoiceServiceTests : IDisposable
             "the ready-audio warm load did not finish within 30 seconds");
         return svc;
     }
+
+    /// <summary>
+    /// THE 2026-09-02 WEDGE. Turn-push phases 3a/3b went live on the hosted Gateway while the newest
+    /// RELEASED Director predated the pusher by a fortnight, so the store never filled for anybody. The arm
+    /// above reads an empty store as "the Director has not pushed YET" and comes back on the next sweep -
+    /// correct for a Director that HAS the pusher, and a promise that never ends for one that does not.
+    /// Eleven of the owner's twenty-one sessions sat yellow reading "Voice did not arrive after 3m..22m"
+    /// while those sessions had actually earned a red "Needs you" he could no longer see.
+    ///
+    /// So the service must record the fact the fold turns into "Update DevThrottle", and it must do so
+    /// WITHOUT spending anything and WITHOUT standing the sweep down - re-checking is free, and it is what
+    /// makes the recovery automatic the moment that machine is updated.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_WhenTheOwningDirectorCannotSendConversations_SaysSoInsteadOfWaitingForever()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.NothingStored();
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-tooold-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new RecordingBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 1 }, persistPath, conversation.Reader,
+                directorCannotSendConversation: (_, _) => true);
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.True(svc.DirectorCannotSendConversationFor(TenantId.Local, "sid-1"));   // the fact the screen renders
+            Assert.Equal(0, brain.AskCount);                                               // nothing translated, nothing spent
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+            // NOT a read failure. NoteReadFailed(Unavailable) would render through the hosted-AI arm and say
+            // "Voice unavailable" in the shared account-condition voice, for something that is neither the
+            // account's fault nor anything to do with hosted AI.
+            Assert.Null(svc.ReadFailedFor(TenantId.Local, "sid-1"));
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            // NOT "waiting on a prompt" either - nobody here has read a conversation to know that.
+            Assert.False(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));
+            // And the sweep keeps coming back, so updating that machine restores narration with nobody
+            // touching the Gateway. A skip here would make the recovery need a restart.
+            Assert.False(svc.ShouldSkipSweep(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// The marker describes a MACHINE, and machines get updated. Once a conversation actually arrives that
+    /// computer has demonstrated it can send one - whatever it last said about itself on Hello, and whoever
+    /// owns the session by then - so the sentence must come off the screen by itself.
+    /// </summary>
+    [Fact]
+    public async Task DirectorCannotSendMarker_ClearsAsSoonAsAConversationArrives()
+    {
+        var director = new TunnelStub();
+        var empty = StoredConversationStub.NothingStored();
+        var full = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var updated = false;
+        Func<TenantId, string, CcDirector.Gateway.History.StoredConversation?> reader =
+            (t, sid) => updated ? full.Reader(t, sid) : empty.Reader(t, sid);
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-tooold-clear-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var svc = ServiceWithBrainAndTts(new RecordingBrain(), new byte[] { 1 }, persistPath, reader,
+                directorCannotSendConversation: (_, _) => true);
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.True(svc.DirectorCannotSendConversationFor(TenantId.Local, "sid-1"));   // control: it was set
+
+            updated = true;   // that computer was updated and pushed its conversation
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.True(full.Reads >= 1);
+            Assert.False(svc.DirectorCannotSendConversationFor(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -73,6 +73,7 @@ internal static class GatewayEndpoints
         Func<TenantId, string, bool>? voiceAudioReadyFor = null,
         Func<TenantId, string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
         Func<TenantId, string, bool>? nothingToNarrateFor = null,
+        Func<TenantId, string, bool>? directorCannotSendConversationFor = null,
         Func<TenantId, string, bool>? servedViaFallbackFor = null,
         /// <summary>Issue #2576: stamps and returns SessionDto.VoiceWaitingSince - when this session's wait
         /// for voice began, or null when it is not waiting. Null delegate leaves the field unset, so a caller
@@ -1520,6 +1521,7 @@ internal static class GatewayEndpoints
                         generating: s.VoiceGenerating,
                         unavailable: voiceUnavailableFor?.Invoke(reqTenant.Value, s.SessionId),
                         nothingToNarrate: nothingToNarrateFor?.Invoke(reqTenant.Value, s.SessionId) ?? false,
+                        directorCannotSendConversation: directorCannotSendConversationFor?.Invoke(reqTenant.Value, s.SessionId) ?? false,
                         servedViaFallback: servedViaFallbackFor?.Invoke(reqTenant.Value, s.SessionId) ?? false,
                         waitingSince: s.VoiceWaitingSince);
                     // Orange "Transcribing..." while a dictated utterance is uploading/transcribing in

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1502,6 +1502,9 @@ public sealed class GatewayHost : IAsyncDisposable
                 nothingToNarrateFor: sid => _tenantPass.Current is { } t
                     && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
                     && _voiceService?.NothingToNarrateFor(t, sid) == true,
+                directorCannotSendConversationFor: sid => _tenantPass.Current is { } t
+                    && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
+                    && _voiceService?.DirectorCannotSendConversationFor(t, sid) == true,
                 voiceWaitingStampFor: (sid, waiting) => _tenantPass.Current is { } t
                     ? _voiceWaitingClock.Stamp(t, sid, waiting)
                     : null),
@@ -2101,6 +2104,28 @@ public sealed class GatewayHost : IAsyncDisposable
             History.StoredConversationWidgets.From(stored.Value.Messages));
     }
 
+    /// <summary>
+    /// Whether the computer that owns this session is CONNECTED but running a build that cannot send its
+    /// conversation - the single reason the Gateway's store will never fill for it, and therefore the single
+    /// reason a wingman narration is never coming without someone updating that machine.
+    ///
+    /// CONNECTION IS ASKED FIRST, and that ordering is the whole correctness of this method rather than a
+    /// tidiness. <see cref="Streaming.TurnPushCapabilityRegistry"/> is in-memory and learns each Director's
+    /// answer from its Hello, so for a Director it has not heard from - one that is away, and every Director
+    /// alive in the seconds after a Gateway restart - it reports "does not push". That is the safe reading
+    /// for Chat, which asks about connection first too and says "that computer has not checked in". Asked in
+    /// the other order here it would be a slander: every session on the fleet would be told its machine
+    /// needed updating for as long as it took the Directors to reconnect after a deploy. So a session whose
+    /// Director is not currently located answers FALSE - no claim about anybody's build.
+    /// </summary>
+    private bool DirectorCannotSendConversation(TenantId tenant, string sessionId)
+    {
+        if (!tenant.IsValid || string.IsNullOrEmpty(sessionId)) return false;
+        // not connected: "that computer is away", never "it is too old"
+        if (PushedSessions.TryLocate(tenant, sessionId, _streamStaleAfter) is not { } located) return false;
+        return !_turnPushCapabilities.PushesTurns(tenant, located.DirectorId);
+    }
+
     private string? ResolveSessionTitle(TenantId tenant, string sessionId)
     {
         if (!tenant.IsValid)
@@ -2450,7 +2475,8 @@ public sealed class GatewayHost : IAsyncDisposable
             // The narration's words now come from the Gateway's own store (turn-push mission, phase 3), not
             // from a tunnel command asking the Director to re-read the user's transcript. See
             // ReadStoredConversation for why the tenant scope is entered there rather than inside the service.
-            conversationReader: ReadStoredConversation);
+            conversationReader: ReadStoredConversation,
+            directorCannotSendConversation: DirectorCannotSendConversation);
 
         // The session supervisor (issue #915). It hangs off the SAME turn-end boundary as the voice refresh
         // below, deliberately: that event is the only thing that can wake it, so a Working session is out of
@@ -3010,6 +3036,10 @@ public sealed class GatewayHost : IAsyncDisposable
             // VoiceDisplay so the screen shows an honest "nothing to read aloud" instead of a Generate
             // button that cannot work - the client no longer rules on this.
             nothingToNarrateFor: (tenant, sid) => _voiceService?.NothingToNarrateFor(tenant, sid) == true,
+            // The owning computer is connected but cannot send its conversation, so no narration will ever
+            // be made for this session until it is updated. Feeds the folded VoiceDisplay so the screen says
+            // which computer to update instead of counting a wait that would not end (2026-09-02).
+            directorCannotSendConversationFor: (tenant, sid) => _voiceService?.DirectorCannotSendConversationFor(tenant, sid) == true,
             // TTS fallback: this session's ready clip was made by the backup voice provider (the primary
             // was overloaded and the cloud proxy failed over). Feeds the folded VoiceDisplay so the screen
             // shows the generic backup-voice notice. A success-with-a-note, never an outage state.
@@ -3209,7 +3239,8 @@ public sealed class GatewayHost : IAsyncDisposable
             // The narration's words now come from the Gateway's own store (turn-push mission, phase 3), not
             // from a tunnel command asking the Director to re-read the user's transcript. See
             // ReadStoredConversation for why the tenant scope is entered there rather than inside the service.
-            conversationReader: ReadStoredConversation);
+            conversationReader: ReadStoredConversation,
+            directorCannotSendConversation: DirectorCannotSendConversation);
         // The session's conversation, served from THIS Gateway's store (turn-push mission, phase 2). A
         // literal route, so it outranks the /sessions/{sid}/{**rest} catch-all - whose "history" verb entry
         // is removed in the same change, because the whole point is that reading a conversation no longer
@@ -4070,6 +4101,7 @@ public sealed class GatewayHost : IAsyncDisposable
         Snooze.SnoozeRegistry? snoozeRegistry,
         Func<string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
         Func<string, bool>? nothingToNarrateFor = null,
+        Func<string, bool>? directorCannotSendConversationFor = null,
         Func<string, bool, DateTime?>? voiceWaitingStampFor = null)
     {
         foreach (var s in sessions)
@@ -4099,6 +4131,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 generating: s.VoiceGenerating,
                 unavailable: unavailable,
                 nothingToNarrate: nothingToNarrateFor?.Invoke(s.SessionId) ?? false,
+                directorCannotSendConversation: directorCannotSendConversationFor?.Invoke(s.SessionId) ?? false,
                 waitingSince: s.VoiceWaitingSince);
         }
         Api.GatewayEndpoints.StampFleetRolesAndFold(sessions, sessions, needsYouStampFor, snoozeRegistry, tenant);

--- a/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
+++ b/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
@@ -61,6 +61,20 @@ public static class VoiceDisplayFold
     public const string BackupVoiceNotice =
         "Some voice providers are overloaded right now, so we switched you to a backup voice. No extra charge.";
 
+    /// <summary>
+    /// Shown when the computer that owns this session is connected but running a build that cannot send its
+    /// conversation. Nothing will ever be stored to narrate until it is updated, so this says the remedy
+    /// instead of asking the reader to keep waiting.
+    ///
+    /// It is the VOICE wording of the fact <see cref="History.SessionConversationFold.DirectorTooOldText"/>
+    /// states for Chat, and the two must keep agreeing about the CAUSE while differing about the
+    /// consequence - one loses the chat, the other loses the narration. They are deliberately not one
+    /// shared string: a sentence that has to be true of both surfaces ends up naming neither.
+    /// </summary>
+    public const string DirectorTooOldText =
+        "This session's computer is running an older DevThrottle that cannot send its conversation, "
+      + "so there is nothing here to read aloud. Update it to hear this session.";
+
     /// <param name="voiceMode">The session is in voice mode (the Director's authoritative flag).</param>
     /// <param name="agentWorking">The agent is mid-turn (a blue / working activity state). The
     /// finished-turn narration is stale while it works, so this dominates: no play, no Generate button,
@@ -83,7 +97,11 @@ public static class VoiceDisplayFold
     /// "gave up" instead of another calm "on its way" - see that field for why a promise with no end is
     /// worse than an admission.</param>
     /// <param name="utcNow">Now, injected so the give-up boundary is testable without waiting for it.</param>
-    public static VoiceDisplay Fold(bool voiceMode, bool agentWorking, bool hasAudio, bool generating, HostedAiState? unavailable, bool nothingToNarrate, bool servedViaFallback = false, DateTime? waitingSince = null, DateTime? utcNow = null)
+    /// <param name="directorCannotSendConversation">The computer that owns this session is connected but
+    /// running a build that cannot send its conversation, so the Gateway will never hold words to narrate
+    /// for it. A SPECIFIC, ACTIONABLE reason with a one-line remedy - which is why it outranks every
+    /// "be patient" verdict below it. See <see cref="DirectorTooOldText"/>.</param>
+    public static VoiceDisplay Fold(bool voiceMode, bool agentWorking, bool hasAudio, bool generating, HostedAiState? unavailable, bool nothingToNarrate, bool servedViaFallback = false, DateTime? waitingSince = null, DateTime? utcNow = null, bool directorCannotSendConversation = false)
     {
         // Computed once, up front, because more than one verdict below carries it: the calm "on its way"
         // wants it so a healthy wait can be seen climbing, and the give-up verdict wants it in its own
@@ -207,6 +225,32 @@ public static class VoiceDisplayFold
                     Reason = HostedAiHttp.Dto(unavailable.Value),
                 };
         }
+
+        // THE OWNING COMPUTER CANNOT SEND ITS CONVERSATION. One more member of the category the comment above
+        // already names - a SPECIFIC, ACTIONABLE reason - so it sits with those, above every sentence whose
+        // content is "be patient". It is placed BELOW the hosted-AI switch on purpose: an account that is out
+        // of credits or needs setup must still be told that first, because those conditions are what the rest
+        // of the product is already saying about the account and this one is about a single machine.
+        //
+        // Above nothingToNarrate as well as above gaveUp. Both would be FALSE CLAIMS here and they are false
+        // in different directions: "nothing to read aloud" asserts the session is parked on a prompt, which
+        // is a statement about the conversation nobody here has read, and "voice did not arrive" reports a
+        // narration that was never attempted. The wingman clears nothingToNarrate on this path for the same
+        // reason, so in practice they do not collide - the ordering is here because a defence that depends on
+        // another file's clearing discipline is not a defence.
+        //
+        // The remedy is a single sentence and the recovery needs nobody: updating that computer flips its
+        // next Hello, the wingman's marker clears on the following pass, and narration resumes.
+        if (directorCannotSendConversation)
+            return new VoiceDisplay
+            {
+                Kind = "directorTooOld",
+                Tone = "red",
+                Label = "Update DevThrottle",
+                Message = DirectorTooOldText,
+                // No Generate button: pressing it would re-read the same empty store. The action is on the
+                // other machine, and the message names it.
+            };
 
         // Nothing to read aloud: the session needs the user, but on a prompt / menu, not a text reply. This
         // is the honest state that replaces the old "red badge next to a Generate button that can never

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -90,6 +90,7 @@ public sealed class WingmanVoiceService
         public readonly ConcurrentDictionary<string, byte> Generating = new();             // sid -> wingman is running now
         public readonly ConcurrentDictionary<string, HostedAiState> Unavailable = new();   // sid -> why voice is off (issue #939)
         public readonly ConcurrentDictionary<string, byte> NothingToNarrate = new();       // sid -> the last turn has no text reply to read aloud (waiting on a prompt)
+        public readonly ConcurrentDictionary<string, byte> DirectorCannotSend = new();     // sid -> the owning Director's build cannot send conversations, so none will ever be stored
         public readonly ConcurrentDictionary<string, DateTime> PreferBackupUntil = new();  // sid -> UTC deadline while this session routes past a silent primary (issue devthrottle_internal#405)
         public readonly ConcurrentDictionary<string, byte> InFlight = new();               // sid -> a generation is running now
 
@@ -137,6 +138,16 @@ public sealed class WingmanVoiceService
     /// wrong account. Null delegate leaves narration with nothing to read, which is what a Gateway with no
     /// store would honestly be.</summary>
     private readonly Func<TenantId, string, History.StoredConversation?>? _conversationReader;
+
+    /// <summary>
+    /// Whether the computer that OWNS this session is connected but running a build that cannot send its
+    /// conversation - the one reason an empty store never fills. Supplied by the host because answering it
+    /// needs two things this service does not hold: the pushed-session roster (to name the owning Director,
+    /// and to know it is connected at all) and the turn-push capability registry (what that Director said
+    /// about itself on Hello). Null in tests and self-host, which reads as "no such claim" - the safe
+    /// direction, because it leaves the pre-existing "the push is simply late" behaviour untouched.
+    /// </summary>
+    private readonly Func<TenantId, string, bool>? _directorCannotSendConversation;
 
     /// <summary>
     /// True only for the EXACT form <see cref="Tenancy.TenantRegistry"/> mints: a canonical lowercase GUID.
@@ -335,9 +346,11 @@ public sealed class WingmanVoiceService
         Func<string>? instructionsProvider = null,
         HttpClient? ttsHttpClient = null,
         Func<TenantId, string, string?>? sessionTitleResolver = null,
-        Func<TenantId, string, History.StoredConversation?>? conversationReader = null)
+        Func<TenantId, string, History.StoredConversation?>? conversationReader = null,
+        Func<TenantId, string, bool>? directorCannotSendConversation = null)
     {
         _conversationReader = conversationReader;
+        _directorCannotSendConversation = directorCannotSendConversation;
         _vault = vault ?? throw new ArgumentNullException(nameof(vault));
         _tenantSettings = tenantSettings ?? throw new ArgumentNullException(nameof(tenantSettings));
         // The account's spoken language comes from the same per-tenant resolver this service already
@@ -745,6 +758,18 @@ public sealed class WingmanVoiceService
     /// </summary>
     public bool NothingToNarrateFor(TenantId tenant, string sid) => StateFor(tenant).NothingToNarrate.ContainsKey(sid);
 
+    /// <summary>
+    /// True when the computer that owns this session is connected but running a build that cannot send its
+    /// conversation, so no narration can ever be produced for it until that computer is updated. A TERMINAL
+    /// condition with a plain remedy, not a wait: it feeds <see cref="VoiceDisplayFold"/> so the screen says
+    /// "Update DevThrottle" rather than counting minutes at a session whose voice is never coming.
+    ///
+    /// Recorded only from an ACTUAL generation attempt that found an empty store, never guessed from the
+    /// capability registry alone - so a session that has simply not been swept yet makes no claim about
+    /// anybody's build.
+    /// </summary>
+    public bool DirectorCannotSendConversationFor(TenantId tenant, string sid) => StateFor(tenant).DirectorCannotSend.ContainsKey(sid);
+
     /// <summary>Set or clear the "nothing to narrate" fact from a caller that has already read the turn
     /// (the on-demand explain path): true when the last reply is empty (waiting on a prompt), false the
     /// moment a text reply exists. The auto path sets/clears it inline in <c>GenerateOnceAsync</c>.</summary>
@@ -812,6 +837,7 @@ public sealed class WingmanVoiceService
         state.Unavailable.TryRemove(sid, out _);        // voice is off, so its unavailable-state is moot (issue #939)
         state.ReadFailed.TryRemove(sid, out _);         // ...and so is whatever the last transcript read recorded
         state.NothingToNarrate.TryRemove(sid, out _);   // voice is off, so "nothing to narrate" is moot too
+        state.DirectorCannotSend.TryRemove(sid, out _); // ...and so is "update that computer to hear this session"
         state.PreferBackupUntil.TryRemove(sid, out _);  // voice is off, so the backup-routing window is moot too (issue devthrottle_internal#405)
         if (state.Ready.TryRemove(sid, out _))
             DeleteReadyAudio(tenant, sid);   // keep the durable cache in step so a stale tap can't 404
@@ -880,6 +906,7 @@ public sealed class WingmanVoiceService
         var state = StateFor(tenant);
         state.Ready[sid] = ready;
         state.NothingToNarrate.TryRemove(sid, out _);   // audio exists, so there was something to narrate after all
+        state.DirectorCannotSend.TryRemove(sid, out _); // ...and a narration proves that computer CAN send its conversation
         SaveReadyAudio(tenant, sid, ready);
     }
 
@@ -998,9 +1025,48 @@ public sealed class WingmanVoiceService
             // late - a small version of the exact confusion this mission exists to remove (found in review).
             // Nothing here stands the sweep down: ShouldSkipSweep keys on a terminal read verdict only.
             SetNothingToNarrate(tenant, sid, false);
+
+            // BUT NOT EVERY EMPTY STORE IS A WAIT, and the sentence above is a promise this arm cannot keep
+            // for the one Director that will never push. "The Director pushes it and the sweep comes back"
+            // assumes a Director that HAS the pusher; a build older than the turn-push mission does not, so
+            // the store stays empty for as long as that computer keeps running, and every calm "on its way"
+            // said about it is false.
+            //
+            // WHAT THAT COST, on 2026-09-02, is why this branch exists. Phases 3a/3b went live on the hosted
+            // Gateway while the newest RELEASED Director (v2.0.4, 16 August) predated the pusher by a
+            // fortnight. Every voice session on every account fell into the arm above: 297 "no conversation
+            // stored yet" lines in forty minutes, ZERO narrations, and - because the colour fold holds yellow
+            // until voice arrives - eleven of the owner's twenty-one sessions showed "Voice did not arrive
+            // after 3m..22m" instead of the red "Needs you" they had actually earned. He could not see which
+            // sessions wanted him. The Gateway KNEW the cause the whole time: SessionConversationFold was
+            // logging director-too-old for the same sessions, and the Chat screen was saying so in plain
+            // English. The fact simply never reached the voice path.
+            //
+            // NOT RECORDED AS A READ FAILURE, deliberately. NoteReadFailed(Unavailable) would render through
+            // the hosted-AI arm of VoiceDisplayFold and say "Voice unavailable" - a symptom, in the shared
+            // account-condition voice, for something that is neither the account's fault nor about hosted AI.
+            // The fold gets its own arm and its own sentence instead, which is the one the reader can act on.
+            //
+            // NOR DOES IT STAND THE SWEEP DOWN. Re-checking costs a dictionary lookup and a store read that
+            // returns null before any model or speech call, so there is no spend to protect - and paying that
+            // nothing buys the recovery for free: the moment that computer is updated, its next Hello flips
+            // the registry, the marker clears on the following pass, and narration resumes with nobody
+            // touching the Gateway.
+            if (_directorCannotSendConversation?.Invoke(tenant, sid) == true)
+            {
+                state.DirectorCannotSend[sid] = 1;
+                FileLog.Write($"[WingmanVoiceService] sid={sid}: the computer that owns this session is connected but runs a build that cannot send its conversation, so nothing will ever be stored to narrate - the screen says to update it instead of counting a wait that would not end");
+                return false;
+            }
+            state.DirectorCannotSend.TryRemove(sid, out _);
             FileLog.Write($"[WingmanVoiceService] no conversation stored yet for sid={sid} - nothing to narrate from, and not counted as an attempt; the Director pushes it and the sweep comes back");
             return false;
         }
+        // A conversation ARRIVED, so that computer plainly can send one - whatever it said about itself, and
+        // whoever owns the session now. Cleared here rather than only where it is set, for the same reason
+        // ClearReadFailed sits on this path: a marker that outlives the condition it describes is the next
+        // stale sentence, and ownership of a session can move to a different Director mid-life.
+        state.DirectorCannotSend.TryRemove(sid, out _);
         // THE ONE TERMINAL ANSWER LEFT. This agent keeps no readable conversation at all, so no amount of
         // waiting or retrying produces words to narrate. It is recorded as the terminal verdict so the voice
         // screen says "Voice unavailable" instead of an endless quiet wait, and so the sweep stops spending


### PR DESCRIPTION
## What broke

Turn-push phase 3a (#2648) moved the wingman's narration onto the Gateway's own conversation store. That store only fills if the owning Director pushes turns - and no **released** Director does. `TurnPusher` was written on 2 September (#2645); the newest release is v2.0.4 from 16 August.

The hosted Gateway was deployed with 3a/3b at 18:24 today. From then on every voice session on every account fell into the "nothing stored **yet**" arm, which assumes the words are merely late:

```
297 x [WingmanVoiceService] no conversation stored yet for sid=... - nothing to
      narrate from, and not counted as an attempt; the Director pushes it and
      the sweep comes back
```

Zero narrations in forty minutes. Because the colour fold holds yellow until voice arrives, 11 of the owner's 21 sessions displayed `Voice did not arrive after 3m..22m` instead of the red **Needs you** they had actually earned - so he could not see which sessions wanted him.

The Gateway knew the cause the whole time. `SessionConversationFold` was logging `director-too-old` for the same sessions and Chat was already saying it in plain English. The fact never reached the voice path.

## What this changes

**`GatewayHost.DirectorCannotSendConversation`** answers the question the voice path was missing. It asks about **connection first**: `TurnPushCapabilityRegistry` is in-memory and reports "does not push" for any Director it has not heard from, so asked the other way round every session on the fleet would be told its machine was out of date for as long as reconnecting took after a deploy. A session whose Director is not currently located makes no claim at all.

**`WingmanVoiceService`** records the fact when a generation attempt finds an empty store, and clears it when a conversation arrives, voice goes off, or a narration is stored. Two deliberate non-choices:

- *Not* a read failure. `NoteReadFailed(Unavailable)` would render through the hosted-AI arm as "Voice unavailable" - a symptom, in the shared account-condition voice, for something that is neither the account's fault nor about hosted AI.
- *Not* a sweep stand-down. Re-checking costs a store read that returns null before any model or speech call, so there is no spend to protect - and paying that nothing makes the recovery automatic: update the machine, its next Hello flips the registry, the marker clears on the next pass, narration resumes with nobody touching the Gateway.

**`VoiceDisplayFold`** gains the arm and the sentence. It sits with the other SPECIFIC, ACTIONABLE reasons the file already ranks above every "be patient" verdict, and below the hosted-AI conditions, which are account-level and are what the rest of the product already tells the member.

## Proof

Tests assert the **sentence the reader gets**, not just the branch taken - the sentence is what was wrong. `DirectorCannotSend_ReplacesTheGaveUpSentence_THE_2026_09_02_DEFECT` pins the 22-minute give-up wording as the negative control, then the update wording in its place at the same inputs.

- Revert-proved: disabling the fold arm and the marker fails **5** of the new tests. The 3 that still pass are the ordering guards (audio, working, account conditions still win), which is correct - they are not the defect.
- Gateway unit suite green: **3246 passed**, 0 failed.
- Full solution builds, 0 warnings.

## Sequencing

Production was recovered separately by swapping back to the pre-3a image (rollback run 33674592794), so the fleet is working now on the 14:00 build. This PR is what lets phase 3a go back out safely - and redeploying main also restores the statistics-store retry from #2652, which the swap-back dropped.

Worth noting for whoever ships it: the deploy's subsystem proof would **not** have caught this. It proves the subsystems behind the pages came up, and a wingman that starts cleanly and then narrates nothing passes it.
