### PR TITLE
release: v2.0.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>2.0.4</Version>
+    <Version>2.0.5</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v2.0.5.md
+++ b/docs/public/release-notes/v2.0.5.md
@@ -1,0 +1,73 @@
+# DevThrottle v2.0.5
+
+**Install this release before the hosted service is updated.** It teaches your computer to send
+its conversations up to DevThrottle, and the next update to the hosted service expects that. The
+order matters and it is explained at the bottom.
+
+## Your computer now sends its conversations, instead of being asked for them every time
+
+Until now, every time DevThrottle needed a conversation - to draw the chat screen, to read a turn
+aloud, to wait for a spoken answer - it sent a request down to your computer asking it to open the
+agent's transcript file and read it back. On the chat screen that happened every two and a half
+seconds.
+
+Your computer now sends each finished turn up as it happens, and DevThrottle keeps them. Chat, the
+transcript view and the spoken narration all read from that copy.
+
+What you get from it:
+
+- **The chat screen stops waiting on a round trip to your machine.** It reads a copy that is
+  already there.
+- **A conversation you have already had stays readable when your computer is briefly unreachable.**
+  To be exact, because this is easy to overstate: the session itself still needs your computer -
+  that is where the agent runs. What changed is that reading what has already been said no longer
+  waits on reaching it.
+- **A whole class of silent failure is gone.** See the next section.
+
+## The narration that went silent for hours, and why
+
+A session could stop producing spoken narration and never recover, with nothing on screen saying
+why. Chat in the same session kept working, which made it look like the voice feature was broken.
+
+The cause: DevThrottle worked out where the agent's transcript file lived by building a path from
+the session's folder. When an agent moved into a Git worktree, the transcript moved with it, and
+every read from then on opened an empty spot - forever, because the calculation would never
+produce a different answer.
+
+Two things changed. The path is now resolved in one place, following the pointer the agent itself
+reports rather than a calculation. And because conversations are sent up as they happen, nothing
+reads that file at all any more on the path that failed.
+
+## Dictation stops changing words you never asked it to change
+
+The correction list is for words you have listed. It had been guessing at words you had not.
+
+- **Only words on your list are replaced.** Between 8 and 17 August the fuzzy matcher turned "sure"
+  into "Soren" 261 times, "many" into "Banya" 138 times, and did the same to "code", "single" and
+  "focus". That matching is off, and stays off.
+- **A model may now check a candidate before an unlisted word is touched**, and it can only choose
+  between candidates - it never supplies text of its own.
+- **Dictation transcripts are kept for 90 days**, matching session history, so you can go back and
+  see what was actually said.
+
+## Smaller things
+
+- **The session picker on the phone is searchable**, so a long list is usable.
+- **An empty recording no longer retries forever**, and a stuck dictation no longer holds its
+  session locked.
+- **The Gateway starts listening before it opens its database**, so a slow database no longer looks
+  like a dead service during startup.
+- **`cc-scrub`**, a screenshot scrubber, for removing private details before sharing an image.
+
+## Please install this before the hosted service is updated
+
+The two halves have to arrive in this order.
+
+This release is **safe to install right now**, while the hosted service is still the current one -
+your computer checks whether the service is ready to receive conversations and simply does not send
+them if it is not. Nothing changes for you today.
+
+The hosted service will then be updated to read conversations from the copy your computer sends.
+**A computer still on v2.0.4 or earlier cannot send them**, and after that update its chat and voice
+screens will say so and ask you to update, rather than showing the conversation. That message is
+correct and installing this release clears it - but you can avoid seeing it at all by updating now.


### PR DESCRIPTION
Version bump and the published release notes for v2.0.5.

The release this carries is the DIRECTOR half of the turn-push work: your computer sends each
finished turn up to the Gateway instead of being asked to re-read the agent's transcript file on
every chat poll and every narration.

It must ship BEFORE the hosted Gateway is updated. The Gateway on main reads conversations only
from its own store, and no released Director fills that store - v2.0.4 predates the pusher by a
fortnight. Deploying the Gateway first is what took voice down on 2 September and forced a
rollback (#2660).

Installing this release against today's live Gateway is safe and changes nothing: the pusher is
gated on the Gateway advertising PushTurns, so it simply does not send until the Gateway is ready
to receive.

The release gate (test-local.ps1 -Parked -Configuration Release) runs against the squashed commit
on main after this merges, before the tag is pushed.