### PR TITLE
feat(gateway): a size ceiling on a turn record's conversation, oldest turns dropped first

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogRecorderTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogRecorderTests.cs
@@ -305,6 +305,94 @@ public sealed class TurnLogRecorderTests
         Parts = new List<HistoryPartDto> { new() { Kind = "ToolResult", Text = "output", ToolId = id } },
     };
 
+    [Fact]
+    public void BuildConversation_AConversationOverTheCeiling_DropsTheOLDESTTurnsAndSaysHowMany()
+    {
+        // Three fat turns, each well over the ceiling on its own tool output. The turns nearest the screen
+        // are the ones a judgement about THIS turn end would read, so they are the ones that must survive.
+        var big = new string('x', 90_000);
+        var messages = new List<HistoryMessageDto>();
+        foreach (var n in new[] { 1, 2, 3 })
+        {
+            messages.Add(Message("User", $"prompt {n}"));
+            messages.Add(ToolResultWith($"call-{n}", big));
+            messages.Add(Message("Assistant", $"answer {n}"));
+        }
+
+        var built = TurnLogRecorder.BuildConversation(
+            new StoredConversationSnapshot(true, "transcript-1", messages));
+
+        Assert.True(built.Truncated);
+        Assert.True(built.TurnsDroppedForSize > 0);
+        Assert.Equal(TurnLogRecorder.MaxConversationBytes, built.SizeCeilingBytes);
+        // The FRONT went, not the back: the newest prompt and its answer are still here.
+        Assert.Equal("User", built.Messages[0].Role);
+        Assert.Equal("prompt 3", built.Messages[0].Parts[0].Text);
+        Assert.Equal("answer 3", built.Messages[^1].Parts[0].Text);
+    }
+
+    [Fact]
+    public void BuildConversation_ATurnsKeptWholeEvenWhenOneTurnAloneExceedsTheCeiling()
+    {
+        // Half a turn would teach the corpus something that never happened - an agent reply with no prompt.
+        // One oversized turn is kept whole and the record is simply large.
+        var messages = new List<HistoryMessageDto>
+        {
+            Message("User", "the only prompt"),
+            ToolResultWith("call-1", new string('y', 400_000)),
+            Message("Assistant", "the only answer"),
+        };
+
+        var built = TurnLogRecorder.BuildConversation(
+            new StoredConversationSnapshot(true, "transcript-1", messages));
+
+        Assert.Equal(3, built.Messages.Count);
+        Assert.Equal("the only prompt", built.Messages[0].Parts[0].Text);
+        Assert.Equal(0, built.TurnsDroppedForSize);
+    }
+
+    [Fact]
+    public void BuildConversation_AnOrdinaryConversation_IsNotTrimmedForSizeAtAll()
+    {
+        var messages = new List<HistoryMessageDto> { Message("User", "hello"), Message("Assistant", "hi") };
+
+        var built = TurnLogRecorder.BuildConversation(
+            new StoredConversationSnapshot(true, "transcript-1", messages));
+
+        Assert.Equal(0, built.TurnsDroppedForSize);
+        Assert.False(built.Truncated);
+        Assert.Equal(2, built.Messages.Count);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_WhenTheCeilingTrimsTurns_TheRecordSaysSoAsAGap()
+    {
+        var big = new string('x', 90_000);
+        var messages = new List<HistoryMessageDto>();
+        foreach (var n in new[] { 1, 2, 3 })
+        {
+            messages.Add(Message("User", $"prompt {n}"));
+            messages.Add(ToolResultWith($"call-{n}", big));
+            messages.Add(Message("Assistant", $"answer {n}"));
+        }
+        var env = new FakeEnvironment
+        {
+            Conversation = new StoredConversationSnapshot(true, "transcript-1", messages),
+        };
+        var recorder = new TurnLogRecorder(env);
+
+        await recorder.CaptureAsync(Signal(), CancellationToken.None);
+
+        var record = Assert.Single(env.Written);
+        Assert.Contains(record.Gaps, g => g.Part == "conversation" && g.Reason.Contains("dropped to stay under"));
+    }
+
+    private static HistoryMessageDto ToolResultWith(string id, string text) => new()
+    {
+        Role = "User",
+        Parts = new List<HistoryPartDto> { new() { Kind = "ToolResult", Text = text, ToolId = id } },
+    };
+
     private static HistoryMessageDto Message(string role, string text) => new()
     {
         Role = role,

--- a/src/CcDirector.Gateway/TurnLog/TurnLogRecord.cs
+++ b/src/CcDirector.Gateway/TurnLog/TurnLogRecord.cs
@@ -224,8 +224,25 @@ public sealed record TurnLogConversation
     /// reply together.</summary>
     [JsonPropertyName("full_turns_requested")] public int FullTurnsRequested { get; init; }
 
-    /// <summary>True when the front of the conversation was cut off to honour that request.</summary>
+    /// <summary>True when the front of the conversation was cut off - by the turn count, by the size
+    /// ceiling, or by both.</summary>
     [JsonPropertyName("truncated")] public bool Truncated { get; init; }
+
+    /// <summary>
+    /// How many whole turns were dropped to get under the size ceiling, beyond any the turn count already
+    /// cut. Zero means the ceiling was never reached.
+    ///
+    /// It is recorded rather than left implicit because the two reasons a conversation is short mean
+    /// different things: a session that has only had three turns, and a session whose turns were so large
+    /// that we could not keep ten. Reading the second as the first would understate how much context the
+    /// judgements actually had.
+    /// </summary>
+    [JsonPropertyName("turns_dropped_for_size")] public int TurnsDroppedForSize { get; init; }
+
+    /// <summary>The ceiling in force when this record was written, in bytes. Stored per record because it
+    /// is a tuning decision that will change, and a corpus spanning a change to it is otherwise
+    /// uninterpretable.</summary>
+    [JsonPropertyName("size_ceiling_bytes")] public int SizeCeilingBytes { get; init; }
 
     /// <summary>
     /// When the computer that owns this session last pushed its conversation.

--- a/src/CcDirector.Gateway/TurnLog/TurnLogRecorder.cs
+++ b/src/CcDirector.Gateway/TurnLog/TurnLogRecorder.cs
@@ -42,6 +42,23 @@ public sealed class TurnLogRecorder : IDisposable
     public const int ScrollbackLinesCaptured = 2000;
 
     /// <summary>
+    /// The ceiling on ONE record's conversation, in bytes of serialized JSON.
+    ///
+    /// Ten full turns is the rule, and it stays the rule - but a "turn" in an agent session is a person's
+    /// prompt plus every tool call and tool result that followed it, and those run to hundreds of messages.
+    /// Measured on the first live records: a median conversation of 271 KB inside a 616 KB record, which at
+    /// four hundred turn ends a day is tens of gigabytes a year in a repository. The corpus is only useful
+    /// if we can actually keep it.
+    ///
+    /// OLDEST TURNS GO FIRST, AND THEY GO WHOLE. Trimming from the front keeps the turns nearest the screen
+    /// - the ones a judgement about THIS turn end would actually read - and dropping whole turns rather
+    /// than messages preserves the property that made the ten-turn rule worth having: no agent reply
+    /// arrives without the prompt that caused it. A record that hits the ceiling says so, and says how many
+    /// turns it lost.
+    /// </summary>
+    public const int MaxConversationBytes = 128 * 1024;
+
+    /// <summary>
     /// The ceiling on one capture. Not a correctness bound - nothing downstream waits on this - but an
     /// unreachable Director must not leave a capture task hanging on to a session's state for the rest of
     /// the day, and a fleet's worth of those would be a leak rather than a log.
@@ -200,6 +217,15 @@ public sealed class TurnLogRecorder : IDisposable
                 });
             }
         }
+        if (conversation.TurnsDroppedForSize > 0)
+        {
+            gaps.Add(new TurnLogGap
+            {
+                Part = "conversation",
+                Reason = $"{conversation.TurnsDroppedForSize} older turn(s) were dropped to stay under the "
+                       + $"{MaxConversationBytes / 1024} KB conversation ceiling - the turns nearest this screen were kept",
+            });
+        }
         overall.Stop();
 
         var record = new TurnLogRecord
@@ -304,16 +330,51 @@ public sealed class TurnLogRecorder : IDisposable
             break;
         }
 
+        var cutByTurnCount = startIndex > 0;
+
+        // THE SIZE CEILING, applied after the turn count and never instead of it. Drop the oldest WHOLE
+        // turn and measure again, until it fits or one turn is left. A single turn over the ceiling is kept
+        // rather than sliced: half a turn teaches the corpus something that never happened, and the record
+        // says plainly that it is oversized.
+        var droppedForSize = 0;
+        while (Serialized(all, startIndex) > MaxConversationBytes)
+        {
+            var next = NextHumanTurn(all, startIndex + 1);
+            if (next < 0) break;   // one turn left - keep it whole and let the record be large
+            startIndex = next;
+            droppedForSize++;
+        }
+
         return new TurnLogConversation
         {
             IsSupported = stored.IsSupported,
             Generation = stored.Generation,
             TotalMessageCount = all.Count,
             FullTurnsRequested = FullTurnsCaptured,
-            Truncated = startIndex > 0,
+            Truncated = cutByTurnCount || droppedForSize > 0,
+            TurnsDroppedForSize = droppedForSize,
+            SizeCeilingBytes = MaxConversationBytes,
             LastPushedAtUtc = stored.LastPushedUtc,
             Messages = all.Skip(startIndex).ToList(),
         };
+    }
+
+    /// <summary>The serialized size of the messages from <paramref name="from"/> onward - what the record
+    /// will actually cost, measured rather than estimated from message counts, because one tool result can
+    /// be larger than a hundred prompts.</summary>
+    private static int Serialized(IReadOnlyList<HistoryMessageDto> all, int from)
+    {
+        var window = from == 0 ? all : all.Skip(from).ToList();
+        return System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(window).Length;
+    }
+
+    /// <summary>The index of the next human turn at or after <paramref name="from"/>, or -1 when there is
+    /// none - which is what stops the trim from cutting into the last turn it holds.</summary>
+    private static int NextHumanTurn(IReadOnlyList<HistoryMessageDto> all, int from)
+    {
+        for (var i = Math.Max(0, from); i < all.Count; i++)
+            if (IsHumanTurn(all[i])) return i;
+        return -1;
     }
 
     /// <summary>


### PR DESCRIPTION
Ten full turns stays the rule. But a turn in an agent session is a prompt plus every tool call and result that followed it, and on the first live records that is a median conversation of 271 KB inside a 616 KB record - about 17 GB a year compressed at four hundred turn ends a day. A corpus we cannot afford to keep answers no questions.

The ceiling applies **after** the turn count, never instead of it. Over it, the **oldest whole turn** goes and the size is measured again.

- **Oldest first**, because the turns nearest the screen are the ones a judgement about this turn end would read.
- **Whole turns**, because that is what the ten-turn rule was for: no agent reply reaches the corpus without the prompt that caused it.
- **One oversized turn is kept whole** and the record is simply large. Half a turn teaches the corpus something that never happened.

A record that hit the ceiling says so - turns dropped, the ceiling in force, and a gap naming it. "Only three turns happened" and "the turns were too big to keep ten" mean different things, and reading the second as the first understates how much context the judgements had.

**Measured against the eleven records already captured:** median 112 KB compressed to 57 KB, largest 1,298 KB raw to 544 KB, roughly 17 GB/year to 9. It touches all eleven, dropping a median of two turns.

Three mutations applied, run, watched go red, reverted: trim from the back; slice mid-turn; raise the ceiling so it never bites.

Gate: 4,850 tests, every suite Completed. The parked Gateway suite is unavailable - its per-user lock is held by a live run in another worktree - and this change is confined to `BuildConversation` and its tests.