### PR TITLE
fix(director): a Pi session's transcript is named by the id it was launched with, not the newest file in the repo

### DIFF
--- a/docs/design/agent-history-capture/drivers/pi.md
+++ b/docs/design/agent-history-capture/drivers/pi.md
@@ -16,8 +16,8 @@ Status: planned. JSONL-file driver (same shape as Codex).
 | Store | `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<session-id>.jsonl` (verified against real data; Pi groups session files under a sanitized per-cwd directory) |
 | Format | JSON lines; `type` in { session, model_change, thinking_level_change, message } |
 | Fidelity | FULL - user + assistant messages, tool results, id/parentId tree |
-| Pointer | Newest `~/.pi/agent/sessions/**/*.jsonl` whose `session` line cwd matches the repo and which is at/after launch (no hooks). The per-cwd directory name is a lossy sanitization, so we match on the authoritative `cwd` inside the `session` record, not the directory name |
-| Launch wiring | None required. Pi also offers live event capture (see open questions) as a future authoritative source |
+| Pointer | The file named by the session id: `**/<timestamp>_<id>.jsonl`, where `<id>` is the id the Director launched pi with. Resolved by `PiSessionLocator.Resolve(agentSessionId)`; null until pi writes the file (on the first message). After pi's `/new` (a new file under an id pi chose) `PiSessionRebinder` finds the file CREATED after the clear in the repo and relinks the session to it at the next turn end. (Was: newest file for the repo - issue #2670, see 4a) |
+| Launch wiring | `--session-id <id>` on every launch (`PiAgent`). pi 0.80.10: "use exact project session ID, creating it if missing" - the same flag resumes a reopened session. Pi also offers live event capture (see open questions) as a future authoritative source |
 
 ---
 
@@ -46,10 +46,23 @@ Each line is a JSON object with a `type`:
 ## 4. The plan
 
 ### 4a. Pointer - find the current Pi session file
-Pi has no hook that pushes the active session to us. Resolve on demand: scan `~/.pi`
-for `*.jsonl`, keep those whose `session` line `cwd` equals the Director session repo
-and whose timestamp is at/after the session launch, pick the newest, and cache the path
-on the session (re-scan only if it disappears). Same newest-for-cwd rule as Codex.
+The Director launches pi with `--session-id <id>` and pi names the session file after
+it, so the file is known from birth: `PiSessionLocator.Resolve(agentSessionId)` finds
+`**/<timestamp>_<id>.jsonl` (skipping pi's `_archived` folders) and caches the path per
+id (re-scan only if it disappears).
+
+This REPLACED a newest-for-cwd scan (issue #2670). pi writes a session's file only on
+its first message, so at launch the newest file for the repo was always the previous
+session's; the scan bound a fresh session to it and cached the answer for the session's
+life. The Cockpit showed, and the wingman narrated, a five-week-old review for a session
+that had not said a word. The launch-window guard Codex has was never added here.
+
+pi's `/new` (the Director's context clear) starts a new file under an id pi chose, and
+only when the next message is sent - so it cannot be learned at clear time.
+`Session.ClearContextAsync` stamps `ContextClearedUtc`; `PiSessionRebinder`, at the
+session's next turn end, finds the file in the repo whose `session` record was CREATED
+after the clear under another id (created-after, never written-after: a second Pi
+session in the same repo keeps writing its own file) and relinks the session to it.
 
 ### 4b. Reader - Pi JSONL to canonical
 Add `PiTranscriptReader.Read(path)` mirroring `ClaudeTranscriptReader` (FileShare.ReadWrite,
@@ -64,16 +77,16 @@ tolerate a truncated final line):
 | session, model_change, thinking_level_change | skipped |
 
 ### 4c. Wiring
-Extend `SessionHistoryReader` with a Pi branch (resolve path, read). No launch change.
+Extend `SessionHistoryReader` with a Pi branch (resolve path, read). Launch passes `--session-id`.
 
 ---
 
 ## 5. Implementation steps
-1. `PiSessionLocator` - newest-for-cwd resolution + per-session cache.
+1. `PiSessionLocator` - by-id resolution + per-id cache; `PiSessionRebinder` follows `/new`.
 2. `PiTranscriptReader.Read(path)` -> `ConversationHistory` (mapping in 4b).
 3. `SessionHistoryReader`: add the Pi branch.
 4. Tests: a fixture file (session + message user/assistant/toolResult + thinking +
-   truncated line) asserting the canonical mapping; a locator test (newest-for-cwd); a
+   truncated line) asserting the canonical mapping; locator tests (by id, not newest; created-after for /new); a
    real-file smoke (not committed).
 5. No UI change.
 

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -142,6 +142,7 @@ public sealed class ControlApiHost : IAsyncDisposable
     private TerminalSessionRecorder? _sessionRecorder;
     private Core.Storage.TurnReviewLogger? _turnReviewLogger;
     private Core.Sessions.SessionRecordsWatcher? _recordsWatcher;
+    private Core.Pi.PiSessionRebinder? _piSessionRebinder;
     // Remove-the-network-port mission, phase 3: the two halves of the session-hook channel that
     // replaced the three Control API routes. Both started by StartSessionStateServices, because
     // neither touches the bound port and both must run even when it fails to bind - a Director whose
@@ -770,6 +771,12 @@ public sealed class ControlApiHost : IAsyncDisposable
         _recordsWatcher = new Core.Sessions.SessionRecordsWatcher(_sessionManager);
         _recordsWatcher.Start();
 
+        // A Pi session's transcript is named by the id the Director launched it with - until pi's /new
+        // starts a new file under an id of its own. On the same turn-end trigger, find that file and
+        // relink the session to it, so the turn push, the gauge and the model report follow (#2670).
+        _piSessionRebinder = new Core.Pi.PiSessionRebinder(_sessionManager);
+        _piSessionRebinder.Start();
+
         // The prompt record (issue #1551): on the same turn-end trigger, read each session's
         // conversation out of the agent's own transcript, join on where each prompt came from, and PUSH
         // it to the Gateway's log. The Director captures because it is the only thing that sees a prompt
@@ -1223,6 +1230,8 @@ public sealed class ControlApiHost : IAsyncDisposable
         _turnReviewLogger = null;
         _recordsWatcher?.Dispose();
         _recordsWatcher = null;
+        _piSessionRebinder?.Dispose();
+        _piSessionRebinder = null;
         _conversationIngestor?.Dispose();
         _conversationIngestor = null;
         _sessionRecorder?.Dispose();

--- a/src/CcDirector.Core.Tests/Agents/PiAgentTests.cs
+++ b/src/CcDirector.Core.Tests/Agents/PiAgentTests.cs
@@ -1,0 +1,74 @@
+using CcDirector.Core.AgentPlugins;
+using CcDirector.Core.Agents;
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Agents;
+
+/// <summary>
+/// The Pi launch contract (issue #2670): every launch names its session with <c>--session-id</c>, so the
+/// transcript file is known from birth instead of guessed from the newest file in the repo.
+/// </summary>
+public class PiAgentTests
+{
+    [Fact]
+    public void SupportsPreassignedSessionId_IsTrue()
+    {
+        var agent = new PiAgent(new AgentOptions());
+        Assert.True(agent.SupportsPreassignedSessionId);
+    }
+
+    [Fact]
+    public void Plugin_LaunchMetadata_DeclaresPreassignedSessionId()
+    {
+        var plugin = AgentPluginRegistry.Get(AgentKind.Pi);
+        Assert.True(plugin.Launch.SupportsPreassignedSessionId);
+    }
+
+    [Fact]
+    public void BuildLaunchSpec_NewSession_EmitsMintedSessionId()
+    {
+        var agent = new PiAgent(new AgentOptions());
+
+        var spec = agent.BuildLaunchSpec(userArgs: null, resumeSessionId: null, studioMode: false);
+
+        Assert.NotNull(spec.PreassignedSessionId);
+        Assert.True(Guid.TryParse(spec.PreassignedSessionId, out _));
+        Assert.Equal($"--session-id {spec.PreassignedSessionId}", spec.Arguments);
+    }
+
+    [Fact]
+    public void BuildLaunchSpec_TwoNewSessions_GetDifferentIds()
+    {
+        var agent = new PiAgent(new AgentOptions());
+
+        var a = agent.BuildLaunchSpec(null, null, false);
+        var b = agent.BuildLaunchSpec(null, null, false);
+
+        Assert.NotEqual(a.PreassignedSessionId, b.PreassignedSessionId);
+    }
+
+    [Fact]
+    public void BuildLaunchSpec_Resume_PassesTheSameIdAsSessionId()
+    {
+        // pi resumes a project session by id ("--session-id: use exact project session ID, creating it if
+        // missing"), so a reopen carries the id it had, and the locator finds the same file.
+        var agent = new PiAgent(new AgentOptions());
+        const string id = "8be79bf8-7db0-46c2-b19e-73857c9a7159";
+
+        var spec = agent.BuildLaunchSpec(userArgs: "--thinking high", resumeSessionId: id, studioMode: false);
+
+        Assert.Equal(id, spec.PreassignedSessionId);
+        Assert.Equal($"--thinking high --session-id {id}", spec.Arguments);
+    }
+
+    [Fact]
+    public void BuildLaunchSpec_UserArgs_KeptAheadOfTheSessionId()
+    {
+        var agent = new PiAgent(new AgentOptions());
+
+        var spec = agent.BuildLaunchSpec(userArgs: "  --model gpt-5.5  ", resumeSessionId: null, studioMode: false);
+
+        Assert.StartsWith("--model gpt-5.5 --session-id ", spec.Arguments);
+    }
+}

--- a/src/CcDirector.Core.Tests/Pi/PiSessionLocatorTests.cs
+++ b/src/CcDirector.Core.Tests/Pi/PiSessionLocatorTests.cs
@@ -4,65 +4,134 @@ using Xunit;
 
 namespace CcDirector.Core.Tests.Pi;
 
+/// <summary>
+/// The Pi transcript is found BY THE SESSION ID the Director launched pi with, never by which file in
+/// the repo is newest (issue #2670: the newest file at launch is always the previous session's, and a
+/// fresh session was shown - and narrated - with five-week-old conversation).
+/// </summary>
 public class PiSessionLocatorTests
 {
+    private const string Repo = @"C:\target\repo";
+    private const string OtherRepo = @"C:\other\repo";
+
     [Fact]
-    public void Scan_ReturnsNewestSessionForMatchingCwd_IgnoringOthers()
+    public void Resolve_FindsTheFileNamedByTheId_NotTheNewestInTheRepo()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "pi-sessions-" + Guid.NewGuid().ToString("N"));
-        // Pi groups files in per-cwd subdirectories; the locator matches on the session record
-        // cwd, so the subdirectory names are arbitrary here.
-        var targetSub = Path.Combine(dir, "--C--target-repo--");
-        var otherSub = Path.Combine(dir, "--C--other-repo--");
-        Directory.CreateDirectory(targetSub);
-        Directory.CreateDirectory(otherSub);
+        using var dir = new TempSessions();
+        var own = dir.Write("sub-a", "11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa", Repo, created: "2026-07-31T04:08:28.319Z", mtimeSeconds: 100);
+        dir.Write("sub-a", "22222222-bbbb-4bbb-8bbb-bbbbbbbbbbbb", Repo, created: "2026-09-03T10:00:00.000Z", mtimeSeconds: 900); // newer, same repo
 
-        const string target = @"C:\target\repo";
-        const string other = @"C:\other\repo";
+        var found = PiSessionLocator.Resolve("11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa", dir.Path);
 
-        WriteSession(targetSub, "older-target", target, mtimeSeconds: 100);
-        var newestTarget = WriteSession(targetSub, "newest-target", target, mtimeSeconds: 300);
-        WriteSession(otherSub, "newest-other", other, mtimeSeconds: 400); // newest overall, wrong cwd
-        WriteSession(otherSub, "old-other", other, mtimeSeconds: 50);
-
-        try
-        {
-            var found = PiSessionLocator.Scan(target, dir);
-            Assert.Equal(newestTarget, found, ignoreCase: true);
-        }
-        finally
-        {
-            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
-        }
+        Assert.Equal(own, found, ignoreCase: true);
     }
 
     [Fact]
-    public void Scan_NoMatchingCwd_ReturnsNull()
+    public void Resolve_NoFileForTheIdYet_ReturnsNull_EvenThoughTheRepoHasOlderSessions()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "pi-sessions-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
-        WriteSession(dir, "other", @"C:\some\other", mtimeSeconds: 100);
-        try
-        {
-            Assert.Null(PiSessionLocator.Scan(@"C:\target\repo", dir));
-        }
-        finally
-        {
-            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
-        }
+        // THE regression: a session whose pi has not written its file (pi writes on the first message)
+        // must answer "nothing yet", not "here is the previous session's file".
+        using var dir = new TempSessions();
+        dir.Write("sub-a", "22222222-bbbb-4bbb-8bbb-bbbbbbbbbbbb", Repo, created: "2026-07-31T04:08:28.319Z", mtimeSeconds: 100);
+
+        Assert.Null(PiSessionLocator.Resolve("33333333-cccc-4ccc-8ccc-cccccccccccc", dir.Path));
     }
 
-    private static string WriteSession(string dir, string name, string cwd, int mtimeSeconds)
+    [Fact]
+    public void Resolve_NoId_ReturnsNull()
     {
-        var path = Path.Combine(dir, $"2026-06-25T13-00-00-000Z_{name}.jsonl");
-        var session = "{\"type\":\"session\",\"version\":3,\"id\":\"" + name
-                      + "\",\"timestamp\":\"2026-06-25T13:00:00.000Z\",\"cwd\":" + JsonSerializer.Serialize(cwd) + "}";
-        File.WriteAllLines(path, new[]
+        using var dir = new TempSessions();
+        dir.Write("sub-a", "22222222-bbbb-4bbb-8bbb-bbbbbbbbbbbb", Repo, created: "2026-07-31T04:08:28.319Z", mtimeSeconds: 100);
+
+        Assert.Null(PiSessionLocator.Resolve(null, dir.Path));
+        Assert.Null(PiSessionLocator.Resolve("", dir.Path));
+    }
+
+    [Fact]
+    public void FindById_SkipsArchivedFolders()
+    {
+        using var dir = new TempSessions();
+        dir.Write("sub-a/_archived_2026", "44444444-dddd-4ddd-8ddd-dddddddddddd", Repo, created: "2026-07-31T04:08:28.319Z", mtimeSeconds: 100);
+
+        Assert.Null(PiSessionLocator.FindById("44444444-dddd-4ddd-8ddd-dddddddddddd", dir.Path));
+    }
+
+    [Fact]
+    public void FindCreatedAfter_PicksTheFileCreatedAfterTheClear_InThisRepo_UnderAnotherId()
+    {
+        using var dir = new TempSessions();
+        var cleared = new DateTime(2026, 9, 3, 12, 0, 0, DateTimeKind.Utc);
+        const string ownId = "11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+        // The session's own file: created before the clear (and still being written after it).
+        dir.Write("sub-a", ownId, Repo, created: "2026-09-03T11:00:00.000Z", mtimeSeconds: 900);
+        // A second Pi session in the same repo: created before the clear, written after it. A last-write
+        // test would pick this one - it must not.
+        dir.Write("sub-a", "22222222-bbbb-4bbb-8bbb-bbbbbbbbbbbb", Repo, created: "2026-09-03T11:30:00.000Z", mtimeSeconds: 950);
+        // Created after the clear, but in another repo.
+        dir.Write("sub-b", "33333333-cccc-4ccc-8ccc-cccccccccccc", OtherRepo, created: "2026-09-03T12:05:00.000Z", mtimeSeconds: 960);
+        // The file pi started for this session after /new.
+        var started = dir.Write("sub-a", "44444444-dddd-4ddd-8ddd-dddddddddddd", Repo, created: "2026-09-03T12:01:00.000Z", mtimeSeconds: 10);
+
+        var found = PiSessionLocator.FindCreatedAfter(Repo, cleared, ownId, dir.Path);
+
+        Assert.NotNull(found);
+        Assert.Equal("44444444-dddd-4ddd-8ddd-dddddddddddd", found!.Id);
+        Assert.Equal(started, found.Path, ignoreCase: true);
+        Assert.Equal(new DateTime(2026, 9, 3, 12, 1, 0, DateTimeKind.Utc), found.CreatedUtc);
+    }
+
+    [Fact]
+    public void FindCreatedAfter_NewestCreatedWins_WhenSeveralWereStartedAfterTheClear()
+    {
+        using var dir = new TempSessions();
+        var cleared = new DateTime(2026, 9, 3, 12, 0, 0, DateTimeKind.Utc);
+        dir.Write("sub-a", "55555555-eeee-4eee-8eee-eeeeeeeeeeee", Repo, created: "2026-09-03T12:01:00.000Z", mtimeSeconds: 990);
+        dir.Write("sub-a", "66666666-ffff-4fff-8fff-ffffffffffff", Repo, created: "2026-09-03T12:02:00.000Z", mtimeSeconds: 10);
+
+        var found = PiSessionLocator.FindCreatedAfter(Repo, cleared, "11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa", dir.Path);
+
+        Assert.Equal("66666666-ffff-4fff-8fff-ffffffffffff", found?.Id);
+    }
+
+    [Fact]
+    public void FindCreatedAfter_NothingStartedYet_ReturnsNull()
+    {
+        using var dir = new TempSessions();
+        var cleared = new DateTime(2026, 9, 3, 12, 0, 0, DateTimeKind.Utc);
+        const string ownId = "11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+        dir.Write("sub-a", ownId, Repo, created: "2026-09-03T11:00:00.000Z", mtimeSeconds: 900);
+
+        Assert.Null(PiSessionLocator.FindCreatedAfter(Repo, cleared, ownId, dir.Path));
+    }
+
+    /// <summary>A throwaway pi sessions directory. Files are laid out as pi lays them out: a per-cwd
+    /// subdirectory holding <c>&lt;timestamp&gt;_&lt;id&gt;.jsonl</c> whose first line is the session record.</summary>
+    private sealed class TempSessions : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "pi-sessions-" + Guid.NewGuid().ToString("N"));
+
+        public TempSessions() => Directory.CreateDirectory(Path);
+
+        public string Write(string sub, string id, string cwd, string created, int mtimeSeconds)
         {
-            session,
-            "{\"type\":\"message\",\"id\":\"u1\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}",
-        });
-        File.SetLastWriteTimeUtc(path, new DateTime(2026, 6, 25, 0, 0, 0, DateTimeKind.Utc).AddSeconds(mtimeSeconds));
-        return path;
+            var dir = System.IO.Path.Combine(Path, sub);
+            Directory.CreateDirectory(dir);
+            var stamp = created.Replace(':', '-').Replace('.', '-');
+            var path = System.IO.Path.Combine(dir, $"{stamp}_{id}.jsonl");
+            var session = "{\"type\":\"session\",\"version\":3,\"id\":\"" + id + "\",\"timestamp\":\"" + created
+                          + "\",\"cwd\":" + JsonSerializer.Serialize(cwd) + "}";
+            File.WriteAllLines(path, new[]
+            {
+                session,
+                "{\"type\":\"message\",\"id\":\"u1\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}",
+            });
+            File.SetLastWriteTimeUtc(path, new DateTime(2026, 9, 3, 0, 0, 0, DateTimeKind.Utc).AddSeconds(mtimeSeconds));
+            return path;
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { /* best effort */ }
+        }
     }
 }

--- a/src/CcDirector.Core.UnitTests/AgentPlugins/AgentPluginRegistryTests.cs
+++ b/src/CcDirector.Core.UnitTests/AgentPlugins/AgentPluginRegistryTests.cs
@@ -172,7 +172,7 @@ public sealed class AgentPluginRegistryTests
         Assert.Equal(AgentHistoryProviderKind.TranscriptFile, plugin.History.ProviderKind);
         Assert.True(plugin.History.SupportsConversationHistory);
         Assert.Contains(".pi", plugin.History.StoreDescription);
-        Assert.False(plugin.Launch.SupportsPreassignedSessionId);
+        Assert.True(plugin.Launch.SupportsPreassignedSessionId);   // pi --session-id (issue #2670)
         Assert.False(plugin.Launch.SupportsStudioMode);
         Assert.True(plugin.Driver.Capabilities.HasFlag(DriverCapabilities.Cancel));
         Assert.True(plugin.Driver.Capabilities.HasFlag(DriverCapabilities.ClearContext));
@@ -196,15 +196,18 @@ public sealed class AgentPluginRegistryTests
         var resume = plugin.BuildLaunchSpec(new AgentPluginLaunchRequest(
             options,
             UserArgs: null,
-            ResumeSessionId: "pi-resume-ignored",
+            ResumeSessionId: "8be79bf8-7db0-46c2-b19e-73857c9a7159",
             StudioMode: false));
 
         Assert.IsType<PiAgent>(agent);
         Assert.Equal("pi-custom", agent.ExecutablePath);
-        Assert.Equal("--model local", newSession.Arguments);
-        Assert.Null(newSession.PreassignedSessionId);
-        Assert.Equal("", resume.Arguments);
-        Assert.Null(resume.PreassignedSessionId);
+        // Every launch names its session (issue #2670): a minted id for a new session, the session's own
+        // id for a reopen, which is also how pi resumes it. Studio mode is not a pi feature and is ignored.
+        Assert.NotNull(newSession.PreassignedSessionId);
+        Assert.True(Guid.TryParse(newSession.PreassignedSessionId, out _));
+        Assert.Equal($"--model local --session-id {newSession.PreassignedSessionId}", newSession.Arguments);
+        Assert.Equal("8be79bf8-7db0-46c2-b19e-73857c9a7159", resume.PreassignedSessionId);
+        Assert.Equal("--session-id 8be79bf8-7db0-46c2-b19e-73857c9a7159", resume.Arguments);
     }
 
     [Fact]

--- a/src/CcDirector.Core/AgentPlugins/PiAgentPlugin.cs
+++ b/src/CcDirector.Core/AgentPlugins/PiAgentPlugin.cs
@@ -58,7 +58,7 @@ public sealed class PiAgentPlugin : IAgentPlugin
 
     public AgentPluginHistoryMetadata History => HistoryMetadata;
 
-    public AgentPluginLaunchMetadata Launch { get; } = new(SupportsPreassignedSessionId: false, SupportsStudioMode: false);
+    public AgentPluginLaunchMetadata Launch { get; } = new(SupportsPreassignedSessionId: true, SupportsStudioMode: false);
 
     public AgentPluginFleetMetadata Fleet { get; } = new(
         FleetPreambleStrategy.InstructionFile, FleetPreambleStatus.Wired,

--- a/src/CcDirector.Core/Agents/PiAgent.cs
+++ b/src/CcDirector.Core/Agents/PiAgent.cs
@@ -5,11 +5,12 @@ namespace CcDirector.Core.Agents;
 
 /// <summary>
 /// Pi coding agent (<c>pi.cmd</c> from <c>@earendil-works/pi-coding-agent</c>).
-/// V1 behavior: spawn pi with optional user args. No session-id preassignment, no resume,
-/// no Studio mode. Pi creates and manages its own session files under
-/// <c>~/.pi/agent/sessions/</c>; Director treats each Pi session as a fresh ephemeral
-/// launch for now. Resume-from-Director and crash recovery can be added in a follow-up
-/// once the basic flow is proven.
+/// Every launch passes <c>--session-id &lt;id&gt;</c>: pi "uses the exact project session id, creating it
+/// if missing" (pi 0.80.10), and names the session file after it
+/// (<c>~/.pi/agent/sessions/&lt;cwd-slug&gt;/&lt;timestamp&gt;_&lt;id&gt;.jsonl</c>). So the Director knows a Pi
+/// session's transcript from birth and never has to guess it from the newest file in the repo - which
+/// guessed wrong (issue #2670). A new session gets a Director-minted id; a reopened one gets the id it
+/// had, which is also how pi resumes it. No Studio mode.
 /// </summary>
 public sealed class PiAgent : IAgent
 {
@@ -24,7 +25,7 @@ public sealed class PiAgent : IAgent
 
     public string ExecutablePath => _options.PiPath;
 
-    public bool SupportsPreassignedSessionId => false;
+    public bool SupportsPreassignedSessionId => true;
 
     public bool SupportsStudioMode => false;
 
@@ -32,15 +33,16 @@ public sealed class PiAgent : IAgent
     {
         FileLog.Write($"[PiAgent] BuildLaunchSpec: userArgs={userArgs ?? "(null)"}, resume={resumeSessionId ?? "(null)"}, studio={studioMode}");
 
-        if (!string.IsNullOrEmpty(resumeSessionId))
-            FileLog.Write($"[PiAgent] BuildLaunchSpec: ignoring resume={resumeSessionId} (Pi v1 does not support Director-initiated resume; use pi's own /resume inside the TUI)");
         if (studioMode)
-            FileLog.Write("[PiAgent] BuildLaunchSpec: ignoring studioMode (Pi v1 does not support Studio stream-json wrapper)");
+            FileLog.Write("[PiAgent] BuildLaunchSpec: ignoring studioMode (Pi does not support the Studio stream-json wrapper)");
 
-        // Pi v1: pass through user args verbatim. Pi has no equivalent of --session-id;
-        // it generates its own session ID and writes to ~/.pi/agent/sessions/<cwd-slug>/<uuid>.jsonl.
-        var args = (userArgs ?? string.Empty).Trim();
-        FileLog.Write($"[PiAgent] BuildLaunchSpec result: argsLen={args.Length}");
-        return new AgentLaunchSpec(args, PreassignedSessionId: null);
+        // One flag serves both cases. A fresh id makes pi create that session; an existing id makes pi
+        // load it (verified against pi 0.80.10: a second launch with the same id recalled the first
+        // launch's conversation). Either way the file on disk is named by the id.
+        var sessionId = string.IsNullOrEmpty(resumeSessionId) ? Guid.NewGuid().ToString() : resumeSessionId;
+        var args = $"{(userArgs ?? string.Empty).Trim()} --session-id {sessionId}".Trim();
+
+        FileLog.Write($"[PiAgent] BuildLaunchSpec result: argsLen={args.Length}, sessionId={sessionId}, resumed={!string.IsNullOrEmpty(resumeSessionId)}");
+        return new AgentLaunchSpec(args, sessionId);
     }
 }

--- a/src/CcDirector.Core/Drivers/PiDriver.cs
+++ b/src/CcDirector.Core/Drivers/PiDriver.cs
@@ -19,9 +19,11 @@ namespace CcDirector.Core.Drivers;
 /// Therefore: <see cref="DriverCapabilities.Interrupt"/> is NOT declared - a naive
 /// Ctrl+C cascade would kill the session, and pi has no safe hard-interrupt distinct
 /// from quit. History is NOT declared - double-Esc opens a different feature.
-/// Transcripts exist (~/.pi/agent/sessions/&lt;cwd-slug&gt;/&lt;uuid&gt;.jsonl) but their format
-/// is unparsed in v1, so TranscriptRead stays undeclared. Launching remains with the
-/// Director's PiAgent (no session-id preassignment in pi).
+/// Transcripts exist (~/.pi/agent/sessions/&lt;cwd-slug&gt;/&lt;timestamp&gt;_&lt;id&gt;.jsonl) and the
+/// conversation reader parses them, but the widget/usage readers below are not implemented, so
+/// TranscriptRead stays undeclared. Launching remains with the Director's PiAgent, which passes
+/// <c>--session-id</c> so the id - and therefore the file - is known from birth (issue #2670);
+/// the records readers below resolve by that id.
 /// </summary>
 public sealed class PiDriver : IAgentDriver
 {
@@ -108,17 +110,17 @@ public sealed class PiDriver : IAgentDriver
     /// <see cref="DriverCapabilities.ContextUsage"/>). pi's session file carries per-message
     /// <c>usage.input</c> and the model id, but NOT the window - and since issue #1100 the window is no
     /// longer derived from that model id, so this reports used tokens with no denominator until pi is
-    /// actually asked. Located by repo path (pi has no Director-preassigned id); the launch args are not
-    /// used.</summary>
+    /// actually asked. Located by the session id the Director launched pi with; the working directory
+    /// and launch args are not used.</summary>
     public ContextUsageDto? ReadContextUsage(string agentSessionId, string workingDirectory, string? launchArgs) =>
-        Pi.PiContextUsage.ReadForRepo(workingDirectory);
+        Pi.PiContextUsage.ReadForSession(agentSessionId);
 
     /// <summary>The model this pi session is currently using (capability
     /// <see cref="DriverCapabilities.ModelReport"/>): the LAST assistant message's model in the
-    /// session file, so a mid-session model switch is reflected. Located by repo path (pi has no
-    /// Director-preassigned id).</summary>
+    /// session file, so a mid-session model switch is reflected. Located by the session id the
+    /// Director launched pi with.</summary>
     public string? ReadCurrentModel(string agentSessionId, string workingDirectory, string? launchArgs) =>
-        Pi.PiCurrentModel.ReadForRepo(workingDirectory);
+        Pi.PiCurrentModel.ReadForSession(agentSessionId);
 
     public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory) =>
         throw new NotSupportedException("[PiDriver] pi transcript listing is not implemented (v1).");

--- a/src/CcDirector.Core/History/SessionHistoryReader.cs
+++ b/src/CcDirector.Core/History/SessionHistoryReader.cs
@@ -20,7 +20,8 @@ namespace CcDirector.Core.History;
 ///   kept current across /clear by the SessionStart hook), falling back to deriving the path from
 ///   the session id.
 /// - Codex: the newest rollout for the session's repo (<see cref="CodexRolloutLocator"/>).
-/// - Pi: the newest session file for the session's repo (<see cref="PiSessionLocator"/>).
+/// - Pi: the session file named by the id the Director launched pi with (<see cref="PiSessionLocator"/>;
+///   pi's /new is followed by <see cref="PiSessionRebinder"/>).
 /// - Grok: the newest chat_history.jsonl for the session's repo (<see cref="GrokSessionLocator"/>).
 /// - Copilot: the newest session in its SQLite store whose cwd matches the session's repo
 ///   (<see cref="CopilotHistoryReader"/>); resolved by repo, not a single transcript file.
@@ -54,7 +55,8 @@ public static class SessionHistoryReader
         {
             AgentKind.ClaudeCode => ResolveClaude(session),
             AgentKind.Codex => CodexRolloutLocator.Resolve(session.Id, session.RepoPath, session.CreatedAt),
-            AgentKind.Pi => PiSessionLocator.Resolve(session.Id, session.RepoPath),
+            // Pi is launched with --session-id, so its file is named by the session's agent id (issue #2670).
+            AgentKind.Pi => PiSessionLocator.Resolve(session.ClaudeSessionId),
             AgentKind.Grok => GrokSessionLocator.Resolve(session.Id, session.RepoPath),
             // Copilot has no per-session transcript file; the readable source is its SQLite store.
             // Return the store path (when present) so a caller can stat it to detect changes.

--- a/src/CcDirector.Core/Pi/PiContextUsage.cs
+++ b/src/CcDirector.Core/Pi/PiContextUsage.cs
@@ -17,16 +17,17 @@ namespace CcDirector.Core.Pi;
 /// ingested = context fullness). pi does NOT record the window anywhere in this file, and since issue
 /// #1100 it is no longer inferred from the model id - the window is reported as unknown and the gauge
 /// shows the raw token count with no percentage. See <see cref="Drivers.ContextWindowSource"/>.
-/// The session file for a repo is located by reading each session line's <c>cwd</c> (pi has no
-/// preassigned id the Director can use), newest matching file wins.
+/// The session file is the one named by the session's id (<see cref="PiSessionLocator"/>): the Director
+/// launches pi with <c>--session-id</c>, so the file is known and never guessed from the newest file in
+/// the repo (issue #2670).
 /// </summary>
 public static class PiContextUsage
 {
-    /// <summary>Context usage for the newest pi session matching <paramref name="repoPath"/>, or null
-    /// when none matches or it has no assistant usage yet.</summary>
-    public static ContextUsageDto? ReadForRepo(string repoPath)
+    /// <summary>Context usage for the pi session with this id, or null when pi has not written its file
+    /// yet or it has no assistant usage yet.</summary>
+    public static ContextUsageDto? ReadForSession(string agentSessionId)
     {
-        var file = LocateNewestForRepo(repoPath);
+        var file = PiSessionLocator.Resolve(agentSessionId);
         if (file is null)
             return null;
         return ReadFromFile(file);
@@ -101,69 +102,6 @@ public static class PiContextUsage
         if (latest is not null)
             FileLog.Write($"[PiContextUsage] used={latest.UsedTokens}, window={latest.WindowTokens}, pct={latest.PercentUsed}");
         return latest;
-    }
-
-    /// <summary>The newest pi session file whose <c>session</c> line cwd matches the repo, or null.
-    /// Scans <c>~/.pi/agent/sessions</c> recursively; skips pi's <c>_archived_*</c> folders.</summary>
-    public static string? LocateNewestForRepo(string repoPath)
-    {
-        var dir = SessionsDirectory();
-        if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(dir))
-            return null;
-        var target = NormalizePath(repoPath);
-
-        List<FileInfo> files;
-        try
-        {
-            files = new DirectoryInfo(dir)
-                .EnumerateFiles("*.jsonl", SearchOption.AllDirectories)
-                .Where(f => !f.FullName.Contains("_archived", StringComparison.OrdinalIgnoreCase))
-                .OrderByDescending(f => f.LastWriteTimeUtc)
-                .ToList();
-        }
-        catch
-        {
-            return null;
-        }
-
-        foreach (var file in files)
-            if (NormalizePath(ReadSessionCwd(file.FullName)) == target)
-                return file.FullName;
-        return null;
-    }
-
-    /// <summary>Read the <c>cwd</c> from a pi session file's first <c>session</c> line, or null.</summary>
-    private static string? ReadSessionCwd(string path)
-    {
-        try
-        {
-            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var reader = new StreamReader(fs);
-            var first = reader.ReadLine();
-            if (string.IsNullOrEmpty(first))
-                return null;
-            using var doc = JsonDocument.Parse(first);
-            var root = doc.RootElement;
-            if (root.ValueKind != JsonValueKind.Object) return null;
-            if (!(root.TryGetProperty("type", out var t) && t.GetString() == "session")) return null;
-            return root.TryGetProperty("cwd", out var cwd) && cwd.ValueKind == JsonValueKind.String
-                ? cwd.GetString()
-                : null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static string SessionsDirectory()
-        => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".pi", "agent", "sessions");
-
-    private static string NormalizePath(string? p)
-    {
-        if (string.IsNullOrWhiteSpace(p)) return "";
-        try { return Path.GetFullPath(p).TrimEnd('\\', '/').ToLowerInvariant(); }
-        catch { return p.TrimEnd('\\', '/').ToLowerInvariant(); }
     }
 
     private static long Long(JsonElement el, string prop)

--- a/src/CcDirector.Core/Pi/PiCurrentModel.cs
+++ b/src/CcDirector.Core/Pi/PiCurrentModel.cs
@@ -10,16 +10,16 @@ namespace CcDirector.Core.Pi;
 ///   {"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.5", ...}}
 ///
 /// The LAST assistant message wins, so a mid-session model switch is reflected. Null until the
-/// first assistant message exists. The session file for a repo is located by
-/// <see cref="PiContextUsage.LocateNewestForRepo"/> (verified against pi 0.79.4, issue #1637).
+/// first assistant message exists. The session file is the one named by the session's id
+/// (<see cref="PiSessionLocator"/>; format verified against pi 0.79.4, issue #1637).
 /// </summary>
 public static class PiCurrentModel
 {
-    /// <summary>The current model of the newest pi session matching <paramref name="repoPath"/>, or
-    /// null when none matches or it has no assistant message yet.</summary>
-    public static string? ReadForRepo(string repoPath)
+    /// <summary>The current model of the pi session with this id, or null when pi has not written its
+    /// file yet or it has no assistant message yet.</summary>
+    public static string? ReadForSession(string agentSessionId)
     {
-        var file = PiContextUsage.LocateNewestForRepo(repoPath);
+        var file = PiSessionLocator.Resolve(agentSessionId);
         if (file is null)
             return null;
         return ReadFromFile(file);

--- a/src/CcDirector.Core/Pi/PiSessionLocator.cs
+++ b/src/CcDirector.Core/Pi/PiSessionLocator.cs
@@ -1,77 +1,137 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Text.Json;
 
 namespace CcDirector.Core.Pi;
 
+/// <summary>One Pi session file as its header describes it: the id pi wrote it under, where it is, and
+/// when pi created it.</summary>
+public sealed record PiSessionFile(string Id, string Path, DateTime CreatedUtc);
+
 /// <summary>
-/// Finds the current Pi session file for a Director session. Pi has no hook that pushes the
-/// active session to us, and the session path is not known at launch, so we resolve it by
-/// scanning <c>~/.pi/agent/sessions</c> for the newest <c>&lt;timestamp&gt;_&lt;session-id&gt;.jsonl</c>
-/// whose first line (its <c>session</c> record) carries a <c>cwd</c> matching the Director
-/// session's repo path. The result is cached per session id (re-scanned only if the cached
-/// file disappears) so the History tab's poll is cheap.
+/// Finds a Pi session's transcript file BY ITS SESSION ID. The Director launches pi with
+/// <c>--session-id &lt;id&gt;</c> (<see cref="Agents.PiAgent"/>) and pi names the file after it:
+/// <c>~/.pi/agent/sessions/&lt;cwd-slug&gt;/&lt;timestamp&gt;_&lt;id&gt;.jsonl</c>. So the transcript is known
+/// from birth and there is nothing to guess.
 ///
-/// Pi groups session files in per-cwd subdirectories, but the subdirectory name is a
-/// sanitized encoding of the path, not the path itself, so we match on the authoritative
-/// <c>cwd</c> from the session record rather than on the directory name.
+/// This replaces a newest-file-for-the-repo scan (issue #2670). That scan bound a fresh session to the
+/// PREVIOUS Pi session's file in the same repo - pi writes its own file only on the first message, so at
+/// launch the newest file is always somebody else's - and then cached that answer for the life of the
+/// session. The Cockpit showed, and the wingman narrated, a review from five weeks earlier for a session
+/// that had not said a word.
 ///
-/// First-cut heuristic: newest-for-cwd by file modified time. Two Pi sessions in the same
-/// repo at once is the known ambiguity (see the plan); the active session is normally the
-/// newest file, so this resolves it in practice.
+/// The one time pi picks an id of its own is <c>/new</c> (the Director's context clear), which starts a
+/// fresh session file. <see cref="FindCreatedAfter(string, DateTime, string?)"/> finds that file - the one
+/// whose session record was CREATED after the clear, in this repo, under an id that is not the one just
+/// left - and <see cref="PiSessionRebinder"/> relinks the session to it at the next turn end.
 /// </summary>
 public static class PiSessionLocator
 {
-    private static readonly ConcurrentDictionary<Guid, string> Cache = new();
+    /// <summary>Agent session id -> file path. An id names exactly one file, so an entry stays valid for as
+    /// long as the file exists; a file that has gone (pi archived it) drops the entry and rescans.</summary>
+    private static readonly ConcurrentDictionary<string, string> Cache = new(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>Resolve (and cache) the session file for a session, or null if none matches the repo.</summary>
-    public static string? Resolve(Guid sessionId, string repoPath)
+    /// <summary>The transcript file of the Pi session with this id, or null when pi has not written it yet
+    /// (pi creates the file on the first message) or the id is unknown.</summary>
+    public static string? Resolve(string? agentSessionId) => Resolve(agentSessionId, SessionsDirectory());
+
+    /// <summary>As <see cref="Resolve(string?)"/>, against an explicit sessions directory (for tests).</summary>
+    public static string? Resolve(string? agentSessionId, string sessionsDirectory)
     {
-        if (Cache.TryGetValue(sessionId, out var cached) && File.Exists(cached))
+        if (string.IsNullOrWhiteSpace(agentSessionId))
+            return null;
+        if (Cache.TryGetValue(agentSessionId, out var cached) && File.Exists(cached))
             return cached;
 
-        var found = Scan(repoPath, SessionsDirectory());
+        var found = FindById(agentSessionId, sessionsDirectory);
         if (found != null)
-            Cache[sessionId] = found;
+            Cache[agentSessionId] = found;
         return found;
     }
 
+    /// <summary>The file named <c>&lt;timestamp&gt;_&lt;agentSessionId&gt;.jsonl</c> anywhere under the sessions
+    /// directory, or null. pi's <c>_archived</c> folders are skipped: an archived session is not a live one.</summary>
+    public static string? FindById(string agentSessionId, string sessionsDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(agentSessionId) || !Directory.Exists(sessionsDirectory))
+            return null;
+
+        var suffix = "_" + agentSessionId + ".jsonl";
+        try
+        {
+            return EnumerateSessionFiles(sessionsDirectory)
+                .FirstOrDefault(f => f.Name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                ?.FullName;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
     /// <summary>
-    /// Scan a Pi sessions directory for the newest session file whose session record cwd matches
-    /// <paramref name="repoPath"/>. Exposed (with an explicit directory) for testing.
+    /// The session file pi started AFTER a context clear: the newest-created file whose session record says
+    /// this repo, was created at or after <paramref name="createdAfterUtc"/>, and carries an id other than
+    /// <paramref name="excludeAgentSessionId"/> (the id the session was on when it was cleared). Null while
+    /// pi has not written it yet.
+    ///
+    /// Judged by the header's CREATION timestamp, never by last-write time: a second Pi session in the
+    /// same repo keeps writing its own file while this one is cleared, and a last-write test would pick it.
+    /// A file created after the clear can only be the cleared session's own.
     /// </summary>
-    public static string? Scan(string repoPath, string sessionsDirectory)
+    public static PiSessionFile? FindCreatedAfter(string repoPath, DateTime createdAfterUtc, string? excludeAgentSessionId)
+        => FindCreatedAfter(repoPath, createdAfterUtc, excludeAgentSessionId, SessionsDirectory());
+
+    /// <summary>As <see cref="FindCreatedAfter(string, DateTime, string?)"/>, against an explicit sessions
+    /// directory (for tests).</summary>
+    public static PiSessionFile? FindCreatedAfter(string repoPath, DateTime createdAfterUtc, string? excludeAgentSessionId, string sessionsDirectory)
     {
         if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(sessionsDirectory))
             return null;
 
         var target = NormalizePath(repoPath);
-
-        List<FileInfo> files;
+        PiSessionFile? newest = null;
         try
         {
-            files = new DirectoryInfo(sessionsDirectory)
-                .EnumerateFiles("*.jsonl", SearchOption.AllDirectories)
-                .OrderByDescending(f => f.LastWriteTimeUtc)
-                .ToList();
+            foreach (var file in EnumerateSessionFiles(sessionsDirectory))
+            {
+                var header = ReadHeader(file.FullName);
+                if (header is null || header.CreatedUtc < createdAfterUtc)
+                    continue;
+                if (NormalizePath(header.Cwd) != target)
+                    continue;
+                if (!string.IsNullOrEmpty(excludeAgentSessionId)
+                    && string.Equals(header.Id, excludeAgentSessionId, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (newest is null || header.CreatedUtc > newest.CreatedUtc)
+                    newest = new PiSessionFile(header.Id, file.FullName, header.CreatedUtc);
+            }
         }
-        catch
+        catch (IOException)
         {
             return null;
         }
-
-        // Newest first; the active session's file is normally the newest matching file, so we
-        // usually inspect only one or two session records.
-        foreach (var file in files)
+        catch (UnauthorizedAccessException)
         {
-            var cwd = ReadSessionCwd(file.FullName);
-            if (cwd != null && NormalizePath(cwd) == target)
-                return file.FullName;
+            return null;
         }
-        return null;
+        return newest;
     }
 
-    /// <summary>Read the cwd from a Pi session file's first line (its session record), or null.</summary>
-    private static string? ReadSessionCwd(string path)
+    private static IEnumerable<FileInfo> EnumerateSessionFiles(string sessionsDirectory)
+        => new DirectoryInfo(sessionsDirectory)
+            .EnumerateFiles("*.jsonl", SearchOption.AllDirectories)
+            .Where(f => !f.FullName.Contains("_archived", StringComparison.OrdinalIgnoreCase));
+
+    private sealed record Header(string Id, string Cwd, DateTime CreatedUtc);
+
+    /// <summary>The session record on a pi session file's first line - id, cwd, creation time - or null when
+    /// the line is missing, torn, or not a session record.</summary>
+    private static Header? ReadHeader(string path)
     {
         try
         {
@@ -87,22 +147,33 @@ public static class PiSessionLocator
                 return null;
             if (!(root.TryGetProperty("type", out var t) && t.GetString() == "session"))
                 return null;
-            return root.TryGetProperty("cwd", out var cwd) && cwd.ValueKind == JsonValueKind.String
-                ? cwd.GetString()
-                : null;
+            if (!root.TryGetProperty("id", out var idEl) || idEl.ValueKind != JsonValueKind.String)
+                return null;
+            if (!root.TryGetProperty("cwd", out var cwdEl) || cwdEl.ValueKind != JsonValueKind.String)
+                return null;
+            if (!root.TryGetProperty("timestamp", out var tsEl) || tsEl.ValueKind != JsonValueKind.String)
+                return null;
+            if (!DateTime.TryParse(tsEl.GetString(), CultureInfo.InvariantCulture,
+                    DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var created))
+                return null;
+            return new Header(idEl.GetString()!, cwdEl.GetString()!, created);
         }
-        catch
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (JsonException)
         {
             return null;
         }
     }
 
     private static string SessionsDirectory()
-        => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".pi", "agent", "sessions");
+        => System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".pi", "agent", "sessions");
 
     private static string NormalizePath(string p)
     {
-        try { return Path.GetFullPath(p).TrimEnd('\\', '/').ToLowerInvariant(); }
+        try { return System.IO.Path.GetFullPath(p).TrimEnd('\\', '/').ToLowerInvariant(); }
         catch { return p.TrimEnd('\\', '/').ToLowerInvariant(); }
     }
 }

--- a/src/CcDirector.Core/Pi/PiSessionRebinder.cs
+++ b/src/CcDirector.Core/Pi/PiSessionRebinder.cs
@@ -1,0 +1,99 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Agents;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Pi;
+
+/// <summary>
+/// Follows a Pi session across pi's own <c>/new</c>. The Director names every Pi session's transcript by
+/// launching pi with <c>--session-id</c>, so the file is known from birth (issue #2670) - except after a
+/// context clear: <c>/new</c> starts a fresh session file under an id pi chose, and pi writes that file
+/// only when the next message is sent, so the id cannot be learned at clear time (the synchronous wait in
+/// <see cref="Session.ClearContextAsync"/> would sit out its whole minute and then fail a clear that had
+/// worked). Instead <see cref="Session.ClearContextAsync"/> stamps <see cref="Session.ContextClearedUtc"/>,
+/// and this watcher, at the session's next turn end - the first moment the new file can exist - looks for
+/// a file in the session's repo CREATED after the clear under an id that is not the one just left, and
+/// relinks the session to it through <see cref="SessionManager.RelinkClaudeSession"/>. From then on every
+/// reader (the turn push, the context gauge, the model report, a later reopen) resolves the new file by
+/// its id, and the turn push starts a new generation for it.
+///
+/// Turn-end-driven for the same reason <see cref="SessionRecordsWatcher"/> is: the scan reads pi's session
+/// headers on disk, and a turn end is the one moment the answer can have changed. One instance per
+/// Director, wired beside that watcher.
+/// </summary>
+public sealed class PiSessionRebinder : IDisposable
+{
+    private readonly SessionManager _sessionManager;
+    private readonly ConcurrentDictionary<Guid, Action<ActivityState, ActivityState>> _handlers = new();
+    private bool _started;
+    private int _disposed;
+
+    public PiSessionRebinder(SessionManager sessionManager)
+        => _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
+
+    public void Start()
+    {
+        if (_started) return;
+        _started = true;
+        FileLog.Write("[PiSessionRebinder] Start");
+        _sessionManager.OnSessionCreated += WireSession;
+        _sessionManager.OnSessionRemoved += UnwireSession;
+        foreach (var s in _sessionManager.ListSessions())
+            WireSession(s);
+    }
+
+    private void WireSession(Session session)
+    {
+        if (session.AgentKind != AgentKind.Pi) return;
+        if (_handlers.ContainsKey(session.Id)) return;
+
+        Action<ActivityState, ActivityState> handler = (oldState, newState) =>
+        {
+            _ = oldState;
+            if (newState != ActivityState.WaitingForInput) return;
+            Task.Run(() => Rebind(session));
+        };
+        _handlers[session.Id] = handler;
+        session.OnActivityStateChanged += handler;
+    }
+
+    private void UnwireSession(Session session)
+    {
+        if (_handlers.TryRemove(session.Id, out var h))
+            session.OnActivityStateChanged -= h;
+    }
+
+    /// <summary>
+    /// If a clear is outstanding on this session, find the file pi started for it and relink. A boundary
+    /// (fire-and-forget target): it owns its try/catch so a disk fault never escapes onto a background
+    /// thread. Nothing found means pi has not written the post-clear file yet; the next turn end looks again.
+    /// </summary>
+    internal void Rebind(Session session)
+    {
+        try
+        {
+            if (session.ContextClearedUtc is not DateTime cleared) return;
+            var found = PiSessionLocator.FindCreatedAfter(session.RepoPath, cleared, session.ClaudeSessionId);
+            if (found is null) return;
+
+            FileLog.Write($"[PiSessionRebinder] session={session.Id}: the clear at {cleared:O} started pi session {found.Id}; relinking from {session.ClaudeSessionId ?? "(none)"}");
+            _sessionManager.RelinkClaudeSession(session.Id, found.Id);
+            session.ClearContextClearedStamp();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[PiSessionRebinder] rebind FAILED: session={session.Id}: {ex.Message}");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _sessionManager.OnSessionCreated -= WireSession;
+        _sessionManager.OnSessionRemoved -= UnwireSession;
+        foreach (var s in _sessionManager.ListSessions())
+            if (_handlers.TryRemove(s.Id, out var h))
+                s.OnActivityStateChanged -= h;
+    }
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -568,6 +568,17 @@ public sealed class Session : IDisposable
     public string? ClaudeSessionId { get; internal set; }
 
     /// <summary>
+    /// When the Director last cleared this session's context through a driver that could not report the
+    /// transcript the clear started (pi's <c>/new</c>: the new file appears only with the next message).
+    /// Null when no such clear is outstanding. <see cref="Pi.PiSessionRebinder"/> consumes it at the next
+    /// turn end and clears it once the session is relinked to the file created after it (issue #2670).
+    /// </summary>
+    public DateTime? ContextClearedUtc { get; private set; }
+
+    /// <summary>The outstanding clear has been resolved to its transcript; nothing is pending.</summary>
+    internal void ClearContextClearedStamp() => ContextClearedUtc = null;
+
+    /// <summary>
     /// The absolute path to the current Claude transcript .jsonl, as reported by the Claude
     /// SessionStart hook. Authoritative across /clear and compaction (Claude mints a new id
     /// and file on each), where deriving the path from a stale <see cref="ClaudeSessionId"/>
@@ -2694,7 +2705,11 @@ public sealed class Session : IDisposable
 
         if (!driver.Capabilities.HasFlag(Drivers.DriverCapabilities.TranscriptRead) || oldId is null)
         {
-            FileLog.Write($"[Session] ClearContextAsync: no transcript tracking for {driver.Kind}, clear submitted");
+            // The clear happened but the transcript it starts cannot be found here: pi, for one, writes
+            // the new file only on the next message. Stamp the moment, so a watcher that runs at the
+            // session's next turn end can find the file created after it (PiSessionRebinder, #2670).
+            ContextClearedUtc = t0;
+            FileLog.Write($"[Session] ClearContextAsync: no synchronous transcript tracking for {driver.Kind}; clear submitted and stamped at {t0:O}");
             return null;
         }
 


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle_internal#1897.

## What was wrong

A fresh Pi session showed - and the wingman narrated - the PREVIOUS Pi session's conversation from the
same repo. Fleet session 118 (cc-consult, launched 2026-09-03 10:29) had a kart-racer review from 31 July
in its Chat tab with zero turns of its own. The Director log shows the turn push binding the July file to
the new session one second after launch.

`PiSessionLocator` found a session's transcript by taking the newest `.jsonl` for the repo. pi writes a
session's file only on the first message, so at launch the newest file is always somebody else's - and
the answer was cached for the life of the session. The context gauge and the model report used the same
newest-for-repo rule.

## What changed

- `PiAgent` launches pi with `--session-id <id>`: a minted GUID for a new session, the session's own id for
  a reopen (pi 0.80.10: "use exact project session ID, creating it if missing"). pi names the file after
  the id, so the transcript is known from birth. Verified on this machine: a launch with a Director GUID
  created `<cwd-dir>/<timestamp>_<guid>.jsonl`, and a second launch with the same id resumed the same
  conversation. `SupportsPreassignedSessionId` is now true for Pi (agent and plugin metadata), so the
  session's agent id is set at creation.
- `PiSessionLocator` resolves BY ID (`*_<id>.jsonl`, skipping pi's `_archived` folders) and caches per id.
  The newest-for-repo scan is gone from the locator, `PiContextUsage` and `PiCurrentModel`; `PiDriver`
  passes the agent session id through to both.
- pi's `/new` starts a new file under an id pi chose, written only with the next message, so it cannot be
  learned at clear time. `Session.ClearContextAsync` now stamps `ContextClearedUtc` when the driver has no
  synchronous transcript tracking, and a new `PiSessionRebinder` (wired beside `SessionRecordsWatcher` in
  `ControlApiHost`) looks at the next turn end for a file in the repo CREATED after the clear under another
  id, and relinks the session to it through the session manager's relink. Created-after, not written-after: a
  second Pi session in the same repo keeps writing its own file and must not be picked.
- `docs/design/agent-history-capture/drivers/pi.md` describes the by-id rule instead of newest-for-cwd.

## Tests

- `PiSessionLocatorTests` rewritten: by id even when a newer file exists for the repo; null when the id
  has no file yet even though the repo has older sessions (the regression); archived folders skipped;
  created-after picks the post-clear file and not the concurrently written neighbour, the other repo's
  file, or the session's own; newest-created wins; null while nothing has been written.
- `PiAgentTests` (new): minted id on a new launch, distinct ids across launches, the resume id passed as
  the session id, user args kept ahead of the flag, plugin metadata declares preassignment.
- Run locally in Release, from this branch: Core.Tests 4385 passed / 8 skipped (in three namespace chunks),
  Core.UnitTests 160, Gateway.UnitTests 3509 / 2 skipped, Engine 63, HostedAgent 88, Launcher 113,
  Avalonia 364, Terminal.Avalonia 24 - no failures. `CcDirector.Gateway.Tests` was NOT run locally: two
  other sessions held and queued on its per-user test lock the whole time; CI runs it here.

## Not covered here

- A Pi session that was already running before this build was launched without `--session-id`; it keeps
  the old behaviour until it is closed and reopened.
- pi prints a one-line "No project session found with id ...; creating a new session with that id" at
  startup for a minted id. That is pi's own notice; it does not affect the launch.
