### PR TITLE
fix(gateway): the turn log's staleness gap was flagging the healthy case

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogRecorderTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogRecorderTests.cs
@@ -219,24 +219,45 @@ public sealed class TurnLogRecorderTests
     }
 
     [Fact]
-    public async Task CaptureAsync_AConversationPushedBeforeTheCapture_IsNamedAsAGap()
+    public async Task CaptureAsync_AConversationPushedBeforeTheTurnEnded_IsNamedAsAGap()
     {
-        // The Director announces the state change BEFORE pushing the turn that caused it, so a capture can
-        // land between the two and store a conversation one turn short of the screen beside it. Unsaid, the
-        // record would claim to contain the turn it describes.
+        // The bad case: the last push predates the session's last activity, so the stored conversation stops
+        // short of the turn the screen beside it is showing.
         var env = new FakeEnvironment
         {
             Conversation = new StoredConversationSnapshot(
                 true, "transcript-1", Array.Empty<HistoryMessageDto>(),
                 LastPushedUtc: new DateTime(2026, 9, 4, 11, 0, 0, DateTimeKind.Utc)),
         };
+        env.Session!.LastActivityAt = new DateTime(2026, 9, 4, 11, 30, 0, DateTimeKind.Utc);
         var recorder = new TurnLogRecorder(env, nowUtc: () => new DateTime(2026, 9, 4, 12, 0, 0, DateTimeKind.Utc));
 
         await recorder.CaptureAsync(Signal(), CancellationToken.None);
 
         var record = Assert.Single(env.Written);
         Assert.Contains(record.Gaps, g => g.Part == "conversation" && g.Reason.Contains("one turn short"));
-        Assert.Equal(new DateTime(2026, 9, 4, 11, 0, 0, DateTimeKind.Utc), record.Conversation.LastPushedAtUtc);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_AConversationPushedAFTERTheTurnEnded_IsNotAGap()
+    {
+        // THE HEALTHY CASE, and the one the first version got backwards. A push that landed after the turn
+        // ended is a conversation that CONTAINS the turn - exactly what we want. Flagging it fired on every
+        // record in the first minutes of live capture, and a gap that marks good records as suspect teaches
+        // everyone to ignore the field.
+        var env = new FakeEnvironment
+        {
+            Conversation = new StoredConversationSnapshot(
+                true, "transcript-1", Array.Empty<HistoryMessageDto>(),
+                LastPushedUtc: new DateTime(2026, 9, 4, 11, 45, 0, DateTimeKind.Utc)),
+        };
+        env.Session!.LastActivityAt = new DateTime(2026, 9, 4, 11, 30, 0, DateTimeKind.Utc);
+        var recorder = new TurnLogRecorder(env, nowUtc: () => new DateTime(2026, 9, 4, 12, 0, 0, DateTimeKind.Utc));
+
+        await recorder.CaptureAsync(Signal(), CancellationToken.None);
+
+        var record = Assert.Single(env.Written);
+        Assert.DoesNotContain(record.Gaps, g => g.Part == "conversation");
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/TurnLog/TurnLogRecorder.cs
+++ b/src/CcDirector.Gateway/TurnLog/TurnLogRecorder.cs
@@ -178,18 +178,27 @@ public sealed class TurnLogRecorder : IDisposable
 
         var conversation = BuildConversation(stored);
 
-        // A CONVERSATION OLDER THAN THE TURN IS A GAP, not a conversation. The Director announces the state
-        // change before it pushes the turn that caused it, so a capture can land between the two and store a
-        // conversation that stops one turn short of the screen it sits beside. Left unsaid, that record
-        // would quietly claim to contain the turn it is describing.
-        if (stored is not null && stored.LastPushedUtc is { } pushed && pushed < startedAt)
+        // A CONVERSATION OLDER THAN THE TURN IS A GAP - but the comparison has to be against the TURN, not
+        // against this capture, and getting that backwards was the first thing the live corpus caught.
+        //
+        // The Director announces the state change before it pushes the turn that caused it, so the risk is a
+        // conversation that stops one turn short of the screen stored beside it. The evidence for that is a
+        // last push older than the session's last activity - the turn ending. Comparing against the capture
+        // instead flags the HEALTHY case, because a push that landed before we read is exactly what we want,
+        // and it fired on every record in the first minutes of real capture. A gap that marks good records
+        // as suspect is worse than no gap: it teaches everyone reading the corpus to ignore the field.
+        if (stored is not null && stored.LastPushedUtc is { } pushed && session?.LastActivityAt is { } lastActivity)
         {
-            gaps.Add(new TurnLogGap
+            var turnEnded = DateTime.SpecifyKind(lastActivity, DateTimeKind.Utc);
+            if (pushed < turnEnded)
             {
-                Part = "conversation",
-                Reason = $"the conversation was last pushed at {pushed:O}, before this capture began at {startedAt:O} - "
-                       + "it may stop one turn short of the screen stored beside it",
-            });
+                gaps.Add(new TurnLogGap
+                {
+                    Part = "conversation",
+                    Reason = $"the conversation was last pushed at {pushed:O}, before this session's last activity at "
+                           + $"{turnEnded:O} - it may stop one turn short of the screen stored beside it",
+                });
+            }
         }
         overall.Stop();
 


### PR DESCRIPTION
Caught by the live corpus within two minutes of switching capture on: every record carried a "the conversation may be one turn short" gap, and every one was healthy.

The comparison was against the start of the capture. A push that landed **before** we read is the good case - it means the conversation contains the turn. The real risk is the reverse: the Director announces the state change before pushing the turn that caused it, so the conversation is short when its last push predates the **turn ending**. It compares against the session's last activity now.

A gap that marks good records as suspect is worse than no gap - it trains everyone to ignore the field, and then a real hole passes unnoticed.

Both directions have a test. Reintroducing the old comparison turns the healthy-case test red and nothing else; checked rather than assumed. Turn-log tests: 42 passing.