### PR TITLE
A per-account switch that turns the mentor report off

### DIFF
--- a/packages/client-core/src/settings/MentorReportCard.test.tsx
+++ b/packages/client-core/src/settings/MentorReportCard.test.tsx
@@ -1,0 +1,163 @@
+// The Mentor report card (devthrottle_internal#1661), rendered against a fake Gateway.
+//
+// What these prove that a Gateway test cannot: the card SHOWS the account its current answer and SENDS the
+// one it clicked. The Gateway's own tests prove the value is stored and served; a card that rendered the box
+// ticked for an account that had turned the mentor OFF would leave those green while the person looking at
+// Settings believed the opposite of what is true - and the thing they believed they had stopped is a model
+// reading their own prompts, which is the one setting on this page where that mistake actually matters.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MentorReportCard } from "./NotificationsTab";
+import { SettingsTabPanel } from "./SettingsTabs";
+import { MemoryRouter } from "react-router-dom";
+
+const LABEL = "Send me the mentor report";
+
+// The per-account snapshot GET /gateway/settings answers with. Only the field under test varies, and it is
+// OMITTED entirely when undefined - that is the older-Gateway shape, which has to read as on.
+function snapshot(mentorReportEnabled?: boolean) {
+  const body: Record<string, unknown> = {
+    snoozeDefaultMinutes: 60,
+    snoozePresets: [15, 60, 240, 480],
+    snoozeMaxPresets: 5,
+    timeZone: "America/Toronto",
+    timeZoneMachineDefault: "America/Toronto",
+    dailyReportCadence: "daily",
+  };
+  if (mentorReportEnabled !== undefined) body.mentorReportEnabled = mentorReportEnabled;
+  return body;
+}
+
+// Every request the card makes, recorded, so a test can assert what actually went over the wire rather
+// than what the component says it did.
+let calls: { url: string; method: string; body: unknown }[] = [];
+
+function fakeGateway(enabled?: boolean) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      const body = init?.body === undefined ? undefined : JSON.parse(String(init.body));
+      calls.push({ url, method, body });
+      if (url === "/gateway/settings") {
+        return new Response(JSON.stringify(snapshot(enabled)), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url === "/gateway/mentor-report") {
+        // The Gateway echoes what it applied; the card must render THAT, not what it sent.
+        return new Response(JSON.stringify({ enabled: (body as { enabled: boolean }).enabled }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected request: ${method} ${url}`);
+    }),
+  );
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the Mentor report card", () => {
+  it("shows an account that never chose as receiving the report", async () => {
+    fakeGateway(true);
+    render(<MentorReportCard />);
+
+    expect(((await screen.findByLabelText(LABEL)) as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("shows an account that turned it off as turned off", async () => {
+    fakeGateway(false);
+    render(<MentorReportCard />);
+
+    expect(((await screen.findByLabelText(LABEL)) as HTMLInputElement).checked).toBe(false);
+  });
+
+  // A Gateway too old to know the field answers a snapshot without it. That must read as ON, not as off:
+  // an account being shown "stopped" for a report that is still being written and sent is the one wrong
+  // answer here that nobody can act on, because the page tells them there is nothing to turn off.
+  it("reads a snapshot with no mentor field as on rather than off", async () => {
+    fakeGateway(undefined);
+    render(<MentorReportCard />);
+
+    expect(((await screen.findByLabelText(LABEL)) as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("sends the opt-out and confirms in words that the prompts will not be read", async () => {
+    fakeGateway(true);
+    render(<MentorReportCard />);
+
+    fireEvent.click(await screen.findByLabelText(LABEL));
+
+    await waitFor(() => expect(calls.some((c) => c.url === "/gateway/mentor-report")).toBe(true));
+    const write = calls.find((c) => c.url === "/gateway/mentor-report")!;
+    expect(write.method).toBe("PUT");
+    expect(write.body).toEqual({ enabled: false });
+    // A silent success reads as a checkbox that did nothing, so the card owes a sentence - and the sentence
+    // has to answer the question somebody turning this off is actually asking.
+    expect(await screen.findByText(/prompts will not be read/i)).toBeTruthy();
+    expect(((await screen.findByLabelText(LABEL)) as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("sends the opt-in when an account that had turned it off turns it back on", async () => {
+    fakeGateway(false);
+    render(<MentorReportCard />);
+
+    fireEvent.click(await screen.findByLabelText(LABEL));
+
+    await waitFor(() => expect(calls.some((c) => c.url === "/gateway/mentor-report")).toBe(true));
+    expect(calls.find((c) => c.url === "/gateway/mentor-report")!.body).toEqual({ enabled: true });
+    expect(((await screen.findByLabelText(LABEL)) as HTMLInputElement).checked).toBe(true);
+  });
+
+  // NOTE on what this asserts: the shared settings client wraps a failure in a GatewayError carrying no
+  // serverReason, so the shared message helper answers with its own sentence for the status rather than the
+  // Gateway's words. That is true of every card on this surface. What matters here is that a refused write
+  // SAYS SO and leaves the box where the Gateway left it - an opt-out that silently appears to have taken
+  // would have somebody believing their prompts are no longer being read when they are.
+  it("reports a refused write rather than pretending the change took", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/gateway/settings") {
+          return new Response(JSON.stringify(snapshot(true)), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ error: "a tenant could not be resolved for this request" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+    render(<MentorReportCard />);
+
+    fireEvent.click(await screen.findByLabelText(LABEL));
+
+    const failure = await screen.findByText(/could not/i);
+    expect(failure.textContent).toContain("403");
+    expect(((await screen.findByLabelText(LABEL)) as HTMLInputElement).checked).toBe(true);
+  });
+
+  // The standing rule is that Settings is one page on two surfaces. The card lives in the shared tab, so
+  // this asserts it through the same panel BOTH shells mount - the phone cannot end up without it.
+  it("is on the Notifications tab that both shells mount", async () => {
+    fakeGateway(true);
+    render(
+      <MemoryRouter>
+        <SettingsTabPanel tab="notifications" />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: /Mentor report/ })).toBeTruthy();
+  });
+});

--- a/packages/client-core/src/settings/NotificationsTab.tsx
+++ b/packages/client-core/src/settings/NotificationsTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import {
   setDailyReportCadence,
+  setMentorReportEnabled,
   setSnoozePresets,
   setTimeZone,
   type ReportCadence,
@@ -29,6 +30,7 @@ export function NotificationsTab() {
       <TimeZoneCard />
       <NotificationsCard />
       <DailyReportCard />
+      <MentorReportCard />
     </>
   );
 }
@@ -426,6 +428,65 @@ export function DailyReportCard() {
             onChange={() => choose("off")}
           />
           Do not send it
+        </label>
+      </div>
+      {msg !== "" && <div className="settings-msg">{msg}</div>}
+    </section>
+  );
+}
+
+// ---- the Development Mentor report (devthrottle_internal#1661) ------------------------------------
+//
+// The second email about you that arrives on a rhythm, so it sits beside the daily report rather than on a
+// tab of its own. Everything else in this file is about how a session that needs you reaches you; these two
+// are about what the product sends you when nothing needs you at all.
+//
+// It is a CHECKBOX and not a pair of radios, which is the opposite of the card above it. The daily report
+// answers "how often" and has a third answer waiting; this one answers "do you want this at all", and a
+// question with two answers is not made clearer by drawing it as a list.
+//
+// The Gateway does not send this report - the mentor harness does, and it reads this setting straight out of
+// the database when it runs. So the hint says the change applies to the next report rather than naming an
+// hour, and it is written not to promise a rhythm the owner has not committed to publicly.
+export function MentorReportCard() {
+  const { settings, setSettings, error, busy, msg, runSave } = useGatewaySettings();
+
+  if (error !== null) {
+    return <div className="settings-error">Could not load the mentor report setting: {error}</div>;
+  }
+  if (settings === null) {
+    return <p className="settings-loading">Loading...</p>;
+  }
+
+  const toggle = (enabled: boolean) => {
+    if (busy || enabled === settings.mentorReportEnabled) return;
+    void runSave(async () => {
+      const applied = await setMentorReportEnabled(enabled);
+      setSettings({ ...settings, mentorReportEnabled: applied });
+      return applied
+        ? "On. Your next mentor report will be sent."
+        : "Off. No more mentor reports will be sent, and your prompts will not be read to write one.";
+    });
+  };
+
+  return (
+    <section className="settings-card">
+      <CardHead title="Mentor report" scope={ACCOUNT_SCOPE} />
+      <p className="settings-hint">
+        Feedback on how you prompt: what you asked for over the week, where the asking cost you time, and
+        what to try next. It is written by AI from your own prompts - no person reads them to produce it -
+        and it goes to your account&apos;s email address. Turn it off here and no report is made for you and
+        your prompts are not read to write one.
+      </p>
+      <div className="settings-field">
+        <label className="settings-check">
+          <input
+            type="checkbox"
+            checked={settings.mentorReportEnabled}
+            disabled={busy}
+            onChange={(e) => toggle(e.target.checked)}
+          />
+          Send me the mentor report
         </label>
       </div>
       {msg !== "" && <div className="settings-msg">{msg}</div>}

--- a/packages/client-core/src/settings/settingsClient.ts
+++ b/packages/client-core/src/settings/settingsClient.ts
@@ -32,6 +32,9 @@ export interface GatewaySettings {
   // this device or this machine: the report is one person and one email, which is exactly why the question
   // left the first-run wizard, where it was asked once per install.
   dailyReportCadence: ReportCadence;
+  // Whether this account receives the Development Mentor report (devthrottle_internal#1661). One value for
+  // the account: the mentor reads one person's own prompts and writes to one person.
+  mentorReportEnabled: boolean;
 }
 
 /**
@@ -103,6 +106,10 @@ export async function getGatewaySettings(signal?: AbortSignal): Promise<GatewayS
     // for the same reason: a card that showed Off because it met a value it did not know would tell the
     // account its report is stopped when it is not.
     dailyReportCadence: body.dailyReportCadence === "off" ? "off" : "daily",
+    // Only an explicit false reads as off, for the same reason the cadence above only reads "off" as off: a
+    // card that showed Off because the field was missing - an older Gateway, a shape this client does not
+    // know - would tell the account the mentor is stopped when it is not.
+    mentorReportEnabled: body.mentorReportEnabled !== false,
   };
 }
 
@@ -120,6 +127,19 @@ export async function setDailyReportCadence(
     signal,
   );
   return body.cadence === "off" ? "off" : "daily";
+}
+
+// PUT /gateway/mentor-report { enabled } - turn the Development Mentor report on or off for this account
+// (devthrottle_internal#1661). The Gateway does not send that report; the harness reads this setting out of
+// the database when it runs, so a change applies to the next run. Returns the applied value.
+export async function setMentorReportEnabled(enabled: boolean, signal?: AbortSignal): Promise<boolean> {
+  const body = await putJson<{ enabled?: boolean }>(
+    "/gateway/mentor-report",
+    "PUT /gateway/mentor-report",
+    { enabled },
+    signal,
+  );
+  return body.enabled !== false;
 }
 
 // PUT /gateway/time-zone { timeZone } - set the display time zone (an IANA id) the private dashboards read

--- a/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedOwnerSettingsSelfHostControlTests.cs
@@ -131,6 +131,7 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
                              "gateway/settings",
                              "gateway/snooze-default",
                              "gateway/daily-report",
+                             "gateway/mentor-report",
                              "gateway/injected-text",
                              "gateway/snooze-presets",
                              "gateway/time-zone",
@@ -181,7 +182,9 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
                 {
                     "snoozeDefaultMinutes", "snoozePresets",
                     "snoozeMaxPresets", "timeZone", "timeZoneMachineDefault", "dailyReportCadence",
+                    "mentorReportEnabled",
                 }, properties);
+                Assert.True(root.GetProperty("mentorReportEnabled").GetBoolean());
                 Assert.Equal(ReportCadences.DailyName, root.GetProperty("dailyReportCadence").GetString());
                 Assert.True(root.GetProperty("snoozePresets").GetArrayLength() > 0);
                 Assert.Equal(SnoozePresetsConfig.MaxPresets, root.GetProperty("snoozeMaxPresets").GetInt32());
@@ -198,6 +201,14 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
                 // mailing everyone who has an address, exactly as it did before the setting existed.
                 Assert.Equal(new[] { "cadence" }, properties);
                 Assert.Equal(ReportCadences.DailyName, root.GetProperty("cadence").GetString());
+                break;
+
+            case "gateway/mentor-report":
+                // Whether this account receives the mentor report (devthrottle_internal#1661). Its
+                // independently knowable value is the documented default - ON - because a Gateway nobody has
+                // configured must answer the way every account was treated before the setting existed.
+                Assert.Equal(new[] { "enabled" }, properties);
+                Assert.True(root.GetProperty("enabled").GetBoolean());
                 break;
 
             case "gateway/injected-text":
@@ -261,6 +272,8 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
                 // "off" is the value that is distinguishable from the default, so the re-read proves a write
                 // rather than a no-op.
                 data.Add(hosted, "PUT", "gateway/daily-report", "{\"cadence\":\"off\"}", "daily-report", "off");
+                // false is the value distinguishable from the default, so the re-read proves a write.
+                data.Add(hosted, "PUT", "gateway/mentor-report", "{\"enabled\":false}", "mentor-report", "false");
                 // transcription-mode is NOT here - it needs a seeded starting value to be distinguishable
                 // from a no-op, so it has its own test below.
                 data.Add(hosted, "PUT", "gateway/tts-voice", "{\"voice\":\"shimmer\"}", "tts-voice", "shimmer");
@@ -294,6 +307,9 @@ public sealed class HostedOwnerSettingsSelfHostControlTests : IAsyncLifetime
         "snooze-presets" => string.Join(",", _gateway.TenantSettingsResolver.SnoozePresets(TenantId.Local)),
         "time-zone" => _gateway.TenantSettingsResolver.TimeZone(TenantId.Local),
         "daily-report" => ReportCadences.Name(_gateway.TenantSettingsResolver.DailyReportCadence(TenantId.Local)),
+        // Lower-cased on purpose: it is compared against the literal the theory row carries, and the
+        // spelling the harness parses out of the store is "true"/"false".
+        "mentor-report" => _gateway.TenantSettingsResolver.MentorReportEnabled(TenantId.Local) ? "true" : "false",
         "transcription-mode" => TranscriptionModeConfig.Get().ToConfigString(),
         "tts-voice" => _gateway.TenantSettingsResolver.TtsVoice(TenantId.Local, TranscriptionModeConfig.Get()),
         "wingman-model" => _gateway.TenantSettingsResolver.WingmanModel(TenantId.Local, TranscriptionModeConfig.Get(), WingmanModelRole.Thinking).Value,

--- a/src/CcDirector.Gateway.Tests/HostedPerAccountSettingsServeTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedPerAccountSettingsServeTests.cs
@@ -121,6 +121,8 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
         ("PUT", "gateway/tts-voice",                "{\"voice\":\"shimmer\"}"),
         ("GET", "gateway/daily-report",             null),
         ("PUT", "gateway/daily-report",             "{\"cadence\":\"off\"}"),
+        ("GET", "gateway/mentor-report",            null),
+        ("PUT", "gateway/mentor-report",            "{\"enabled\":false}"),
         ("GET", "gateway/injected-text",            null),
         ("PUT", "gateway/injected-text",            "{\"use_yours\":true,\"yours\":\"words for one account only\"}"),
         // Issue #1360: these three setters REFUSE any id that is not a devthrottle/ included
@@ -222,6 +224,42 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
         Assert.Equal("daily", await ReadString(_httpB, "gateway/daily-report", "cadence"));
     }
 
+    /// <summary>
+    /// ISOLATED - the mentor report switch (devthrottle_internal#1661). A turns the mentor off; B still has
+    /// it on. The same property that matters most for the daily report matters more here: what an account is
+    /// turning off is a model reading that account's own prompts, so one person's opt-out leaking onto
+    /// somebody else's row would silence a report nobody asked to stop - and leaking the other way would keep
+    /// reading the prompts of somebody who asked us not to.
+    /// </summary>
+    [Fact]
+    public async Task Mentor_report_turned_off_by_one_tenant_does_not_silence_another_on_hosted()
+    {
+        (await OwnerSettingsRoutes.SendAsync(_httpA, "PUT", "gateway/mentor-report", "{\"enabled\":false}"))
+            .EnsureSuccessStatusCode();
+
+        Assert.False(await ReadBool(_httpA, "gateway/mentor-report", "enabled"));
+        Assert.True(await ReadBool(_httpB, "gateway/mentor-report", "enabled"));
+        // And the snapshot the Settings page actually renders agrees with the route it writes through.
+        Assert.False(await ReadBool(_httpA, "gateway/settings", "mentorReportEnabled"));
+        Assert.True(await ReadBool(_httpB, "gateway/settings", "mentorReportEnabled"));
+    }
+
+    /// <summary>
+    /// A body with no "enabled" is REFUSED, not read as either answer. Guessing would answer "saved" for a
+    /// choice nobody made, and one of the two guesses keeps reading the prompts of somebody who asked us to
+    /// stop.
+    /// </summary>
+    [Fact]
+    public async Task Mentor_report_write_without_a_value_is_refused_and_changes_nothing()
+    {
+        var before = await ReadBool(_httpA, "gateway/mentor-report", "enabled");
+
+        var response = await OwnerSettingsRoutes.SendAsync(_httpA, "PUT", "gateway/mentor-report", "{}");
+
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(before, await ReadBool(_httpA, "gateway/mentor-report", "enabled"));
+    }
+
     /// <summary>ISOLATED - the text-to-speech voice. A picks a distinctive voice; B is unaffected.</summary>
     [Fact]
     public async Task Tts_voice_written_by_one_tenant_is_invisible_to_another_on_hosted()
@@ -302,6 +340,12 @@ public sealed class HostedPerAccountSettingsServeTests : IAsyncLifetime
     {
         using var doc = await ReadJson(http, path);
         return doc.RootElement.GetProperty(property).GetString();
+    }
+
+    private static async Task<bool> ReadBool(HttpClient http, string path, string property)
+    {
+        using var doc = await ReadJson(http, path);
+        return doc.RootElement.GetProperty(property).GetBoolean();
     }
 
     private static async Task<int> ReadInt(HttpClient http, string path, string property)

--- a/src/CcDirector.Gateway.UnitTests/TenantSettingsResolverTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TenantSettingsResolverTests.cs
@@ -267,4 +267,91 @@ public sealed class TenantSettingsResolverTests
 
         Assert.Equal(ReportCadences.DailyName, store.Get(TenantA, TenantSettingKeys.DailyReportCadence));
     }
+
+    // ---- the mentor report switch (devthrottle_internal#1661) ----------------------------------------
+    //
+    // This Gateway does not SEND the mentor report - the harness does, reading this same row out of the
+    // database. So what these prove is that the row an account writes here is the row that harness will
+    // read: stored under the documented key, in the documented "true"/"false" spelling, per tenant.
+
+    [Fact]
+    public void MentorReportEnabled_NoChoice_IsOn()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        // What every account received before this setting existed. Defaulting to OFF would silently stop
+        // the report for everybody the moment the setting shipped, and nobody would have asked for that.
+        Assert.True(r.MentorReportEnabled(TenantA));
+    }
+
+    [Fact]
+    public void MentorReportEnabled_Off_RoundTrips()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        r.SetMentorReportEnabled(TenantA, false, Now);
+
+        Assert.False(r.MentorReportEnabled(TenantA));
+    }
+
+    [Fact]
+    public void MentorReportEnabled_OneTenantsOptOut_DoesNotSilenceAnother()
+    {
+        using var h = new GatewayDbTestHarness();
+        var r = NewResolver(h);
+
+        r.SetMentorReportEnabled(TenantA, false, Now);
+
+        Assert.False(r.MentorReportEnabled(TenantA));
+        Assert.True(r.MentorReportEnabled(TenantB));
+    }
+
+    [Fact]
+    public void MentorReportEnabled_UnreadableValue_ReadsAsOn_NotAsSilence()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new TenantSettingsStore(h.Open());
+        var r = new TenantSettingsResolver(store);
+
+        foreach (var junk in new[] { "", "   ", "off", "no", "0" })
+        {
+            store.Set(TenantA, TenantSettingKeys.MentorReportEnabled, junk, Now);
+            Assert.True(r.MentorReportEnabled(TenantA));
+        }
+    }
+
+    [Fact]
+    public void MentorReportEnabled_IsStoredUnderTheDocumentedKey_InTheSpellingTheHarnessReads()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new TenantSettingsStore(h.Open());
+        var r = new TenantSettingsResolver(store);
+
+        // The harness parses this row itself, in Python, out of gateway.tenant_settings. It accepts exactly
+        // "true" and "false" and REFUSES anything else rather than guessing, so the spelling written here is
+        // not a detail: a value this assertion let drift would stop that account's report with an error
+        // instead of sending it.
+        r.SetMentorReportEnabled(TenantA, false, Now);
+        Assert.Equal("false", store.Get(TenantA, TenantSettingKeys.MentorReportEnabled));
+
+        r.SetMentorReportEnabled(TenantA, true, Now);
+        Assert.Equal("true", store.Get(TenantA, TenantSettingKeys.MentorReportEnabled));
+    }
+
+    [Fact]
+    public void MentorReportEnabled_TurningItBackOn_IsStoredRatherThanLeftAbsent()
+    {
+        using var h = new GatewayDbTestHarness();
+        var store = new TenantSettingsStore(h.Open());
+        var r = new TenantSettingsResolver(store);
+
+        r.SetMentorReportEnabled(TenantA, false, Now);
+        r.SetMentorReportEnabled(TenantA, true, Now);
+
+        // "Back on" is a choice this account made, and a later look at the store can tell it apart from an
+        // account that never touched the setting.
+        Assert.Equal("true", store.Get(TenantA, TenantSettingKeys.MentorReportEnabled));
+    }
 }

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -22,9 +22,12 @@ namespace CcDirector.Gateway.Api;
 ///
 ///   SERVE ON HOSTED (per-account, resolve the caller tenant, 403 if unresolved):
 ///   GET  /gateway/settings        -> { snoozeDefaultMinutes, snoozePresets, snoozeMaxPresets,
-///                                       timeZone, timeZoneMachineDefault, dailyReportCadence }
+///                                       timeZone, timeZoneMachineDefault, dailyReportCadence,
+///                                       mentorReportEnabled }
 ///   GET+PUT /gateway/snooze-default, /gateway/snooze-presets, /gateway/time-zone
 ///   GET+PUT /gateway/daily-report               (per-account report cadence; issue #1000)
+///   GET+PUT /gateway/mentor-report              (per-account mentor report on/off;
+///                                                devthrottle_internal#1661)
 ///   GET  /gateway/ai-provider     -> { provider, wingmanModel, wingmanFastModel, carModeModel,
 ///                                       carModeEndPhrase, transcriptionModel, ttsModel, ttsVoice, voices[],
 ///                                       catalogAvailable }
@@ -193,7 +196,47 @@ internal static class SettingsEndpoints
                 // answer (weekly) is waiting on the report being able to summarize a range.
                 dailyReportCadence = Settings.ReportCadences.Name(
                     host.TenantSettingsResolver.DailyReportCadence(t.Value)),
+                // Whether this account receives the Development Mentor report
+                // (devthrottle_internal#1661). A boolean and not a cadence name: the question is whether the
+                // mentor reads this person's prompts at all, and that has exactly two answers.
+                mentorReportEnabled = host.TenantSettingsResolver.MentorReportEnabled(t.Value),
             });
+        });
+
+        // Whether this account receives the Development Mentor report (devthrottle_internal#1661). Per
+        // ACCOUNT, because the mentor reads one person's own prompts and writes to one person. The Gateway
+        // does not send that report - the harness does, and it reads this same row out of the database
+        // directly - so this route's only job is to let the person say yes or no somewhere they can find it.
+        app.MapGet("/gateway/mentor-report", (HttpContext ctx) =>
+        {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, host.TenantBoundary);
+            if (t is null) return TenantRequired();
+            return Results.Json(new { enabled = host.TenantSettingsResolver.MentorReportEnabled(t.Value) });
+        });
+
+        app.MapPut("/gateway/mentor-report", async (HttpContext ctx) =>
+        {
+            var t = GatewayEndpoints.ResolveReadTenant(ctx, host.TenantBoundary);
+            if (t is null) return TenantRequired();
+            try
+            {
+                var body = await JsonSerializer.DeserializeAsync<MentorReportBody>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+                // A missing or non-boolean "enabled" is REFUSED, never read as either answer. Guessing here
+                // would answer "saved" for a choice nobody made, and one of the two guesses silences a report
+                // the account still wants while the other keeps mailing one it asked to stop.
+                if (body?.Enabled is null)
+                    return Results.BadRequest(new { error = "body { \"enabled\": true|false } is required" });
+
+                host.TenantSettingsResolver.SetMentorReportEnabled(t.Value, body.Enabled.Value, DateTime.UtcNow);
+                FileLog.Write($"[SettingsEndpoints] mentor_report_enabled set to {body.Enabled.Value} for tenant={t.Value.ToLogString()}");
+                return Results.Json(new { enabled = body.Enabled.Value });
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[SettingsEndpoints] PUT /gateway/mentor-report bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
         });
 
         // How often this account wants the daily report email (issue #1000, follow-up to
@@ -793,4 +836,7 @@ internal static class SettingsEndpoints
     private sealed record SnoozePresetsBody(int[]? Presets, int? DefaultMinutes);
     private sealed record TimeZoneBody(string? TimeZone);
     private sealed record DailyReportBody(string? Cadence);
+
+    /// <summary>Nullable on purpose: a body with no "enabled" is refused rather than read as false.</summary>
+    private sealed record MentorReportBody(bool? Enabled);
 }

--- a/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingKeys.cs
@@ -90,6 +90,20 @@ public static class TenantSettingKeys
     public const string DailyReportCadence = "daily_report_cadence";
 
     /// <summary>
+    /// Whether this account receives the Development Mentor report - the weekly written-and-spoken feedback on
+    /// how the person prompts (devthrottle_internal#1661). Stored as "true"/"false". Like
+    /// <see cref="VoiceModeAll"/> there is no operator global default to fall back to: it is one account's
+    /// choice about one account's mail, and its default is ON.
+    ///
+    /// A BOOLEAN and not a cadence name, which is the opposite of the call
+    /// <see cref="DailyReportCadence"/> made, on purpose. That setting answers "how often" and had a third
+    /// answer already waiting. This one answers "do you want this at all": the mentor reads a person's own
+    /// prompts to write it, and the question somebody asks about that is whether it happens, never how often.
+    /// A rhythm the account cannot choose is not a rhythm it should be offered a name for.
+    /// </summary>
+    public const string MentorReportEnabled = "mentor_report_enabled";
+
+    /// <summary>
     /// The language this account is SPOKEN TO in, stored as the short code (<c>en</c>/<c>fr</c>/<c>es</c>)
     /// - issue #1008. Like <see cref="VoiceModeAll"/> there is no operator global default to fall back
     /// to: which language a person wants to be spoken to in is that person's own choice and nobody
@@ -150,7 +164,7 @@ public static class TenantSettingKeys
         WingmanModel, WingmanFastModel, TtsModel, TtsVoice,
         CarModeModel, CarModeEndPhrase, SnoozePresets, SnoozeDefaultMinutes, TimeZone, InjectedText,
         VoiceModeAll, DictationSuggestionsInDailyEmail, DictationEmailCadence, DailyReportCadence,
-        SpokenLanguage, SpokenVoiceByLanguage,
+        MentorReportEnabled, SpokenLanguage, SpokenVoiceByLanguage,
         SessionSupervisorEnabled, SessionSupervisorFirstRetrySeconds, SessionSupervisorRetryCadenceMinutes,
         SessionSupervisorMaxLongRetries, SessionSupervisorModelFallbackEnabled,
     };

--- a/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
+++ b/src/CcDirector.Gateway/Settings/TenantSettingsResolver.cs
@@ -286,6 +286,26 @@ public sealed class TenantSettingsResolver
             : ReportCadences.Default;
 
     /// <summary>
+    /// Whether this account receives the Development Mentor report (devthrottle_internal#1661). Defaults to
+    /// <see cref="MentorReportEnabledDefault"/> - ON - when the account has expressed no choice, which is what
+    /// every account received before the setting existed.
+    ///
+    /// AN UNREADABLE VALUE ALSO READS AS ON, matching <see cref="DailyReportCadence"/> and for its reason: a
+    /// report somebody silenced arrives visibly and carries its own way out, while a report somebody wants
+    /// going silent is invisible to them. It also keeps a Gateway rollback safe.
+    ///
+    /// THIS READ IS NOT THE GATE. Nothing in this process sends the mentor report - it is produced and sent by
+    /// the harness in devthrottle_internal, which reads this same row out of the database directly. The harness
+    /// refuses on an unreadable value rather than defaulting to ON, and the difference is deliberate rather
+    /// than an inconsistency: this read answers "what does the card show", where being wrong costs a wrong
+    /// checkbox, and that one answers "does an email quoting this person's prompts go out", where being wrong
+    /// costs the send an opt-out was supposed to stop.
+    /// </summary>
+    public bool MentorReportEnabled(TenantId tenant)
+        => ParseBool(_store.Get(tenant, TenantSettingKeys.MentorReportEnabled))
+           ?? MentorReportEnabledDefault;
+
+    /// <summary>
     /// The language this tenant is SPOKEN TO in (issue #1008) - the single source every spoken path
     /// reads, so a language reaches all of them or none of them. Defaults to English when the tenant has
     /// expressed no choice, which is what every account got before the setting existed.
@@ -458,6 +478,12 @@ public sealed class TenantSettingsResolver
     public void SetDailyReportCadence(TenantId tenant, ReportCadence cadence, DateTime nowUtc)
         => _store.Set(tenant, TenantSettingKeys.DailyReportCadence, ReportCadences.Name(cadence), nowUtc);
 
+    /// <summary>Set whether this account receives the Development Mentor report. ON is stored EXPLICITLY
+    /// rather than by clearing the override, so "turn it back on" is a choice this account made and a later
+    /// look at the store can tell it apart from an account that never touched the setting.</summary>
+    public void SetMentorReportEnabled(TenantId tenant, bool enabled, DateTime nowUtc)
+        => _store.Set(tenant, TenantSettingKeys.MentorReportEnabled, enabled ? "true" : "false", nowUtc);
+
     /// <summary>
     /// Set the language this tenant is spoken to in. English is stored EXPLICITLY rather than by
     /// clearing the override, so "back to English" is a choice this account made and a later look at
@@ -569,6 +595,12 @@ public sealed class TenantSettingsResolver
     /// ON. The suggestions feature exists to help people who never open Settings, so the one place it reaches
     /// them when they are not in the app has to be on by default.</summary>
     public const bool SuggestionsInDailyEmailDefault = true;
+
+    /// <summary>The default for <see cref="MentorReportEnabled"/> when an account has expressed no choice: ON.
+    /// The same reasoning as the daily report's default - an account that never opens Settings goes on
+    /// receiving what it received before the setting existed, and the report itself carries the way out in its
+    /// footer, so nobody has to find this page to be told the setting is here.</summary>
+    public const bool MentorReportEnabledDefault = true;
 
     /// <summary>The "this account has chosen no voice for any language" answer. One shared instance, so the
     /// common read allocates nothing.</summary>


### PR DESCRIPTION
The Development Mentor reads a person's own prompts to write them weekly feedback. Until now there was nowhere for that person to say no. This adds the switch.

## Where it is

Settings -> Notifications -> **Mentor report**, beside Daily report, because it is the same kind of thing: an email about you that arrives on a rhythm. Shared tab, so the phone gets it too.

A checkbox rather than a pair of radios, which is deliberately not what the card above it does. Daily report answers "how often" and already has a third answer waiting; this one answers "do you want this at all", and a question with two answers is not made clearer by drawing it as a list.

## What it stores

`mentor_report_enabled` on `tenant_settings`, "true"/"false", per tenant, no operator global default. **Default ON** - the same reasoning the daily report's default rests on: a report somebody silenced arrives visibly and carries its own way out in its footer, while a report somebody wants going silent is invisible to them and leaves them nothing to act on.

`GET /gateway/settings` carries `mentorReportEnabled`; `GET+PUT /gateway/mentor-report` reads and writes it, per-account, 403 on an unresolved tenant, the same shape as `/gateway/daily-report`. A PUT with no `enabled` is refused rather than read as either answer - guessing would answer "saved" for a choice nobody made, and one of the two guesses keeps reading the prompts of somebody who asked us to stop.

## The seam this shares with the other repo

**The Gateway does not send this report.** The harness in `devthrottle_internal/tools/mentor` does, and it reads this same row straight out of the database when it runs. So the stored spelling is a contract between two repositories, and `MentorReportEnabled_IsStoredUnderTheDocumentedKey_InTheSpellingTheHarnessReads` is the assertion on this side that keeps it from drifting under the other one.

The two sides read a corrupt value **differently, on purpose**, and the resolver documents why rather than leaving it looking like an inconsistency: this read only decides which way a checkbox is drawn, so it degrades to ON like the daily report does; the harness's read decides whether an email quoting somebody's own prompts goes out, so it refuses.

## Proof

- 26 store tests (6 new): no choice is on, off round-trips, one tenant's opt-out does not silence another, a corrupt value reads as on, the stored spelling, and turning it back on is stored rather than left absent.
- 111 endpoint tests pass, including the new isolation test (A opts out, B still has it on, and the snapshot agrees with the route that writes it) and the refusal of a body with no value.
- 71 settings UI tests (7 new). Watched red: flipping the client's missing-field default from "not false" to "=== true" reddened the test that an older Gateway's snapshot must read as ON.
- `tsc --noEmit` clean.

devthrottle_internal#1661
