### PR TITLE
release: v2.0.6 - a new Pi session no longer shows the previous session's conversation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>2.0.5</Version>
+    <Version>2.0.6</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v2.0.6.md
+++ b/docs/public/release-notes/v2.0.6.md
@@ -1,0 +1,40 @@
+# DevThrottle v2.0.6
+
+A small release with one fix that matters if you run the Pi coding agent: a new Pi session no
+longer shows, or reads aloud, a conversation that belongs to an earlier session.
+
+## A new Pi session showed the previous session's conversation
+
+Open a Pi session in a repository where you had used Pi before, and the chat screen filled with
+the conversation from that earlier session - a review from weeks ago, in one case - before you had
+typed a word. The spoken narration read that same old conversation out. The turn counter on the
+session card counted the old session's turns as well.
+
+The cause: DevThrottle found a Pi session's transcript by taking the newest transcript file in
+that repository. Pi writes a session's file only when the first message is sent, so at the moment
+a new session starts, the newest file is always the previous session's. That wrong answer was then
+kept for the whole life of the session, so it never corrected itself.
+
+What changed:
+
+- **Every Pi session is now started with its own session id**, and Pi names the transcript file
+  after it. DevThrottle knows which file belongs to which session from the moment it starts, and
+  never has to guess.
+- **Reopening a Pi session brings its conversation back.** The same id that names the file is
+  what Pi uses to resume, so a reopened session picks up where it left off instead of starting
+  from nothing.
+- **Clearing a Pi session's context is followed correctly.** Pi starts a fresh transcript when
+  you clear its context. DevThrottle now finds that new file and follows it, rather than staying
+  on the old one.
+- The context gauge and the model shown for a Pi session come from that session's own file, not
+  the newest file in the repository.
+
+A Pi session that was already open before you install this release keeps the old behaviour until
+you close it. Sessions opened after the update behave as described above.
+
+## Also in this release
+
+- The `cc-devthrottle` command line tool gains `session raise` and `session workers`, for a session
+  that is being driven by another session to put its hand up when it is blocked, and for the
+  driving session to see who is blocked. These two commands need the hosted service update that
+  follows this release, and do not work until it is deployed.


### PR DESCRIPTION
Version bump to 2.0.6 in Directory.Build.props and the written release notes at docs/public/release-notes/v2.0.6.md. The Director-side change since v2.0.5 is thefrederiksen/devthrottle#2673 (fixes thefrederiksen/devthrottle_internal#1897). No Gateway hub method changed since v2.0.5, so no hosted deploy is a prerequisite for this tag. The release gate (test-local.ps1 -Parked -Configuration Release plus the two installer test projects) runs on the merged commit before the tag is pushed.