### PR TITLE
feat(gateway): say a rule in plain English and the Gateway writes it, grounded in a real screen

### DIFF
--- a/docs/missions/session-rules-2026-09-02/guard-fix-report.md
+++ b/docs/missions/session-rules-2026-09-02/guard-fix-report.md
@@ -1,0 +1,229 @@
+# The rule routes reach the guard - fix report
+
+Branch `mission/rules-guard`, worktree `D:\ReposFred\devthrottle-rules-guard`, written 2026-09-03.
+Read it against the code, not against this document.
+
+---
+
+## What was broken
+
+`SessionKeyGuard` is a deliberate literal allow list of the routes a session key may call. Nothing
+under `/gateway/rules` was on it, so every rule route was refused with HTTP 403 and the code
+`session_key_out_of_scope`. The whole rule command group authenticates with a session key, so
+"set up a rule" could not work at all - not partly, not sometimes, at all.
+
+Every suite was green throughout, and that is the part worth keeping. The guard's own unit tests are
+written from the guard's own list, so they agreed with it. The command line's tests mock the
+transport, so they never sent a request. Nothing anywhere connected "a route was added" to "the guard
+was told about it". This is the third time the same mechanism has bitten this one file: the skill
+catalogue and the schedule surface each shipped refused-by-accident before it, and each was fixed by
+adding rows to the hand-kept list, which fixes the instance and leaves the mechanism running.
+
+---
+
+## What was built
+
+### The ruling, implemented exactly as the owner gave it
+
+An agent credential may do everything with rules EXCEPT move one out of dry run.
+
+| Verb | Route | Ruling |
+| --- | --- | --- |
+| GET | `/gateway/rules` | allowed |
+| GET | `/gateway/rules/{id}` | allowed |
+| GET | `/gateway/rules/{id}/firings` | allowed |
+| POST | `/gateway/rules/draft` | allowed |
+| POST | `/gateway/rules` | allowed - lands in dry run by the store's own shape |
+| DELETE | `/gateway/rules/{id}` | allowed |
+| POST | `/gateway/rules/{id}/promote` | REFUSED, deliberately and permanently |
+
+It is a literal switch in a named helper (`RuleRoute`, with `IsRuleRoute` as the boolean the allow
+list calls), not a prefix rule, and the comment says why in terms of this surface rather than in
+general: `promote` sits one path parameter under the routes being opened, so a prefix on
+`/gateway/rules` would have handed it over on the same day it handed over the list, silently, with
+nothing written down that said so.
+
+The refusal also carries its own sentence rather than the guard's general one. The general sentence
+talks about the admission surface, which promoting a rule is not, and an agent handed the wrong
+reason goes hunting the wrong problem.
+
+### The test that would have caught it
+
+`src/CcDirector.Gateway.Tests/SessionRuleRouteGuardCensusTests.cs`, built the way
+`ContextLessRouteCensusTests` and `CensusRouteTenancyProbeTests` are built: it starts a real
+`GatewayHost` and reads the FINALISED route table off it, so the subject of the test is the
+application as built and never a list somebody maintains. It runs for both deployments - hosted and
+self-host - because they map different route tables.
+
+For that it needed a third state. An allow list denies a route it has never heard of, which is the
+right default and a useless signal: from outside, a route nobody classified looks exactly like a
+route somebody refused, and `Check` returns 403 for both. So `SessionKeyGuard` now exposes
+`ClassifyRuleRoute`, returning `Allowed`, `RefusedOnPurpose`, or `Unclassified`. The test asserts
+that no mapped `/gateway/rules` route is `Unclassified`. A route added to this surface tomorrow
+cannot be forgotten - only classified.
+
+Two further assertions, both there because of how this class of test fails open:
+
+- **The surface must not be empty.** The headline assertion is "nothing was unclassified", and a
+  pass condition that is an absence certifies a run that never happened: an enumeration that returned
+  nothing - a filter typo, a route table that failed to build - would find no unclassified route and
+  report success without having looked at anything. The presence of the surface is asserted first.
+- **Both verdicts must actually occur.** Deleting every arm of the switch is caught by the
+  unclassified assertion, but collapsing the switch to one blanket verdict would not be - and a
+  blanket "allowed" is exactly the prefix rule the guard exists to avoid.
+
+### The rows in the fast suite
+
+`SessionKeyGuardTests` (in `Gateway.UnitTests`, which is not parked) gains the six allowed rows, the
+promote refusal with its reason, ten shapes under `/gateway/rules` that the Gateway does not route
+and must therefore not be authorized, the three-state classifier, and case and trailing-slash
+handling.
+
+Where those rows came from matters more than the rows: every one is read off the OTHER side - the
+route table in `SessionRuleEndpoints`, and the client's own `RuleClient` - and never off the guard. A
+test written from the implementation agrees with the implementation's mistakes.
+
+---
+
+## Watching each new test fail first
+
+Three red runs, on the real suites, quoted from the console.
+
+### Red run 1 - the pre-fix state: nothing on the surface classified
+
+Every arm of the rules switch deleted, which is the state main was in.
+
+Fast suite, `SessionKeyGuardTests`:
+
+```
+  Failed ...An_agent_may_draft_store_read_and_delete_a_rule(method: "GET", path: "/gateway/rules")
+  Failed ...An_agent_may_draft_store_read_and_delete_a_rule(method: "POST", path: "/gateway/rules")
+  Failed ...An_agent_may_draft_store_read_and_delete_a_rule(method: "POST", path: "/gateway/rules/draft")
+  Failed ...An_agent_may_draft_store_read_and_delete_a_rule(method: "GET", path: "/gateway/rules/6b2f...")
+  Failed ...An_agent_may_draft_store_read_and_delete_a_rule(method: "GET", path: "/gateway/rules/6b2f.../firings")
+  Failed ...An_agent_may_draft_store_read_and_delete_a_rule(method: "DELETE", path: "/gateway/rules/6b2f...")
+  Failed ...An_agent_may_not_move_a_rule_out_of_dry_run
+   Assert.Contains() Failure: Sub-string not found
+  Failed ...Case_and_a_trailing_slash_do_not_open_or_close_a_rule_route
+  Failed ...The_classifier_tells_a_deliberate_refusal_apart_from_one_nobody_decided
+Failed!  - Failed:     9, Passed:   154, Skipped:     0, Total:   163
+```
+
+Parked Gateway suite, the census test, which names every route it read off the built application:
+
+```
+ hosted=True: 7 mapped routes under /gateway/rules
+ Unclassified     GET /gateway/rules
+ Unclassified     POST /gateway/rules
+ Unclassified     POST /gateway/rules/draft
+ Unclassified     DELETE /gateway/rules/{id:guid}
+ Unclassified     GET /gateway/rules/{id:guid}
+ Unclassified     GET /gateway/rules/{id:guid}/firings
+ Unclassified     POST /gateway/rules/{id:guid}/promote
+  Error Message:
+   Assert.Empty() Failure: Collection was not empty
+Failed!  - Failed:     2, Passed:     0, Skipped:     0, Total:     2
+```
+
+That is the reported symptom of the original defect, printed route by route.
+
+### Red run 2 - one route added and forgotten
+
+Restored, then only the `promote` arm deleted. This is the case the census test exists for: six
+routes classified, one nobody looked at.
+
+```
+ hosted=True: 7 mapped routes under /gateway/rules
+ Allowed          GET /gateway/rules
+ Allowed          POST /gateway/rules
+ Allowed          POST /gateway/rules/draft
+ Allowed          DELETE /gateway/rules/{id:guid}
+ Allowed          GET /gateway/rules/{id:guid}
+ Allowed          GET /gateway/rules/{id:guid}/firings
+ Unclassified     POST /gateway/rules/{id:guid}/promote
+  Error Message:
+   Assert.Empty() Failure: Collection was not empty
+Collection: ["POST /gateway/rules/{id:guid}/promote"]
+Failed!  - Failed:     2, Passed:     0, Skipped:     0, Total:     2
+```
+
+### Red run 3 - the boundary given away
+
+Restored, then `promote` flipped from `RefusedOnPurpose` to `Allowed`.
+
+```
+  Failed ...An_agent_may_not_move_a_rule_out_of_dry_run
+   Assert.False() Failure
+  Failed ...Case_and_a_trailing_slash_do_not_open_or_close_a_rule_route
+   Assert.False() Failure
+  Failed ...The_classifier_tells_a_deliberate_refusal_apart_from_one_nobody_decided
+   Assert.Equal() Failure: Values differ
+Failed!  - Failed:     3, Passed:   160, Skipped:     0, Total:   163
+```
+
+and the census test's blanket-verdict assertion:
+
+```
+  Error Message:
+   Assert.NotEmpty() Failure: Collection was empty
+Failed!  - Failed:     2, Passed:     0, Skipped:     0, Total:     2
+```
+
+### Restored - green
+
+```
+Passed!  - Failed:     0, Passed:   163, Skipped:     0, Total:   163  (SessionKeyGuardTests)
+Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2  (the census test, both deployments)
+```
+
+and the census test's own output on the restored guard, which is the classification as it now
+stands, read off the built application rather than off this document:
+
+```
+ hosted=False: 7 mapped routes under /gateway/rules
+ Allowed          GET /gateway/rules
+ Allowed          POST /gateway/rules
+ Allowed          POST /gateway/rules/draft
+ Allowed          DELETE /gateway/rules/{id:guid}
+ Allowed          GET /gateway/rules/{id:guid}
+ Allowed          GET /gateway/rules/{id:guid}/firings
+ RefusedOnPurpose POST /gateway/rules/{id:guid}/promote
+```
+
+---
+
+## The gate
+
+- `.\scripts\test-local.ps1` - GREEN. Nine projects, every one `outcome=Completed`, 4863 tests, no
+  failures. The Postgres proof rig (`cc-pg-test`, port 55432) was up for the run.
+- `.\scripts	est-local.ps1 -Gateway` - GREEN. The parked suite, which is where the new census
+  test lives: `outcome=Completed`, 2331 tests, 2327 passed, 0 failed, 4 skipped, 33 minutes 13
+  seconds. It holds the machine-wide lock for the whole run; the wait is the design, not a hang.
+- No non-ASCII bytes in any file touched (checked byte by byte, not by eye). No assistant, model,
+  vendor or tool named anywhere in the change.
+
+---
+
+## What is NOT proven, said plainly
+
+- **Nothing here was exercised against the live hosted Gateway.** The proof is the guard as a pure
+  function and the route table of a locally-started host. The observed 403 that started this task was
+  against the live service; the fix has not been re-observed there, because that needs a deploy, and
+  this branch is not landed.
+- **The census covers `/gateway/rules` and nothing else.** Every other surface on this guard is still
+  a hand-kept list with no derived check behind it. The mechanism that produced this defect three
+  times is closed for one surface, not for the file. Widening it to the whole route table is real
+  work and was not in this task.
+- **The test says every route has a verdict. It does not say the verdicts are right.** Whether an
+  agent should be able to delete a rule is the owner's ruling, and it lives in the guard's comments
+  and in the hand-written unit rows, both of which a determined mistake can change.
+- **The guard is the only thing standing between an agent credential and promotion.**
+  `RulePromotionGrant.FromAuthenticatedRequest` refuses a request with no caller it can name, but a
+  session key resolves to a named caller like any other credential, so that factory would accept one.
+  This was read in the code, not executed. It is why the refusal is in the guard and why the test
+  that pins it matters.
+- **The client-side `rule` command group is not on this base.** `tools/cc-devthrottle/src/rule_ops.py`
+  exists on `origin/rule-authoring-by-conversation` and on neither `origin/main` nor this branch. The
+  six routes above were read off that file to make sure the guard opens what the client actually
+  sends, but nothing in this change tests the client, and the end-to-end path is only real once both
+  land.

--- a/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
+++ b/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
@@ -171,6 +171,96 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
         Assert.Equal(whyB, Str(survivingBAgain, "why"));
     }
 
+    // =============================================== session rules (session_rules, session_rule_firings)
+
+    /// <summary>
+    /// GET and DELETE /gateway/rules/{id:guid} - both context-less (SessionRuleEndpoints.cs, handlers
+    /// <c>(Guid id)</c>), scoped ONLY by the ambient request scope and the entity global query filter,
+    /// exactly like the workflow and skill families this file's companion proved.
+    ///
+    /// WHY THE FAMILY NEEDED THIS. The rules routes shipped in the Session Rules mission and were never
+    /// entered in the context-less census, so this suite was RED on main and nobody saw it: the suite is
+    /// parked and, on the mission's own record, had not run all day. A route family reachable on the
+    /// multi-tenant deployment with no written verdict and no executed probe is exactly what the census
+    /// exists to prevent.
+    ///
+    /// A rule id is Gateway-minted (both tables derive from <c>GatewayMintedKeyEntity</c>), so a caller
+    /// cannot present one - which makes the sharpest available probe the one below: tenant A is HANDED
+    /// tenant B's real id and still cannot read it, and cannot delete it either.
+    ///
+    /// WHAT THIS DOES NOT COVER, stated rather than inferred: <c>GET /gateway/rules/{id}/firings</c> is
+    /// the third context-less route in the family and is NOT cross-probed here, because no route can
+    /// write a firing - only the evaluator does - so both tenants would read an empty list and two empty
+    /// lists prove nothing about a partition. Its verdict is the same store and the same filter as the
+    /// two proved below, and that is a code-read verdict, not an executed one.
+    /// </summary>
+    [Fact]
+    public async Task SessionRules_AreNotReachableAcrossTenantsEvenHoldingTheOtherTenantsRuleId()
+    {
+        var createdA = await Json(await Send("POST", "gateway/rules", _keyA, RuleBody("tenant-A-rule-probe")),
+            HttpStatusCode.OK, "SEED    POST /gateway/rules (tenant A)");
+        var createdB = await Json(await Send("POST", "gateway/rules", _keyB, RuleBody("tenant-B-rule-probe")),
+            HttpStatusCode.OK, "SEED    POST /gateway/rules (tenant B)");
+        var idA = Str(Obj(createdA, "rule"), "id");
+        var idB = Str(Obj(createdB, "rule"), "id");
+        Assert.NotEqual(idA, idB);
+
+        // OWNER CONTROLS, asserting the EXACT SEEDED FINGERPRINT rather than a bare 200: a wrong route,
+        // a catch-all or a failed seed answering empty would all pass a status-only check.
+        var ownA = await Json(await Send("GET", $"gateway/rules/{idA}", _keyA, null),
+            HttpStatusCode.OK, "READ    GET /gateway/rules/{A} (tenant A)");
+        Assert.Equal("tenant-A-rule-probe", Str(Obj(ownA, "rule"), "instruction"));
+
+        var ownB = await Json(await Send("GET", $"gateway/rules/{idB}", _keyB, null),
+            HttpStatusCode.OK, "READ    GET /gateway/rules/{B} (tenant B)");
+        Assert.Equal("tenant-B-rule-probe", Str(Obj(ownB, "rule"), "instruction"));
+
+        // Each tenant's LIST holds exactly its own rule - so a leak would show as a second row even if
+        // the by-id read were somehow refused.
+        Assert.Equal(1, Arr(await Json(await Send("GET", "gateway/rules", _keyA, null),
+            HttpStatusCode.OK, "READ    GET /gateway/rules (tenant A)"), "rules").GetArrayLength());
+
+        // CROSS-TENANT: A holds B's real id and gets the same answer as for an id that does not exist,
+        // so the id cannot be probed for existence either.
+        var crossRead = await Send("GET", $"gateway/rules/{idB}", _keyA, null);
+        Assert.Equal(HttpStatusCode.NotFound, crossRead.StatusCode);
+
+        var crossDelete = await Send("DELETE", $"gateway/rules/{idB}", _keyA, null);
+        Assert.Equal(HttpStatusCode.OK, crossDelete.StatusCode);
+        Assert.False(Bool(await Json(crossDelete, HttpStatusCode.OK, "CROSS   DELETE /gateway/rules/{B} (tenant A)"),
+            "deleted"));
+
+        // ...and the refused delete changed nothing: B's rule is still there, byte-for-byte.
+        var survivingB = await Json(await Send("GET", $"gateway/rules/{idB}", _keyB, null),
+            HttpStatusCode.OK, "AFTER   GET /gateway/rules/{B} (after A tried to delete it)");
+        Assert.Equal("tenant-B-rule-probe", Str(Obj(survivingB, "rule"), "instruction"));
+
+        // DESTRUCTIBILITY CONTROL: B can perform the SAME delete on its own rule. Without this, the
+        // refusal above could be an inert route rather than a partitioned one.
+        Assert.True(Bool(await Json(await Send("DELETE", $"gateway/rules/{idB}", _keyB, null),
+            HttpStatusCode.OK, "CONTROL DELETE /gateway/rules/{B} (tenant B, its OWN rule)"), "deleted"));
+        Assert.Equal(HttpStatusCode.NotFound,
+            (await Send("GET", $"gateway/rules/{idB}", _keyB, null)).StatusCode);
+
+        // ...and A's rule is untouched by any of it.
+        var stillA = await Json(await Send("GET", $"gateway/rules/{idA}", _keyA, null),
+            HttpStatusCode.OK, "AFTER   GET /gateway/rules/{A}");
+        Assert.Equal("tenant-A-rule-probe", Str(Obj(stillA, "rule"), "instruction"));
+    }
+
+    /// <summary>A rule the write gate accepts: every part a rule has to have, said out loud.</summary>
+    private static string RuleBody(string instruction) =>
+        System.Text.Json.JsonSerializer.Serialize(new
+        {
+            instruction,
+            screenDescription = "The session has stopped on a provider error.",
+            triggerWords = new[] { "API Error" },
+            checks = Array.Empty<object>(),
+            scope = "all-sessions",
+            cooldownSeconds = 900,
+            dailyCap = 6,
+        });
+
     private static string MissionBody(string missionName) =>
         System.Text.Json.JsonSerializer.Serialize(new { missionName });
 

--- a/src/CcDirector.Gateway.Tests/ContextLessRouteCensusTests.cs
+++ b/src/CcDirector.Gateway.Tests/ContextLessRouteCensusTests.cs
@@ -64,6 +64,22 @@ public sealed class ContextLessRouteCensusTests
     ///   /gateway/workflow-runs/{id}                workflow_runs
     ///   /gateway/skills/{id} and its family        skills, skill_versions, skill_files,
     ///                                              skill_tenant_overrides
+    ///   /gateway/rules/{id:guid} (+ /firings)      session_rules, session_rule_firings
+    ///
+    /// The rules family was added by the Session Rules mission and reached this census LATE - it shipped
+    /// while this suite was parked, so these three rows were missing and this test was red on main with
+    /// nobody watching. Its verdict is the same seam as the skills and workflow families: both tables
+    /// derive from GatewayMintedKeyEntity (tenant-scoped, and the key is Gateway-minted so no caller can
+    /// present a rule id) and both carry the entity global query filter. GET and DELETE
+    /// /gateway/rules/{id} are EXECUTED cross-tenant by
+    /// CensusRouteTenancyProbeTests.SessionRules_AreNotReachableAcrossTenantsEvenHoldingTheOtherTenantsRuleId.
+    /// GET /gateway/rules/{id}/firings is NOT executed cross-tenant and that is stated rather than
+    /// implied: no route can write a firing (only the evaluator does), so both tenants read an empty list
+    /// and two empty lists prove nothing. Its verdict is a code read - same store, same filter.
+    ///
+    /// POST /gateway/rules/draft and POST /gateway/rules/{id}/promote are deliberately NOT in this census:
+    /// draft takes no path parameter, and promote takes the HttpContext (it mints the promotion grant from
+    /// the authenticated request), so neither is context-less.
     ///
     /// Hosted deny (the legacy same-machine discovery plane - not a tenant surface at all; refused on
     /// hosted, gated on the process-level hosted flag and proven by
@@ -74,6 +90,7 @@ public sealed class ContextLessRouteCensusTests
     {
         "DELETE /cron/jobs/{id}",
         "DELETE /directors/{id}/registration",
+        "DELETE /gateway/rules/{id:guid}",
         "DELETE /gateway/skills/{id}",
         "DELETE /gateway/workflows/{id}",
         "DELETE /lists/{name}/consumer",
@@ -81,6 +98,8 @@ public sealed class ContextLessRouteCensusTests
         "GET /cron/jobs/{id}",
         "GET /cron/jobs/{id}/runs",
         "GET /gateway/governance/session-spend/{sessionId}",
+        "GET /gateway/rules/{id:guid}",
+        "GET /gateway/rules/{id:guid}/firings",
         "GET /gateway/skills/{id}",
         "GET /gateway/skills/{id}/body",
         "GET /gateway/skills/{id}/files/{**filePath}",

--- a/src/CcDirector.Gateway.Tests/SessionRuleRouteGuardCensusTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionRuleRouteGuardCensusTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// EVERY MAPPED ROUTE OF THE SESSION-RULES SURFACE HAS BEEN CLASSIFIED BY <see cref="SessionKeyGuard"/> -
+/// allowed to a session key, or refused to one on purpose. There is no third state, and a route that
+/// reaches this application without somebody reaching a verdict about it makes this test red.
+///
+/// THE DEFECT THIS EXISTS FOR, OBSERVED RATHER THAN IMAGINED. The rules surface shipped with none of its
+/// routes on the guard's allow list, so every call from an agent's command line came back HTTP 403
+/// <c>session_key_out_of_scope</c> - the whole feature was unreachable to the credential it was built for.
+/// Every suite was green throughout. It could not have been otherwise: the guard's own unit tests are
+/// written against the guard's own list, and the command line's tests mock the transport, so nothing
+/// anywhere connected "a route was added" to "the guard was told about it". The same defect had already
+/// happened twice on this file, to the skill catalogue and to the schedules, and each time it was fixed by
+/// adding rows to a hand-kept list - which fixes the instance and leaves the mechanism running.
+///
+/// SO THIS TEST DERIVES ITS SUBJECT FROM THE BUILT APPLICATION, NEVER FROM A LIST. It reads the finalised
+/// route table off a real <see cref="GatewayHost"/> - the same instrument
+/// <see cref="ContextLessRouteCensusTests"/> uses, and for the same reason: patterns come from the router
+/// with group prefixes already applied, so a route cannot be missed by a mistake in reading source. Add a
+/// route under <c>/gateway/rules</c> and this test fails until the guard says, in its literal switch, what
+/// an agent may do with it.
+///
+/// WHAT IT DOES NOT PROVE. It says every route has a verdict; it does not say the verdicts are the right
+/// ones. Whether an agent SHOULD be able to delete a rule is the owner's ruling and lives in the guard's
+/// own comments and in the guard's own unit tests. This test is the mechanism, not the judgement.
+/// </summary>
+public sealed class SessionRuleRouteGuardCensusTests
+{
+    private readonly ITestOutputHelper _out;
+
+    public SessionRuleRouteGuardCensusTests(ITestOutputHelper output) => _out = output;
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Every_mapped_session_rule_route_is_classified_by_the_session_key_guard(bool hosted)
+    {
+        var routes = await RuleRoutes(hosted);
+
+        // THE INSTRUMENT CHECK, FIRST. The assertion below is "nothing was unclassified", and a pass
+        // condition that is an absence certifies a run that never happened: if this enumeration returned
+        // an empty set - a renamed host, a route table that failed to build, a filter typo - the loop
+        // would find no unclassified route and report success without having looked at anything. So the
+        // presence of the surface is asserted before its contents are judged.
+        Assert.NotEmpty(routes);
+        _out.WriteLine($"hosted={hosted}: {routes.Count} mapped routes under /gateway/rules");
+
+        var unclassified = new List<string>();
+        var allowed = new List<string>();
+        var refused = new List<string>();
+
+        foreach (var (method, pattern) in routes)
+        {
+            var ruling = SessionKeyGuard.ClassifyRuleRoute(method, ProbePath(pattern));
+            _out.WriteLine($"{ruling,-16} {method} {pattern}");
+
+            switch (ruling)
+            {
+                case RuleRouteRuling.Allowed: allowed.Add($"{method} {pattern}"); break;
+                case RuleRouteRuling.RefusedOnPurpose: refused.Add($"{method} {pattern}"); break;
+                default: unclassified.Add($"{method} {pattern}"); break;
+            }
+        }
+
+        // If this fails, a route was added to the session-rules surface and nobody decided what an agent
+        // may do with it. The guard denies it today - it is an allow list - but that denial is the default
+        // falling through rather than a decision, and the agent hitting it reads a 403 that says nothing
+        // true about why. Classify it in SessionKeyGuard.RuleRoute, allowed or refused, and say why there.
+        Assert.Empty(unclassified);
+
+        // Both verdicts must actually occur. Without this, deleting every arm of the guard's switch would
+        // leave a surface that is entirely unclassified (caught above) - but collapsing the switch to one
+        // blanket verdict would not be caught at all, and a blanket "allowed" is precisely the prefix rule
+        // the guard exists to avoid.
+        Assert.NotEmpty(allowed);
+        Assert.NotEmpty(refused);
+    }
+
+    /// <summary>
+    /// A concrete path a guard can be asked about, built from a route pattern by replacing each parameter
+    /// segment with a real identifier. The guard reads structure and never the identifier itself, so any
+    /// value does; a genuine identifier is used anyway so the probe is a path the router would accept.
+    /// </summary>
+    private static string ProbePath(string pattern)
+    {
+        var segments = pattern.Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .Select(seg => seg.Contains('{', StringComparison.Ordinal)
+                ? "6b2f4b1e-6d5a-4a2f-9f5f-9d7c0f3a1b2c"
+                : seg);
+        return "/" + string.Join('/', segments);
+    }
+
+    /// <summary>
+    /// The finalised route table of a real host, reduced to the routes under <c>/gateway/rules</c>. The
+    /// hosted refusal catch-alls are excluded by name exactly as the context-less census excludes them:
+    /// they carry no handler and exist to make a denied family unreachable, so counting one would invert
+    /// its meaning.
+    /// </summary>
+    private static async Task<List<(string Method, string Pattern)>> RuleRoutes(bool hosted)
+    {
+        var prior = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", hosted ? "1" : null);
+        var dir = Path.Combine(Path.GetTempPath(), "cc-rule-guard-census-" + Guid.NewGuid().ToString("N"));
+        var gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: "census-token",
+            authEnabled: true,
+            instancesDirectory: dir,
+            workListsPath: Path.Combine(dir, "worklists", "worklists.json"));
+        try
+        {
+            await gateway.StartAsync();
+
+            return gateway.MappedEndpoints.OfType<RouteEndpoint>()
+                .Select(e => new
+                {
+                    Pattern = "/" + (e.RoutePattern.RawText ?? "").TrimStart('/'),
+                    Methods = e.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods ?? Array.Empty<string>(),
+                })
+                .Where(r => r.Pattern.Equals("/gateway/rules", StringComparison.OrdinalIgnoreCase)
+                            || r.Pattern.StartsWith("/gateway/rules/", StringComparison.OrdinalIgnoreCase))
+                .Where(r => !r.Pattern.Contains("hostedDeniedPath", StringComparison.Ordinal))
+                .SelectMany(r => r.Methods.DefaultIfEmpty("ANY"), (r, m) => (Method: m, r.Pattern))
+                .Distinct()
+                .OrderBy(r => r.Pattern, StringComparer.Ordinal)
+                .ThenBy(r => r.Method, StringComparer.Ordinal)
+                .ToList();
+        }
+        finally
+        {
+            await gateway.StopAsync();
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", prior);
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/Rules/RuleAgentContractTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/Rules/RuleAgentContractTests.cs
@@ -44,6 +44,34 @@ public sealed class RuleAgentContractTests
 
     // ---- the prompt --------------------------------------------------------------------------------
 
+    /// <summary>
+    /// THE JUDGE IS TOLD WHICH AGENT'S SCREEN IT IS READING. The same trouble prints different words on
+    /// different agents, so a yes/no about "is this that situation" is a question about one agent's
+    /// screen, and the judge is told which one rather than left to infer it from the wording.
+    /// </summary>
+    [Fact]
+    public void The_question_says_which_agent_the_session_runs()
+    {
+        var facts = new RuleSessionFacts("sid", "ClaudeCode", @"D:\repo", "SOREN_NORTH", "", "WaitingForInput");
+
+        var prompt = RuleAgentContract.BuildPrompt(new[] { Rule() }, Screen, Registry, facts);
+
+        Assert.Contains("running the agent ClaudeCode", prompt, StringComparison.Ordinal);
+        // The machine is deliberately NOT in the question - ruling A11, the screen is the only input to the
+        // decision, and RuleEvaluatorTests asserts the same from the evaluator's side.
+        Assert.DoesNotContain("SOREN_NORTH", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>Without facts - the older callers - the question is unchanged, so nothing that used to
+    /// pass now says "running the agent" about nothing.</summary>
+    [Fact]
+    public void Without_session_facts_the_question_names_no_agent()
+    {
+        var prompt = RuleAgentContract.BuildPrompt(new[] { Rule() }, Screen, Registry);
+
+        Assert.DoesNotContain("running the agent", prompt, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void The_prompt_carries_every_candidate_rules_id_and_the_sentence_the_account_said()
     {

--- a/src/CcDirector.Gateway.UnitTests/Rules/RuleAuthorTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/Rules/RuleAuthorTests.cs
@@ -1,0 +1,332 @@
+using System.Text.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Rules;
+using CcDirector.Gateway.Tests.Data;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Rules;
+
+/// <summary>
+/// MAKING A RULE BY TALKING, end to end short of the network: what somebody said goes in, a rule to
+/// confirm comes out, and posting that rule back is a real write into the real store.
+///
+/// The round-trip tests are the ones that matter, and they are here rather than in the parked host-bound
+/// suite on purpose. A drafted rule that looks right and that the writing route would then refuse is the
+/// worst outcome this feature has: somebody would have read a rule, agreed to it, and been told no
+/// afterwards. So the proposal is projected exactly as the route projects it, read back by exactly the
+/// readers the writing route uses, and written to a real migrated database.
+///
+/// Every model answer here is a canned string. That proves the PATH carries a rule, not that a live model
+/// writes good ones - which is a separate claim and is not made anywhere in this file.
+/// </summary>
+public sealed class RuleAuthorTests : IDisposable
+{
+    private readonly GatewayDbTestHarness _h = new();
+
+    public void Dispose() => _h.Dispose();
+
+    private static readonly DateTime Now = new(2026, 9, 3, 9, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>An author whose model always says this.</summary>
+    private static RuleAuthor AuthorSaying(string? reply) =>
+        new((_, _, _) => Task.FromResult(reply));
+
+    private static IReadOnlyList<RuleDraftTurn> Said(params string[] words) =>
+        words.Select(w => new RuleDraftTurn(RuleDraftSpeakers.Person, w)).ToList();
+
+    private const string TheAllowanceSentence =
+        "When a session runs out of its allowance, switch it to another model and carry on.";
+
+    private const string AnAllowanceReply = """
+    {
+      "answer": "propose",
+      "screen_description": "The session has stopped on a notice that the account is out of allowance.",
+      "trigger_words": ["usage limit", "out of credits"],
+      "checks": [ { "name": "matches_any", "arguments": { "text": "<screen_text>", "terms": ["usage limit"] } } ],
+      "scope": "all-sessions",
+      "cooldown_seconds": 600,
+      "daily_cap": 4,
+      "read_back": "When one of your sessions stops on an allowance notice I will switch it to another model and tell it to carry on."
+    }
+    """;
+
+    // ---- what goes in ------------------------------------------------------------------------------
+
+    /// <summary>A conversation in which the person said nothing is not a rule waiting to be written. It
+    /// is refused, because the instruction is the sentence they said and there is not one.</summary>
+    [Fact]
+    public async Task Nothing_the_person_said_is_refused_rather_than_drafted()
+    {
+        var reading = await AuthorSaying(AnAllowanceReply).DraftAsync(
+            TenantId.Local,
+            new[] { new RuleDraftTurn(RuleDraftSpeakers.DevThrottle, "Which sessions?") },
+            CancellationToken.None);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("nothing to turn into one", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A MODEL THAT CANNOT BE ASKED PRODUCES A REFUSAL AND NEVER A RULE. The asking seam answers null when
+    /// the model could not be reached, and there is no partial rule, no default rule and nothing assembled
+    /// out of what could be read.
+    /// </summary>
+    [Fact]
+    public async Task A_model_that_cannot_be_asked_produces_a_refusal_and_never_a_rule()
+    {
+        var reading = await AuthorSaying(null).DraftAsync(
+            TenantId.Local, Said(TheAllowanceSentence), CancellationToken.None);
+
+        Assert.Null(reading.Proposal);
+        Assert.Null(reading.Question);
+        Assert.Contains("no answer at all", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// RUNNING OUT OF TIME IS NOT ANSWERING NOTHING, and the person is told which. Measured against the
+    /// hosted model on 3 September 2026: the same sentence asked five times ran out of the sixty-second
+    /// limit three times and answered twice. Someone who waits a minute and is then told "the model gave
+    /// no answer at all" is being told something true about the call and misleading about what to do
+    /// next - the answer is to try again, and the refusal has to say so.
+    /// </summary>
+    [Fact]
+    public async Task A_model_that_ran_out_of_time_says_so_and_says_to_try_again()
+    {
+        var author = new RuleAuthor((_, _, _) =>
+            Task.FromException<string?>(new TimeoutException("The wingman model call did not answer within 60 seconds.")));
+
+        var reading = await author.DraftAsync(
+            TenantId.Local, Said(TheAllowanceSentence), CancellationToken.None);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("longer than the model is given", reading.Refusal!, StringComparison.Ordinal);
+        Assert.Contains("worth trying again", reading.Refusal!, StringComparison.Ordinal);
+
+        // And it is NOT the "answered nothing" sentence - the two events have to be told apart by the
+        // person reading them, not only in the log.
+        Assert.DoesNotContain("no answer at all", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    /// <summary>Any other failure to reach the model is stated too, carrying what went wrong.</summary>
+    [Fact]
+    public async Task A_model_that_could_not_be_reached_at_all_says_what_went_wrong()
+    {
+        var author = new RuleAuthor((_, _, _) =>
+            Task.FromException<string?>(new HttpRequestException("no such host is known")));
+
+        var reading = await author.DraftAsync(
+            TenantId.Local, Said(TheAllowanceSentence), CancellationToken.None);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("could not be asked", reading.Refusal!, StringComparison.Ordinal);
+        Assert.Contains("no such host is known", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    /// <summary>Everything the person said becomes the instruction, in their own words and in order - a
+    /// conversation is still one instruction.</summary>
+    [Fact]
+    public async Task The_instruction_is_everything_the_person_said_in_their_own_words()
+    {
+        var reading = await AuthorSaying(AnAllowanceReply).DraftAsync(
+            TenantId.Local,
+            new[]
+            {
+                new RuleDraftTurn(RuleDraftSpeakers.Person, TheAllowanceSentence),
+                new RuleDraftTurn(RuleDraftSpeakers.DevThrottle, "Which sessions should this apply to?"),
+                new RuleDraftTurn(RuleDraftSpeakers.Person, "All of them."),
+            },
+            CancellationToken.None);
+
+        Assert.Equal(TheAllowanceSentence + " All of them.", reading.Proposal!.Instruction);
+    }
+
+    // ---- the gate, run before anybody is asked to agree ---------------------------------------------
+
+    /// <summary>
+    /// A rule the writing route would refuse is never offered, and the refusal is the STORE'S OWN WORDS.
+    /// This is the one implementation of what a rule is being asked the question early, so nobody can
+    /// confirm a rule that then turns out not to exist.
+    /// </summary>
+    [Fact]
+    public async Task A_rule_the_store_would_refuse_is_not_offered_and_says_the_stores_reason()
+    {
+        var noTriggerWords = AnAllowanceReply.Replace(
+            "\"trigger_words\": [\"usage limit\", \"out of credits\"],", "\"trigger_words\": [],",
+            StringComparison.Ordinal);
+
+        var reading = await AuthorSaying(noTriggerWords).DraftAsync(
+            TenantId.Local, Said(TheAllowanceSentence), CancellationToken.None);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("at least one word to watch for", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    /// <summary>The same for a ceiling that is not a ceiling. A rule with no cooldown is a rule that can
+    /// act on one session without limit, and the store refuses it - so it is refused here first.</summary>
+    [Fact]
+    public async Task A_rule_with_no_cooldown_is_not_offered()
+    {
+        var noCooldown = AnAllowanceReply.Replace(
+            "\"cooldown_seconds\": 600,", "\"cooldown_seconds\": 0,", StringComparison.Ordinal);
+
+        var reading = await AuthorSaying(noCooldown).DraftAsync(
+            TenantId.Local, Said(TheAllowanceSentence), CancellationToken.None);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("how long to wait before acting on the same session again",
+            reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    // ---- the round trip: a drafted rule is a rule the writing route takes ---------------------------
+
+    /// <summary>
+    /// The drafted rule projected exactly as the draft route projects it, read back by exactly the readers
+    /// the writing route uses, and written to the real store. This is the join between the two halves, and
+    /// it is the join where a scope or a check could silently become something else.
+    /// </summary>
+    private SessionRule Store(RuleProposal proposal)
+    {
+        var projected = JsonSerializer.SerializeToElement(SessionRuleWire.Project(proposal));
+        var body = projected.GetProperty("rule");
+
+        return new SessionRuleStore(_h.Open()).Create(
+            RuleCallJson.Text(body, "instruction") ?? "",
+            RuleCallJson.Text(body, "screenDescription") ?? "",
+            SessionRuleWire.Strings(body, "triggerWords"),
+            SessionRuleWire.Calls(body),
+            SessionRuleWire.ReadScope(body),
+            SessionRuleWire.Number(body, "cooldownSeconds"),
+            SessionRuleWire.Number(body, "dailyCap"),
+            Now);
+    }
+
+    [Fact]
+    public async Task A_drafted_rule_is_stored_by_the_writing_route_with_every_part_intact()
+    {
+        var reading = await AuthorSaying(AnAllowanceReply).DraftAsync(
+            TenantId.Local, Said(TheAllowanceSentence), CancellationToken.None);
+
+        var stored = Store(reading.Proposal!);
+
+        Assert.Equal(TheAllowanceSentence, stored.Instruction);
+        Assert.Equal("The session has stopped on a notice that the account is out of allowance.", stored.ScreenDescription);
+        Assert.Equal(new[] { "usage limit", "out of credits" }, stored.TriggerWords);
+        Assert.Equal(RuleScope.AllSessions, stored.Scope);
+        Assert.Equal(600, stored.CooldownSeconds);
+        Assert.Equal(4, stored.DailyCap);
+        Assert.Equal("matches_any(text=<screen_text>, terms=usage limit)", Assert.Single(stored.Calls).Describe());
+    }
+
+    /// <summary>A rule made by talking is in DRY RUN like every other rule. Talking to it is a way to
+    /// write a rule, never a way to skip the person who makes one live.</summary>
+    [Fact]
+    public async Task A_rule_made_by_talking_is_in_dry_run_like_every_other_rule()
+    {
+        var reading = await AuthorSaying(AnAllowanceReply).DraftAsync(
+            TenantId.Local, Said(TheAllowanceSentence), CancellationToken.None);
+
+        var stored = Store(reading.Proposal!);
+
+        Assert.Equal(RuleState.DryRun, stored.State);
+        Assert.Equal("", stored.PromotedBy);
+    }
+
+    /// <summary>
+    /// A NARROWER SCOPE SURVIVES THE ROUND TRIP, with the parts that were not set still meaning "any".
+    /// </summary>
+    [Fact]
+    public async Task A_rule_scoped_to_one_repository_survives_the_round_trip()
+    {
+        var oneRepository = AnAllowanceReply.Replace(
+            "\"scope\": \"all-sessions\",",
+            "\"scope\": { \"repository\": \"D:\\\\ReposFred\\\\devthrottle\" },",
+            StringComparison.Ordinal);
+
+        var reading = await AuthorSaying(oneRepository).DraftAsync(
+            TenantId.Local, Said(TheAllowanceSentence), CancellationToken.None);
+
+        var stored = Store(reading.Proposal!);
+
+        Assert.Equal(@"D:\ReposFred\devthrottle", stored.Scope.Repository);
+        Assert.Null(stored.Scope.Agent);
+        Assert.Null(stored.Scope.Machine);
+        Assert.Null(stored.Scope.Mission);
+    }
+
+    /// <summary>
+    /// A SCOPE THAT SAYS NOTHING IS REFUSED EVEN WHEN IT SAYS IT WITH WORDS. The writing route already
+    /// refuses an omitted scope and an empty object, on the stated grounds that the widest possible value
+    /// is the one an omission must never quietly become. An object whose four parts are all null was
+    /// getting through that: each null was read as an empty string, so the object was not equal to the
+    /// empty one, it was accepted as a NARROW scope of four empty strings, and the store then blanked all
+    /// four back to null - producing a rule that acts on every session the account has, from a request
+    /// that chose nothing.
+    ///
+    /// It matters more now than it did, because the thing filling that object in is a model. This is the
+    /// exact shape a model produces when it does not know the answer and fills the fields in anyway.
+    /// </summary>
+    [Fact]
+    public async Task A_scope_whose_parts_are_all_null_is_refused_rather_than_read_as_every_session()
+    {
+        var nullScope = AnAllowanceReply.Replace(
+            "\"scope\": \"all-sessions\",",
+            "\"scope\": { \"agent\": null, \"repository\": null, \"machine\": null, \"mission\": null },",
+            StringComparison.Ordinal);
+
+        var reading = await AuthorSaying(nullScope).DraftAsync(
+            TenantId.Local, Said(TheAllowanceSentence), CancellationToken.None);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("which sessions", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    // ---- the language is not shaped around one kind of trouble --------------------------------------
+
+    /// <summary>
+    /// THE OWNER'S SECOND CASE, EXPRESSED IN THE SAME LANGUAGE: a provider that stops working, which wants
+    /// a wait and a restart rather than a switch to another model. It is a different trigger and a
+    /// different act, and it has to go through the same authoring path without anything being widened for
+    /// it.
+    ///
+    /// The waiting is the COOLDOWN. A rule that should leave a session alone for a while and then try
+    /// again is a rule with a long cooldown and a low daily cap, and both are already part of what a rule
+    /// is - so "wait, then start it back up" needs no new machinery at all.
+    ///
+    /// WHAT THIS DOES NOT PROVE, and it is the part the owner should read: this is a rule that fires on
+    /// WORDS AN OUTAGE PUTS ON THE SCREEN. An outage that leaves a session hung mid-turn, or that shows
+    /// nothing at all, is not reachable by any rule, because a rule only ever looks at the screen of a
+    /// session that has gone idle.
+    /// </summary>
+    [Fact]
+    public async Task A_rule_about_a_provider_that_stopped_working_goes_through_the_same_path()
+    {
+        const string outageSentence =
+            "When the provider stops working, wait a while and then start the session back up.";
+        const string outageReply = """
+        {
+          "answer": "propose",
+          "screen_description": "The session has stopped on an error from the provider's own interface rather than on any work of its own.",
+          "trigger_words": ["API Error", "overloaded", "connection error", "internal server error"],
+          "checks": [],
+          "scope": "all-sessions",
+          "cooldown_seconds": 900,
+          "daily_cap": 6,
+          "read_back": "When one of your sessions stops on a provider error I will wait fifteen minutes and then tell it to carry on, at most six times a day for any one session."
+        }
+        """;
+
+        var reading = await AuthorSaying(outageReply).DraftAsync(
+            TenantId.Local, Said(outageSentence), CancellationToken.None);
+
+        var stored = Store(reading.Proposal!);
+
+        Assert.Equal(outageSentence, stored.Instruction);
+        Assert.Contains("API Error", stored.TriggerWords);
+        Assert.Equal(900, stored.CooldownSeconds);
+        Assert.Equal(6, stored.DailyCap);
+
+        // A rule that stakes nothing on a check is a real rule: none is a statement, not an omission.
+        Assert.Empty(stored.Calls);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/Rules/RuleDraftContractTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/Rules/RuleDraftContractTests.cs
@@ -1,0 +1,498 @@
+using CcDirector.Gateway.Rules;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Rules;
+
+/// <summary>
+/// THE AUTHORING CALL: the question that turns what somebody said into a rule, and the reading of the
+/// answer. This is the half the Session Rules mission named as missing - trigger words and checks used to
+/// be worked out by hand while the store refused a rule without them on the stated grounds that a model
+/// works them out.
+///
+/// Two things are covered here and they are different. The QUESTION is covered because what it offers is
+/// what may be named: it is built off the derived registry, so it can never advertise a check we do not
+/// ship, and it must not quietly teach the model that rules are about one kind of trouble. The ANSWER is
+/// covered because every part of it is validated before anything is put in front of a person - a check
+/// that does not exist, a missing scope, a rule that cannot be read back.
+/// </summary>
+public sealed class RuleDraftContractTests
+{
+    private static readonly RulePrimitiveRegistry Registry = RulePrimitiveRegistry.Default;
+
+    private static readonly string TheSentence =
+        "When a session runs out of its allowance, switch it to another model and carry on.";
+
+    private static IReadOnlyList<RuleDraftTurn> OneTurn(string said) =>
+        new[] { new RuleDraftTurn(RuleDraftSpeakers.Person, said) };
+
+    // ---- the question ------------------------------------------------------------------------------
+
+    /// <summary>Every check the product ships is offered, by the name a rule stores it under. The question
+    /// is built off the registry, so a check added to the product turns up here without anybody editing a
+    /// list.</summary>
+    [Fact]
+    public void The_question_offers_every_check_the_product_ships()
+    {
+        var prompt = RuleDraftContract.BuildDraftPrompt(OneTurn(TheSentence), Registry);
+
+        Assert.NotEmpty(Registry.Primitives);
+        foreach (var primitive in Registry.Primitives)
+            Assert.Contains(primitive.Name, prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>The runtime inputs are offered in the same angle-bracket notation the stored rule and the
+    /// firing record use, so there is one notation in this feature rather than three.</summary>
+    [Fact]
+    public void The_question_offers_the_runtime_inputs_in_angle_brackets()
+    {
+        var prompt = RuleDraftContract.BuildDraftPrompt(OneTurn(TheSentence), Registry);
+
+        Assert.NotEmpty(RuleInputs.Names);
+        foreach (var name in RuleInputs.Names)
+            Assert.Contains("<" + name + ">", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>Both sides of the conversation reach the question, and are told apart - an answer to a
+    /// question the model cannot see is an answer to nothing.</summary>
+    [Fact]
+    public void The_question_carries_what_was_said_by_both_sides()
+    {
+        var prompt = RuleDraftContract.BuildDraftPrompt(new[]
+        {
+            new RuleDraftTurn(RuleDraftSpeakers.Person, TheSentence),
+            new RuleDraftTurn(RuleDraftSpeakers.DevThrottle, "Which sessions should this apply to?"),
+            new RuleDraftTurn(RuleDraftSpeakers.Person, "All of them."),
+        }, Registry);
+
+        Assert.Contains("they said: " + TheSentence, prompt, StringComparison.Ordinal);
+        Assert.Contains("you asked: Which sessions should this apply to?", prompt, StringComparison.Ordinal);
+        Assert.Contains("they said: All of them.", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// THE QUESTION DOES NOT PRESUME WHAT A RULE IS ABOUT. The evaluator was demonstrated on a provider
+    /// allowance notice, and the standing danger is that the authoring question gets written around that
+    /// one case - at which point every rule an account writes comes back shaped like an allowance rule and
+    /// nobody can tell whether the language was ever general.
+    ///
+    /// The owner's own second case is exactly this: a provider that stops answering is not a session
+    /// calmly reporting that it is out of allowance, and the two want different acts. So the question
+    /// itself must name no kind of trouble as the expected one. Its only mention of allowance is whatever
+    /// the person said, which is why the sentence used here is deliberately an allowance one: the words
+    /// must appear ONCE, in their turn, and nowhere in the framing.
+    /// </summary>
+    [Fact]
+    public void The_question_names_no_kind_of_trouble_as_the_expected_one()
+    {
+        var prompt = RuleDraftContract.BuildDraftPrompt(OneTurn(TheSentence), Registry);
+
+        var framing = prompt.Replace(TheSentence, "", StringComparison.Ordinal);
+
+        foreach (var presumed in new[] { "allowance", "usage limit", "credit", "rate limit" })
+            Assert.DoesNotContain(presumed, framing, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The framing says an instruction may be about anything the screen can show, which is the
+    /// positive form of the test above - an absence alone would pass just as happily over an empty
+    /// prompt.</summary>
+    [Fact]
+    public void The_question_says_an_instruction_may_be_about_anything_the_screen_shows()
+    {
+        var prompt = RuleDraftContract.BuildDraftPrompt(OneTurn(TheSentence), Registry);
+
+        Assert.Contains("can be about anything a session's screen can show", prompt, StringComparison.Ordinal);
+        Assert.Contains("not assume you know which kind of trouble is meant",
+            prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---- the answer: a rule -------------------------------------------------------------------------
+
+    private const string AGoodReply = """
+    {
+      "answer": "propose",
+      "screen_description": "The session has stopped on a notice that the account is out of allowance.",
+      "trigger_words": ["usage limit", "out of credits"],
+      "checks": [ { "name": "matches_any", "arguments": { "text": "<screen_text>", "terms": ["usage limit", "out of credits"] } } ],
+      "scope": "all-sessions",
+      "cooldown_seconds": 600,
+      "daily_cap": 4,
+      "read_back": "When one of your sessions stops on an allowance notice, I will switch it to another model and tell it to carry on."
+    }
+    """;
+
+    [Fact]
+    public void A_proposed_rule_is_read_with_every_part_intact()
+    {
+        var reading = RuleDraftContract.Read(AGoodReply, TheSentence, Registry);
+
+        Assert.Null(reading.Refusal);
+        Assert.Null(reading.Question);
+        var proposal = Assert.IsType<RuleProposal>(reading.Proposal);
+
+        Assert.Equal("The session has stopped on a notice that the account is out of allowance.", proposal.ScreenDescription);
+        Assert.Equal(new[] { "usage limit", "out of credits" }, proposal.TriggerWords);
+        Assert.Equal(RuleScope.AllSessions, proposal.Scope);
+        Assert.Equal(600, proposal.CooldownSeconds);
+        Assert.Equal(4, proposal.DailyCap);
+        Assert.Contains("switch it to another model", proposal.ReadBack, StringComparison.Ordinal);
+
+        var call = Assert.Single(proposal.Calls);
+        Assert.Equal("matches_any", call.Name);
+        Assert.Equal("matches_any(text=<screen_text>, terms=usage limit,out of credits)", call.Describe());
+    }
+
+    /// <summary>
+    /// THE INSTRUCTION IS THE PERSON'S OWN WORDS, and it does not come out of the reply at all. The store
+    /// treats the instruction as the authority; a model asked to restate a sentence will eventually
+    /// improve it, and an improved authority is a different authority from the one the account gave.
+    /// </summary>
+    [Fact]
+    public void The_instruction_is_the_persons_words_and_not_the_models()
+    {
+        var replyThatRewritesIt = AGoodReply.Replace(
+            "\"answer\": \"propose\"",
+            "\"answer\": \"propose\", \"instruction\": \"Handle rate limits automatically.\"",
+            StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(replyThatRewritesIt, TheSentence, Registry);
+
+        Assert.Equal(TheSentence, reading.Proposal!.Instruction);
+    }
+
+    [Fact]
+    public void A_check_that_does_not_exist_is_refused_by_name()
+    {
+        var reply = AGoodReply.Replace("\"matches_any\"", "\"screen_contains_regex\"", StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(reply, TheSentence, Registry);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("screen_contains_regex", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_real_check_given_the_wrong_arguments_is_refused()
+    {
+        var reply = AGoodReply.Replace(
+            "{ \"text\": \"<screen_text>\", \"terms\": [\"usage limit\", \"out of credits\"] }",
+            "{ \"text\": \"<screen_text>\" }",
+            StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(reply, TheSentence, Registry);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("terms", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    /// <summary>A rule that does not say which sessions it may act on is refused rather than read as every
+    /// session there is. The widest possible value is the one an omission must never become.</summary>
+    [Fact]
+    public void A_rule_that_does_not_say_which_sessions_is_refused()
+    {
+        var reply = AGoodReply.Replace("\"scope\": \"all-sessions\",", "", StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(reply, TheSentence, Registry);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("which sessions", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    /// <summary>A rule with nothing to read back is refused: the read-back is what the person confirms,
+    /// and without it they would be agreeing to a list of trigger words.</summary>
+    [Fact]
+    public void A_rule_that_cannot_be_read_back_is_refused()
+    {
+        var reply = AGoodReply.Replace(
+            "\"read_back\": \"When one of your sessions stops on an allowance notice, I will switch it to another model and tell it to carry on.\"",
+            "\"read_back\": \"   \"",
+            StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(reply, TheSentence, Registry);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("what it would actually do", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    /// <summary>A reply wrapped in prose or a fenced block is still read - chat models do this - but the
+    /// reading is the JSON, never the prose.</summary>
+    [Fact]
+    public void A_reply_wrapped_in_prose_is_still_read()
+    {
+        var reading = RuleDraftContract.Read(
+            "Here is the rule I would write:\n```json\n" + AGoodReply + "\n```\nLet me know.",
+            TheSentence, Registry);
+
+        Assert.NotNull(reading.Proposal);
+    }
+
+    // ---- the captured screen: the words have to be ON it ---------------------------------------------
+
+    /// <summary>The real thing a person captures when a session stops on a limit - the case that cost the
+    /// owner a night. The wording is a real Claude Code notice, not a paraphrase.</summary>
+    private const string ACapturedLimitScreen = """
+    > carry on with the refactor
+
+    Claude usage limit reached. Your limit will reset at 11:50pm.
+
+    >
+    """;
+
+    /// <summary>
+    /// WHEN THERE IS A SCREEN, THE QUESTION SAYS TO READ THE WORDS OFF IT. Without one the model guesses
+    /// what a screen says, and it guesses plausibly and wrongly - asked about a provider outage with no
+    /// screen, a live model proposed ECONNREFUSED, ETIMEDOUT and 429, none of which a coding agent
+    /// necessarily prints. A rule watching for a word that never appears never fires, and looks entirely
+    /// correct sitting in the list.
+    /// </summary>
+    [Fact]
+    public void A_captured_screen_reaches_the_question_with_the_instruction_to_use_it()
+    {
+        var prompt = RuleDraftContract.BuildDraftPrompt(
+            OneTurn("when this happens, wait and then carry on"), Registry, ACapturedLimitScreen);
+
+        Assert.Contains("Claude usage limit reached", prompt, StringComparison.Ordinal);
+        Assert.Contains("TAKE THE TRIGGER WORDS FROM THIS SCREEN", prompt, StringComparison.Ordinal);
+        Assert.Contains("do not invent likely-looking error strings", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>With no screen captured, the question carries no screen section at all - it must not
+    /// invite the model to read words off something that is not there.</summary>
+    [Fact]
+    public void With_no_captured_screen_the_question_says_nothing_about_one()
+    {
+        var prompt = RuleDraftContract.BuildDraftPrompt(OneTurn(TheSentence), Registry);
+
+        Assert.DoesNotContain("the screen they captured", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("TAKE THE TRIGGER WORDS FROM THIS SCREEN", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A WORD THAT IS NOT ON THE CAPTURED SCREEN IS REFUSED, BY NAME. This is the whole value of capturing
+    /// one: the rule can be checked against reality at the moment it is written, instead of looking
+    /// perfectly good and never firing.
+    /// </summary>
+    [Fact]
+    public void Trigger_words_that_are_not_on_the_captured_screen_are_refused_by_name()
+    {
+        var reply = AGoodReply.Replace(
+            "\"trigger_words\": [\"usage limit\", \"out of credits\"],",
+            "\"trigger_words\": [\"usage limit\", \"ECONNREFUSED\"],",
+            StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(reply, TheSentence, Registry, ACapturedLimitScreen);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("ECONNREFUSED", reading.Refusal!, StringComparison.Ordinal);
+        Assert.Contains("not on the screen you captured", reading.Refusal!, StringComparison.Ordinal);
+
+        // And it does NOT complain about the word that really is there.
+        Assert.DoesNotContain("\"usage limit\"", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    /// <summary>Words that ARE on the screen pass, and the proposal keeps the screen it was checked
+    /// against - so the rule carries the example it was made from.</summary>
+    [Fact]
+    public void Trigger_words_that_are_on_the_captured_screen_are_accepted_and_the_screen_is_kept()
+    {
+        var reply = AGoodReply.Replace(
+            "\"trigger_words\": [\"usage limit\", \"out of credits\"],",
+            "\"trigger_words\": [\"usage limit reached\", \"11:50pm\"],",
+            StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(reply, TheSentence, Registry, ACapturedLimitScreen);
+
+        Assert.Null(reading.Refusal);
+        Assert.Equal(new[] { "usage limit reached", "11:50pm" }, reading.Proposal!.TriggerWords);
+        Assert.Contains("Claude usage limit reached", reading.Proposal!.ExampleScreen, StringComparison.Ordinal);
+    }
+
+    /// <summary>The check ignores case, because a screen and a model disagree about capitals constantly and
+    /// the matching that runs later ignores case too. A guard stricter than the thing it guards would
+    /// refuse rules that would have worked perfectly.</summary>
+    [Fact]
+    public void The_check_ignores_case_because_the_matching_it_guards_does()
+    {
+        var reply = AGoodReply.Replace(
+            "\"trigger_words\": [\"usage limit\", \"out of credits\"],",
+            "\"trigger_words\": [\"USAGE LIMIT REACHED\"],",
+            StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(reply, TheSentence, Registry, ACapturedLimitScreen);
+
+        Assert.Null(reading.Refusal);
+        Assert.NotNull(reading.Proposal);
+    }
+
+    /// <summary>With NO screen captured there is nothing to check against, so nothing is refused on those
+    /// grounds - a rule written without an example is still a rule.</summary>
+    [Fact]
+    public void With_no_captured_screen_no_word_is_refused_for_being_absent_from_it()
+    {
+        var reading = RuleDraftContract.Read(AGoodReply, TheSentence, Registry);
+
+        Assert.Null(reading.Refusal);
+        Assert.Equal("", reading.Proposal!.ExampleScreen);
+    }
+
+    // ---- which agent's screen this is, and who decides the agent scope -------------------------------
+
+    private static readonly RuleSessionOrigin ClaudeOnNorth = new("ClaudeCode", "SOREN_NORTH");
+
+    /// <summary>
+    /// THE MODEL IS TOLD WHICH AGENT IT IS LOOKING AT. A usage-limit notice on Claude Code reads "Claude
+    /// usage limit reached"; on Codex or Gemini it reads something else. Trigger words are agent-specific
+    /// whether anyone says so or not, so a model that does not know which agent printed the screen cannot
+    /// know which words are that agent's and which are universal.
+    /// </summary>
+    [Fact]
+    public void The_question_says_which_agent_the_captured_screen_came_from()
+    {
+        var prompt = RuleDraftContract.BuildDraftPrompt(
+            OneTurn("wait until it resets and carry on"), Registry, ACapturedLimitScreen, ClaudeOnNorth);
+
+        Assert.Contains("running the agent ClaudeCode", prompt, StringComparison.Ordinal);
+        Assert.Contains("SOREN_NORTH", prompt, StringComparison.Ordinal);
+        Assert.Contains("for ClaudeCode sessions only", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_question_says_when_the_rule_is_for_every_agent()
+    {
+        var prompt = RuleDraftContract.BuildDraftPrompt(
+            OneTurn("wait until it resets and carry on"), Registry, ACapturedLimitScreen, ClaudeOnNorth,
+            allAgents: true);
+
+        Assert.Contains("for EVERY agent", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("sessions only", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// THE AGENT PART OF THE SCOPE IS OURS, NOT THE MODEL'S. A rule written against a session is for that
+    /// session's agent by default (the owner's ruling) - whatever the model wrote. Here the model said
+    /// "all-sessions" and the proposal still comes back scoped to ClaudeCode, because that is a fact we
+    /// hold rather than something to trust a guess about.
+    /// </summary>
+    [Fact]
+    public void A_rule_written_against_a_session_is_scoped_to_that_sessions_agent_whatever_the_model_said()
+    {
+        var reply = AGoodReply.Replace(
+            "\"trigger_words\": [\"usage limit\", \"out of credits\"],",
+            "\"trigger_words\": [\"usage limit reached\"],",
+            StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(reply, TheSentence, Registry, ACapturedLimitScreen, ClaudeOnNorth);
+
+        Assert.Null(reading.Refusal);
+        Assert.Equal("ClaudeCode", reading.Proposal!.Scope.Agent);
+    }
+
+    /// <summary>The star: the account said every agent, so the agent part is lifted even though the
+    /// session it was written against was a Claude Code one.</summary>
+    [Fact]
+    public void Saying_every_agent_lifts_the_agent_scope()
+    {
+        var reply = AGoodReply.Replace(
+            "\"trigger_words\": [\"usage limit\", \"out of credits\"],",
+            "\"trigger_words\": [\"usage limit reached\"],",
+            StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(
+            reply, TheSentence, Registry, ACapturedLimitScreen, ClaudeOnNorth, allAgents: true);
+
+        Assert.Null(reading.Refusal);
+        Assert.Null(reading.Proposal!.Scope.Agent);
+    }
+
+    /// <summary>A model that tried to scope the rule to a DIFFERENT agent than the one the screen came
+    /// from is overruled: the fact wins.</summary>
+    [Fact]
+    public void A_model_naming_a_different_agent_is_overruled_by_the_sessions_real_agent()
+    {
+        var reply = AGoodReply
+            .Replace("\"trigger_words\": [\"usage limit\", \"out of credits\"],",
+                     "\"trigger_words\": [\"usage limit reached\"],", StringComparison.Ordinal)
+            .Replace("\"scope\": \"all-sessions\",", "\"scope\": { \"agent\": \"Codex\" },", StringComparison.Ordinal);
+
+        var reading = RuleDraftContract.Read(reply, TheSentence, Registry, ACapturedLimitScreen, ClaudeOnNorth);
+
+        Assert.Equal("ClaudeCode", reading.Proposal!.Scope.Agent);
+    }
+
+    /// <summary>With no session known there is no fact to apply, so the model's scope stands - a rule
+    /// described from memory keeps whatever scope it was given.</summary>
+    [Fact]
+    public void With_no_session_known_the_agent_scope_is_left_as_the_model_wrote_it()
+    {
+        var reading = RuleDraftContract.Read(AGoodReply, TheSentence, Registry);
+
+        Assert.Null(reading.Refusal);
+        Assert.Equal(RuleScope.AllSessions, reading.Proposal!.Scope);
+    }
+
+    // ---- the answer: a question ---------------------------------------------------------------------
+
+    /// <summary>A model that does not know something asks, and that is a first-class answer. The
+    /// alternative is a model that picks the widest scope it can and hands back a rule nobody asked
+    /// for.</summary>
+    [Fact]
+    public void A_question_comes_back_as_a_question()
+    {
+        var reading = RuleDraftContract.Read(
+            """{ "answer": "ask", "question": "Should this apply to every session, or only the ones in one repository?" }""",
+            TheSentence, Registry);
+
+        Assert.Null(reading.Proposal);
+        Assert.Null(reading.Refusal);
+        Assert.Equal("Should this apply to every session, or only the ones in one repository?", reading.Question);
+    }
+
+    [Fact]
+    public void Saying_it_needs_something_and_then_asking_nothing_is_refused()
+    {
+        var reading = RuleDraftContract.Read("""{ "answer": "ask", "question": "  " }""", TheSentence, Registry);
+
+        Assert.Null(reading.Question);
+        Assert.Contains("asked nothing", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    // ---- the answer: not an answer at all -----------------------------------------------------------
+
+    [Fact]
+    public void No_answer_at_all_is_refused_and_is_never_a_rule()
+    {
+        var reading = RuleDraftContract.Read(null, TheSentence, Registry);
+
+        Assert.Null(reading.Proposal);
+        Assert.Null(reading.Question);
+        Assert.Contains("no answer at all", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Prose_with_no_answer_in_it_is_refused_and_quoted_back()
+    {
+        var reading = RuleDraftContract.Read(
+            "Sure, I will watch for rate limits and handle it.", TheSentence, Registry);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("Sure, I will watch for rate limits", reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void An_answer_outside_the_two_there_are_is_refused()
+    {
+        var reading = RuleDraftContract.Read("""{ "answer": "maybe" }""", TheSentence, Registry);
+
+        Assert.Null(reading.Proposal);
+        Assert.Contains("maybe", reading.Refusal!, StringComparison.Ordinal);
+        Assert.Contains(RuleDraftAnswers.Propose, reading.Refusal!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Broken_json_is_refused_and_never_partly_read()
+    {
+        var reading = RuleDraftContract.Read("""{ "answer": "propose", "trigger_words": [ """, TheSentence, Registry);
+
+        Assert.Null(reading.Proposal);
+        Assert.NotNull(reading.Refusal);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/Rules/RuleEvaluatorTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/Rules/RuleEvaluatorTests.cs
@@ -626,6 +626,14 @@ public sealed class RuleEvaluatorTests
         Assert.DoesNotContain("zz-distinctive-repository-name", prompt, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("2031", prompt, StringComparison.Ordinal);
         Assert.DoesNotContain("SOREN_NORTH", prompt, StringComparison.Ordinal);
+
+        // THE ONE SESSION FACT THAT IS ALLOWED IN, and why it is not a breach of A11: the agent does not
+        // decide whether the instruction applies - the scope filter already removed every other agent's
+        // session before this question was asked - it decides how the screen is READ. The same trouble
+        // prints different words on different agents. This was added on 3 September 2026 when the owner
+        // ruled rules are agent-specific by default, and it stopped at the agent because this test said
+        // the machine stays out.
+        Assert.Contains("running the agent", prompt, StringComparison.Ordinal);
     }
 
     // ---- ruling A12: an act's reason has to be grounded in the screen it was given ------------------

--- a/src/CcDirector.Gateway.UnitTests/SessionKeyGuardTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionKeyGuardTests.cs
@@ -353,4 +353,94 @@ public sealed class SessionKeyGuardTests
         Assert.False(SessionKeyGuard.Check("GET", "/").Allowed);
         Assert.False(SessionKeyGuard.Check(null, "/sessions").Allowed);
     }
+
+    // ---------- The session-rules surface ----------
+    //
+    // The owner's ruling of 2026-09-03: an agent credential may do everything with rules EXCEPT move one
+    // out of dry run.
+    //
+    // WHERE THESE ROWS COME FROM, WHICH IS THE ONLY REASON THEY ARE WORTH ANYTHING. Every one is read off
+    // the OTHER side - the route table in SessionRuleEndpoints, and the client's own RuleClient - and not
+    // off the guard. The whole surface was refused with HTTP 403 on every call for the same reason the
+    // catalogue and schedule surfaces were before it: nobody had told the guard the routes existed, and
+    // the guard's tests are written against the guard, so they agreed with it and stayed green. A test
+    // written from the implementation cannot disagree with the implementation.
+    //
+    // These rows are a hand-kept list and cannot catch the NEXT route added here. That is the job of the
+    // census test over the built application in Gateway.Tests, which fails on any mapped /gateway/rules
+    // route the guard has not classified either way.
+
+    private const string RuleId = "6b2f4b1e-6d5a-4a2f-9f5f-9d7c0f3a1b2c";
+
+    [Theory]
+    [InlineData("GET", "/gateway/rules")]
+    [InlineData("GET", "/gateway/rules/" + RuleId)]
+    [InlineData("GET", "/gateway/rules/" + RuleId + "/firings")]
+    [InlineData("POST", "/gateway/rules/draft")]
+    [InlineData("POST", "/gateway/rules")]
+    [InlineData("DELETE", "/gateway/rules/" + RuleId)]
+    public void An_agent_may_draft_store_read_and_delete_a_rule(string method, string path)
+        => Assert.True(SessionKeyGuard.Check(method, path).Allowed,
+            $"{method} {path} is what the rule command line sends; refusing it returns 403 to every agent");
+
+    [Fact]
+    public void An_agent_may_not_move_a_rule_out_of_dry_run()
+    {
+        var verdict = SessionKeyGuard.Check("POST", $"/gateway/rules/{RuleId}/promote");
+
+        // The one real exposure on this surface, and the owner's ruling. Promotion is the moment a rule may
+        // start typing into a session. Note that it sits one path parameter under the routes opened above,
+        // which is exactly why the guard spells it out rather than opening /gateway/rules by prefix.
+        Assert.False(verdict.Allowed);
+
+        // A refusal that does not say why sends the agent hunting a credential problem it does not have.
+        Assert.Contains("POST", verdict.Reason);
+        Assert.Contains("/promote", verdict.Reason);
+        Assert.Contains("dry run", verdict.Reason);
+    }
+
+    [Theory]
+    // Shapes under /gateway/rules that the Gateway does not route. Authorizing one is latent widening: it
+    // is invisible today, because the router answers 404, and it is open to every session key on the day
+    // somebody maps a route there.
+    [InlineData("PUT", "/gateway/rules/" + RuleId)]
+    [InlineData("POST", "/gateway/rules/" + RuleId)]
+    [InlineData("DELETE", "/gateway/rules")]
+    [InlineData("PUT", "/gateway/rules")]
+    [InlineData("GET", "/gateway/rules/draft")]
+    [InlineData("POST", "/gateway/rules/" + RuleId + "/firings")]
+    [InlineData("GET", "/gateway/rules/" + RuleId + "/promote")]
+    [InlineData("DELETE", "/gateway/rules/" + RuleId + "/promote")]
+    // Deeper than anything mapped, and a sibling nobody has classified.
+    [InlineData("GET", "/gateway/rules/" + RuleId + "/firings/latest")]
+    [InlineData("POST", "/gateway/rules/" + RuleId + "/arm")]
+    public void A_rule_shape_the_gateway_does_not_route_is_not_authorized(string method, string path)
+        => Assert.False(SessionKeyGuard.Check(method, path).Allowed,
+            $"{method} {path} is not a mapped route; authorizing it is latent widening");
+
+    [Fact]
+    public void The_classifier_tells_a_deliberate_refusal_apart_from_one_nobody_decided()
+    {
+        // Check() answers 403 for both, which is why the whole surface could be refused by accident with
+        // every suite green. This is the distinction the census test in Gateway.Tests fails on.
+        Assert.Equal(RuleRouteRuling.Allowed, SessionKeyGuard.ClassifyRuleRoute("GET", "/gateway/rules"));
+        Assert.Equal(RuleRouteRuling.RefusedOnPurpose,
+            SessionKeyGuard.ClassifyRuleRoute("POST", $"/gateway/rules/{RuleId}/promote"));
+        Assert.Equal(RuleRouteRuling.Unclassified,
+            SessionKeyGuard.ClassifyRuleRoute("POST", $"/gateway/rules/{RuleId}/arm"));
+
+        // It rules on one surface and says nothing about any other - including routes that ARE allowed
+        // elsewhere in the guard, so a caller cannot read this as a second opinion on them.
+        Assert.Equal(RuleRouteRuling.Unclassified, SessionKeyGuard.ClassifyRuleRoute("GET", "/sessions"));
+        Assert.Equal(RuleRouteRuling.Unclassified, SessionKeyGuard.ClassifyRuleRoute("POST", "/account/sign-in"));
+    }
+
+    [Fact]
+    public void Case_and_a_trailing_slash_do_not_open_or_close_a_rule_route()
+    {
+        Assert.True(SessionKeyGuard.Check("GET", "/Gateway/Rules/").Allowed);
+        Assert.False(SessionKeyGuard.Check("POST", $"/Gateway/Rules/{RuleId}/Promote/").Allowed);
+        Assert.Equal(RuleRouteRuling.RefusedOnPurpose,
+            SessionKeyGuard.ClassifyRuleRoute("POST", $"/Gateway/Rules/{RuleId}/Promote/"));
+    }
 }

--- a/src/CcDirector.Gateway/Api/SessionRuleEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionRuleEndpoints.cs
@@ -12,11 +12,13 @@ namespace CcDirector.Gateway.Api;
 /// read a rule's firing record. Device-authed client routes under the non-public "/gateway/..." prefix, so
 /// the host-wide device-key middleware gates them exactly like every other client data endpoint.
 ///
-/// THIS IS NOT THE AUTHORING CONVERSATION. Phase 3 builds the part where a person says a sentence and a
-/// model turns it into a rule. These routes carry an ALREADY-BUILT rule, so that the phase 2 slice can put a
-/// real rule into the real store from outside the process and then be watched acting on it. Every write goes
-/// through <see cref="SessionRuleStore"/>, which is the gate: a rule naming a check we do not ship, or
-/// supplying the wrong arguments to one we do, is refused here with the store's own stated reason.
+/// THE AUTHORING CONVERSATION IS THE DRAFT ROUTE, and it is deliberately not a write. A person says a
+/// sentence, a model turns it into a rule, and the rule comes BACK to be confirmed; storing it is a
+/// separate call the person makes, and making it live is a third. Every write goes through
+/// <see cref="SessionRuleStore"/>, which is the gate: a rule naming a check we do not ship, or supplying
+/// the wrong arguments to one we do, is refused here with the store's own stated reason - and the draft
+/// route runs a proposal through that same gate before offering it, so nobody is ever asked to agree to a
+/// rule the writing route would then refuse.
 ///
 /// A REFUSAL COMES BACK AS A REFUSAL. The store's reason is returned verbatim with a 400, never flattened
 /// into a generic failure - a caller that cannot see why its rule was rejected will guess, and guessing is
@@ -30,8 +32,62 @@ namespace CcDirector.Gateway.Api;
 [Rules.RuleFeature]
 internal static class SessionRuleEndpoints
 {
-    public static void Map(IEndpointRouteBuilder app, SessionRuleStore store)
+    public static void Map(
+        IEndpointRouteBuilder app,
+        SessionRuleStore store,
+        RuleAuthor author,
+        Func<CcDirector.Core.Tenancy.TenantId> currentTenant)
     {
+        if (author is null) throw new ArgumentNullException(nameof(author));
+        if (currentTenant is null) throw new ArgumentNullException(nameof(currentTenant));
+
+        // MAKE A RULE BY TALKING. Say what you want in ordinary words; a model works out what the product
+        // has to hold and hands it BACK to be confirmed. THIS ROUTE STORES NOTHING - it answers with a
+        // rule to look at, or with the one question it needs answered, or with a stated refusal. What
+        // comes back under "rule" is exactly the body the writing route above takes, so confirming a
+        // drafted rule is posting it, and the rule that is then stored is in dry run like every other one.
+        // The person is still between the sentence and the first real act, twice: once to store it and
+        // once to promote it.
+        app.MapPost("/gateway/rules/draft", async (JsonElement body, CancellationToken ct) =>
+        {
+            var turns = SessionRuleWire.Turns(body);
+            if (turns.Count == 0)
+                return Results.Json(
+                    new { error = "say what you want the rule to do - there is nothing here to turn into one." },
+                    statusCode: StatusCodes.Status400BadRequest);
+
+            // The screen they captured, when they captured one. It is what turns "guess what the screen
+            // probably says" into "read the words off this". With it comes WHICH SESSION it came from -
+            // the agent and the machine - because the same trouble prints different words on different
+            // agents, and because a rule written against a session is for that session's agent by default.
+            // "allAgents" is the star: the account saying this one is for every agent.
+            var origin = new RuleSessionOrigin(
+                RuleCallJson.Text(body, "sessionAgent") ?? "",
+                RuleCallJson.Text(body, "sessionMachine") ?? "");
+            var allAgents = body.ValueKind == JsonValueKind.Object
+                && body.TryGetProperty("allAgents", out var star)
+                && star.ValueKind == JsonValueKind.True;
+            var reading = await author.DraftAsync(
+                currentTenant(), turns, ct, RuleCallJson.Text(body, "screen") ?? "", origin, allAgents);
+
+            if (reading.Proposal is not null)
+            {
+                FileLog.Write("[SessionRuleEndpoints] POST /gateway/rules/draft: drafted a rule to confirm");
+                return Results.Json(SessionRuleWire.Project(reading.Proposal));
+            }
+
+            if (reading.Question is not null)
+            {
+                FileLog.Write("[SessionRuleEndpoints] POST /gateway/rules/draft: asked a question back");
+                return Results.Json(new { question = reading.Question });
+            }
+
+            // A DRAFT THAT COULD NOT BE MADE SAYS SO. It never degrades into a rule assembled out of the
+            // parts that could be read - a rule nobody meant is worse than no rule.
+            FileLog.Write($"[SessionRuleEndpoints] POST /gateway/rules/draft REFUSED: {reading.Refusal}");
+            return Results.Json(new { error = reading.Refusal }, statusCode: StatusCodes.Status400BadRequest);
+        });
+
         // Every rule this account has, newest first - the account's own sentences.
         app.MapGet("/gateway/rules", () => Results.Json(new { rules = store.All().Select(SessionRuleWire.Project).ToList() }));
 

--- a/src/CcDirector.Gateway/Api/SessionRuleWire.cs
+++ b/src/CcDirector.Gateway/Api/SessionRuleWire.cs
@@ -68,6 +68,13 @@ internal static class SessionRuleWire
     /// output would have been read as permission to act on everything. Now: the string "all-sessions" is
     /// the explicit way to say every session, an object naming at least one part is a narrower scope, and
     /// anything else is null, which the store refuses with a reason.
+    ///
+    /// A PART THAT IS THERE AND EMPTY IS A PART THAT WAS NOT SAID. This is the hole the check below used
+    /// to have: a null or an empty string was read as the empty-string VALUE, so an object whose four
+    /// parts were all null was not equal to the empty one, came through as a narrow scope of four empty
+    /// strings, and was then blanked back to four nulls by the store - which is every session the account
+    /// has, produced by a request that chose nothing. It is exactly the shape something filling the fields
+    /// in without knowing the answers produces.
     /// </summary>
     internal static RuleScope? ReadScope(JsonElement body)
     {
@@ -81,14 +88,21 @@ internal static class SessionRuleWire
         if (scope.ValueKind != JsonValueKind.Object) return null;
 
         var built = new RuleScope(
-            RuleCallJson.Text(scope, "agent"),
-            RuleCallJson.Text(scope, "repository"),
-            RuleCallJson.Text(scope, "machine"),
-            RuleCallJson.Text(scope, "mission"));
+            Part(scope, "agent"),
+            Part(scope, "repository"),
+            Part(scope, "machine"),
+            Part(scope, "mission"));
 
         // An object with nothing in it is not a choice of "all sessions"; it is the same omission wearing
         // a pair of braces.
         return built == RuleScope.AllSessions ? null : built;
+    }
+
+    /// <summary>One part of a scope: what it names, or null when it names nothing.</summary>
+    private static string? Part(JsonElement scope, string name)
+    {
+        var value = RuleCallJson.Text(scope, name);
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
     }
 
     internal static IReadOnlyList<string> Strings(JsonElement body, string name)
@@ -117,4 +131,100 @@ internal static class SessionRuleWire
 
     internal static int Number(JsonElement body, string name) =>
         body.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.Number ? value.GetInt32() : 0;
+
+    // ---- authoring by conversation ------------------------------------------------------------------
+
+    /// <summary>
+    /// A drafted rule, as the account receives it: what it would actually do in plain words, and the rule
+    /// itself.
+    ///
+    /// THE RULE HERE IS EXACTLY THE BODY THE WRITING ROUTE TAKES, and that is the point rather than a
+    /// convenience. Confirming a drafted rule is posting it back unchanged, so the thing the person read
+    /// and the thing that gets stored are the same document - there is no second translation step in which
+    /// a scope or a check could quietly become something else. A test round-trips it through the readers
+    /// above and into the real store.
+    /// </summary>
+    internal static object Project(RuleProposal proposal) => new
+    {
+        readBack = proposal.ReadBack,
+        rule = WriteBody(proposal),
+        // The screen it was made from, returned so the page can show what the rule was checked against.
+        // Every trigger word above was verified to appear in THIS text before the rule was offered.
+        exampleScreen = proposal.ExampleScreen,
+    };
+
+    /// <summary>The drafted rule written the way a caller writes one.</summary>
+    internal static object WriteBody(RuleProposal proposal) => new
+    {
+        instruction = proposal.Instruction,
+        screenDescription = proposal.ScreenDescription,
+        triggerWords = proposal.TriggerWords,
+        checks = proposal.Calls.Select(AsWritten).ToList(),
+        scope = ScopeAsWritten(proposal.Scope),
+        cooldownSeconds = proposal.CooldownSeconds,
+        dailyCap = proposal.DailyCap,
+    };
+
+    /// <summary>
+    /// One check written the way <see cref="RuleCallJson.ReadCall"/> reads one: a name, and an argument per
+    /// parameter whose value is either written out, a list of written-out terms, or a runtime input in
+    /// angle brackets. The angle-bracket notation is the same one the question to the model uses and the
+    /// same one the firing record prints, so there is one notation in this feature and not three.
+    /// </summary>
+    private static object AsWritten(RulePrimitiveCall call)
+    {
+        var arguments = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var argument in call.Arguments ?? new List<RuleArgument>())
+        {
+            arguments[argument.Parameter] = argument.Source == InputWireValue
+                ? "<" + string.Join(",", argument.Values) + ">"
+                : argument.Values.Count == 1 ? argument.Values[0] : argument.Values.Cast<object?>().ToList();
+        }
+        return new { name = call.Name, arguments };
+    }
+
+    /// <summary>How a runtime-input argument says so.</summary>
+    private static readonly string InputWireValue = RuleWireNames.ToWireName(nameof(RuleArgumentSource.Input));
+
+    /// <summary>
+    /// The scope written so <see cref="ReadScope"/> reads back the same scope. Every session is the string
+    /// that says so; a narrower scope names ONLY the parts that are set, because a part written as null
+    /// comes back as an empty string rather than as "any", and an object of empty strings is a scope that
+    /// matches nothing.
+    /// </summary>
+    private static object ScopeAsWritten(RuleScope scope)
+    {
+        if (scope == RuleScope.AllSessions) return AllSessionsWireValue;
+
+        var parts = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (!string.IsNullOrWhiteSpace(scope.Agent)) parts["agent"] = scope.Agent;
+        if (!string.IsNullOrWhiteSpace(scope.Repository)) parts["repository"] = scope.Repository;
+        if (!string.IsNullOrWhiteSpace(scope.Machine)) parts["machine"] = scope.Machine;
+        if (!string.IsNullOrWhiteSpace(scope.Mission)) parts["mission"] = scope.Mission;
+        return parts;
+    }
+
+    /// <summary>
+    /// The conversation so far. A turn that does not say who said it is read as the PERSON, because the
+    /// person is who the account is - reading an unlabelled turn as the product would put words in the
+    /// account's mouth that it never said, and the instruction is assembled from what the person said.
+    /// </summary>
+    internal static IReadOnlyList<RuleDraftTurn> Turns(JsonElement body)
+    {
+        if (body.ValueKind != JsonValueKind.Object
+            || !body.TryGetProperty("turns", out var array)
+            || array.ValueKind != JsonValueKind.Array)
+            return Array.Empty<RuleDraftTurn>();
+
+        var turns = new List<RuleDraftTurn>();
+        foreach (var entry in array.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Object) continue;
+            var who = (RuleCallJson.Text(entry, "who") ?? "").Trim().ToLowerInvariant();
+            turns.Add(new RuleDraftTurn(
+                who == RuleDraftSpeakers.DevThrottle ? RuleDraftSpeakers.DevThrottle : RuleDraftSpeakers.Person,
+                RuleCallJson.Text(entry, "text") ?? ""));
+        }
+        return turns;
+    }
 }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Net;
 using System.Text.Json;
 using CcDirector.Core;
@@ -3428,7 +3428,22 @@ public sealed class GatewayHost : IAsyncDisposable
         // The standing instructions an account gives about its sessions, and the record of every firing
         // (Session Rules mission). A device-authed client route under the "/gateway/..." prefix, gated by
         // the host-wide token middleware like every other client data endpoint.
-        Api.SessionRuleEndpoints.Map(_app, _sessionRules);
+        // The authoring conversation asks the SAME model in the SAME role the evaluator asks, and is
+        // wired to the brain DIRECTLY rather than through the evaluator's AskAgentAsync. That looks like
+        // duplication and is not: the evaluator's seam swallows every failure into "no answer", which is
+        // right for an unattended pass nobody is waiting on, and wrong here - a person IS waiting, and
+        // being told "the model gave no answer" after sixty seconds of silence hides the one fact they
+        // need, which is that it ran out of time and trying again usually works. RuleAuthor classifies
+        // the failure, so it has to be able to see it.
+        var ruleAuthor = new Rules.RuleAuthor(
+            async (tenant, prompt, ct) =>
+            {
+                using var brain = await WingmanBrainAsync(tenant, Core.Configuration.WingmanModelRole.Thinking, ct)
+                    .ConfigureAwait(false);
+                var answer = await brain.AskAsync(prompt, ct).ConfigureAwait(false);
+                return answer?.Text;
+            });
+        Api.SessionRuleEndpoints.Map(_app, _sessionRules, ruleAuthor, () => _tenantContext.Current);
 
         // Workflow runs (phase 4, issue #1771): the outcome spine's REST surface. One row per
         // execution of a workflow, pinned to the exact published version that governed it.

--- a/src/CcDirector.Gateway/Rules/RuleAgentContract.cs
+++ b/src/CcDirector.Gateway/Rules/RuleAgentContract.cs
@@ -51,10 +51,17 @@ public static class RuleAgentContract
     /// that exist, and the exact shape of the answer.
     /// </summary>
     /// <exception cref="ArgumentNullException">The registry is null.</exception>
+    /// <param name="facts">The session being judged, when known. ONLY the agent is taken from it: a screen
+    /// means something relative to the agent that printed it, so the judge is told which one. The machine,
+    /// the repository and the clock are NOT put in the question - ruling A11 says the screen is the only
+    /// input to the decision, and <c>RuleEvaluatorTests</c> asserts the machine name stays out. The agent
+    /// does not decide WHETHER the instruction applies (scope already removed every other agent's session
+    /// before this was asked); it decides how the screen is read.</param>
     public static string BuildPrompt(
         IReadOnlyList<SessionRule> candidates,
         IReadOnlyList<string> screenRows,
-        RulePrimitiveRegistry registry)
+        RulePrimitiveRegistry registry,
+        RuleSessionFacts? facts = null)
     {
         if (registry is null) throw new ArgumentNullException(nameof(registry));
 
@@ -79,6 +86,12 @@ public static class RuleAgentContract
         }
         sb.AppendLine("--- end of instructions ---");
         sb.AppendLine();
+
+        if (facts is not null && !string.IsNullOrWhiteSpace(facts.Agent))
+        {
+            sb.AppendLine($"The session is running the agent {facts.Agent}. Read the screen as that agent's screen.");
+            sb.AppendLine();
+        }
 
         sb.AppendLine("--- the session's screen ---");
         foreach (var line in Tail(screenRows, ScreenTailLines)) sb.AppendLine(line);

--- a/src/CcDirector.Gateway/Rules/RuleAuthor.cs
+++ b/src/CcDirector.Gateway/Rules/RuleAuthor.cs
@@ -1,0 +1,172 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Data.Entities;
+
+namespace CcDirector.Gateway.Rules;
+
+/// <summary>
+/// MAKING A RULE BY TALKING. The account says what it wants in ordinary words, a model works out what the
+/// product needs to hold - what the screen looks like, the cheap words that make it worth a closer look,
+/// any check the act depends on, which sessions, and the two ceilings - and the result is handed BACK to
+/// the person to confirm.
+///
+/// NOTHING HERE WRITES. This type has no store, no database and no session; it asks a model a question and
+/// reads the answer. The proposal it returns is exactly the body the writing route already takes, so the
+/// person confirming a rule is the person posting it, and the rule that is stored is stored in dry run
+/// like every other rule. A person then promotes it. Both of the confirmations that already existed are
+/// untouched, and this adds no third way into the table.
+///
+/// A PROPOSAL IS CHECKED AGAINST THE SAME GATE THE STORE USES BEFORE IT IS SHOWN. It would be worse than
+/// useless to put a rule in front of somebody, have them agree to it, and only then discover the writing
+/// route will not take it - they would have confirmed something that never existed. So the assembled rule
+/// is run through <see cref="SessionRuleRecordRules.CheckRule"/>, the one implementation the store and the
+/// database write gate both call, and a rule that would be refused there is refused HERE, in the same
+/// words, before anybody is asked to agree to it.
+///
+/// A MODEL THAT CANNOT BE ASKED PRODUCES A REFUSAL, NEVER A RULE. There is no default rule, no partial
+/// rule and no rule assembled out of what could be read; a draft that could not be made says so.
+///
+/// AND IT SAYS WHICH KIND OF "COULD NOT". Running out of time is not the same event as answering
+/// nothing, and collapsing them costs the person the one thing they need to know: whether trying again
+/// is worth it. Measured on the hosted model on 3 September 2026, the same sentence asked five times
+/// ran out of the sixty-second limit three times and answered twice - so a person who is told "the
+/// model gave no answer at all" after waiting a minute is being told something true about the call and
+/// misleading about their situation. The timeout is reported as a timeout, and it says to try again.
+/// </summary>
+public sealed class RuleAuthor
+{
+    private readonly Func<TenantId, string, CancellationToken, Task<string?>> _ask;
+    private readonly RulePrimitiveRegistry _registry;
+
+    /// <param name="ask">Asks the model a question and returns what it said, or null when it could not be
+    /// asked. The same narrow seam the evaluator uses - deliberately not the whole environment, which can
+    /// type into a session.</param>
+    /// <param name="registry">The verified checks a rule may name. Defaults to what the product ships.</param>
+    /// <exception cref="ArgumentNullException">The asking seam is null.</exception>
+    public RuleAuthor(
+        Func<TenantId, string, CancellationToken, Task<string?>> ask,
+        RulePrimitiveRegistry? registry = null)
+    {
+        _ask = ask ?? throw new ArgumentNullException(nameof(ask));
+        _registry = registry ?? RulePrimitiveRegistry.Default;
+    }
+
+    /// <summary>
+    /// Turn what has been said so far into a rule to confirm, a question to answer, or a stated refusal.
+    /// </summary>
+    /// <param name="tenant">The account the rule would belong to.</param>
+    /// <param name="turns">The conversation so far. It has to contain something the person said.</param>
+    /// <param name="ct">Cancellation.</param>
+    /// <param name="exampleScreen">A REAL screen the account captured from a session, or empty. When it is
+    /// present the model reads the trigger words off it instead of imagining them, and a word that is not
+    /// on it is refused - see <see cref="RuleDraftContract"/>.</param>
+    /// <param name="origin">The session the screen came from, or none. Decides the agent part of the
+    /// scope - see <see cref="RuleDraftContract"/>.</param>
+    /// <param name="allAgents">The account said this rule is for every agent (the star).</param>
+    public async Task<RuleDraftReading> DraftAsync(
+        TenantId tenant,
+        IReadOnlyList<RuleDraftTurn> turns,
+        CancellationToken ct,
+        string exampleScreen = "",
+        RuleSessionOrigin? origin = null,
+        bool allAgents = false)
+    {
+        // THE INSTRUCTION IS THE PERSON'S OWN WORDS AND NOT THE MODEL'S. The store treats the instruction
+        // as the authority, so it is assembled here from what the person actually said rather than read
+        // out of the reply - a model asked to restate a sentence will eventually improve it, and an
+        // improved authority is a different authority.
+        var said = (turns ?? Array.Empty<RuleDraftTurn>())
+            .Where(t => t is not null && !string.Equals(t.Who, RuleDraftSpeakers.DevThrottle, StringComparison.Ordinal))
+            .Select(t => (t.Text ?? "").Trim())
+            .Where(t => t.Length > 0)
+            .ToList();
+
+        if (said.Count == 0)
+            return RuleDraftReading.Refused(
+                "there is nothing here that you said, and a rule is the sentence you said - so there is " +
+                "nothing to turn into one.");
+
+        var instruction = string.Join(" ", said);
+
+        FileLog.Write($"[RuleAuthor] DraftAsync: turns={turns!.Count}, instruction length={instruction.Length}");
+
+        var prompt = RuleDraftContract.BuildDraftPrompt(turns, _registry, exampleScreen, origin, allAgents);
+
+        string? raw;
+        try
+        {
+            raw = await _ask(tenant, prompt, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // The CALLER gave up, which is not a failure to report back to them.
+            throw;
+        }
+        catch (TimeoutException ex)
+        {
+            FileLog.Write($"[RuleAuthor] DraftAsync: the model ran out of time: {ex.Message}");
+            return RuleDraftReading.Refused(
+                "working out this rule took longer than the model is given, so nothing was drafted and " +
+                "nothing was stored. This one is worth trying again - the same sentence often works on " +
+                "the next attempt.");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[RuleAuthor] DraftAsync: the model could not be asked: {ex.Message}");
+            return RuleDraftReading.Refused(
+                "the model could not be asked, so no rule was drafted and nothing was stored (" +
+                ex.Message + ").");
+        }
+
+        var reading = RuleDraftContract.Read(raw, instruction, _registry, exampleScreen, origin, allAgents);
+        if (reading.Proposal is null)
+        {
+            FileLog.Write($"[RuleAuthor] DraftAsync: no proposal (question={reading.Question is not null})");
+            return reading;
+        }
+
+        var refusal = WhyTheStoreWouldRefuse(reading.Proposal);
+        if (refusal is not null)
+        {
+            FileLog.Write($"[RuleAuthor] DraftAsync REFUSED by the write gate: {refusal}");
+            return RuleDraftReading.Refused(
+                "the rule that was drafted is not one that could be stored, so it is not being offered to " +
+                "you: " + refusal);
+        }
+
+        FileLog.Write($"[RuleAuthor] DraftAsync: proposed a rule with {reading.Proposal.TriggerWords.Count} trigger words");
+        return reading;
+    }
+
+    /// <summary>
+    /// What the store would say if this proposal were written, or null when it would take it. The rule is
+    /// assembled exactly as <see cref="SessionRuleStore.Create"/> assembles one and handed to the same
+    /// check, so there is no second opinion here about what a rule is.
+    /// </summary>
+    private string? WhyTheStoreWouldRefuse(RuleProposal proposal)
+    {
+        var candidate = new SessionRuleEntity
+        {
+            Instruction = proposal.Instruction,
+            ScreenDescription = proposal.ScreenDescription,
+            TriggerWords = proposal.TriggerWords.ToList(),
+            Calls = proposal.Calls.ToList(),
+            ScopeAgent = proposal.Scope.Agent,
+            ScopeRepository = proposal.Scope.Repository,
+            ScopeMachine = proposal.Scope.Machine,
+            ScopeMission = proposal.Scope.Mission,
+            CooldownSeconds = proposal.CooldownSeconds,
+            DailyCap = proposal.DailyCap,
+        };
+
+        try
+        {
+            SessionRuleRecordRules.CheckRule(candidate, _registry);
+            return null;
+        }
+        catch (RuleRejectedException ex)
+        {
+            return ex.Reason;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Rules/RuleDraftContract.cs
+++ b/src/CcDirector.Gateway/Rules/RuleDraftContract.cs
@@ -1,0 +1,405 @@
+using System.Text;
+using System.Text.Json;
+using CcDirector.Gateway.Api;
+
+namespace CcDirector.Gateway.Rules;
+
+/// <summary>Who said one thing in an authoring conversation. A closed set, because the prompt renders the
+/// two sides differently and a third speaker would silently be rendered as one of them.</summary>
+public static class RuleDraftSpeakers
+{
+    /// <summary>The account holder, in their own words. This is the authority.</summary>
+    public const string Person = "person";
+
+    /// <summary>What DevThrottle asked back, so the model can see the question its answer belongs to.</summary>
+    public const string DevThrottle = "devthrottle";
+}
+
+/// <summary>What the model may answer when it is asked to turn a sentence into a rule.</summary>
+public static class RuleDraftAnswers
+{
+    /// <summary>It has a rule to propose.</summary>
+    public const string Propose = "propose";
+
+    /// <summary>It cannot write the rule yet and needs one thing answered first.</summary>
+    public const string Ask = "ask";
+}
+
+/// <summary>One thing that was said while a rule was being worked out.</summary>
+/// <param name="Who">One of <see cref="RuleDraftSpeakers"/>.</param>
+/// <param name="Text">What was said.</param>
+public sealed record RuleDraftTurn(string Who, string Text);
+
+/// <summary>
+/// The session a captured screen came from - the two facts the engine already holds about every session
+/// that change what a screen MEANS. A usage-limit notice on Claude Code reads "Claude usage limit
+/// reached"; on Codex or Gemini it reads something else, so a rule's trigger words are agent-specific
+/// whether anyone says so or not. Empty means the rule was written from memory, with no session.
+/// </summary>
+public sealed record RuleSessionOrigin(string Agent, string Machine)
+{
+    /// <summary>No session: the rule is being described from memory.</summary>
+    public static RuleSessionOrigin None { get; } = new("", "");
+
+    /// <summary>Whether a real session is known.</summary>
+    public bool IsKnown => !string.IsNullOrWhiteSpace(Agent);
+}
+
+/// <summary>
+/// A rule the model has worked out from what the account said, NOT YET STORED and not yet live.
+///
+/// <see cref="Instruction"/> is deliberately not something the model produces: it is the account's own
+/// words, carried through unchanged, because the store treats the instruction as the authority and a model
+/// rewrite of it would make the authority a paraphrase. Everything else here is derived from those words
+/// and is checked against the same gate that guards the store before this record is ever handed back.
+/// </summary>
+public sealed record RuleProposal(
+    string Instruction,
+    string ExampleScreen,
+    string ScreenDescription,
+    IReadOnlyList<string> TriggerWords,
+    IReadOnlyList<RulePrimitiveCall> Calls,
+    RuleScope Scope,
+    int CooldownSeconds,
+    int DailyCap,
+    string ReadBack);
+
+/// <summary>
+/// The answer to one authoring turn: a rule to confirm, a question to answer, or a stated refusal. Exactly
+/// one of the three is set.
+///
+/// A QUESTION IS A FIRST-CLASS ANSWER, exactly as a decline is for the evaluator. A model that does not
+/// know which sessions a rule is for must be able to say so; the alternative is a model that picks the
+/// widest scope it can and hands back something the account did not ask for.
+/// </summary>
+public sealed record RuleDraftReading(RuleProposal? Proposal, string? Question, string? Refusal)
+{
+    /// <summary>A rule to put in front of the person.</summary>
+    public static RuleDraftReading Proposed(RuleProposal proposal) => new(proposal, null, null);
+
+    /// <summary>One thing that has to be answered before a rule can be written.</summary>
+    public static RuleDraftReading Asked(string question) => new(null, question, null);
+
+    /// <summary>Nothing was drafted, and this is why, in words the account reads.</summary>
+    public static RuleDraftReading Refused(string reason) => new(null, null, reason);
+}
+
+/// <summary>
+/// THE AUTHORING CALL: the account says a sentence, and a model turns it into a rule the product can
+/// actually hold. This is the half the Session Rules mission named as missing - until it existed the
+/// trigger words and the checks had to be worked out by hand, while the store refused a rule without them
+/// on the stated grounds that "the words are worked out from the instruction, not chosen by hand".
+///
+/// IT IS A SECOND CALL AND NOT THE EVALUATOR'S. <see cref="RuleAgentContract"/> asks whether a standing
+/// instruction reaches a screen that exists now. This one asks what a standing instruction IS, before any
+/// screen exists. They share the registry, the argument notation and the reader for a check written as
+/// JSON, so a check means one thing in this feature; they share nothing else, because the questions are
+/// not the same question.
+///
+/// WHAT IS OFFERED IS WHAT MAY BE NAMED, exactly as at evaluation time. The checks in the question are
+/// read off the derived registry, so the question can never advertise a check we do not ship, and a reply
+/// naming one that is not in the registry - or handing it the wrong arguments - is refused by the SAME
+/// validator that guards the store.
+///
+/// NOTHING HERE IS SHAPED AROUND ONE KIND OF TROUBLE. The mission that built the evaluator was
+/// demonstrated on a provider allowance notice, and the temptation is to write this question as though an
+/// allowance notice were what a rule is for. It is not: an account may just as well be describing a
+/// provider that has stopped answering, a session sitting on a question, or a build that failed the same
+/// way twice. The question below names no kind of trouble as the expected one, and deliberately carries no
+/// worked example, because an example is the fastest way to make every rule an account writes come back
+/// shaped like the example.
+///
+/// THE REPLY IS NEVER STORED FROM HERE. This type reads an answer; it writes nothing. A person posts the
+/// proposal to the writing route, which stores it in dry run, and a person promotes it after that. Both
+/// confirmations that already existed are still there, and this adds no third path into the store.
+/// </summary>
+public static class RuleDraftContract
+{
+    /// <summary>
+    /// Build the question that turns what the account said into a rule: what a rule is made of, the
+    /// conversation so far, the checks that exist, and the exact shape of the answer.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The registry is null.</exception>
+    /// <param name="turns">The conversation so far.</param>
+    /// <param name="registry">The checks this build ships.</param>
+    /// <param name="exampleScreen">The REAL screen the account captured, or empty when they wrote the rule
+    /// without one. When it is present the trigger words are read off it rather than imagined - see the
+    /// note on this type.</param>
+    /// <param name="origin">The session the screen came from, when there is one. The model is told which
+    /// agent it is looking at so its words fit THAT agent's screens, and told that the agent scope is
+    /// already decided - see <paramref name="allAgents"/>.</param>
+    /// <param name="allAgents">The account said this rule is for every agent (the star). Otherwise a rule
+    /// written against a session is for that session's agent alone, which is the default the owner set:
+    /// trigger words are agent-specific, so a rule that claims every agent with one agent's words silently
+    /// never fires on the others while looking correct in the list.</param>
+    public static string BuildDraftPrompt(
+        IReadOnlyList<RuleDraftTurn> turns,
+        RulePrimitiveRegistry registry,
+        string exampleScreen = "",
+        RuleSessionOrigin? origin = null,
+        bool allAgents = false)
+    {
+        if (registry is null) throw new ArgumentNullException(nameof(registry));
+        origin ??= RuleSessionOrigin.None;
+
+        var sb = new StringBuilder();
+        sb.AppendLine("Somebody is telling you what they want their coding sessions to do without them. Turn");
+        sb.AppendLine("what they said into a standing instruction the product can hold, or ask them the ONE thing");
+        sb.AppendLine("you need to know before you can.");
+        sb.AppendLine();
+        sb.AppendLine("A standing instruction works like this. When one of their sessions stops and goes idle, the");
+        sb.AppendLine("tail of its terminal screen is read. If any of the instruction's trigger words is on that");
+        sb.AppendLine("screen, a model is asked whether the instruction reaches this screen, and if it does, the");
+        sb.AppendLine("model composes text and it is typed into the session. So the trigger words are a cheap");
+        sb.AppendLine("first filter and not the decision: they decide what is worth looking at closely.");
+        sb.AppendLine();
+        sb.AppendLine("The instruction can be about anything a session's screen can show once it has stopped. Do");
+        sb.AppendLine("not assume you know which kind of trouble is meant, and do not widen what they said: if");
+        sb.AppendLine("they described one situation, the rule is about that situation and not about the family of");
+        sb.AppendLine("situations it belongs to.");
+        sb.AppendLine();
+        sb.AppendLine("You are NOT asked to restate their instruction. Their own words are kept as written.");
+        sb.AppendLine();
+
+        sb.AppendLine("--- what has been said so far ---");
+        foreach (var turn in turns ?? Array.Empty<RuleDraftTurn>())
+        {
+            var who = string.Equals(turn?.Who, RuleDraftSpeakers.DevThrottle, StringComparison.Ordinal)
+                ? "you asked"
+                : "they said";
+            sb.AppendLine($"{who}: {(turn?.Text ?? "").Trim()}");
+        }
+        sb.AppendLine("--- end of what has been said ---");
+        sb.AppendLine();
+
+        // THE REAL SCREEN, WHEN THERE IS ONE. Without it the model is guessing what the screen will say,
+        // and it guesses plausibly and wrongly: asked about a provider outage with no screen, a live model
+        // proposed ECONNREFUSED, ETIMEDOUT and 429 as the words to watch for - reasonable-sounding strings
+        // that a coding agent's screen may never print. A rule whose trigger words are not on the screen
+        // never fires, and looks perfectly good sitting in the list.
+        var screen = (exampleScreen ?? "").Trim();
+        if (screen.Length > 0)
+        {
+            sb.AppendLine("They captured this screen from a real session. It is an EXAMPLE of the situation");
+            sb.AppendLine("they mean.");
+            if (origin.IsKnown)
+            {
+                // WHICH AGENT, said plainly. The same trouble prints different words on different agents,
+                // so a model that does not know which one it is looking at cannot know which words are
+                // this agent's and which are universal.
+                sb.AppendLine($"The session is running the agent {origin.Agent}" +
+                              (string.IsNullOrWhiteSpace(origin.Machine) ? "." : $" on the machine {origin.Machine}."));
+                sb.AppendLine(allAgents
+                    ? "They said this rule is for EVERY agent, so choose words that any agent's screen would show."
+                    : $"This rule is for {origin.Agent} sessions only - that is already decided, do not put an agent in " +
+                      "the scope yourself. Choose words as they appear on THIS agent's screens.");
+            }
+            sb.AppendLine();
+            sb.AppendLine("--- the screen they captured ---");
+            foreach (var line in Tail(screen)) sb.AppendLine(line);
+            sb.AppendLine("--- end of the captured screen ---");
+            sb.AppendLine();
+            sb.AppendLine("TAKE THE TRIGGER WORDS FROM THIS SCREEN, word for word. Every one has to appear on");
+            sb.AppendLine("it exactly as written above - do not invent likely-looking error strings, and do not");
+            sb.AppendLine("tidy the spelling or the case. Choose words that would NOT be on an ordinary screen.");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("You may ask for any of these checks to be run when the rule fires. They are the ONLY checks");
+        sb.AppendLine("that exist; you cannot write code and you cannot invent one. Ask for a check only when its");
+        sb.AppendLine("answer is a condition the act depends on - a check whose plain yes-or-no answer is no will");
+        sb.AppendLine("stop the act. Most instructions need none at all, and none is a perfectly good answer.");
+        foreach (var primitive in registry.Primitives)
+        {
+            sb.AppendLine($"  {primitive.Name}({string.Join(", ", primitive.Parameters.Select(p => p.Name))}) - {primitive.Summary}");
+        }
+        sb.AppendLine();
+        sb.AppendLine("An argument's value is either written out, or one of these things read when the rule runs,");
+        sb.AppendLine("written in angle brackets: " + string.Join(", ", RuleInputs.Names.Select(n => "<" + n + ">")) + ".");
+        sb.AppendLine();
+
+        sb.AppendLine("The two ceilings are what stop a rule that is wrong from being wrong forever, so each has to");
+        sb.AppendLine("be a real number greater than zero, chosen for THIS instruction. The cooldown is also the");
+        sb.AppendLine("waiting: an instruction that should leave something alone for a while and then try again is");
+        sb.AppendLine("an instruction with a long cooldown.");
+        sb.AppendLine();
+
+        sb.AppendLine("Answer with JSON and nothing else, in exactly this shape:");
+        sb.AppendLine("{");
+        sb.AppendLine($"  \"answer\": \"{RuleDraftAnswers.Propose}\" or \"{RuleDraftAnswers.Ask}\",");
+        sb.AppendLine($"  \"question\": \"the one thing you need answered (only when the answer is {RuleDraftAnswers.Ask})\",");
+        sb.AppendLine("  \"screen_description\": \"what the screen looks like when this instruction applies, in plain words\",");
+        sb.AppendLine("  \"trigger_words\": [\"words that would be on such a screen and not on an ordinary one\"],");
+        sb.AppendLine("  \"checks\": [ { \"name\": \"a check from the list above\", \"arguments\": { \"parameter\": \"value\" } } ],");
+        sb.AppendLine($"  \"scope\": \"{SessionRuleWire.AllSessionsWireValue}\", or an object with any of agent, repository, machine, mission,");
+        sb.AppendLine("  \"cooldown_seconds\": how long to wait before acting on the same session again,");
+        sb.AppendLine("  \"daily_cap\": how many times a day it may act on one session,");
+        sb.AppendLine("  \"read_back\": \"what will actually happen, in two or three sentences, addressed to them\"");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Read the model's answer, refusing anything that names something it was not offered. Every refusal
+    /// says what was wrong in words the account reads.
+    /// </summary>
+    /// <param name="raw">What the model said.</param>
+    /// <param name="instruction">The account's own words, which become the rule's instruction unchanged.</param>
+    /// <param name="registry">The checks this build ships.</param>
+    /// <exception cref="ArgumentNullException">The registry is null.</exception>
+    public static RuleDraftReading Read(
+        string? raw,
+        string instruction,
+        RulePrimitiveRegistry registry,
+        string exampleScreen = "",
+        RuleSessionOrigin? origin = null,
+        bool allAgents = false)
+    {
+        if (registry is null) throw new ArgumentNullException(nameof(registry));
+        origin ??= RuleSessionOrigin.None;
+
+        if (string.IsNullOrWhiteSpace(raw))
+            return RuleDraftReading.Refused(
+                "the model gave no answer at all, so no rule was drafted and nothing was stored.");
+
+        var json = OnlyTheJson(raw);
+        if (json is null)
+            return RuleDraftReading.Refused(
+                "the model's answer was not the answer shape that was asked for, so it was not read as a " +
+                "rule. It said: " + Shorten(raw));
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            return RuleDraftReading.Refused(
+                "the model's answer could not be read as the answer shape that was asked for (" +
+                ex.Message + "). It said: " + Shorten(raw));
+        }
+
+        using (document)
+        {
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return RuleDraftReading.Refused(
+                    "the model's answer was not the answer shape that was asked for. It said: " + Shorten(raw));
+
+            var answer = (RuleCallJson.Text(root, "answer") ?? "").Trim().ToLowerInvariant();
+            if (answer != RuleDraftAnswers.Propose && answer != RuleDraftAnswers.Ask)
+                return RuleDraftReading.Refused(
+                    $"the model answered '{Shorten(answer)}', and the only answers there are are " +
+                    $"'{RuleDraftAnswers.Propose}' and '{RuleDraftAnswers.Ask}'.");
+
+            if (answer == RuleDraftAnswers.Ask)
+            {
+                var question = (RuleCallJson.Text(root, "question") ?? "").Trim();
+                // A QUESTION WITH NOTHING IN IT IS NOT A QUESTION. Read as one it would put an empty
+                // prompt in front of the account, who would have nothing to answer and no way to tell that
+                // from the product having failed.
+                return question.Length == 0
+                    ? RuleDraftReading.Refused(
+                        "the model said it needed something answered and then asked nothing, so there is " +
+                        "nothing to put in front of you and no rule was drafted.")
+                    : RuleDraftReading.Asked(question);
+            }
+
+            var checks = RuleCallJson.ReadChecks(root, "checks", required: true, out var checksProblem);
+            if (checks is null)
+                return RuleDraftReading.Refused("the drafted rule does not say what it wants checked: " + checksProblem);
+
+            var validation = RuleCallValidator.ValidateAll(checks, registry);
+            if (!validation.IsValid)
+                return RuleDraftReading.Refused("the drafted rule asks for a check that cannot be run: " + validation.Reason);
+
+            // THE SAME SCOPE READER THE WRITING ROUTE USES. An absent or empty scope comes back null here
+            // exactly as it does there, and is refused rather than being read as every session the account
+            // has - the fail-open that reading omitted as widest would be.
+            var scope = SessionRuleWire.ReadScope(root);
+            if (scope is null)
+                return RuleDraftReading.Refused(
+                    "the drafted rule does not say which sessions it may act on. Every session is a choice " +
+                    "that can be made, but it has to be said, so nothing was drafted.");
+
+            // THE AGENT PART OF THE SCOPE IS OURS TO DECIDE, NOT THE MODEL'S. When the screen came from a
+            // known session, the rule is for that session's agent unless the account said "every agent" -
+            // whatever the model wrote. It is a fact we hold, so asking a model to guess it and then
+            // checking the guess would be the long way round to the same answer with a failure mode added.
+            if (origin.IsKnown)
+                scope = scope with { Agent = allAgents ? null : origin.Agent };
+
+            // A PROPOSAL NOBODY CAN READ IS NOT A PROPOSAL. The read-back is the whole point of this step:
+            // it is what the person confirms. A rule offered without one would be asking somebody to agree
+            // to a list of trigger words.
+            var readBack = (RuleCallJson.Text(root, "read_back") ?? "").Trim();
+            if (readBack.Length == 0)
+                return RuleDraftReading.Refused(
+                    "the drafted rule does not say what it would actually do, and a rule you cannot read " +
+                    "back is a rule you cannot agree to. Nothing was drafted.");
+
+            var triggerWords = SessionRuleWire.Strings(root, "trigger_words");
+
+            // THE WORDS HAVE TO BE ON THE SCREEN THEY WERE TAKEN FROM. This is the whole value of
+            // capturing one: a word that is not on the example is a word the model invented, and a rule
+            // whose trigger words never appear is a rule that sits in the list looking correct and never
+            // fires once. Refusing here is cheap; discovering it at 3am is not.
+            var screenToCheck = (exampleScreen ?? "").Trim();
+            if (screenToCheck.Length > 0)
+            {
+                var invented = triggerWords
+                    .Where(w => !string.IsNullOrWhiteSpace(w))
+                    .Where(w => !screenToCheck.Contains(w, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                if (invented.Count > 0)
+                    return RuleDraftReading.Refused(
+                        "the drafted rule watches for words that are not on the screen you captured: " +
+                        string.Join(", ", invented.Select(w => "\"" + w + "\"")) + ". A rule only ever " +
+                        "looks at a screen, so a word that is not there is a rule that never fires. " +
+                        "Nothing was drafted.");
+            }
+
+            return RuleDraftReading.Proposed(new RuleProposal(
+                Instruction: instruction ?? "",
+                ExampleScreen: screenToCheck,
+                ScreenDescription: (RuleCallJson.Text(root, "screen_description") ?? "").Trim(),
+                TriggerWords: triggerWords,
+                Calls: checks,
+                Scope: scope,
+                CooldownSeconds: SessionRuleWire.Number(root, "cooldown_seconds"),
+                DailyCap: SessionRuleWire.Number(root, "daily_cap"),
+                ReadBack: readBack));
+        }
+    }
+
+    /// <summary>
+    /// The JSON out of a reply a chat model wrapped in prose or a fenced block, or null when there is none.
+    /// Deliberately narrow: the first open brace to the last close brace. A reply with no braces at all is
+    /// not an answer, and is refused rather than guessed at.
+    /// </summary>
+    private static string? OnlyTheJson(string raw)
+    {
+        var start = raw.IndexOf('{');
+        var end = raw.LastIndexOf('}');
+        if (start < 0 || end <= start) return null;
+        return raw[start..(end + 1)];
+    }
+
+    /// <summary>The last lines of a captured screen. A whole scrollback would bury the instruction in
+    /// text that has nothing to do with it; the tail is where a session's own state is printed.</summary>
+    private static IReadOnlyList<string> Tail(string screen, int lines = 40)
+    {
+        var rows = screen.ReplaceLineEndings("\n").Split('\n')
+            .Select(r => r.TrimEnd())
+            .Where(r => r.Length > 0)
+            .ToList();
+        return rows.Count <= lines ? rows : rows.GetRange(rows.Count - lines, lines);
+    }
+
+    private static string Shorten(string? value)
+    {
+        var text = (value ?? "").Trim().ReplaceLineEndings(" ");
+        return text.Length <= 200 ? text : text[..200] + "...";
+    }
+}

--- a/src/CcDirector.Gateway/Rules/RuleEvaluator.cs
+++ b/src/CcDirector.Gateway/Rules/RuleEvaluator.cs
@@ -263,7 +263,7 @@ public sealed class RuleEvaluator
 
         FileLog.Write($"[RuleEvaluator] sid={sessionId}: {candidates.Chosen.Count} rule(s) worth asking about");
 
-        var prompt = RuleAgentContract.BuildPrompt(candidates.Chosen, rows, _registry);
+        var prompt = RuleAgentContract.BuildPrompt(candidates.Chosen, rows, _registry, facts);
         var raw = await _env.AskAgentAsync(tenant, prompt, ct).ConfigureAwait(false);
         var reading = RuleAgentContract.Read(raw, candidates.Chosen, _registry);
 

--- a/src/CcDirector.Gateway/Speech/SpokenPaths.cs
+++ b/src/CcDirector.Gateway/Speech/SpokenPaths.cs
@@ -113,5 +113,14 @@ public static class SpokenPaths
             + "run, and the exact text to TYPE INTO A TERMINAL. Nothing it produces is spoken. The text it "
             + "yields is a keystroke, not prose, so translating it would change what is typed - the reply "
             + "is machine-read from end to end and an unreadable one is recorded as a refusal.",
+        ["RuleDraftContract.BuildDraftPrompt"] =
+            "Turns what somebody said into a standing instruction and returns JSON that code validates: a "
+            + "screen description, trigger words, checks, a scope and two ceilings. Nothing it produces is "
+            + "ever spoken. Two of its fields ARE read by a person - the question it may ask back and the "
+            + "read-back it offers for confirmation - and they are shown on a screen rather than heard, so "
+            + "the spoken contract is the wrong instrument for them; when the rule surface is built and "
+            + "those two fields have somewhere to appear, the account's language belongs on them and this "
+            + "entry should be revisited rather than left as an exemption that has quietly stopped being "
+            + "true.",
     };
 }

--- a/src/CcDirector.Gateway/Util/SessionKeyGuard.cs
+++ b/src/CcDirector.Gateway/Util/SessionKeyGuard.cs
@@ -10,6 +10,25 @@ public readonly record struct SessionKeyVerdict(bool Allowed, string Reason)
 }
 
 /// <summary>
+/// The ruling on ONE route of the session-rules surface: a session key may call it, may not call it on
+/// purpose, or nobody has classified it at all. The third state is the whole point of this type - see
+/// <see cref="SessionKeyGuard.ClassifyRuleRoute"/>.
+/// </summary>
+public enum RuleRouteRuling
+{
+    /// <summary>Nobody has ruled on this route. The guard denies it, because it is an allow list - but that
+    /// denial is the default falling through, not a decision anybody made, and the two are indistinguishable
+    /// from the outside. The route census test over the built application fails on this state.</summary>
+    Unclassified = 0,
+
+    /// <summary>A session key may call it.</summary>
+    Allowed = 1,
+
+    /// <summary>A session key may not call it, and somebody decided that rather than forgetting it.</summary>
+    RefusedOnPurpose = 2,
+}
+
+/// <summary>
 /// What a SESSION KEY may call on the Gateway (Remove-the-network-port mission, phase 1b).
 ///
 /// This began as the Gateway twin of the Director's ControlApiGuard.CheckSessionChild (deleted with the Director's listener; this guard is the surviving one), and it is written the same way and
@@ -29,7 +48,9 @@ public readonly record struct SessionKeyVerdict(bool Allowed, string Reason)
 /// spawn one, take a mission or a role, mark itself done, and read and publish the fleet's shared skills and
 /// workflows. Plus CONFIGURATION, in both directions: a Director's settings, the application's own settings
 /// (the closed <c>/gateway</c> set in <see cref="IsApplicationSetting"/>), and handovers - which are content
-/// agents produce, and which moving a session needs.
+/// agents produce, and which moving a session needs. Plus the SESSION RULES surface bar exactly one route:
+/// an agent may draft, store, read and delete a rule, and may not move one out of dry run. See
+/// <see cref="IsRuleRoute"/> for the owner's ruling and why that one exception cannot be a prefix rule.
 ///
 /// WHO IS ALLOWED IN - refused. Device registration, enrollment and revocation, because a credential that
 /// can admit a NEW device is not configuring the product, it IS the boundary, and an agent holding one could
@@ -67,15 +88,19 @@ public static class SessionKeyGuard
         var p = (path ?? "").TrimEnd('/');
         if (p.Length == 0) p = "/";
 
-        // Matched lower-cased, because ASP.NET routing matches a path case-insensitively and a guard that
-        // did not would be bypassed by /Sessions. Only the STRUCTURE is compared - the identifier segments
-        // ({sid}, {id}) are never read here - so folding their case cannot change a decision.
-        var segments = p.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        for (var i = 0; i < segments.Length; i++)
-            segments[i] = segments[i].ToLowerInvariant();
+        var segments = Segments(p);
 
         if (IsAllowed(verb, segments))
             return SessionKeyVerdict.Allow;
+
+        // A route the session-rules switch refuses ON PURPOSE answers with the reason that is actually true
+        // of it. The general sentence below talks about the admission surface, which promoting a rule is
+        // not, and an agent handed the wrong reason goes hunting the wrong problem.
+        if (RuleRoute(verb, segments) == RuleRouteRuling.RefusedOnPurpose)
+            return SessionKeyVerdict.Refuse(
+                $"a session key may not call {verb} {p}; an agent may draft, store, read and delete rules, " +
+                "but moving one out of dry run is a person's act - it is the moment a rule may start typing " +
+                "into a session");
 
         return SessionKeyVerdict.Refuse(
             $"a session key may not call {verb} {p}; it may run the fleet's agent routes and configure the " +
@@ -83,8 +108,38 @@ public static class SessionKeyGuard
             "identity, Director registration, or force-killing a Director");
     }
 
+    /// <summary>
+    /// How this guard has ruled on ONE route of the session-rules surface, for a caller that needs to tell
+    /// "refused because somebody decided to refuse it" apart from "refused because nobody has looked at it
+    /// yet". <see cref="Check"/> cannot: both are a 403 with a sentence, and that indistinguishability is
+    /// exactly how the entire rules surface shipped refused by accident with every suite green.
+    ///
+    /// A path outside <c>/gateway/rules</c> answers <see cref="RuleRouteRuling.Unclassified"/> as well -
+    /// this method rules on one surface and says nothing at all about any other.
+    /// </summary>
+    public static RuleRouteRuling ClassifyRuleRoute(string? method, string? path)
+        => RuleRoute((method ?? "").ToUpperInvariant(), Segments((path ?? "").TrimEnd('/')));
+
+    /// <summary>
+    /// The path split into segments and lower-cased, because ASP.NET routing matches a path
+    /// case-insensitively and a guard that did not would be bypassed by /Sessions. Only the STRUCTURE is
+    /// ever compared - the identifier segments ({sid}, {id}) are never read - so folding their case cannot
+    /// change a decision.
+    /// </summary>
+    private static string[] Segments(string p)
+    {
+        var segments = p.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < segments.Length; i++)
+            segments[i] = segments[i].ToLowerInvariant();
+        return segments;
+    }
+
     private static bool IsAllowed(string verb, string[] s)
     {
+        // The session-rules surface, ruled on in ONE place ahead of the verb branches rather than split
+        // across four of them, so that "has this route been classified?" has a single switch to read.
+        if (IsRuleRoute(verb, s)) return true;
+
         // ---------- Reads ----------
         if (verb is "GET" or "HEAD")
         {
@@ -267,6 +322,75 @@ public static class SessionKeyGuard
 
         return false;
     }
+
+    /// <summary>
+    /// The session-rules surface: <c>/gateway/rules</c> and everything under it.
+    ///
+    /// THE OWNER'S RULING, 2026-09-03: an agent credential may do everything with rules EXCEPT move one out
+    /// of dry run. Drafting, storing, reading and deleting a rule are the product BEHAVING, which the ruling
+    /// of 2026-08-03 puts in an agent's hands - and a stored rule is in dry run by the store's own shape,
+    /// which takes no state parameter at all, so it watches and records and types nothing. Promotion is the
+    /// moment a rule may start typing into a session, and that is a person's act.
+    ///
+    /// A LITERAL SWITCH, NOT A PREFIX - AND THIS SURFACE IS THE EXACT CASE THE REST OF THIS FILE WARNS
+    /// ABOUT. <c>promote</c> sits under the very segment being opened, one path parameter deep, so a prefix
+    /// rule on <c>/gateway/rules</c> would hand it over on the same day it handed over the list, silently
+    /// and with nothing written down that said so. The refusal is therefore spelled out here beside the
+    /// allowances: written down, it survives the next person who widens this surface, and a switch arm
+    /// somebody deletes is a visible act rather than an omission.
+    ///
+    /// WHY THIS RETURNS THREE STATES AND NOT A BOOLEAN. An allow list denies a route it has never heard of,
+    /// which is the right default and a terrible signal: from outside, a route nobody classified looks
+    /// exactly like a route somebody refused. That is what happened here - every rule route was refused with
+    /// HTTP 403 because none of them had ever been added, and every suite stayed green, because the guard's
+    /// own tests are written against the guard's own list. The third state gives the route census test in
+    /// <c>Gateway.Tests</c> something to fail on: it reads the mapped <c>/gateway/rules</c> routes off the
+    /// built application and requires every one of them to be Allowed or RefusedOnPurpose, so the next route
+    /// added to this surface cannot be forgotten - only classified.
+    /// </summary>
+    private static RuleRouteRuling RuleRoute(string verb, string[] s)
+    {
+        if (s.Length < 2 || s.Length > 4 || s[0] != "gateway" || s[1] != "rules")
+            return RuleRouteRuling.Unclassified;
+
+        // The shape, with the identifier segment written as {id} so the switch below reads the way the
+        // route table does. The identifier is never inspected - only its position is.
+        var shape = s.Length switch
+        {
+            2 => "gateway/rules",
+            3 when s[2] == "draft" => "gateway/rules/draft",
+            3 => "gateway/rules/{id}",
+            _ => "gateway/rules/{id}/" + s[3],
+        };
+
+        return (verb, shape) switch
+        {
+            // Read the account's own sentences: the list, one rule, and the record of every time it fired -
+            // including the times it looked and declined, which is most of what the record is for.
+            ("GET", "gateway/rules") => RuleRouteRuling.Allowed,
+            ("GET", "gateway/rules/{id}") => RuleRouteRuling.Allowed,
+            ("GET", "gateway/rules/{id}/firings") => RuleRouteRuling.Allowed,
+
+            // Work a rule out and hand it back to look at. Stores nothing.
+            ("POST", "gateway/rules/draft") => RuleRouteRuling.Allowed,
+
+            // Store one. It lands in dry run whatever the caller sends, because there is no state parameter.
+            ("POST", "gateway/rules") => RuleRouteRuling.Allowed,
+
+            // Remove one. The firings outlive it, so the record is not lost with the rule.
+            ("DELETE", "gateway/rules/{id}") => RuleRouteRuling.Allowed,
+
+            // REFUSED, deliberately and permanently. Arming a rule is the one real exposure on this surface.
+            ("POST", "gateway/rules/{id}/promote") => RuleRouteRuling.RefusedOnPurpose,
+
+            _ => RuleRouteRuling.Unclassified,
+        };
+    }
+
+    /// <summary>Whether a session key may call this route of the session-rules surface. See
+    /// <see cref="RuleRoute"/> for the ruling and for why the refusal is written out beside it.</summary>
+    private static bool IsRuleRoute(string verb, string[] s)
+        => RuleRoute(verb, s) == RuleRouteRuling.Allowed;
 
     /// <summary>
     /// The automation-browser shapes under <c>/directors/{id}/browsers</c>.


### PR DESCRIPTION
Built and tested on the Session Rules mission worktree; this is the first of two slices landing it.

## What this is

Until now a standing instruction had to be assembled by hand - trigger words, checks, scope and the
two ceilings, written in the shape the store wanted. This adds the authoring conversation: you say
what you want in ordinary words, a model works out the rule, and you get it read back before
anything is stored.

## The three things that make it safe

**The words have to be on the screen.** A drafted rule's trigger words are checked against the real
captured terminal text, and a word that is not there is refused with the invented word named. A rule
watching for something never on the screen is one that sits in the list looking correct and never
fires.

**The rule is for one agent by default.** A usage-limit notice reads "Claude usage limit reached" on
Claude Code and something else elsewhere. When the screen came from a known session the rule is
scoped to that session's agent - a fact we hold, not a guess the model makes. Every agent is a star
you choose, never the default.

**A question back is a first-class answer,** as a decline is for the evaluator. A model that does not
know which sessions a rule is for says so and nothing is drafted. An empty scope is refused for the
same reason - reading omitted as widest would be a fail-open.

Authoring asks the thinking model (a person is waiting), wired to the brain directly rather than
through the evaluator's seam, which swallows every failure into "no answer" - right for an
unattended pass, wrong when somebody is watching a spinner and needs to know it timed out.

Storing a drafted rule still puts it in as a dry run. Promotion is still a separate act.

## The gate

Run locally on this commit's tree, not waited for on CI:

| Suite | Result |
| --- | --- |
| `.\scripts\test-local.ps1` (9 projects) | green, 4,848 tests, every outcome Completed |
| `Gateway.Tests` (parked) filtered to the two new classes | green, 7 tests |
| Every web workspace + `npm run typecheck` | green (979 + 106 + 292 + 14) |
| `pytest tools/cc-devthrottle/tests/test_rule_ops.py` | green, 10 tests |

The full parked `Gateway.Tests` run is the remaining coverage gap and runs before the second slice
merges; this slice touches `GatewayHost.cs`, so it is owed.

## What is NOT proven here

The grounding check is skipped entirely when no example screen is supplied, and nothing forces one
to be supplied. That is arguably right - a rule described from memory has no screen to check against
- but it means grounding is enforced only when a screen happens to be present. Called out for the
inspection rather than decided quietly.