### PR TITLE
fix(gateway): a stalled narration retries for real, and the sweep budget goes to work that costs something (#2675, #2676)

### DIFF
--- a/src/CcDirector.Gateway.Tests/VoiceSweepBudgetTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceSweepBudgetTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
@@ -128,15 +128,15 @@ public sealed class VoiceSweepBudgetTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task A_no_op_session_stays_in_the_sweep_so_its_recovery_needs_nobody()
+    public async Task A_no_op_session_recovers_on_the_next_pass_with_nobody_touching_the_gateway()
     {
         // The fix must NOT be "drop these sessions from the sweep". Keeping them is what makes the recovery
         // free: the moment that computer is updated it starts pushing, the next pass finds words, and
-        // narration resumes with nobody touching the Gateway. Two cycles, and the sweep comes back to every
-        // one of them both times.
+        // narration resumes with nobody touching the Gateway.
         await _gateway.SweepVoiceSessionsAsync();
         foreach (var sid in NoOpSessions)
-            Assert.True(_gateway.VoiceService!.DirectorCannotSendConversationFor(TenantNoOp, sid));
+            Assert.True(_gateway.VoiceService!.DirectorCannotSendConversationFor(TenantNoOp, sid),
+                $"session {sid} was never attempted on the first pass");
 
         // That computer is updated and pushes its conversation for one of them.
         _gateway.SeedStoredConversationForTest(TenantNoOp, "dir-noop", NoOpSessions[0],
@@ -144,11 +144,16 @@ public sealed class VoiceSweepBudgetTests : IAsyncLifetime
 
         await _gateway.SweepVoiceSessionsAsync();
 
-        // The marker comes off by itself on the very next pass - no restart, nothing to clear by hand.
+        // The marker comes off by itself on the very next pass - no restart, nothing to clear by hand. A
+        // CHANGE from true to false, which is the one observation here that only the second pass can have
+        // produced.
         Assert.False(_gateway.VoiceService!.DirectorCannotSendConversationFor(TenantNoOp, NoOpSessions[0]));
-        // ...and the sessions still waiting on that computer are still being visited, not stood down.
-        foreach (var sid in NoOpSessions.Skip(1))
-            Assert.True(_gateway.VoiceService!.DirectorCannotSendConversationFor(TenantNoOp, sid));
+
+        // NOTHING IS ASSERTED HERE ABOUT THE OTHER THREE. Their markers are still set - but they were set by
+        // the FIRST pass, so their presence is a leftover and would hold just as well if the second pass had
+        // skipped them entirely (found in review). A check a stale value satisfies is not a check. The claim
+        // that every one of them is visited in a single cycle is made, as a presence, by
+        // One_accounts_no_op_sessions_cannot_starve_another_accounts_session_out_of_the_same_cycle.
     }
 
     /// <summary>Poll for a verb+session rather than sleeping a fixed time: the sweep fires generation onto

--- a/src/CcDirector.Gateway.Tests/VoiceSweepBudgetTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceSweepBudgetTests.cs
@@ -38,12 +38,28 @@ public sealed class VoiceSweepBudgetTests : IAsyncLifetime
 {
     private const string Token = "test-token";
 
+    /// <summary>
+    /// A suffix unique to THIS test instance, so no two tests in this class ever name the same session.
+    ///
+    /// It is not tidiness, it is the isolation this class depends on, and it was missing: the tests here
+    /// share a process, xunit gives each one a fresh GatewayHost but the Gateway's turn store resolves under
+    /// the process-wide CcStorage root, so a conversation SEEDED for a session id by one test is still there
+    /// when another test uses the same id. The recovery test seeds one; with the ids shared, whichever order
+    /// put it first left the starvation test looking at a session that already had words - which reads
+    /// exactly like the sweep having skipped it. Caught by the full suite after both tests passed together
+    /// in isolation, because the two orders are not the same experiment.
+    ///
+    /// The rule to carry: a test's isolation is only as deep as the deepest thing the production code
+    /// derives from, and a Gateway per test is NOT a store per test.
+    /// </summary>
+    private readonly string _run = Guid.NewGuid().ToString("N")[..8];
+
     /// <summary>Four, because that is how many the account on the hosted Gateway had, and because it is more
     /// than the three-generation cap - so the starvation is reproduced rather than merely described.</summary>
-    private static readonly string[] NoOpSessions =
-        { "sweep-noop-1", "sweep-noop-2", "sweep-noop-3", "sweep-noop-4" };
+    private string[] NoOpSessions => new[]
+        { $"sweep-noop-1-{_run}", $"sweep-noop-2-{_run}", $"sweep-noop-3-{_run}", $"sweep-noop-4-{_run}" };
 
-    private const string NarratableSession = "sweep-narratable";
+    private string NarratableSession => $"sweep-narratable-{_run}";
 
     private TenantId TenantNoOp { get; set; }
     private TenantId TenantNarratable { get; set; }

--- a/src/CcDirector.Gateway.Tests/VoiceSweepBudgetTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceSweepBudgetTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// THE VOICE SWEEP'S PER-CYCLE BUDGET IS SPENT ON WORK, NOT ON ATTEMPTS (issue #2675).
+///
+/// What happened. The background narration sweep starts at most three generations per 45-second cycle,
+/// and the cap is global across accounts on purpose - the wingman brain is one serialized resource. It
+/// counted every attempt it DISPATCHED. One account's four sessions were owned by a computer running a
+/// build that cannot send its conversation, so each attempt reached the Gateway's own store, found it
+/// empty, recorded the honest "update that computer" fact and returned - having called neither the model
+/// nor the speech provider. Each still took a slot. On 2026-09-04 that account consumed 4,356 slots and
+/// every other account on the hosted Gateway got 5, so the one loop that recovers a session whose
+/// narration failed never reached the sessions that needed it.
+///
+/// This test is the fleet in miniature: an account whose every voice session takes a no-op arm, beside a
+/// second account with one session that genuinely has words to narrate, and ONE cycle of the REAL sweep.
+///
+/// IT DOES NOT DEPEND ON WHICH ACCOUNT IS SWEPT FIRST, which matters because nothing promises an order.
+/// It asserts that FIVE sessions were all attempted in the one cycle; the old code could attempt three,
+/// so it fails whichever account the pass happens to reach first.
+///
+/// REVERT-PROOF (against the real production lines in GatewayHost.SweepVoiceSessionsAsync): replace the
+/// callback-counted budget with the old unconditional `generated++` after the dispatch and
+/// <see cref="One_accounts_no_op_sessions_cannot_starve_another_accounts_session_out_of_the_same_cycle"/>
+/// goes RED - three of the five sessions are attempted and the rest of the cycle never happens. Confirmed
+/// by running it that way before the fix was written.
+/// </summary>
+public sealed class VoiceSweepBudgetTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+
+    /// <summary>Four, because that is how many the account on the hosted Gateway had, and because it is more
+    /// than the three-generation cap - so the starvation is reproduced rather than merely described.</summary>
+    private static readonly string[] NoOpSessions =
+        { "sweep-noop-1", "sweep-noop-2", "sweep-noop-3", "sweep-noop-4" };
+
+    private const string NarratableSession = "sweep-narratable";
+
+    private TenantId TenantNoOp { get; set; }
+    private TenantId TenantNarratable { get; set; }
+
+    private GatewayHost _gateway = null!;
+    private FakeTunnelDirector _dirNoOp = null!;
+    private FakeTunnelDirector _dirNarratable = null!;
+
+    private readonly ConcurrentQueue<DirectorCommand> _seenByNarratable = new();
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-voice-budget-" + Guid.NewGuid().ToString("N"));
+    private string? _priorHosted;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        var deviceNoOp = HostedTestEnrollment.Enroll(_gateway, "sub-noop", "noop@example.com", "dev-noop", "MN");
+        var deviceNarratable = HostedTestEnrollment.Enroll(_gateway, "sub-real", "real@example.com", "dev-real", "MR");
+        TenantNoOp = deviceNoOp.Tenant;
+        TenantNarratable = deviceNarratable.Tenant;
+
+        _dirNoOp = await FakeTunnelDirector.StartAsync(_gateway, deviceNoOp.DeviceKey, "dir-noop", "MN",
+            dispatch: _ => FakeTunnelDirector.Ok(new { ok = true }));
+        _dirNarratable = await FakeTunnelDirector.StartAsync(_gateway, deviceNarratable.DeviceKey, "dir-real", "MR",
+            dispatch: cmd => { _seenByNarratable.Enqueue(cmd); return FakeTunnelDirector.Ok(new { ok = true }); });
+
+        // Neither fake Director's Hello claims it sends conversations, which is exactly the state of the
+        // real computer in the incident - so a session with nothing in the store takes the
+        // "that computer cannot send its conversation" arm, the no-op arm this test is about.
+        await _dirNoOp.PushSnapshotAsync(NoOpSessions.Select(Sample).ToArray());
+        await _dirNarratable.PushSnapshotAsync(Sample(NarratableSession));
+
+        foreach (var sid in NoOpSessions)
+            _gateway.VoiceService!.Mark(TenantNoOp, sid);
+        _gateway.VoiceService!.Mark(TenantNarratable, NarratableSession);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dirNoOp.DisposeAsync();
+        await _dirNarratable.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public async Task One_accounts_no_op_sessions_cannot_starve_another_accounts_session_out_of_the_same_cycle()
+    {
+        // Only the second account has words to narrate. The first account's four sessions have nothing in
+        // the store and a computer that cannot send one - they cost a dictionary lookup and a store read,
+        // and nothing else.
+        _gateway.SeedStoredConversationForTest(TenantNarratable, "dir-real", NarratableSession,
+            ("User", "do the thing"), ("Assistant", "it is done"));
+
+        // ONE cycle of the REAL production sweep - the timer callback itself, not a re-implementation.
+        await _gateway.SweepVoiceSessionsAsync();
+
+        // THE NO-OP ACCOUNT WAS FULLY SWEPT. The marker is recorded only by an ACTUAL attempt that read the
+        // store and found it empty, so its presence on all four is the evidence that all four were tried -
+        // and, under the old budget, at most three of these five facts could hold.
+        foreach (var sid in NoOpSessions)
+            Assert.True(_gateway.VoiceService!.DirectorCannotSendConversationFor(TenantNoOp, sid),
+                $"session {sid} was never attempted, so the cycle ran out of budget on sessions that spend nothing");
+
+        // AND THE OTHER ACCOUNT'S SESSION WAS REACHED IN THE SAME CYCLE. Its narration is the only attempt
+        // here that costs the shared model and speech legs, and it is the one the budget exists to ration -
+        // so it is the one that must survive a cycle full of attempts that cost neither. The live-screen
+        // read arriving at ITS OWN Director is the proof the generation actually started.
+        Assert.NotNull(await WaitForVerb(_seenByNarratable, "screen-grid", NarratableSession));
+    }
+
+    [Fact]
+    public async Task A_no_op_session_stays_in_the_sweep_so_its_recovery_needs_nobody()
+    {
+        // The fix must NOT be "drop these sessions from the sweep". Keeping them is what makes the recovery
+        // free: the moment that computer is updated it starts pushing, the next pass finds words, and
+        // narration resumes with nobody touching the Gateway. Two cycles, and the sweep comes back to every
+        // one of them both times.
+        await _gateway.SweepVoiceSessionsAsync();
+        foreach (var sid in NoOpSessions)
+            Assert.True(_gateway.VoiceService!.DirectorCannotSendConversationFor(TenantNoOp, sid));
+
+        // That computer is updated and pushes its conversation for one of them.
+        _gateway.SeedStoredConversationForTest(TenantNoOp, "dir-noop", NoOpSessions[0],
+            ("User", "ask"), ("Assistant", "answered"));
+
+        await _gateway.SweepVoiceSessionsAsync();
+
+        // The marker comes off by itself on the very next pass - no restart, nothing to clear by hand.
+        Assert.False(_gateway.VoiceService!.DirectorCannotSendConversationFor(TenantNoOp, NoOpSessions[0]));
+        // ...and the sessions still waiting on that computer are still being visited, not stood down.
+        foreach (var sid in NoOpSessions.Skip(1))
+            Assert.True(_gateway.VoiceService!.DirectorCannotSendConversationFor(TenantNoOp, sid));
+    }
+
+    /// <summary>Poll for a verb+session rather than sleeping a fixed time: the sweep fires generation onto
+    /// the thread pool and the tunnel round-trip is asynchronous.</summary>
+    private static async Task<DirectorCommand?> WaitForVerb(ConcurrentQueue<DirectorCommand> seen, string verb, string sessionId)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            var hit = seen.FirstOrDefault(c => c.Verb == verb && c.SessionId == sessionId);
+            if (hit is not null) return hit;
+            await Task.Delay(50);
+        }
+        return null;
+    }
+
+    private static SessionDto Sample(string sid) => new()
+    {
+        SessionId = sid,
+        Agent = "claude",
+        RepoPath = "/repo",
+        // Settled at a turn end - the idle sweep only pre-builds Idle / WaitingForInput / WaitingForPerm.
+        ActivityState = "WaitingForInput",
+        Status = "Running",
+        StatusColor = "red",
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+}

--- a/src/CcDirector.Gateway.UnitTests/VoiceDisplayFoldTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceDisplayFoldTests.cs
@@ -279,4 +279,96 @@ public sealed class VoiceDisplayFoldTests
         Assert.Equal("off", d.Kind);
     }
 
+    // ------------------------------------------------------------------------------------------------
+    // THE NARRATION WAS ABANDONED (issue #2676). The model leg did not answer, the voice path's bounded
+    // re-attempts for this turn are spent, and NOTHING further is scheduled. Before this arm the same
+    // session rendered the calm "Voice is taking a moment - retrying automatically. It should come through
+    // shortly", which described work nobody was doing. These pin the SENTENCE, because the sentence is
+    // what was wrong.
+    // ------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void NarrationAbandoned_ReplacesTheRetryingPromise_THE_2026_09_04_DEFECT()
+    {
+        // NEGATIVE CONTROL: while re-attempts remain, the calm sentence is TRUE and must still be said.
+        var stillTrying = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: HostedAiState.Retrying, nothingToNarrate: false, narrationAbandoned: false);
+        Assert.Equal("retrying", stillTrying.Kind);
+        Assert.Equal("Voice on its way", stillTrying.Label);
+
+        // ...and once they are spent it must stop.
+        var abandoned = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: HostedAiState.Retrying, nothingToNarrate: false, narrationAbandoned: true);
+        Assert.Equal("notNarrated", abandoned.Kind);
+        Assert.Equal("red", abandoned.Tone);
+        Assert.Equal("Turn not narrated", abandoned.Label);
+        Assert.DoesNotContain("on its way", abandoned.Label, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("shortly", abandoned.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("retrying automatically", abandoned.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(abandoned.CanPlay);
+        // The one action left that can still work: the automatic attempts have stopped, and a model
+        // non-answer is transient, so asking for one by hand is not a dead end.
+        Assert.True(abandoned.CanGenerate);
+    }
+
+    [Fact]
+    public void NarrationAbandoned_ReplacesTheGaveUpSentence_BecauseNothingIsStillTrying()
+    {
+        // gaveUp is said WHILE the work continues ("The Gateway is still trying"). When the retries are
+        // spent that clause is false, and it is the clause that keeps a reader waiting.
+        var waitingSince = new DateTime(2026, 9, 4, 19, 45, 0, DateTimeKind.Utc);
+        var now = waitingSince.AddMinutes(18);
+
+        var before = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: HostedAiState.Retrying, nothingToNarrate: false,
+            waitingSince: waitingSince, utcNow: now, narrationAbandoned: false);
+        Assert.Equal("gaveUp", before.Kind);                       // NEGATIVE CONTROL: what it used to say
+        Assert.Contains("still trying", before.Message);
+
+        var after = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: HostedAiState.Retrying, nothingToNarrate: false,
+            waitingSince: waitingSince, utcNow: now, narrationAbandoned: true);
+        Assert.Equal("notNarrated", after.Kind);
+        Assert.DoesNotContain("still trying", after.Message);
+        Assert.Equal("18m", after.WaitedLabel);                    // the wait is still reported, just not sold as progress
+    }
+
+    [Fact]
+    public void NarrationAbandoned_NeverHidesAnActionableAccountCondition()
+    {
+        // The same rule every other reason arm follows: a member who has to add credit must be told that,
+        // not handed a report of a symptom. An account condition is written into the same slot, so this
+        // pins that the abandoned fact riding alongside it does not displace it.
+        foreach (var state in new[] { HostedAiState.NeedsCredits, HostedAiState.CapReached, HostedAiState.NeedsKey })
+        {
+            var d = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+                unavailable: state, nothingToNarrate: false, narrationAbandoned: true);
+            Assert.Equal("blocked", d.Kind);
+        }
+
+        // And the same for the one machine-specific remedy, which has a one-line fix the reader can carry out.
+        var tooOld = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+            unavailable: null, nothingToNarrate: false, directorCannotSendConversation: true, narrationAbandoned: true);
+        Assert.Equal("directorTooOld", tooOld.Kind);
+    }
+
+    [Fact]
+    public void NarrationAbandoned_NeverHidesPlayableAudioOrALiveAttempt()
+    {
+        // Audio that exists, and a generation running right now, both outrank every reason arm. A stale
+        // abandoned marker must never take a clip away from somebody in the middle of playing it.
+        var ready = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: true, generating: false,
+            unavailable: HostedAiState.Retrying, nothingToNarrate: false, narrationAbandoned: true);
+        Assert.Equal("ready", ready.Kind);
+        Assert.True(ready.CanPlay);
+
+        var generating = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: false, hasAudio: false, generating: true,
+            unavailable: HostedAiState.Retrying, nothingToNarrate: false, narrationAbandoned: true);
+        Assert.Equal("preparing", generating.Kind);
+
+        var working = VoiceDisplayFold.Fold(voiceMode: true, agentWorking: true, hasAudio: false, generating: false,
+            unavailable: HostedAiState.Retrying, nothingToNarrate: false, narrationAbandoned: true);
+        Assert.Equal("working", working.Kind);
+    }
+
 }

--- a/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
@@ -1653,7 +1653,14 @@ public sealed class WingmanVoiceServiceTests : IDisposable
             Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")),
                 "the retry budget never ran out, so nothing ever told the reader the turn was not narrated");
             // The cap held: the first attempt plus exactly the two booked re-attempts, and no more.
+            //
+            // SETTLE BEFORE COUNTING. Asserting the moment the verdict appears would also pass if a fourth
+            // re-attempt were still sitting on a timer - the count would simply be read before it fired, and
+            // a runaway ladder would look identical to a capped one (found in review). The wait is many
+            // times the 30ms backoff, so anything booked would have run by now.
+            await Task.Delay(500);
             Assert.Equal(3, brain.AskCount);
+            Assert.True(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // and it stayed abandoned
             Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
 
             // AND THE SCREEN SAYS SO. The fold is the only thing a client renders, so the state is honest
@@ -1698,10 +1705,13 @@ public sealed class WingmanVoiceServiceTests : IDisposable
             Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
 
             // The new turn gets its own attempt AND its own re-attempt - the budget was genuinely reset,
-            // not merely hidden from the screen.
+            // not merely hidden from the screen. Pinned EXACTLY rather than as a lower bound: ">= 2 more"
+            // is also satisfied by a ladder that has stopped respecting its cap (found in review).
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
             Assert.True(await Eventually(() => brain.AskCount >= asksBefore + 2),
                 "the new turn did not get its own re-attempt - the old turn's spent budget carried over");
+            await Task.Delay(500);
+            Assert.Equal(asksBefore + 2, brain.AskCount);   // one attempt, one re-attempt, and no more
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
@@ -1726,6 +1736,209 @@ public sealed class WingmanVoiceServiceTests : IDisposable
             svc.Unmark(TenantId.Local, "sid-1");
 
             Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// A re-attempt booked for the PREVIOUS turn must stand down, not narrate.
+    ///
+    /// Found in review, and the harm is specific rather than theoretical. A retry that woke up during the
+    /// next turn could win the per-session coalescing race against that turn's own narration, make it return
+    /// having done nothing, and then store the OLD turn's clip. The session would then HAVE audio, so the
+    /// sweep - which skips any session with audio - would never come back to it, and the phone would play a
+    /// stale narration of the wrong turn for as long as the session lived.
+    /// </summary>
+    [Fact]
+    public async Task AReattemptBookedForASupersededTurn_StandsDown_InsteadOfNarratingTheOldTurn()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelsuperseded-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new TimingOutBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 5 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(400));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.Equal(1, brain.AskCount);                                   // control: the attempt happened
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));  // control: a re-attempt is booked
+
+            // A new turn starts while that re-attempt is still waiting out its backoff.
+            svc.OnSessionWorking(TenantId.Local, "sid-1");
+
+            // It must never run. Waited well past its backoff so this is a real absence, not an early read.
+            await Task.Delay(900);
+            Assert.Equal(1, brain.AskCount);
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));               // no stale clip was stored
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));  // and no verdict about the old turn
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// A re-attempt never turns voice back ON by attempting. It wakes up as much as a minute and a half
+    /// after it was booked, and voice may have been switched off in between; every other caller of
+    /// GenerateAsync marks the session as a side effect, which for a retry would mean the Gateway resuming a
+    /// narration for a session whose owner had just stopped one (found in review).
+    ///
+    /// WHAT THIS DOES NOT CLAIM, stated because the narrower truth is the useful one. A retry that goes on
+    /// to SUCCEED still marks the session, because StoreSpokenAsync marks on the success path for every
+    /// caller - that is shared, pre-existing behaviour, identical for an ordinary turn-end narration, and
+    /// its window is the length of one generation rather than the length of a backoff. What is closed here
+    /// is the wide window: the ninety seconds a booked re-attempt spends waiting, during which it must be
+    /// able to wake up and do nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAsync_OnTheRetryPath_DoesNotMakeASessionAVoiceSessionByAttempting()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelnomark-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            // A brain that never answers, so this is purely about the ATTEMPT: no synthesis, no store, and
+            // therefore nothing but the entry-point marking under test.
+            var svc = ServiceWithBrainAndTts(new TimingOutBrain(), new byte[] { 5 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest();   // no rungs, so the attempt does not book more work
+            Assert.False(svc.IsVoiceSession(TenantId.Local, "sid-1"));   // control: it is not one to start with
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None,
+                showReadingWindow: false, markAsVoiceSession: false);
+
+            Assert.False(svc.IsVoiceSession(TenantId.Local, "sid-1"));   // still not one
+
+            // POSITIVE CONTROL: the ordinary path DOES mark on the very same failing attempt, so the
+            // assertion above is about the flag and not about a call that quietly did nothing.
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
+            Assert.True(svc.IsVoiceSession(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// "Nothing further is scheduled" must be TRUE when it is said.
+    ///
+    /// A concurrent attempt - the background sweep, or a person pressing Generate - can fail while a booked
+    /// re-attempt is still waiting out its backoff. Counting that failure against the ladder would push the
+    /// count past the cap and declare the turn abandoned while a task genuinely existed: the same false
+    /// sentence this change removes, only inverted (found in review). The concurrent failure must spend
+    /// nothing and claim nothing.
+    /// </summary>
+    [Fact]
+    public async Task AConcurrentFailure_WhileAReattemptIsBooked_DoesNotDeclareTheTurnAbandoned()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelpending-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new TimingOutBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 5 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromSeconds(3));   // one rung, long enough to still be pending
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.Equal(1, brain.AskCount);
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // control: the rung is booked
+
+            // The sweep comes past and fails too, while that rung is still pending.
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
+
+            Assert.Equal(2, brain.AskCount);                                    // it really did attempt
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // and it claimed nothing
+            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+
+            // POSITIVE CONTROL: the verdict is not simply unreachable - once the booked rung runs and fails,
+            // nothing is pending and the turn IS abandoned.
+            Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")),
+                "the abandoned verdict never arrived, so the assertion above proved nothing");
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// A NEW REPLY GETS ITS OWN BUDGET EVEN WHEN THE WORKING TRANSITION IS MISSED.
+    ///
+    /// Resetting the ladder on the Working edge alone would have been the same mistake issue #1322 already
+    /// taught this file about the narration cache: that edge is observed on a racy sampled boundary and a
+    /// quick turn can be missed entirely. A turn whose edge was missed would then inherit the previous
+    /// turn's exhausted budget and be denied its first re-attempt - silent for exactly the reason the change
+    /// exists to prevent (found in review). The budget is keyed on the reply instead, so this test never
+    /// calls OnSessionWorking.
+    /// </summary>
+    [Fact]
+    public async Task ANewReply_GetsItsOwnRetryBudget_EvenWithoutTheWorkingTransition()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the FIRST reply"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelreplykey-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new TimingOutBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 5 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(40));   // one rung
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")));   // control
+            var asksBefore = brain.AskCount;
+
+            // The agent answered again. NO OnSessionWorking - this is the missed edge.
+            conversation.Store(("Text", "the SECOND reply"));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            // The new reply was attempted AND given its own re-attempt, rather than inheriting an exhausted
+            // ladder and being abandoned on its first failure.
+            Assert.True(await Eventually(() => brain.AskCount >= asksBefore + 2),
+                "the new reply inherited the previous reply's spent budget and was denied its re-attempt");
+            await Task.Delay(400);
+            Assert.Equal(asksBefore + 2, brain.AskCount);   // its own ladder, and the cap still holds
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// "Nothing to read aloud" is FRESHER evidence than an old turn's model timeout, so it supersedes the
+    /// abandoned verdict rather than sitting behind it. Found in review: the fold gives abandoned precedence,
+    /// so without this clear a session parked on a prompt would be told the model did not answer.
+    /// </summary>
+    [Fact]
+    public async Task NothingToNarrate_SupersedesAnAbandonedNarration()
+    {
+        var director = new TunnelStub();
+        var withReply = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var empty = StoredConversationStub.Of(("Prompt", "pick one"));
+        var useEmpty = false;
+        Func<TenantId, string, CcDirector.Gateway.History.StoredConversation?> reader =
+            (t, sid) => useEmpty ? empty.Reader(t, sid) : withReply.Reader(t, sid);
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelnothing-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var svc = ServiceWithBrainAndTts(new TimingOutBrain(), new byte[] { 5 }, persistPath, reader);
+            svc.UseModelRetryBackoffForTest();   // no rungs: the first non-answer abandons immediately
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.True(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // control
+
+            // The session is now parked on a prompt with no text reply.
+            useEmpty = true;
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.True(svc.NothingToNarrateFor(TenantId.Local, "sid-1"));
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            // ...so the screen says the honest thing, and does not blame a model that was never asked.
+            var display = VoiceDisplayFold.Fold(
+                voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+                unavailable: null,
+                nothingToNarrate: svc.NothingToNarrateFor(TenantId.Local, "sid-1"),
+                narrationAbandoned: svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            Assert.Equal("nothingToNarrate", display.Kind);
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }

--- a/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
@@ -1538,4 +1538,196 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
 
+    // ---------- The model leg's OWN bounded retry, and the end of the promise (issue #2676) ----------
+
+    /// <summary>
+    /// A brain that does not answer for its first <c>failures</c> asks and answers normally after that -
+    /// the shape of a model stall that clears, which is what a bounded retry is for. Counts its asks so a
+    /// test can prove a SECOND attempt was made rather than inferring it from the audio.
+    /// </summary>
+    private sealed class StallsThenAnswersBrain : IAgentBrain
+    {
+        private readonly int _failures;
+        private int _askCount;
+        public StallsThenAnswersBrain(int failures) => _failures = failures;
+        public int AskCount => _askCount;
+        public string? SessionId => "stalls-then-answers-brain";
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            var n = Interlocked.Increment(ref _askCount);
+            if (n <= _failures) throw new TimeoutException("The wingman model call did not answer within 60 seconds.");
+            var wrapped = $"{SessionAskRunner.AnswerBeginMarker}\nnarrated spoken text\n{SessionAskRunner.AnswerEndMarker}";
+            return Task.FromResult(new AskResult { Text = wrapped, ReplySeconds = 0.1 });
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth { IsAlive = true });
+        public void Dispose() { }
+    }
+
+    /// <summary>Poll a condition rather than sleeping a fixed time: the re-attempt runs on the thread pool
+    /// after its backoff, so a fixed wait would be either flaky or slow. Returns the condition's final value
+    /// on the deadline so the caller's own assertion reports what was actually missing.</summary>
+    private static async Task<bool> Eventually(Func<bool> condition, int seconds = 20)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(seconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(25);
+        }
+        return condition();
+    }
+
+    /// <summary>
+    /// THE 2026-09-04 WEDGE. A model-leg timeout recorded Retrying and logged "the session retries on its
+    /// own". Nothing retried it. The only mechanism that would ever come back was the shared voice sweep,
+    /// whose whole per-cycle budget another account's unnarratable sessions were consuming (issue #2675), so
+    /// in practice the turn was never narrated: three sessions sat yellow for eleven minutes, eighteen
+    /// minutes, and until they were snoozed, each showing "retrying automatically, it should come through
+    /// shortly" with nothing scheduled anywhere.
+    ///
+    /// So the leg that failed books the re-attempt itself. This proves the whole promise end to end: a
+    /// stall that clears produces AUDIO, without a sweep, without a new turn, and without anybody pressing
+    /// anything.
+    ///
+    /// REVERT-PROOF: put the old body back in the IsModelDidNotAnswer catch (record Retrying, return) and
+    /// this goes RED on the "never led to another attempt" assertion. Confirmed against the pre-fix code.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheModelDoesNotAnswer_TheVoicePathBooksItsOwnReattempt_AndTheTurnIsNarrated()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelretry-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new StallsThenAnswersBrain(failures: 1);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 5, 5, 5 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(50));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            // CONTROL, and the exact state the old code stopped at: one attempt, no audio, calm "on its way".
+            Assert.Equal(1, brain.AskCount);
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            // ...and the promise is honest here, because an attempt really is booked.
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+
+            // THE THING THAT DID NOT EXIST: a second attempt, made by the voice path, on its own.
+            Assert.True(await Eventually(() => svc.HasVoice(TenantId.Local, "sid-1")),
+                "the model timeout never led to another attempt - the turn stayed silent");
+            Assert.Equal(2, brain.AskCount);
+
+            // A narration arrived, so nothing is owed and nothing was abandoned.
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// The retry is BOUNDED, and where it runs out the screen stops promising. "Voice is taking a moment -
+    /// retrying automatically. It should come through shortly" said about a turn no loop will touch again is
+    /// an absence dressed as progress; the honest answer is that the turn was not narrated.
+    /// </summary>
+    [Fact]
+    public async Task WhenEveryReattemptIsSpent_TheNarrationIsAbandoned_AndTheScreenStopsPromisingAudio()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelgiveup-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new TimingOutBrain();   // never answers, so every re-attempt is spent
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 5 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(30), TimeSpan.FromMilliseconds(30));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")),
+                "the retry budget never ran out, so nothing ever told the reader the turn was not narrated");
+            // The cap held: the first attempt plus exactly the two booked re-attempts, and no more.
+            Assert.Equal(3, brain.AskCount);
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+
+            // AND THE SCREEN SAYS SO. The fold is the only thing a client renders, so the state is honest
+            // only if the fold turns it into an honest sentence.
+            var display = VoiceDisplayFold.Fold(
+                voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+                unavailable: svc.VoiceUnavailableFor(TenantId.Local, "sid-1"),
+                nothingToNarrate: false,
+                narrationAbandoned: svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            Assert.Equal("notNarrated", display.Kind);
+            Assert.DoesNotContain("on its way", display.Label, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("shortly", display.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// The budget belongs to the TURN, not to the session. A new turn arriving after an abandoned one must
+    /// start with a full set of re-attempts and a clean screen - otherwise one stalled turn would spend the
+    /// next turn's retries, and "not narrated" would sit on a narration nobody had tried yet.
+    /// </summary>
+    [Fact]
+    public async Task ANewTurn_ClearsTheAbandonedVerdict_AndGivesTheTurnItsOwnRetryBudget()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelreset-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new TimingOutBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 5 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(30));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")));   // control
+            var asksBefore = brain.AskCount;
+
+            svc.OnSessionWorking(TenantId.Local, "sid-1");   // the agent starts a new turn
+
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+
+            // The new turn gets its own attempt AND its own re-attempt - the budget was genuinely reset,
+            // not merely hidden from the screen.
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.True(await Eventually(() => brain.AskCount >= asksBefore + 2),
+                "the new turn did not get its own re-attempt - the old turn's spent budget carried over");
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>Switching voice off must not leave a re-attempt booked against a session nobody wants
+    /// narrated, and must not leave "not narrated" standing on it either.</summary>
+    [Fact]
+    public async Task Unmark_ClearsTheAbandonedVerdict()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-modelunmark-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var svc = ServiceWithBrainAndTts(new TimingOutBrain(), new byte[] { 5 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest();   // no re-attempts at all: the first non-answer is the last
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.True(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // control: with no budget, immediate
+
+            svc.Unmark(TenantId.Local, "sid-1");
+
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -74,6 +74,10 @@ internal static class GatewayEndpoints
         Func<TenantId, string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
         Func<TenantId, string, bool>? nothingToNarrateFor = null,
         Func<TenantId, string, bool>? directorCannotSendConversationFor = null,
+        /// <summary>Issue #2676: this turn's narration was abandoned - the model did not answer and the voice
+        /// path's bounded re-attempts are spent, so nothing further is scheduled. Feeds the folded
+        /// VoiceDisplay so the screen stops promising audio nobody is making.</summary>
+        Func<TenantId, string, bool>? narrationAbandonedFor = null,
         Func<TenantId, string, bool>? servedViaFallbackFor = null,
         /// <summary>Issue #2576: stamps and returns SessionDto.VoiceWaitingSince - when this session's wait
         /// for voice began, or null when it is not waiting. Null delegate leaves the field unset, so a caller
@@ -1528,6 +1532,7 @@ internal static class GatewayEndpoints
                         unavailable: voiceUnavailableFor?.Invoke(reqTenant.Value, s.SessionId),
                         nothingToNarrate: nothingToNarrateFor?.Invoke(reqTenant.Value, s.SessionId) ?? false,
                         directorCannotSendConversation: directorCannotSendConversationFor?.Invoke(reqTenant.Value, s.SessionId) ?? false,
+                        narrationAbandoned: narrationAbandonedFor?.Invoke(reqTenant.Value, s.SessionId) ?? false,
                         servedViaFallback: servedViaFallbackFor?.Invoke(reqTenant.Value, s.SessionId) ?? false,
                         waitingSince: s.VoiceWaitingSince);
                     // Orange "Transcribing..." while a dictated utterance is uploading/transcribing in

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2216,16 +2216,21 @@ public sealed class GatewayHost : IAsyncDisposable
     private const int MaxVoiceGenerationsPerSweep = 3;
 
     /// <summary>
-    /// How many sessions one sweep cycle may LOOK AT. Far larger than the generation cap because the arms it
-    /// bounds are cheap - a dictionary lookup and one read of the Gateway's own turn store - and because a
-    /// tight bound here would re-create the starvation issue #2675 removed, just at a higher number.
+    /// How many sessions one sweep cycle may LOOK AT WITHIN ONE ACCOUNT. Far larger than the generation cap
+    /// because the arms it bounds are cheap - a dictionary lookup and one read of the Gateway's own turn
+    /// store - but a bound all the same, because that store read is a database query and an unbounded pass
+    /// over every voice session on a busy hosted Gateway every 45 seconds would be a real new cost
+    /// introduced by fixing issue #2675.
     ///
-    /// It is not zero-cost, though, which is why it is a bound at all: the store read is a database query, so
-    /// an unbounded pass over every voice session on a busy hosted Gateway every 45 seconds would be a real
-    /// new cost. Sized to be out of the way of any account a person actually runs, and in the way of a
-    /// pathological one.
+    /// PER ACCOUNT, NOT GLOBAL, and that is the whole difference between a bound and a smaller version of
+    /// the bug. A global ceiling is spent by whichever accounts the pass happens to reach first, so an
+    /// account with enough sessions would consume it before the later accounts were visited at all - the
+    /// exact starvation this issue is about, moved from three to sixty rather than removed (found in
+    /// review). Charged to each account separately, no account can spend another's, and the only shared
+    /// budget left is the generation cap - which is right, because that one rations a genuinely shared
+    /// resource and this one does not.
     /// </summary>
-    private const int MaxVoiceAttemptsPerSweep = 60;
+    private const int MaxVoiceAttemptsPerTenantPerSweep = 60;
 
     /// <summary>
     /// Pre-build voice for voice sessions that are idle and missing it, so the session list shows
@@ -2266,16 +2271,17 @@ public sealed class GatewayHost : IAsyncDisposable
             // (WingmanVoiceService announces that at its own commit point, which is the one place that knows),
             // and a second, far larger ATTEMPTS budget keeps the pass itself bounded - a no-op attempt is
             // cheap, but it is a store read, and an unbounded loop over every voice session on the Gateway
-            // every 45 seconds would be a new cost introduced by fixing this one.
+            // every 45 seconds would be a new cost introduced by fixing this one. That second budget is
+            // charged PER ACCOUNT, so it cannot become a smaller copy of the starvation it bounds.
             var generated = 0;
-            var attempted = 0;
             _tenantPass.ForEachTenant(() =>
             {
                 if (_tenantPass.Current is not { } tenant) return;   // deny: no scope in effect -> sweep nothing
+                var attempted = 0;                                   // this account's own, never shared
                 foreach (var sid in vs.VoiceSessionIds(tenant))
                 {
-                    if (generated >= MaxVoiceGenerationsPerSweep) break;   // gentle on the serialized brain (global cap)
-                    if (attempted >= MaxVoiceAttemptsPerSweep) break;      // and the pass itself stays bounded
+                    if (generated >= MaxVoiceGenerationsPerSweep) break;              // gentle on the serialized brain (global cap)
+                    if (attempted >= MaxVoiceAttemptsPerTenantPerSweep) break;        // and this account's pass stays bounded
                     if (vs.HasVoice(tenant, sid)) continue;          // already cached, nothing to do
                     // A session whose agent exposes NO conversation history will not become readable by being
                     // asked again immediately, and asking is not free: this pass generates at most three per

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1531,6 +1531,9 @@ public sealed class GatewayHost : IAsyncDisposable
                 directorCannotSendConversationFor: sid => _tenantPass.Current is { } t
                     && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
                     && _voiceService?.DirectorCannotSendConversationFor(t, sid) == true,
+                narrationAbandonedFor: sid => _tenantPass.Current is { } t
+                    && Wingman.WingmanVoiceService.CanNameVoicePartition(t)
+                    && _voiceService?.NarrationAbandonedFor(t, sid) == true,
                 voiceWaitingStampFor: (sid, waiting) => _tenantPass.Current is { } t
                     ? _voiceWaitingClock.Stamp(t, sid, waiting)
                     : null),
@@ -2205,6 +2208,26 @@ public sealed class GatewayHost : IAsyncDisposable
             is { IsValid: true } t ? t : (TenantId?)null;
 
     /// <summary>
+    /// How many narrations one sweep cycle may actually START. The wingman brain is one serialized resource,
+    /// so this stays deliberately small and stays GLOBAL across tenants. Unchanged by issue #2675 - what
+    /// changed is what counts against it (an attempt that reaches the model or speech legs, not an attempt
+    /// that is dispatched).
+    /// </summary>
+    private const int MaxVoiceGenerationsPerSweep = 3;
+
+    /// <summary>
+    /// How many sessions one sweep cycle may LOOK AT. Far larger than the generation cap because the arms it
+    /// bounds are cheap - a dictionary lookup and one read of the Gateway's own turn store - and because a
+    /// tight bound here would re-create the starvation issue #2675 removed, just at a higher number.
+    ///
+    /// It is not zero-cost, though, which is why it is a bound at all: the store read is a database query, so
+    /// an unbounded pass over every voice session on a busy hosted Gateway every 45 seconds would be a real
+    /// new cost. Sized to be out of the way of any account a person actually runs, and in the way of a
+    /// pathological one.
+    /// </summary>
+    private const int MaxVoiceAttemptsPerSweep = 60;
+
+    /// <summary>
     /// Pre-build voice for voice sessions that are idle and missing it, so the session list shows
     /// them "voice ready" BEFORE the person enters - including after a gateway restart (the voice-
     /// session set is persisted). Gentle: at most a few per cycle, idle sessions only (a working
@@ -2226,13 +2249,33 @@ public sealed class GatewayHost : IAsyncDisposable
             // resource, so the whole cycle stays gentle no matter how many tenants are live.
             var stale = TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
             Api.DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = SendCommandAsync;
+            // TWO BUDGETS, BECAUSE THERE ARE TWO COSTS (issue #2675).
+            //
+            // What went wrong with one. The cap is three per cycle and it counted every attempt DISPATCHED,
+            // not every attempt that cost anything. One account's four sessions were owned by a Director too
+            // old to send its conversations, so each of them reached GenerateOnceAsync, found an empty store,
+            // said so, and returned - having touched neither the model nor the speech provider. They still
+            // took a slot each. On 2026-09-04 that account burned 4,356 slots and every other account on the
+            // hosted Gateway got 5, so the one loop that recovers a session whose narration failed never
+            // reached the sessions that needed it (companion issue #2676).
+            //
+            // Not fixed by dropping those sessions from the sweep, deliberately: keeping them is exactly what
+            // makes their recovery free - the moment that computer is updated, the next pass narrates it with
+            // nobody touching the Gateway. What they must stop doing is spending a budget they cost nothing
+            // against. So GENERATIONS counts only attempts that reached the shared model / speech legs
+            // (WingmanVoiceService announces that at its own commit point, which is the one place that knows),
+            // and a second, far larger ATTEMPTS budget keeps the pass itself bounded - a no-op attempt is
+            // cheap, but it is a store read, and an unbounded loop over every voice session on the Gateway
+            // every 45 seconds would be a new cost introduced by fixing this one.
             var generated = 0;
+            var attempted = 0;
             _tenantPass.ForEachTenant(() =>
             {
                 if (_tenantPass.Current is not { } tenant) return;   // deny: no scope in effect -> sweep nothing
                 foreach (var sid in vs.VoiceSessionIds(tenant))
                 {
-                    if (generated >= 3) break;                       // gentle on the serialized brain (global cap)
+                    if (generated >= MaxVoiceGenerationsPerSweep) break;   // gentle on the serialized brain (global cap)
+                    if (attempted >= MaxVoiceAttemptsPerSweep) break;      // and the pass itself stays bounded
                     if (vs.HasVoice(tenant, sid)) continue;          // already cached, nothing to do
                     // A session whose agent exposes NO conversation history will not become readable by being
                     // asked again immediately, and asking is not free: this pass generates at most three per
@@ -2259,8 +2302,13 @@ public sealed class GatewayHost : IAsyncDisposable
                         // A pre-build is not a new turn - generate quietly so an idle session a client
                         // may be listening to is never flipped yellow mid-play (issue #1322). Fire-and-forget.
                         var route = new Api.SessionVerbClient(director, sendCommand);
-                        _ = vs.GenerateAsync(tenant, sid, route, CancellationToken.None, showReadingWindow: false);
-                        generated++;
+                        attempted++;
+                        // The slot is spent by the CALLBACK, not by this line. It fires synchronously, before
+                        // the returned task is handed back, at the point the attempt commits to the model and
+                        // speech legs - so an attempt that returns having produced nothing and spent nothing
+                        // leaves the budget where it was, and the next session in the loop still gets it.
+                        _ = vs.GenerateAsync(tenant, sid, route, CancellationToken.None, showReadingWindow: false,
+                            onProviderReached: () => generated++);
                     }
                 }
             });
@@ -3196,6 +3244,10 @@ public sealed class GatewayHost : IAsyncDisposable
             // be made for this session until it is updated. Feeds the folded VoiceDisplay so the screen says
             // which computer to update instead of counting a wait that would not end (2026-09-02).
             directorCannotSendConversationFor: (tenant, sid) => _voiceService?.DirectorCannotSendConversationFor(tenant, sid) == true,
+            // The model leg did not answer and the voice path's bounded re-attempts for this turn are spent,
+            // so nothing further is scheduled. Feeds the folded VoiceDisplay so the screen reports a turn that
+            // was not narrated instead of an arrival nobody is working on (issue #2676).
+            narrationAbandonedFor: (tenant, sid) => _voiceService?.NarrationAbandonedFor(tenant, sid) == true,
             // TTS fallback: this session's ready clip was made by the backup voice provider (the primary
             // was overloaded and the cloud proxy failed over). Feeds the folded VoiceDisplay so the screen
             // shows the generic backup-voice notice. A success-with-a-note, never an outage state.
@@ -4274,6 +4326,7 @@ public sealed class GatewayHost : IAsyncDisposable
         Func<string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
         Func<string, bool>? nothingToNarrateFor = null,
         Func<string, bool>? directorCannotSendConversationFor = null,
+        Func<string, bool>? narrationAbandonedFor = null,
         Func<string, bool, DateTime?>? voiceWaitingStampFor = null)
     {
         foreach (var s in sessions)
@@ -4304,6 +4357,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 unavailable: unavailable,
                 nothingToNarrate: nothingToNarrateFor?.Invoke(s.SessionId) ?? false,
                 directorCannotSendConversation: directorCannotSendConversationFor?.Invoke(s.SessionId) ?? false,
+                narrationAbandoned: narrationAbandonedFor?.Invoke(s.SessionId) ?? false,
                 waitingSince: s.VoiceWaitingSince);
         }
         Api.GatewayEndpoints.StampFleetRolesAndFold(sessions, sessions, needsYouStampFor, snoozeRegistry, tenant, handRaises);

--- a/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
+++ b/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
@@ -101,7 +101,12 @@ public static class VoiceDisplayFold
     /// running a build that cannot send its conversation, so the Gateway will never hold words to narrate
     /// for it. A SPECIFIC, ACTIONABLE reason with a one-line remedy - which is why it outranks every
     /// "be patient" verdict below it. See <see cref="DirectorTooOldText"/>.</param>
-    public static VoiceDisplay Fold(bool voiceMode, bool agentWorking, bool hasAudio, bool generating, HostedAiState? unavailable, bool nothingToNarrate, bool servedViaFallback = false, DateTime? waitingSince = null, DateTime? utcNow = null, bool directorCannotSendConversation = false)
+    /// <param name="narrationAbandoned">The model leg did not answer, every re-attempt in the voice path's
+    /// bounded budget has been spent, and NOTHING further is scheduled for this turn (issue #2676). The one
+    /// input here that reports a stopped effort rather than a slow one, which is why it displaces the calm
+    /// retrying sentence: "retrying automatically, it should come through shortly" is not a description of a
+    /// turn nobody is working on any more. See <see cref="WingmanVoiceService.NarrationAbandonedFor"/>.</param>
+    public static VoiceDisplay Fold(bool voiceMode, bool agentWorking, bool hasAudio, bool generating, HostedAiState? unavailable, bool nothingToNarrate, bool servedViaFallback = false, DateTime? waitingSince = null, DateTime? utcNow = null, bool directorCannotSendConversation = false, bool narrationAbandoned = false)
     {
         // Computed once, up front, because more than one verdict below carries it: the calm "on its way"
         // wants it so a healthy wait can be seen climbing, and the give-up verdict wants it in its own
@@ -188,6 +193,12 @@ public static class VoiceDisplayFold
         switch (unavailable)
         {
             case HostedAiState.Retrying:
+                // NOTHING IS SCHEDULED, so nothing is on its way. Checked before the elapsed-time give-up
+                // because the two say different things and this one is the stronger claim: gaveUp is "it has
+                // not arrived in three minutes, and we are still trying", while this is "we have stopped
+                // trying". A reader who is told the Gateway is still working on it waits; one who is told the
+                // turn was not narrated goes and reads it.
+                if (narrationAbandoned) return NotNarratedDisplay(waited);
                 // "Voice on its way" is true for a minute and a lie at forty-eight. Past the threshold the
                 // retry stops being news and becomes the thing being reported.
                 if (gaveUp) return GaveUpDisplay(waited);
@@ -252,6 +263,17 @@ public static class VoiceDisplayFold
                 // other machine, and the message names it.
             };
 
+        // THE NARRATION WAS ABANDONED, reached here when the cause was never written into the hosted-AI slot
+        // above (it is cleared on a new turn, and the two are set by different paths). Below the actionable
+        // account conditions and below "update that computer", for the same reason gaveUp is: a remedy the
+        // reader can carry out beats a report of what did not happen. Above nothingToNarrate because the two
+        // describe the same session from different evidence and this one has more - "nothing to read aloud"
+        // is a claim about a conversation, while this was recorded after a reply WAS read and handed to the
+        // model. In practice they never collide (the narration path clears nothingToNarrate before it calls
+        // the model), and the ordering is here because a defence that relies on another file's clearing
+        // discipline is not a defence.
+        if (narrationAbandoned) return NotNarratedDisplay(waited);
+
         // Nothing to read aloud: the session needs the user, but on a prompt / menu, not a text reply. This
         // is the honest state that replaces the old "red badge next to a Generate button that can never
         // work". No button - generating cannot narrate a text reply that does not exist.
@@ -309,6 +331,29 @@ public static class VoiceDisplayFold
         Message = "This turn's narration has not been produced. The Gateway is still trying, "
                 + "and you can read the turn instead.",
         // No Generate button: it would re-run exactly what has already not worked for the whole wait.
+        WaitedLabel = waited,
+    };
+
+    /// <summary>
+    /// The verdict for a turn whose narration was ABANDONED (issue #2676): the model did not answer, every
+    /// re-attempt the voice path books has been spent, and no further attempt exists anywhere.
+    ///
+    /// Two things separate it from <see cref="GaveUpDisplay"/>, which it sits next to and must not be merged
+    /// with. It makes NO claim that anything is still being tried - that sentence is what turned a stalled
+    /// narration into a permanent calm wait. And it DOES offer the Generate button, which gaveUp deliberately
+    /// withholds: gaveUp is said while automatic attempts continue, so a button would only duplicate them,
+    /// whereas here the automatic attempts have stopped and a person asking for one is the only thing left
+    /// that can produce this turn's audio. A model non-answer is transient by definition, so the button is
+    /// not a dead end - it is the one action on this screen that can still work.
+    /// </summary>
+    private static VoiceDisplay NotNarratedDisplay(string? waited) => new()
+    {
+        Kind = "notNarrated",
+        Tone = "red",
+        Label = "Turn not narrated",
+        Message = "The wingman model did not answer, and the retries for this turn are used up, so this turn "
+                + "has no narration. Read the turn, or ask for the narration again.",
+        CanGenerate = true,
         WaitedLabel = waited,
     };
 

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -113,11 +113,34 @@ public sealed class WingmanVoiceService
         public readonly ConcurrentDictionary<string, ReadFailure> ReadFailed = new();
 
         /// <summary>
-        /// How many model-leg re-attempts this session's CURRENT unnarrated turn has already been given
-        /// (issue #2676). Counted per turn, not per session lifetime: a new turn, a successful narration
-        /// and switching voice off each reset it, so the budget belongs to the turn that lost its voice.
+        /// The model-leg retry ledger for ONE session's current unnarrated turn (issue #2676).
+        ///
+        /// KEYED ON THE REPLY, not on the session and not on a transition. The budget belongs to the turn
+        /// that lost its voice, and the obvious way to reset it - the Working transition - is the one signal
+        /// this file already knows it cannot trust: it is observed on a racy sampled edge and a quick turn
+        /// can be missed entirely (see the note above GenerateAsync, and issue #1322, which is the same
+        /// lesson learned about the narration cache). Resetting on the edge alone would let a turn whose
+        /// edge was missed inherit the previous turn's exhausted budget and be denied its first re-attempt.
+        /// Comparing the reply the failure was FOR removes that dependency, exactly as ShouldRegenerate did.
+        ///
+        /// <paramref name="Pending"/> is what keeps the abandoned verdict honest. A concurrent attempt - the
+        /// sweep, or a person pressing Generate - can fail while a booked re-attempt is still waiting out its
+        /// backoff. Counting that failure against the ladder would declare "nothing further is scheduled"
+        /// while a task existed, which is the same false sentence this whole change removes, only inverted.
         /// </summary>
-        public readonly ConcurrentDictionary<string, int> ModelRetries = new();
+        /// <param name="ReplyKey">Identity of the reply this budget belongs to.</param>
+        /// <param name="Booked">How many re-attempts of the ladder have been spent on that reply.</param>
+        /// <param name="Pending">1 while a booked re-attempt is waiting out its backoff, else 0.</param>
+        public sealed record ModelRetryLedger(string ReplyKey, int Booked, int Pending);
+
+        /// <summary>Guards <see cref="ModelRetries"/>. A plain lock rather than a concurrent dictionary
+        /// because the decision - book the next rung, stand aside for one already booked, or abandon - reads
+        /// and writes the entry as ONE step, and a compare-and-swap loop around a three-way decision is
+        /// harder to read than the two lines it replaces.</summary>
+        public readonly object ModelRetryGate = new();
+
+        /// <summary>The retry ledger, one entry per session with a turn still owed a narration.</summary>
+        public readonly Dictionary<string, ModelRetryLedger> ModelRetries = new(StringComparer.Ordinal);
 
         /// <summary>
         /// The model leg did not answer, every re-attempt in the budget has been spent, and NOTHING further
@@ -792,7 +815,11 @@ public sealed class WingmanVoiceService
     public void SetNothingToNarrate(TenantId tenant, string sid, bool nothing)
     {
         var state = StateFor(tenant);
-        if (nothing) state.NothingToNarrate[sid] = 1;
+        if (nothing)
+        {
+            state.NothingToNarrate[sid] = 1;
+            ClearModelRetryState(state, sid);   // fresher evidence than an old turn's model timeout (issue #2676)
+        }
         else state.NothingToNarrate.TryRemove(sid, out _);
     }
 
@@ -824,8 +851,17 @@ public sealed class WingmanVoiceService
     /// nothing tells the reader an arrival is on its way when no attempt is booked.
     ///
     /// The three delays cover the shape the evidence showed: a stall that clears in seconds, one that clears
-    /// in a minute, and one that does not clear at all - the last reaching its verdict inside the three
-    /// minutes <see cref="VoiceDisplayFold.GaveUpAfter"/> already allows a wait to run.
+    /// in a minute, and one that does not clear at all.
+    ///
+    /// HOW LONG THE WHOLE LADDER TAKES, stated properly because an earlier version of this comment claimed
+    /// it finished inside the three minutes <see cref="VoiceDisplayFold.GaveUpAfter"/> allows a wait to run,
+    /// and that was arithmetic with the attempts left out (found in review). The model's own deadline is 60
+    /// seconds, so four attempts plus 10 + 30 + 90 seconds of backoff is about six minutes and ten seconds
+    /// to the abandoned verdict, and longer if an attempt queues behind the serialized brain. That is
+    /// deliberate and the two numbers do different jobs: at three minutes the fold already stops saying the
+    /// audio is coming SOON, and at about six the service stops claiming anything is coming at all. Against
+    /// the eleven and eighteen minutes of silence this replaces, and set against the cost of abandoning a
+    /// narration that a fourth attempt would have produced, six minutes is the right side of that trade.
     /// </summary>
     private static readonly TimeSpan[] DefaultModelRetryBackoff =
     {
@@ -853,13 +889,24 @@ public sealed class WingmanVoiceService
     public bool NarrationAbandonedFor(TenantId tenant, string sid) => StateFor(tenant).NarrationAbandoned.ContainsKey(sid);
 
     /// <summary>This turn's narration is being attempted again from the start, so neither the spent-retry
-    /// count nor the abandoned verdict describes it any more. Called wherever a turn's voice facts are
-    /// reset.</summary>
+    /// ledger nor the abandoned verdict describes it any more. Called wherever a turn's voice facts are
+    /// reset. Dropping the ledger entry also RETIRES any re-attempt already booked against it: the delayed
+    /// task re-reads the ledger when it wakes and stands down when its own entry is gone.</summary>
     private static void ClearModelRetryState(TenantVoiceState state, string sid)
     {
-        state.ModelRetries.TryRemove(sid, out _);
+        lock (state.ModelRetryGate) state.ModelRetries.Remove(sid);
         state.NarrationAbandoned.TryRemove(sid, out _);
     }
+
+    /// <summary>
+    /// Identity of the reply a retry budget belongs to. Hashed rather than stored whole: the ledger is held
+    /// for every session with a turn still owed a narration, and an agent's last reply is occasionally very
+    /// large. Trimmed and ordinal, matching <see cref="ShouldRegenerate"/>, so the two agree about when a
+    /// reply is "the same reply".
+    /// </summary>
+    private static string ReplyKey(string? reply)
+        => Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes((reply ?? string.Empty).Trim())));
 
     /// <summary>Test seam: seed a standing ACCOUNT / provider condition (the state a failed synthesis
     /// records) so a test can prove a later read failure does not overwrite it.</summary>
@@ -1022,9 +1069,20 @@ public sealed class WingmanVoiceService
     /// answer in time to decide about the NEXT session, and it is a contract on this method - a new await
     /// added ahead of the commit point would break it.
     /// </param>
-    internal async Task GenerateAsync(TenantId tenant, string sid, SessionVerbClient route, CancellationToken ct = default, bool showReadingWindow = true, Action? onProviderReached = null)
+    /// <param name="markAsVoiceSession">
+    /// Make this a voice session as a side effect of narrating it - true for every caller that is acting on
+    /// a person's intent (entering voice, a turn ending on a session already in voice mode, the sweep, which
+    /// only ever visits sessions already marked).
+    ///
+    /// FALSE FOR THE MODEL-LEG RETRY, and it is not a nicety. A retry wakes up to a minute and a half after
+    /// it was booked, and voice may have been switched off in between. Marking would turn it back ON - the
+    /// Gateway resuming a narration for a session whose owner had just stopped one, which is a worse outcome
+    /// than the silence the retry exists to prevent. The retry checks <see cref="IsVoiceSession"/> for
+    /// itself and does nothing when the answer is no.
+    /// </param>
+    internal async Task GenerateAsync(TenantId tenant, string sid, SessionVerbClient route, CancellationToken ct = default, bool showReadingWindow = true, Action? onProviderReached = null, bool markAsVoiceSession = true)
     {
-        Mark(tenant, sid);
+        if (markAsVoiceSession) Mark(tenant, sid);
 
         // The "already narrated" skip is now IDENTITY-AWARE and lives in GenerateOnceAsync, after the
         // current reply has actually been read (issue #1322 done right). The old guard here was a bare
@@ -1185,6 +1243,12 @@ public sealed class WingmanVoiceService
             // screen (via VoiceDisplayFold) says so, instead of offering a Generate button that would re-run
             // this same empty read and never produce audio.
             state.NothingToNarrate[sid] = 1;
+            // ...and it SUPERSEDES an abandoned narration, so the two can never be in the reader's way at
+            // once. This read succeeded and found no reply, which is fresher evidence than a model timeout
+            // recorded against a reply that is no longer the last one. Cleared here rather than relying on
+            // the fold's ordering, because a defence that lives in another file's precedence list stops
+            // working the day somebody reorders it for a good reason (found in review).
+            ClearModelRetryState(state, sid);
             return false;  // nothing to say yet - the provider was not called
         }
         state.NothingToNarrate.TryRemove(sid, out _);   // there IS a text reply now - clear any stale "nothing to narrate"
@@ -1246,7 +1310,7 @@ public sealed class WingmanVoiceService
                 // account's unnarratable sessions were consuming (issue #2675). The leg that failed now owns
                 // the re-attempt, so the promise on the screen is backed by a booked piece of work rather
                 // than by a loop nobody here controls.
-                NoteModelDidNotAnswer(tenant, state, sid, route, ex);
+                NoteModelDidNotAnswer(tenant, state, sid, route, lastReply, ex);
                 return false;   // nothing produced; the provider was not usefully reached
             }
             // Announce a waiting menu AS THE TURN IS READ (issue #2193). A turn that ends on a picker is the
@@ -1284,39 +1348,65 @@ public sealed class WingmanVoiceService
     }
 
     /// <summary>
-    /// The model leg did not answer for this session's current turn: either book the next re-attempt, or -
-    /// when the budget in <see cref="DefaultModelRetryBackoff"/> is spent - stop promising one (issue #2676).
+    /// The model leg did not answer for this session's current turn. Three outcomes, decided in one place
+    /// because they are one decision (issue #2676): book the next re-attempt, stand aside for one already
+    /// booked, or - when the ladder in <see cref="DefaultModelRetryBackoff"/> is spent - stop promising one.
     ///
-    /// The two outcomes are deliberately written in one place. They are the two halves of a single decision,
-    /// and the defect this fixes was exactly a codebase that had the optimistic half and not the pessimistic
-    /// one: the screen kept saying "retrying automatically. It should come through shortly" about a turn no
-    /// loop was going to touch again.
+    /// The defect this fixes was a codebase that had the optimistic outcome and neither of the others: the
+    /// screen kept saying "retrying automatically. It should come through shortly" about a turn no loop was
+    /// going to touch again. Writing only the pessimistic half would have been the same mistake mirrored -
+    /// hence the middle case, which is the one that keeps "nothing further is scheduled" true.
     /// </summary>
-    private void NoteModelDidNotAnswer(TenantId tenant, TenantVoiceState state, string sid, SessionVerbClient route, Exception ex)
+    /// <param name="lastReply">The reply this attempt was trying to narrate. It IDENTIFIES the budget - see
+    /// <see cref="TenantVoiceState.ModelRetryLedger"/> for why a turn cannot be identified by a transition.</param>
+    private void NoteModelDidNotAnswer(TenantId tenant, TenantVoiceState state, string sid, SessionVerbClient route, string lastReply, Exception ex)
     {
         var schedule = _modelRetryBackoff;
-        // The count is of re-attempts ALREADY BOOKED, so this call is asking for number (n+1). AddOrUpdate
-        // rather than a read-then-write: the turn-end path and the sweep can both reach here for the same
-        // session, and two racing failures must not each book "retry 1" and double the spend.
-        var booked = state.ModelRetries.AddOrUpdate(sid, 1, (_, n) => n + 1);
-        if (booked <= schedule.Length)
+        var replyKey = ReplyKey(lastReply);
+        bool standAside, abandon;
+        int rung;
+        lock (state.ModelRetryGate)
         {
-            var delay = schedule[booked - 1];
-            state.Unavailable[sid] = HostedAiState.Retrying;
+            // A ledger for a DIFFERENT reply is a different turn's budget and says nothing about this one,
+            // so it is replaced rather than continued. This is the reset that does not depend on anybody
+            // having observed a Working transition.
+            if (!state.ModelRetries.TryGetValue(sid, out var ledger)
+                || !string.Equals(ledger.ReplyKey, replyKey, StringComparison.Ordinal))
+                ledger = new TenantVoiceState.ModelRetryLedger(replyKey, 0, 0);
+
+            standAside = ledger.Pending > 0;
+            abandon = !standAside && ledger.Booked >= schedule.Length;
+            rung = standAside || abandon ? ledger.Booked : ledger.Booked + 1;
+            state.ModelRetries[sid] = standAside || abandon ? ledger : ledger with { Booked = rung, Pending = 1 };
+        }
+
+        // Retrying is the true CAUSE in all three cases - the model did not answer, and nothing here is
+        // evidence of an outage or of an account problem. Only the PROMISE differs, and that is carried by
+        // the abandoned fact beside it, which VoiceDisplayFold reads as a pair.
+        state.Unavailable[sid] = HostedAiState.Retrying;
+
+        if (standAside)
+        {
+            // A concurrent attempt failed while a booked re-attempt is still waiting out its backoff - the
+            // sweep, or a person pressing Generate. It must not spend a rung of a ladder it does not own,
+            // and above all it must not declare the turn abandoned while that task exists.
             state.NarrationAbandoned.TryRemove(sid, out _);
-            ScheduleModelRetry(tenant, sid, route, delay, booked, schedule.Length);
-            FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - Retrying (audio on its way); re-attempt {booked} of {schedule.Length} is booked for {delay.TotalSeconds:F0}s from now");
+            FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - Retrying; re-attempt {rung} of {schedule.Length} is already booked, so this attempt spends nothing");
             return;
         }
-        // THE BUDGET IS SPENT. The state stays Retrying because Retrying is still the true CAUSE - the model
-        // did not answer, and nothing here is evidence of an outage or an account problem. What changes is
-        // the PROMISE: the abandoned fact rides alongside it and VoiceDisplayFold reads the pair, so the
-        // screen reports a turn that was not narrated instead of an arrival that is not coming. Recorded as a
-        // separate fact rather than as a new HostedAiState because it is not a condition of the hosted
-        // service - the service's answer is unchanged, it is OUR attempts that have run out.
-        state.Unavailable[sid] = HostedAiState.Retrying;
+        if (!abandon)
+        {
+            var delay = schedule[rung - 1];
+            state.NarrationAbandoned.TryRemove(sid, out _);
+            ScheduleModelRetry(tenant, sid, route, delay, replyKey, rung, schedule.Length);
+            FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - Retrying (audio on its way); re-attempt {rung} of {schedule.Length} is booked for {delay.TotalSeconds:F0}s from now");
+            return;
+        }
+        // THE LADDER IS SPENT AND NOTHING IS PENDING. Recorded as its own fact rather than as a new
+        // HostedAiState because it is not a condition of the hosted service - the service's answer is
+        // unchanged, it is OUR attempts that have run out.
         state.NarrationAbandoned[sid] = 1;
-        FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - all {schedule.Length} re-attempt(s) spent, so THIS TURN WAS NOT NARRATED and nothing further is scheduled; the screen says so instead of promising audio");
+        FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - all {schedule.Length} re-attempt(s) spent and none pending, so THIS TURN WAS NOT NARRATED and nothing further is scheduled; the screen says so instead of promising audio");
     }
 
     /// <summary>
@@ -1327,25 +1417,52 @@ public sealed class WingmanVoiceService
     /// and block the one thing that must never be blocked - a genuinely NEW turn arriving and narrating
     /// itself. Returning immediately releases the marker, and the delayed call takes it again on its own.
     ///
+    /// IT CAN ARRIVE INTO A WORLD THAT HAS MOVED ON, so it re-reads the ledger before doing anything. Four
+    /// things retire it, and each was a way for a retry to do harm rather than nothing:
+    ///  - its ledger entry is GONE or now belongs to another reply: a new turn, a successful narration or
+    ///    voice-off has superseded it. Without this a re-attempt booked for the previous turn could win the
+    ///    coalescing race against the new turn's own narration and then store the OLD turn's clip over it,
+    ///    where the sweep would never look again because the session now has audio.
+    ///  - the session is no longer a voice session.
+    ///  - it already has audio - a new turn narrated it while this waited, and re-minting would pull the rug
+    ///    on a listener.
+    /// It also never MARKS the session as a voice session (unlike every other caller of GenerateAsync): a
+    /// retry must be able to do nothing, and a retry that turned voice back on for a session somebody had
+    /// just switched off would be the worst kind of nothing.
+    ///
     /// It re-enters <see cref="GenerateAsync"/> rather than the inner attempt, so every guard on the ordinary
-    /// path still applies to a retry: coalescing, the identity-aware "already narrated" skip, and the reply
-    /// read itself. A retry is therefore never a replay of the old turn - it narrates whatever the session's
-    /// CURRENT last reply is by then, which is the right answer if the agent has moved on.
+    /// path still applies: coalescing, the identity-aware "already narrated" skip, and the reply read itself.
     /// </summary>
-    private void ScheduleModelRetry(TenantId tenant, string sid, SessionVerbClient route, TimeSpan delay, int attempt, int cap)
+    private void ScheduleModelRetry(TenantId tenant, string sid, SessionVerbClient route, TimeSpan delay, string replyKey, int attempt, int cap)
     {
         _ = Task.Run(async () =>
         {
             try
             {
                 await Task.Delay(delay).ConfigureAwait(false);
-                // Two cheap reasons not to bother, both checked AFTER the wait because both can become true
-                // during it: voice was switched off for this session, or a new turn already narrated it. A
-                // retry that ran anyway would only re-mint a clip somebody may already be playing.
-                if (!IsVoiceSession(tenant, sid)) return;
-                if (HasVoice(tenant, sid)) return;
+                var state = StateFor(tenant);
+                // Release the pending marker as this attempt STARTS, and only if the ledger is still waiting
+                // for THIS re-attempt. Releasing it here rather than at the end is what lets this attempt's
+                // own failure book the next rung; leaving it set would make the attempt stand aside from
+                // itself and the ladder would never advance.
+                bool stillOurs;
+                lock (state.ModelRetryGate)
+                {
+                    stillOurs = state.ModelRetries.TryGetValue(sid, out var ledger)
+                                && string.Equals(ledger.ReplyKey, replyKey, StringComparison.Ordinal)
+                                && ledger.Pending > 0;
+                    if (stillOurs) state.ModelRetries[sid] = state.ModelRetries[sid] with { Pending = 0 };
+                }
+                if (!stillOurs)
+                {
+                    FileLog.Write($"[WingmanVoiceService] model retry {attempt} of {cap} for sid={sid} stood down - the turn it was booked for has been superseded");
+                    return;
+                }
+                if (!IsVoiceSession(tenant, sid)) return;   // voice was switched off while this waited
+                if (HasVoice(tenant, sid)) return;          // a new turn already narrated it
                 FileLog.Write($"[WingmanVoiceService] model retry {attempt} of {cap} starting for sid={sid} (the voice path's own re-attempt, not the sweep)");
-                await GenerateAsync(tenant, sid, route, CancellationToken.None, showReadingWindow: false).ConfigureAwait(false);
+                await GenerateAsync(tenant, sid, route, CancellationToken.None, showReadingWindow: false,
+                    markAsVoiceSession: false).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -111,6 +111,22 @@ public sealed class WingmanVoiceService
         /// precedence in ONE place.
         /// </summary>
         public readonly ConcurrentDictionary<string, ReadFailure> ReadFailed = new();
+
+        /// <summary>
+        /// How many model-leg re-attempts this session's CURRENT unnarrated turn has already been given
+        /// (issue #2676). Counted per turn, not per session lifetime: a new turn, a successful narration
+        /// and switching voice off each reset it, so the budget belongs to the turn that lost its voice.
+        /// </summary>
+        public readonly ConcurrentDictionary<string, int> ModelRetries = new();
+
+        /// <summary>
+        /// The model leg did not answer, every re-attempt in the budget has been spent, and NOTHING further
+        /// is scheduled for this turn (issue #2676). The one fact that separates "still coming" from "not
+        /// coming", and the reason it has to be stored rather than inferred: every other no-audio fact this
+        /// service holds is either a wait or an actionable condition, so a turn nobody is working on any
+        /// more matched the calm "voice on its way" sentence forever.
+        /// </summary>
+        public readonly ConcurrentDictionary<string, byte> NarrationAbandoned = new();
     }
 
     private readonly WingmanTranslator _translator;
@@ -790,6 +806,61 @@ public sealed class WingmanVoiceService
     /// </summary>
     public void NoteRetrying(TenantId tenant, string sid) => StateFor(tenant).Unavailable[sid] = HostedAiState.Retrying;
 
+    /// <summary>
+    /// THE RETRY THE VOICE PATH OWNS (issue #2676). One entry per re-attempt, in order, giving the delay
+    /// before it; the length of the array IS the cap.
+    ///
+    /// It exists because the sentence "the session retries on its own" was not true of anything. A model
+    /// non-answer recorded <see cref="HostedAiState.Retrying"/> and returned, and the only thing that would
+    /// ever come back to that session was the background voice sweep - a shared, three-per-cycle budget that
+    /// belongs to no session in particular and that another account's sessions were consuming whole (issue
+    /// #2675). On 2026-09-04 four model timeouts produced three sessions sitting yellow for eleven, eighteen
+    /// and unlimited minutes, each showing "retrying automatically", with nothing scheduled anywhere.
+    ///
+    /// So the leg that failed schedules its own re-attempt. Backed off because a model that just failed to
+    /// answer within its deadline is the last thing to hammer, and capped because a retry loop with no end
+    /// is how one stalled session quietly spends an account's credit all night. Past the cap the promise
+    /// STOPS - see <see cref="NarrationAbandonedFor"/>; the sweep may still find the session later, but
+    /// nothing tells the reader an arrival is on its way when no attempt is booked.
+    ///
+    /// The three delays cover the shape the evidence showed: a stall that clears in seconds, one that clears
+    /// in a minute, and one that does not clear at all - the last reaching its verdict inside the three
+    /// minutes <see cref="VoiceDisplayFold.GaveUpAfter"/> already allows a wait to run.
+    /// </summary>
+    private static readonly TimeSpan[] DefaultModelRetryBackoff =
+    {
+        TimeSpan.FromSeconds(10),
+        TimeSpan.FromSeconds(30),
+        TimeSpan.FromSeconds(90),
+    };
+
+    private TimeSpan[] _modelRetryBackoff = DefaultModelRetryBackoff;
+
+    /// <summary>Test seam: run the bounded model-leg retry on a schedule a test can wait for. Same code
+    /// path, same cap semantics (the number of delays IS the cap) - only the delays differ.</summary>
+    internal void UseModelRetryBackoffForTest(params TimeSpan[] delays)
+        => _modelRetryBackoff = delays.Length == 0 ? Array.Empty<TimeSpan>() : delays;
+
+    /// <summary>
+    /// True when this turn's narration was ABANDONED: the model leg did not answer, the bounded retry budget
+    /// is spent, and nothing further is scheduled for it. Fed to <see cref="VoiceDisplayFold"/> so the screen
+    /// stops saying the audio is on its way - an absence must not be dressed as progress.
+    ///
+    /// Distinct from the fold's elapsed-time give-up, which says "nothing has arrived in three minutes" while
+    /// work continues. This says the work has STOPPED. Cleared by a new turn, a successful narration, and by
+    /// switching voice off - the same three events that clear every other per-turn voice fact.
+    /// </summary>
+    public bool NarrationAbandonedFor(TenantId tenant, string sid) => StateFor(tenant).NarrationAbandoned.ContainsKey(sid);
+
+    /// <summary>This turn's narration is being attempted again from the start, so neither the spent-retry
+    /// count nor the abandoned verdict describes it any more. Called wherever a turn's voice facts are
+    /// reset.</summary>
+    private static void ClearModelRetryState(TenantVoiceState state, string sid)
+    {
+        state.ModelRetries.TryRemove(sid, out _);
+        state.NarrationAbandoned.TryRemove(sid, out _);
+    }
+
     /// <summary>Test seam: seed a standing ACCOUNT / provider condition (the state a failed synthesis
     /// records) so a test can prove a later read failure does not overwrite it.</summary>
     internal void NoteUnavailableForTest(TenantId tenant, string sid, HostedAiState state)
@@ -839,6 +910,7 @@ public sealed class WingmanVoiceService
         state.NothingToNarrate.TryRemove(sid, out _);   // voice is off, so "nothing to narrate" is moot too
         state.DirectorCannotSend.TryRemove(sid, out _); // ...and so is "update that computer to hear this session"
         state.PreferBackupUntil.TryRemove(sid, out _);  // voice is off, so the backup-routing window is moot too (issue devthrottle_internal#405)
+        ClearModelRetryState(state, sid);               // ...and nobody is owed a re-attempt for a turn nobody wants narrated (issue #2676)
         if (state.Ready.TryRemove(sid, out _))
             DeleteReadyAudio(tenant, sid);   // keep the durable cache in step so a stale tap can't 404
         if (wasVoice)
@@ -860,6 +932,11 @@ public sealed class WingmanVoiceService
         state.Unavailable.TryRemove(sid, out _);        // a fresh turn clears the old unavailable-state (dismissible, issue #939)
         state.ReadFailed.TryRemove(sid, out _);         // ...and re-opens the read: a new turn is a new transcript to try
         state.NothingToNarrate.TryRemove(sid, out _);   // a fresh turn supersedes "nothing to narrate" - re-evaluated on its turn-end
+        // A NEW TURN GETS A NEW RETRY BUDGET (issue #2676). The count and the abandoned verdict are facts
+        // about the turn that lost its voice, not about the session: carrying them forward would let one
+        // stalled turn spend the next turn's re-attempts, and would leave "not narrated" on a screen whose
+        // narration has not even been tried yet.
+        ClearModelRetryState(state, sid);
         if (state.Ready.TryRemove(sid, out _))
         {
             DeleteReadyAudio(tenant, sid);   // issue #553: keep the durable cache in step so a stale tap can't 404
@@ -907,6 +984,7 @@ public sealed class WingmanVoiceService
         state.Ready[sid] = ready;
         state.NothingToNarrate.TryRemove(sid, out _);   // audio exists, so there was something to narrate after all
         state.DirectorCannotSend.TryRemove(sid, out _); // ...and a narration proves that computer CAN send its conversation
+        ClearModelRetryState(state, sid);               // ...and the audio ARRIVED, so no re-attempt is owed and nothing was abandoned (issue #2676)
         SaveReadyAudio(tenant, sid, ready);
     }
 
@@ -933,7 +1011,18 @@ public sealed class WingmanVoiceService
     /// boundary): show the yellow "wingman reading" hold until the summary lands. False for a
     /// background refresh, a startup catch-up, or an idle pre-build sweep: generate silently so a
     /// session a client is already listening to is never flipped yellow.</param>
-    internal async Task GenerateAsync(TenantId tenant, string sid, SessionVerbClient route, CancellationToken ct = default, bool showReadingWindow = true)
+    /// <param name="onProviderReached">
+    /// Invoked at the moment this attempt COMMITS to the shared model and speech legs - after every arm that
+    /// returns having produced nothing and spent nothing (no conversation stored, that computer cannot send
+    /// one, no text reply to read aloud, this reply is already narrated). Optional; only the background sweep
+    /// passes it, to spend its per-cycle budget on attempts that actually cost the serialized brain.
+    ///
+    /// GUARANTEED SYNCHRONOUS, on the caller's thread, before this method's task is handed back: nothing
+    /// before the commit point awaits. That is what lets a caller counting slots in a plain loop see the
+    /// answer in time to decide about the NEXT session, and it is a contract on this method - a new await
+    /// added ahead of the commit point would break it.
+    /// </param>
+    internal async Task GenerateAsync(TenantId tenant, string sid, SessionVerbClient route, CancellationToken ct = default, bool showReadingWindow = true, Action? onProviderReached = null)
     {
         Mark(tenant, sid);
 
@@ -963,7 +1052,7 @@ public sealed class WingmanVoiceService
             return;
         try
         {
-            await GenerateOnceAsync(tenant, sid, route, ct, showReadingWindow);
+            await GenerateOnceAsync(tenant, sid, route, ct, showReadingWindow, onProviderReached);
         }
         catch (WingmanModelRateLimitedException rl)
         {
@@ -992,7 +1081,7 @@ public sealed class WingmanVoiceService
     /// no longer needs the distinction now that the shared rate-limit gate is gone, but it is kept because
     /// it honestly reports whether the provider was reached.
     /// </summary>
-    private async Task<bool> GenerateOnceAsync(TenantId tenant, string sid, SessionVerbClient route, CancellationToken ct, bool showReadingWindow)
+    private async Task<bool> GenerateOnceAsync(TenantId tenant, string sid, SessionVerbClient route, CancellationToken ct, bool showReadingWindow, Action? onProviderReached = null)
     {
         var state = StateFor(tenant);
 
@@ -1109,6 +1198,13 @@ public sealed class WingmanVoiceService
             FileLog.Write($"[WingmanVoiceService] GenerateOnce skip (same reply already narrated): sid={sid}");
             return false;   // nothing to do - the provider was not called, so we know nothing new about it
         }
+        // THE COMMIT POINT (issue #2675). Everything above this line is a no-op arm: it reads what is already
+        // in memory or in the Gateway's own store, decides there is nothing to make, and returns having spent
+        // nothing on the model or the speech provider. From here on the attempt costs the shared, serialized
+        // resources - so this, and not the dispatch of the attempt, is where a caller rationing them should
+        // count a slot. Announced BEFORE the first await, so a caller counting in a loop has the answer in
+        // time (see the parameter's contract on GenerateAsync).
+        onProviderReached?.Invoke();
         // Recent conversation so the wingman can add context to a short/terse latest reply.
         var recentContext = WingmanTranslator.BuildRecentContext(widgets);
         // The LIVE screen goes into the same call (issue devthrottle_internal#1195): the model that writes
@@ -1142,8 +1238,15 @@ public sealed class WingmanVoiceService
                 // A rate-limit (WingmanModelRateLimitedException) is NOT caught here - it stays thrown so
                 // GenerateAsync's handler records THIS session's Retrying state (it does not reach any
                 // other session; the shared cooldown that used to do so is gone).
-                state.Unavailable[sid] = HostedAiState.Retrying;
-                FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - Retrying (audio on its way); the session retries on its own");
+                //
+                // AND THE RETRY IS BOOKED HERE, BY THIS LEG (issue #2676). Recording Retrying and returning
+                // is what this arm used to do, and its log line claimed "the session retries on its own" -
+                // which was true of nothing. Nothing on this path scheduled another attempt; the only thing
+                // that would come back was the shared voice sweep, whose whole per-cycle budget another
+                // account's unnarratable sessions were consuming (issue #2675). The leg that failed now owns
+                // the re-attempt, so the promise on the screen is backed by a booked piece of work rather
+                // than by a loop nobody here controls.
+                NoteModelDidNotAnswer(tenant, state, sid, route, ex);
                 return false;   // nothing produced; the provider was not usefully reached
             }
             // Announce a waiting menu AS THE TURN IS READ (issue #2193). A turn that ends on a picker is the
@@ -1178,6 +1281,79 @@ public sealed class WingmanVoiceService
             return true;
         }
         finally { if (showReadingWindow) EndGenerating(tenant, sid); }
+    }
+
+    /// <summary>
+    /// The model leg did not answer for this session's current turn: either book the next re-attempt, or -
+    /// when the budget in <see cref="DefaultModelRetryBackoff"/> is spent - stop promising one (issue #2676).
+    ///
+    /// The two outcomes are deliberately written in one place. They are the two halves of a single decision,
+    /// and the defect this fixes was exactly a codebase that had the optimistic half and not the pessimistic
+    /// one: the screen kept saying "retrying automatically. It should come through shortly" about a turn no
+    /// loop was going to touch again.
+    /// </summary>
+    private void NoteModelDidNotAnswer(TenantId tenant, TenantVoiceState state, string sid, SessionVerbClient route, Exception ex)
+    {
+        var schedule = _modelRetryBackoff;
+        // The count is of re-attempts ALREADY BOOKED, so this call is asking for number (n+1). AddOrUpdate
+        // rather than a read-then-write: the turn-end path and the sweep can both reach here for the same
+        // session, and two racing failures must not each book "retry 1" and double the spend.
+        var booked = state.ModelRetries.AddOrUpdate(sid, 1, (_, n) => n + 1);
+        if (booked <= schedule.Length)
+        {
+            var delay = schedule[booked - 1];
+            state.Unavailable[sid] = HostedAiState.Retrying;
+            state.NarrationAbandoned.TryRemove(sid, out _);
+            ScheduleModelRetry(tenant, sid, route, delay, booked, schedule.Length);
+            FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - Retrying (audio on its way); re-attempt {booked} of {schedule.Length} is booked for {delay.TotalSeconds:F0}s from now");
+            return;
+        }
+        // THE BUDGET IS SPENT. The state stays Retrying because Retrying is still the true CAUSE - the model
+        // did not answer, and nothing here is evidence of an outage or an account problem. What changes is
+        // the PROMISE: the abandoned fact rides alongside it and VoiceDisplayFold reads the pair, so the
+        // screen reports a turn that was not narrated instead of an arrival that is not coming. Recorded as a
+        // separate fact rather than as a new HostedAiState because it is not a condition of the hosted
+        // service - the service's answer is unchanged, it is OUR attempts that have run out.
+        state.Unavailable[sid] = HostedAiState.Retrying;
+        state.NarrationAbandoned[sid] = 1;
+        FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - all {schedule.Length} re-attempt(s) spent, so THIS TURN WAS NOT NARRATED and nothing further is scheduled; the screen says so instead of promising audio");
+    }
+
+    /// <summary>
+    /// Book one delayed re-attempt at this session's narration, owned by the voice path (issue #2676).
+    ///
+    /// Fire-and-forget on purpose, and it must be: the caller is inside <see cref="GenerateAsync"/>'s
+    /// per-session coalescing marker, so awaiting the delay here would hold that marker for the whole backoff
+    /// and block the one thing that must never be blocked - a genuinely NEW turn arriving and narrating
+    /// itself. Returning immediately releases the marker, and the delayed call takes it again on its own.
+    ///
+    /// It re-enters <see cref="GenerateAsync"/> rather than the inner attempt, so every guard on the ordinary
+    /// path still applies to a retry: coalescing, the identity-aware "already narrated" skip, and the reply
+    /// read itself. A retry is therefore never a replay of the old turn - it narrates whatever the session's
+    /// CURRENT last reply is by then, which is the right answer if the agent has moved on.
+    /// </summary>
+    private void ScheduleModelRetry(TenantId tenant, string sid, SessionVerbClient route, TimeSpan delay, int attempt, int cap)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(delay).ConfigureAwait(false);
+                // Two cheap reasons not to bother, both checked AFTER the wait because both can become true
+                // during it: voice was switched off for this session, or a new turn already narrated it. A
+                // retry that ran anyway would only re-mint a clip somebody may already be playing.
+                if (!IsVoiceSession(tenant, sid)) return;
+                if (HasVoice(tenant, sid)) return;
+                FileLog.Write($"[WingmanVoiceService] model retry {attempt} of {cap} starting for sid={sid} (the voice path's own re-attempt, not the sweep)");
+                await GenerateAsync(tenant, sid, route, CancellationToken.None, showReadingWindow: false).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // A boundary: this runs on the thread pool with nobody to catch for it, and a narration
+                // retry must never be able to take the Gateway down.
+                FileLog.Write($"[WingmanVoiceService] model retry {attempt} of {cap} FAILED for sid={sid}: {ex.Message}");
+            }
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1898. Closes thefrederiksen/devthrottle_internal#1899.

Three sessions sat yellow on 2026-09-04 with no narration and a screen that said "retrying automatically. It should come through shortly". Nothing was retrying them.

The speech service was healthy the whole time - every synthesis that day returned on the primary provider in 1.4 to 2.0 seconds. What failed was the model leg that writes the narration text. It timed out four times, on exactly those sessions, and each timeout recorded the calm Retrying state and returned. The only thing that would ever come back was the background voice sweep, and that sweep never reached the account: another account's four permanently unnarratable sessions were consuming its whole per-cycle budget on every pass, 4,356 slots to them against 5 to everybody else in one day.

## thefrederiksen/devthrottle_internal#1898 - the sweep spends its budget on work, not on dispatches

The issue offered two shapes. **This takes the first: count a slot only when the attempt reaches the model or the speech provider.**

It is the better of the two because it fixes what the cap was always for. The cap exists because "the wingman brain is one serialized resource" - so an attempt that never touches that resource was never something the cap had a reason to ration. Every arm that returns having spent nothing stops taking slots, not only the one the incident happened to expose: no conversation stored yet, that computer cannot send one, no text reply to read aloud, and this reply is already narrated.

The second shape - a bounded revalidation deadline on the "cannot send its conversation" marker, matching what `ShouldSkipSweep` already does for a terminal read verdict - would have fixed the incident too, but it would only have moved the starvation. On the pass where those four sessions came up for revalidation together they would still have taken three of the three slots, and every other no-op arm would have gone on burning budget for nothing.

`WingmanVoiceService` announces its own commit point, because it is the only place that knows which arm an attempt took - a second copy of that decision in the sweep would diverge the day the definition moved. The announcement is synchronous and happens before the returned task is handed back, so a sweep counting slots in a plain loop has the answer in time to decide about the next session.

**These sessions are not dropped from the sweep.** Keeping them is exactly what makes their recovery free: the moment that computer is updated, the next pass narrates it with nobody touching the Gateway. What they stop doing is spending a budget they cost nothing against. A second, much larger cap on attempts examined per cycle keeps the pass itself bounded, because a no-op attempt is cheap but it is still a read of the turn store. That second cap is charged PER ACCOUNT (see the review round below), so it cannot become a smaller copy of the starvation it bounds.

## thefrederiksen/devthrottle_internal#1899 - the leg that failed books the retry, and where it cannot, the screen stops promising

A model non-answer now schedules its own re-attempt: backed off at 10 seconds, 30 seconds and 90 seconds, capped at three, owned by the voice path rather than by a shared loop another account can starve. The whole ladder takes about six minutes ten to reach its verdict - four sixty-second model deadlines plus the backoff - which is deliberate: at three minutes the fold already stops saying the audio is coming soon, and at about six the service stops claiming anything is coming at all. (An earlier draft of this description and of the code comment said the ladder finished inside three minutes. That was arithmetic with the attempts left out; the review caught it.)

The re-attempt re-enters the ordinary generation path, so every existing guard still applies to it - the per-session coalescing, the identity-aware "already narrated" skip, and the reply read itself. A retry therefore narrates whatever the session's current last reply is by then, rather than replaying a stale turn. It is fired and not awaited on purpose: awaiting the backoff inside the coalescing marker would hold it for the whole delay and block the one thing that must never be blocked, a genuinely new turn arriving and narrating itself.

The budget belongs to the TURN, not the session, and it is identified by the REPLY it was trying to narrate rather than by a transition - see the review round below for why keying it on the Working edge was wrong. A successful narration and switching voice off also reset it.

**Past the cap the promise stops.** A new fact travels to `VoiceDisplayFold` beside the cause and produces a "Turn not narrated" verdict instead of another calm "on its way". It is deliberately not merged with the existing elapsed-time give-up: that one is said while automatic attempts continue and says "The Gateway is still trying", which is the clause that keeps a reader waiting. This one makes no such claim, and it does offer the Generate button, because the automatic attempts have stopped and a person asking for one is the only thing left that can produce this turn's audio.

No client change was needed. The roster rail and both web shells render the fold's own words for any verdict they do not specially handle, so the new state reached all three surfaces by being added once, in the fold. That deny-list design was written to make exactly this true, and it held.

## Tests - each confirmed red against the code as it was

- **One account whose every voice session takes a no-op arm cannot starve a second account's session out of the same cycle.** Two accounts, two Directors over the real tunnel, one cycle of the real `SweepVoiceSessionsAsync`. It asserts all five sessions were attempted, so it does not depend on which account the pass reaches first - the old budget could attempt three, whatever the order.
- **A no-op session stays in the sweep**, and its marker comes off by itself on the pass after that computer starts pushing.
- **A model timeout leads to another attempt, and the turn is narrated** - proved by the audio actually arriving, with no sweep, no new turn, and nobody pressing anything.
- **When every re-attempt is spent** the narration is abandoned, the cap holds at exactly three model calls, and the folded screen says the turn was not narrated rather than promising audio.
- **A new turn clears the abandoned verdict and gets its own retry budget**; switching voice off clears it too. A new REPLY gets its own budget even when the Working transition was never observed.
- The abandoned verdict never hides playable audio, a live attempt, an actionable account condition, or the "update that computer" remedy.

Revert-proofs were run, not assumed: restoring the unconditional `generated++` turns both sweep tests red, restoring the old timeout body turns the four retry tests red, and removing the two fold arms turns the three sentence tests red.

## What the issues got slightly wrong

thefrederiksen/devthrottle_internal#1899 says the session "holds yellow with 'Voice did not arrive after Nm'". Both sentences appear, in that order - the calm retrying line first, and the elapsed-time give-up after three minutes. The give-up was already there and already stops saying "on its way"; what it goes on saying, wrongly, is "The Gateway is still trying". So the missing piece was narrower and worse than described: not the absence of an end to the promise, but a second promise underneath it that was equally untrue.

## Not changed, and worth a look separately

The rate-limit arm in `GenerateAsync` has the same defect in miniature: a 429 records Retrying and logs "this session retries on its own", and nothing schedules anything. It is left alone because the right policy there is different - it should respect the `Retry-After` the provider sends rather than a fixed backoff ladder - and that is its own change.

The release gate ran with `-Parked`. One unrelated failure appeared in the parallel run, `GatewayInputStatsAggregatorTests.AgentDrivenTurns_SurviveAGatewayRestart`, an `ObjectDisposedException` on the shared SQLitePCL native handle. It passes in isolation, and nothing in this change is on its call path - it constructs a stats aggregator against a temporary database and never touches the voice service, the sweep, or the fold.

---

## Second commit: the independent review round

Per the repository's merge rule the change was reviewed by a different agent family before merging. The review found six real defects, four of them the same class of dishonesty this change exists to remove, only inverted. All are fixed in the second commit, each with a test, and each test was confirmed red against the first commit.

- **The retry ladder was reset by the Working transition** - the one signal this file already knows it cannot trust, because it is sampled and a quick turn can be missed. A turn whose edge was missed inherited the previous turn's exhausted ladder and was denied its first re-attempt. The ledger is now keyed on the identity of the reply the budget belongs to, so a different reply starts a fresh ladder whether or not anybody saw the turn begin.
- **A re-attempt could wake up during the NEXT turn**, win the coalescing race against that turn's own narration, and store the OLD turn's clip - after which the session has audio, the sweep skips it forever, and the phone plays a stale narration of the wrong turn for the life of the session. The delayed task now re-reads the ledger and retires itself when its entry is gone or belongs to another reply.
- **A concurrent failure could declare the turn abandoned while a re-attempt was still pending**, putting "nothing further is scheduled" on the screen while a task genuinely existed. The ledger tracks the pending re-attempt; a concurrent failure now spends nothing and claims nothing.
- **A re-attempt turned voice back on**, because every caller of `GenerateAsync` marks the session as a side effect and a retry wakes up to ninety seconds later. The retry path no longer marks. Deliberately not claimed: a retry that succeeds still marks, because the success path marks for every caller - shared, pre-existing behaviour whose window is one generation rather than one backoff, and the test says so.
- **"Nothing to read aloud" now supersedes an abandoned narration** at the point it is established, rather than relying on the fold's precedence list. A defence that lives in another file's ordering stops working the day somebody reorders it for a good reason.
- **The new attempt budget was global**, so it was spent by whichever accounts the pass reached first - the same starvation, moved from three to sixty rather than removed. It is now charged per account. The generation cap stays global, which is right: that one rations a genuinely shared resource and this one does not.
- **A comment's arithmetic was wrong.** It claimed the ladder reaches its verdict inside the fold's three-minute give-up, leaving out the attempts themselves. Four sixty-second model deadlines plus 10 + 30 + 90 seconds of backoff is about six minutes ten. The comment now says that, and why the two numbers do different jobs.

The review also found two test defects, both fixed: the second sweep test asserted markers that the FIRST pass had set, so it was satisfied by a leftover and would have held had the second pass skipped those sessions entirely; and the cap test read its count the instant the verdict appeared, which a fourth re-attempt still on a timer would also have satisfied.

Still not changed, and noted for a separate look: a rate-limited or unexpectedly failing re-attempt leaves the calm Retrying state with nothing booked, because the right policy for a 429 is to respect the provider's Retry-After rather than a fixed ladder. The delayed tasks are also untracked and uncancellable across a Gateway shutdown; they are bounded at three per turn and each retires itself on waking.
