### PR TITLE
feat(gateway): a free tier, so an expiring trial downgrades instead of cutting off

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedProTrialTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedProTrialTests.cs
@@ -165,11 +165,19 @@ public sealed class HostedProTrialTests : IDisposable
     // ---------------------------------------------------------------------------------------------------
 
     [Fact]
-    public void Fifteen_days_later_with_no_subscription_the_entitlement_read_says_NOT_ENTITLED()
+    public void Fifteen_days_later_with_no_subscription_the_account_lands_on_FREE_and_keeps_running()
     {
-        // The acceptance criterion for expiry. This is the read the request-path cutoff calls on every hosted
-        // request, so a NotEntitled here IS the 402 on dictation, spoken replies and the wingman. If this
-        // returned Entitled, the trial would be a permanent free plan.
+        // The acceptance criterion for expiry, REWRITTEN for the owner decision of 2026-09-02. It used to read
+        // NotEntitled, and that answer travelled all the way to a tombstone: the member devices were revoked
+        // and their sessions dropped, so the end of a trial broke the machine instead of quietening it.
+        //
+        // Now the trial ENDS but the account does not. The assertions below are the whole policy and must be
+        // read together - Entitled ALONE would be a permanent free Pro, which is the failure this test guarded
+        // against before and still guards against now:
+        //   - it is Entitled, so nothing revokes and the sessions keep running;
+        //   - the tier is FREE, not pro, so it is a different plan and not a silent extension of the trial;
+        //   - free grants hosted capacity and NONE of the three artificial-intelligence scopes, which is what
+        //     actually makes dictation, spoken replies and the wingman go quiet.
         var db = OpenWithEntitlements();
         var trials = new TrialRegistry(db);
         var entitlements = new EntitlementRegistry(db, requireLivemode: false, trials: trials);
@@ -178,8 +186,18 @@ public sealed class HostedProTrialTests : IDisposable
 
         var decision = entitlements.Evaluate(Subject, SignupMoment.AddDays(15));
 
-        Assert.Equal(EntitlementOutcome.NotEntitled, decision.Outcome);
-        Assert.NotEqual(EntitlementOutcome.Unknown, decision.Outcome);   // a refusal, not a retry
+        Assert.Equal(EntitlementOutcome.Entitled, decision.Outcome);
+        Assert.Equal(EntitlementRegistry.TierFree, decision.Tier);
+        Assert.NotEqual(EntitlementRegistry.TierPro, decision.Tier);
+
+        // The plan, stated where plans are decided. This is the assertion that stops "the trial never ends".
+        Assert.True(EntitlementScopes.GrantsHostedGateway(decision.Tier));
+        Assert.False(EntitlementScopes.Grants(decision.Tier, EntitlementScopes.Dictation));
+        Assert.False(EntitlementScopes.Grants(decision.Tier, EntitlementScopes.Tts));
+        Assert.False(EntitlementScopes.Grants(decision.Tier, EntitlementScopes.Wingman));
+
+        // A free plan has no paid period, so nothing may be clipped to one.
+        Assert.Null(decision.CurrentPeriodEnd);
     }
 
     [Fact]
@@ -197,17 +215,31 @@ public sealed class HostedProTrialTests : IDisposable
         var oneTickBefore = entitlements.Evaluate(Subject, SignupMoment.AddDays(14).AddTicks(-1));
         var atExpiry = entitlements.Evaluate(Subject, SignupMoment.AddDays(14));
 
+        // The boundary is now a TIER change rather than an outcome change - both instants are Entitled, because
+        // the account survives its own trial. Asserting only the outcome would pass while the trial ran forever,
+        // so the tier is what this test turns on, and the artificial-intelligence scope is what proves the tier
+        // means something.
         Assert.Equal(EntitlementOutcome.Entitled, oneTickBefore.Outcome);
-        Assert.Equal(EntitlementOutcome.NotEntitled, atExpiry.Outcome);
+        Assert.Equal(EntitlementRegistry.TierPro, oneTickBefore.Tier);
+        Assert.True(EntitlementScopes.Grants(oneTickBefore.Tier, EntitlementScopes.Dictation));
+
+        Assert.Equal(EntitlementOutcome.Entitled, atExpiry.Outcome);
+        Assert.Equal(EntitlementRegistry.TierFree, atExpiry.Tier);
+        Assert.False(EntitlementScopes.Grants(atExpiry.Tier, EntitlementScopes.Dictation));
     }
 
     [Fact]
-    public void Enrolling_again_after_the_trial_has_ended_is_refused_and_mints_nothing()
+    public void Enrolling_again_after_the_trial_has_ended_SUCCEEDS_on_the_free_plan()
     {
-        // The expiry proven end to end, through the enrollment path rather than the registry: a member whose
-        // fourteen days are up meets a 402 and gets no key. The tenant they minted during the trial still
-        // exists - the account is not deleted, self-host remains available - so this asserts the DEVICE KEY
-        // was withheld, which is what actually gates hosted use.
+        // The expiry proven end to end through the enrollment path, and this is the test that states the owner
+        // decision most directly: a member whose fourteen days are up used to meet a 402 and get no device key,
+        // which meant a new machine could not be connected and - through the request-path cutoff - the ones
+        // already connected were revoked. Now they enroll, on free.
+        //
+        // The DEVICE KEY is the assertion that matters, exactly as it was when this test asserted the opposite.
+        // The key is what actually unlocks hosted use, so proving it is ISSUED is proving the member still has
+        // a working product. What they no longer have is the artificial intelligence, and that is asserted on
+        // the plan by the tests above rather than re-derived here.
         var db = OpenWithEntitlements();
         var (devices, tenants, validator) = Wire(db);
         var trials = new TrialRegistry(db);
@@ -220,8 +252,15 @@ public sealed class HostedProTrialTests : IDisposable
         var after = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
             entitlements, SignupMoment.AddDays(15), trials);
 
-        Assert.Equal(402, after.Status);
-        Assert.Null(after.Response);
+        Assert.Equal(200, after.Status);
+        Assert.NotNull(after.Response);
+        Assert.False(string.IsNullOrWhiteSpace(after.Response!.DeviceKey));
+
+        // And enrolling on free must never look like a fresh trial: no trial is running afterwards. That the
+        // spent window is never re-granted is asserted separately, by the second-grant test above.
+        Assert.Equal(TrialOutcome.None, trials.Evaluate(Subject, SignupMoment.AddDays(15)).Outcome);
+        Assert.Equal(EntitlementRegistry.TierFree,
+            entitlements.Evaluate(Subject, SignupMoment.AddDays(15)).Tier);
     }
 
     // ---------------------------------------------------------------------------------------------------
@@ -281,9 +320,15 @@ public sealed class HostedProTrialTests : IDisposable
         var result = HostedEnrollmentEndpoint.Enroll(Token(), Req(), devices, tenants, validator,
             new EntitlementRegistry(db, requireLivemode: false, trials: trials), SignupMoment, trials);
 
-        Assert.Equal(402, result.Status);
-        Assert.Null(result.Response);
+        // NO TRIAL is still the rule, and it is the assertion this test exists for - the owner rollout decision
+        // is untouched by the free plan. What changed is the consequence: being refused a trial is no longer
+        // being refused the product. The account enrolls on free.
         Assert.Equal(TrialOutcome.None, trials.Evaluate(Subject, SignupMoment).Outcome);
+
+        Assert.Equal(200, result.Status);
+        Assert.NotNull(result.Response);
+        Assert.Equal(EntitlementRegistry.TierFree,
+            new EntitlementRegistry(db, requireLivemode: false, trials: trials).Evaluate(Subject, SignupMoment).Tier);
     }
 
     // ---------------------------------------------------------------------------------------------------
@@ -398,19 +443,71 @@ public sealed class HostedProTrialTests : IDisposable
     // ---------------------------------------------------------------------------------------------------
 
     [Fact]
-    public async Task The_402_a_member_meets_after_the_trial_says_what_to_do_about_it()
+    public async Task Over_the_wire_a_member_past_their_trial_is_enrolled_on_free_and_not_refused()
     {
-        // The acceptance criterion is not just "denied" - it is "a message that points at subscribing, not a
-        // raw error". So this drives the REAL endpoint over HTTP and reads the body the client renders. The
-        // Gateway owns the wording; the client only shows it. Asserted on the wire because a constant that is
-        // never written into a response is not a message anybody sees.
+        // THE OWNER DECISION, PROVEN ON THE WIRE. This test used to assert the opposite - that a member past
+        // their trial met a 402 - and it drove the real endpoint over HTTP precisely because the refusal had to
+        // be shown to be real rather than merely coded. The same standard applies to the grant that replaced
+        // it: the member must actually receive a device key from a live endpoint, not just a 200 from a method.
+        //
+        // The account here is already known to this Gateway, so the rollout rule refuses it a trial. That is
+        // exactly the member the old code turned away. Under the free plan they are enrolled.
         var db = OpenWithEntitlements();
         var (devices, tenants, validator) = Wire(db);
         var trials = new TrialRegistry(db);
         var entitlements = new EntitlementRegistry(db, requireLivemode: false, trials: trials);
 
-        // Already known to this Gateway, so the trial is refused and the refusal is the one under test.
         tenants.MintOrLookupBySubject(Subject, "returning@example.com");
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+        HostedEnrollmentEndpoint.Map(app, devices, tenants, validator, entitlements, trials);
+        await app.StartAsync();
+
+        try
+        {
+            using var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+            var msg = new HttpRequestMessage(HttpMethod.Post, HostedEnrollmentEndpoint.Path)
+            {
+                Content = JsonContent.Create(new { deviceId = "device-1", machineName = "M", platform = "linux", deviceType = "workstation" }),
+            };
+            msg.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token());
+
+            var resp = await http.SendAsync(msg);
+            var body = await resp.Content.ReadAsStringAsync();
+
+            Assert.Equal(200, (int)resp.StatusCode);
+            Assert.Contains("deviceKey", body, StringComparison.OrdinalIgnoreCase);
+
+            // And it is free, not a trial and not a paid plan.
+            Assert.Equal(EntitlementRegistry.TierFree, entitlements.Evaluate(Subject, SignupMoment).Tier);
+            Assert.Equal(TrialOutcome.None, trials.Evaluate(Subject, SignupMoment).Outcome);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task The_402_that_remains_still_says_what_to_do_about_it()
+    {
+        // THE COVERAGE THE TEST ABOVE GAVE UP, RETARGETED RATHER THAN DELETED. The wire assertion on
+        // SubscribeMessage and SubscribeUrl existed to hold a real acceptance criterion - a refusal must point
+        // at subscribing rather than being a raw error - and those two constants are asserted on the wire in
+        // this file and nowhere else. The free plan removed the 402 that test was reading, so deleting it would
+        // have quietly dropped the only proof that a refusal a member actually meets carries its message.
+        //
+        // A 402 still exists: a plan that pays for the artificial intelligence but NOT for hosted capacity.
+        // That is the pro self-host plan, and it is refused hosted provisioning by the plan gate. Same endpoint,
+        // same response shaping, same two constants - so the criterion is still proven, on the refusal that
+        // still happens.
+        var db = OpenWithEntitlements(status: "active", tier: EntitlementRegistry.TierProSelfHost);
+        var (devices, tenants, validator) = Wire(db);
+        var trials = new TrialRegistry(db);
+        var entitlements = new EntitlementRegistry(db, requireLivemode: false, trials: trials);
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
@@ -434,6 +531,7 @@ public sealed class HostedProTrialTests : IDisposable
             Assert.Equal(402, (int)resp.StatusCode);
             Assert.Contains(EntitlementRegistry.SubscribeMessage, body, StringComparison.Ordinal);
             Assert.Contains(EntitlementRegistry.SubscribeUrl, body, StringComparison.Ordinal);
+            AssertNothingWasGivenAway(tenants);
         }
         finally
         {

--- a/src/CcDirector.Gateway.UnitTests/HostedAccessPlanScopeTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/HostedAccessPlanScopeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CcDirector.Core.Tenancy;
@@ -128,6 +129,49 @@ public sealed class HostedAccessPlanScopeTests : IDisposable
     }
 
     [Fact]
+    public async Task AuthorizeAsync_NoPaidRowAndNoTrial_IsAllowedOnFreeAndIsNEVER_Revoked()
+    {
+        // THE REQUEST-PATH HALF OF THE FREE PLAN, and the assertion that matters most in this file.
+        //
+        // This is the gate that used to end trials by DESTRUCTION. An account with no paid row read NotEntitled,
+        // and this service answered that by tombstoning every device credential the tenant owned and dropping
+        // its Director connections - so on day fifteen a member with four machines connected watched all four
+        // fall off, and re-enrolling was refused. The owner decision of 2026-09-02 is that they land on free
+        // instead, and free grants hosted capacity, so there is nothing here to revoke.
+        //
+        // BOTH assertions are load bearing and neither implies the other. Allow alone would still be a
+        // regression if the revoker had already fired - a tombstone is durable, so a member could be "allowed"
+        // by this decision while their device credentials were already dead. Empty-revoked alone would pass on
+        // a gate that denied without tombstoning. Together they are the promise: the product keeps running.
+        var db = _harness.Open();
+        using (var ctx = db.CreateUnscopedContext())
+        {
+            // The payment-side table EXISTS and is EMPTY. That distinction is the whole test: an empty table is
+            // a SUCCESSFUL read that finds no subscription, which is what a free member looks like. A missing
+            // table would be a FAILED read - Unknown - and Unknown must still retry rather than fall to free.
+            ctx.Database.ExecuteSqlRaw(
+                "CREATE TABLE IF NOT EXISTS entitlements (" +
+                "subject TEXT NOT NULL PRIMARY KEY, status TEXT NOT NULL, " +
+                "current_period_end TEXT NULL, stripe_subscription_id TEXT NULL, updated_at TEXT NULL, " +
+                "livemode INTEGER NULL, tier TEXT NULL)");
+        }
+
+        var tenants = new TenantRegistry(db);
+        var tenant = tenants.MintOrLookupBySubject(Subject, "free@example.com");
+        var revoker = new RecordingRevoker();
+
+        // Trials WIRED, and no trial granted to this subject - so the trial read succeeds and finds nothing,
+        // which is the state a member is in once their fourteen days are spent.
+        var leases = new HostedAccessLeaseService(
+            new EntitlementRegistry(db, requireLivemode: true, trials: new TrialRegistry(db)), tenants, revoker);
+
+        var decision = await leases.AuthorizeAsync(tenant);
+
+        Assert.Equal(HostedAccessDecision.Allow, decision);
+        Assert.Empty(revoker.Revoked);
+    }
+
+    [Fact]
     public async Task AuthorizeAsync_RowPredatingTheTierColumn_AllowsHostedAccess()
     {
         // The established customers who predate the tier column. A null tier is an OLD HOSTED ROW, not an
@@ -212,6 +256,42 @@ public sealed class EntitlementScopeTableTests
         Assert.True(pro.Contains(EntitlementScopes.HostedGateway));         // "pro" carries it, on purpose
         Assert.False(selfHost.Contains(EntitlementScopes.HostedGateway));   // "pro_selfhost" never does
         Assert.NotEqual(pro.Count, selfHost.Count);
+    }
+
+    [Fact]
+    public void ForTier_Free_GrantsHostedGatewayAndNOTHING_Else()
+    {
+        // The free plan is the exact MIRROR of pro self-host: that plan buys the artificial intelligence and
+        // not the hosting, this one buys the hosting and not the artificial intelligence. Both are one line in
+        // the table, and in both cases what is ABSENT from the line is the commercial point of the plan.
+        //
+        // Asserted as an exact set rather than scope by scope, so a future edit that adds a fourth capability
+        // to free has to come here and change this test deliberately. A test that only checked the three
+        // artificial-intelligence scopes were absent would silently accept a new expensive one.
+        var scopes = EntitlementScopes.ForTier(EntitlementRegistry.TierFree);
+
+        Assert.Equal(new[] { EntitlementScopes.HostedGateway }, scopes.OrderBy(x => x, StringComparer.Ordinal));
+
+        Assert.True(EntitlementScopes.GrantsHostedGateway(EntitlementRegistry.TierFree));
+        Assert.False(EntitlementScopes.Grants(EntitlementRegistry.TierFree, EntitlementScopes.Dictation));
+        Assert.False(EntitlementScopes.Grants(EntitlementRegistry.TierFree, EntitlementScopes.Tts));
+        Assert.False(EntitlementScopes.Grants(EntitlementRegistry.TierFree, EntitlementScopes.Wingman));
+    }
+
+    [Fact]
+    public void ForTier_Free_IsNeverTreatedAsThePlainProTier()
+    {
+        // The two tiers a lapsed trial sits between. If free ever resolved to the pro entitlement set, the
+        // trial would silently never end - the member would keep dictation, spoken replies and the wingman
+        // forever and nothing would look wrong. The string comparison is ordinal and this pins that "free" and
+        // "pro" are different plans rather than different spellings.
+        Assert.NotEqual(EntitlementScopes.ForTier(EntitlementRegistry.TierPro),
+                        EntitlementScopes.ForTier(EntitlementRegistry.TierFree));
+
+        Assert.True(EntitlementRegistry.IsFree(EntitlementRegistry.TierFree));
+        Assert.False(EntitlementRegistry.IsFree(EntitlementRegistry.TierPro));
+        Assert.False(EntitlementRegistry.IsFree(null));
+        Assert.False(EntitlementRegistry.IsFree("Free"));   // ordinal: the payment side never writes this
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/HostedEnrollmentEndpoint.cs
@@ -148,7 +148,20 @@ internal static class HostedEnrollmentEndpoint
             // hosted before the trial existed, and the owner's rollout rule grants it nothing (issue #2117).
             // TrialRegistry re-checks its own ledger, so an account whose trial has already ended is refused
             // here rather than being handed a second one.
-            if (outcome == Tenancy.EntitlementOutcome.NotEntitled && trials is not null)
+            // "NOT PAYING" IS THE CONDITION, AND IT IS NOT THE SAME AS "NOT ENTITLED" ANY MORE. Since the free
+            // plan arrived (2026-09-02) an account with no paid row and no running trial comes back ENTITLED, on
+            // tier free - so a test for NotEntitled alone would silently stop handing out trials, and every new
+            // member would be enrolled straight onto free and quietly lose the fourteen days they are owed.
+            // Nothing would look broken: enrolment would simply succeed. The question this gate has always been
+            // asking is "is this account PAYING", so it now asks exactly that.
+            //
+            // Unknown is still excluded, for the reason stated above: a trial granted on a failed read hands a
+            // free window to an account whose subscription we could not see.
+            var notPaying = outcome == Tenancy.EntitlementOutcome.NotEntitled
+                            || (outcome == Tenancy.EntitlementOutcome.Entitled
+                                && Tenancy.EntitlementRegistry.IsFree(tier));
+
+            if (notPaying && trials is not null)
             {
                 var alreadyKnown = tenants.LookupBySubject(validation.Subject) is not null;
                 var trial = trials.GrantIfFirstArrival(validation.Subject, alreadyKnown, now);
@@ -181,6 +194,10 @@ internal static class HostedEnrollmentEndpoint
                     "the entitlement service is temporarily unavailable; please try again");
             }
 
+            // Reachable only where the free plan is not in play - a Gateway wired with no trial ledger at all,
+            // which is the self-host control. On the hosted service a successful pair of reads now yields free
+            // rather than a refusal, which is the whole point of the change: the door below is the plan gate,
+            // not a paywall.
             if (outcome == Tenancy.EntitlementOutcome.NotEntitled)
             {
                 FileLog.Write("[HostedEnrollment] REFUSED: the entitlement read succeeded and this account has no active entitlement (no tenant minted, no device key issued)");

--- a/src/CcDirector.Gateway/Tenancy/EntitlementRegistry.cs
+++ b/src/CcDirector.Gateway/Tenancy/EntitlementRegistry.cs
@@ -188,8 +188,36 @@ public sealed class EntitlementRegistry
             return new EntitlementDecision(EntitlementOutcome.Unknown, null);
         }
 
-        // The trial read succeeded and no trial covers this account. The paid answer stands, whatever it was -
-        // a NotEntitled refusal, or an Unknown that must still be retried rather than refused.
+        // BOTH READS SUCCEEDED, AND NEITHER GRANTS. This is the FREE plan, and it is the one branch here that
+        // is a grant rather than a refusal.
+        //
+        // WHY A REFUSAL BECAME A GRANT. Until now this returned the paid NotEntitled, and that answer travelled:
+        // enrolment refused with a 402 and minted nothing, and - worse - an account that already held a tenant
+        // was REVOKED, its device credentials tombstoned and its connections dropped. So the end of a trial did
+        // not quieten the product, it broke the machine. A member who had connected four computers watched all
+        // four fall off on day fifteen. The owner's decision (2026-09-02) is that a lapsed trial lands on a free
+        // plan instead: the sessions keep running, and only the artificial-intelligence features go quiet.
+        //
+        // THIS DOES NOT GIVE ANYTHING AWAY THAT COSTS US A MODEL. Free is a TIER like any other, so what it
+        // grants is decided in the one table that owns that question - see EntitlementScopes, where free carries
+        // the hosted-gateway scope and NONE of the three artificial-intelligence scopes. Returning Entitled here
+        // is therefore not "entitled to everything"; it is "entitled to whatever free grants", which is
+        // orchestration and nothing else.
+        //
+        // THE TRIAL IS NOT SHORT-CIRCUITED BY THIS. A brand-new account reaches this line too, and if it were
+        // simply enrolled on free it would never be handed the fourteen days it is owed. The grant lives at the
+        // enrolment door rather than here, and that door reads the free tier as "no paid entitlement" exactly as
+        // it used to read NotEntitled - see HostedEnrollmentEndpoint. Anything that learns to act on this
+        // outcome must make the same distinction: Entitled-on-free is NOT a paying account.
+        if (paid.Outcome == EntitlementOutcome.NotEntitled)
+        {
+            FileLog.Write("[EntitlementRegistry] Evaluate: ENTITLED on the FREE plan (no paid entitlement and no running trial; orchestration only - no artificial-intelligence scopes)");
+            return new EntitlementDecision(EntitlementOutcome.Entitled, TierFree);
+        }
+
+        // The PAID read FAILED. Ignorance is still never a verdict, and it is not downgraded to free either: we
+        // cannot tell a lapsed account from a paying one whose row we could not read, and quietly serving the
+        // paying one a plan without its artificial intelligence is a silent wrong answer. Retry.
         return paid;
     }
 
@@ -306,6 +334,30 @@ public sealed class EntitlementRegistry
 
     /// <summary>The pro plan tier.</summary>
     public const string TierPro = "pro";
+
+    /// <summary>
+    /// The FREE plan tier: hosted gateway capacity and nothing else. It is what an account holds when it has no
+    /// paid row and no running trial, and it is the reason the end of a trial is a downgrade rather than a
+    /// cutoff (owner decision, 2026-09-02).
+    ///
+    /// It is a real tier and not a null, absence, or sentinel, deliberately. Every capability question in this
+    /// Gateway is answered by asking <see cref="EntitlementScopes"/> what a TIER grants; a free plan expressed
+    /// as "no tier" would have to be special-cased at each of those call sites, and a call site that forgot
+    /// would fail in the granting direction. As a tier string it flows through the same allowlist as every
+    /// other plan and is refused everything it is not explicitly given.
+    ///
+    /// The payment side never writes this value - there is no free row in Stripe - so it originates here and
+    /// only here. It nonetheless carries no period end, because a free plan has no paid period to expire.
+    /// </summary>
+    public const string TierFree = "free";
+
+    /// <summary>
+    /// Is this the free plan? Asked wherever code needs "this account is entitled, but it is not PAYING" - the
+    /// distinction the enrolment door makes before handing out a trial. Stated once so no call site re-derives
+    /// it by comparing strings.
+    /// </summary>
+    public static bool IsFree(string? tier) =>
+        string.Equals((tier ?? "").Trim(), TierFree, StringComparison.Ordinal);
 
     /// <summary>
     /// Where a member goes to subscribe. Stated ONCE so every refusal the Gateway writes points at the same

--- a/src/CcDirector.Gateway/Tenancy/EntitlementScopes.cs
+++ b/src/CcDirector.Gateway/Tenancy/EntitlementScopes.cs
@@ -69,6 +69,24 @@ public static class EntitlementScopes
             // The pro SELF-HOST plan: the artificial-intelligence features and NOTHING ELSE. The absence of
             // HostedGateway on this line is the whole point of the plan and of this file.
             [EntitlementRegistry.TierProSelfHost] = Set(AiScopes),
+
+            // The FREE plan: hosted capacity and NOTHING ELSE - the exact mirror of the self-host line above.
+            // An account with no paid row and no running trial holds this, so this single line is what makes
+            // the end of a trial a downgrade instead of a cutoff: the member keeps the tunnel, the cockpit, the
+            // mobile application and every session on every machine, and loses dictation, spoken replies and
+            // the wingman.
+            //
+            // THE THREE ABSENT SCOPES ARE THE PRICE OF THE PLAN. Free costs us hosting, which is small and
+            // fixed; it must never cost us a model call, which is neither. If a future feature runs a model on
+            // our meter, it belongs behind one of the artificial-intelligence scopes and therefore behind Pro -
+            // adding it to this line would give away the thing the plans are drawn around.
+            //
+            // Note that this Gateway does not itself police the three artificial-intelligence scopes today -
+            // they are enforced at the website proxy that actually calls the models, and a free account is
+            // refused there because it has neither a subscription row nor a live trial. This line is still the
+            // truthful statement of what the plan grants, and it is what any Gateway-side check must read the
+            // day one is added.
+            [EntitlementRegistry.TierFree] = Set(HostedGateway),
         };
 
     // The pre-column row. Carried separately from the table because its key is null and because its reason is


### PR DESCRIPTION
## The problem

The end of a trial did not quieten the product, it broke the machine.

Day fifteen read `NotEntitled`, and that answer travelled. `HostedAccessLeaseService`
answered it by tombstoning **every device credential the tenant owned** and dropping its
Director connections, and re-enrolment was refused with a 402. A member with four machines
connected watched all four fall off, and could not put them back.

## The change

A **free** plan: hosted gateway capacity, and none of the three AI scopes. An account with
no paid row and no running trial holds it, so a trial ending is a downgrade. The sessions
keep running on every machine; dictation, spoken replies and the wingman go quiet.

The line, and every feature falls out of it: **free is the orchestration, Pro is the AI.**

### Three files

| File | Change |
|---|---|
| `EntitlementScopes.cs` | The `free` tier granting `hosted_gateway` and nothing else - the exact mirror of pro self-host. What is absent from the line is the commercial point of the plan. |
| `EntitlementRegistry.cs` | Both reads succeed and neither grants, so the answer is Entitled on tier free rather than a refusal. A **failed** read still returns Unknown and retries. |
| `HostedEnrollmentEndpoint.cs` | The gate now asks whether the account is **paying**, not whether it is entitled. |

### The trap worth naming

The 14-day trial is granted at the enrolment door on `NotEntitled`. A free tier on its own
would have **silently stopped handing out trials** - every new member enrolled straight onto
free and quietly losing the fourteen days they are owed. Nothing would have looked broken:
enrolment would simply have succeeded. That is why the enrolment condition changed too.

### Nothing was needed for the AI

Dictation, TTS and the wingman are enforced at the website proxy, not here. A free account
has neither a subscription row nor a live trial, so they already refuse with the right
on-screen message. This pull request does not touch them.

## Tests

`50` unit, `16` trial, `36` mobile-enrol/revoke/lease - all green, run unpiped.

Five existing tests encoded the old cutoff. Each was **rewritten to assert the new policy
rather than deleted**:

- the boundary test now proves the tier flips `pro` to `free` at the exact expiry instant,
  which is stronger than the outcome check it replaced - asserting the outcome alone would
  pass while the trial ran forever;
- the wire test that asserted a 402 now asserts a device key **is** issued;
- `SubscribeMessage` / `SubscribeUrl` were asserted on the wire in that test and **nowhere
  else in the codebase**, so rather than lose that coverage they were retargeted at the 402
  that still exists: a self-host plan reaching for hosted capacity.

Added: the request-path proof that free is allowed **and never revoked** (both halves are
load bearing - a tombstone is durable, so "allowed" alone would still be a regression), and
the scope table pinned as an exact set so a future capability added to free has to change
the test deliberately.

**Revert-prove:** remove the free line from the scope table and exactly the two free-tier
tests redden while the other twenty-one stay green - so the tests are aimed at this plan and
are not a gate that passes everything.

## Pairs with

thefrederiksen/devthrottle_internal#1653 - the four-card pricing page that sells this plan.
That page describes this behaviour, so the two should land together.
