### PR TITLE
Keep hosted Gateway logs off the durable file share

### DIFF
--- a/src/CcDirector.Core.Tests/Utilities/FileLogConsoleMirrorTests.cs
+++ b/src/CcDirector.Core.Tests/Utilities/FileLogConsoleMirrorTests.cs
@@ -10,8 +10,8 @@ namespace CcDirector.Core.Tests.Utilities;
 //   1. MirrorToConsole puts every line on standard output as well - the sink the
 //      container platform captures per container, and the one with no queue in front of
 //      it, so it survives the file-share stall that erased three startup records.
-//   2. UseUniqueInstanceId REFUSES to run after Start(), instead of quietly leaving the
-//      process writing to the shared file it was supposed to move off.
+//   2. UseUniqueInstanceId installs the caller-selected directory before Start(), and
+//      REFUSES to run after Start() instead of splitting one process record across files.
 // =====================================================================================
 public sealed class FileLogConsoleMirrorTests
 {
@@ -74,5 +74,30 @@ public sealed class FileLogConsoleMirrorTests
 
         var ex = Assert.Throws<InvalidOperationException>(FileLog.UseUniqueInstanceId);
         Assert.Contains("before FileLog.Start()", ex.Message);
+    }
+
+    [Fact]
+    public void UseUniqueInstanceId_WithDirectory_WritesToTheSelectedDirectory()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-filelog-selected-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            FileLog.UseUniqueInstanceId(dir);
+            FileLog.Start();
+            FileLog.Write("[FileLog] selected directory proof");
+            FileLog.Stop();
+
+            var file = Assert.Single(Directory.GetFiles(dir, "director-*.log"));
+            Assert.Equal(Path.GetFullPath(dir), Path.GetDirectoryName(Path.GetFullPath(file)));
+            Assert.Contains("selected directory proof", File.ReadAllText(file));
+        }
+        finally
+        {
+            FileLog.Stop();
+            FileLog.UseUniqueInstanceId();
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
     }
 }

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -17,7 +17,7 @@ namespace CcDirector.Core.Storage;
 ///   CC_DIRECTOR_INSTANCES_DIR - Override the Director instance-discovery directory specifically
 ///
 /// NOTE: CcStorage methods intentionally omit FileLog.Write calls because
-/// FileLog.LogDir is initialized from CcStorage.ToolLogs(), creating a
+/// FileLog's default directory is initialized from CcStorage.ToolLogs(), creating a
 /// circular dependency at static initialization time.
 /// </summary>
 public static class CcStorage

--- a/src/CcDirector.Core/Utilities/FileLog.cs
+++ b/src/CcDirector.Core/Utilities/FileLog.cs
@@ -3,7 +3,8 @@ using CcDirector.Core.Storage;
 namespace CcDirector.Core.Utilities;
 
 /// <summary>
-/// Simple thread-safe file logger. Writes to cc-director logs/director/ directory.
+/// Simple thread-safe file logger. Writes to cc-director logs/director/ by default; a hosted process may
+/// select container-local storage before it starts.
 ///
 /// The actual dequeue/rollover/flush work lives in <see cref="FileLogWriter"/> so the day-rollover
 /// behavior can be unit-tested with an injectable clock (issue #171). This type is the thin static
@@ -12,7 +13,8 @@ namespace CcDirector.Core.Utilities;
 /// </summary>
 public static class FileLog
 {
-    private static readonly string LogDir = CcStorage.ToolLogs("director");
+    private static readonly string DefaultLogDir = CcStorage.ToolLogs("director");
+    private static string _logDir = DefaultLogDir;
 
     // What distinguishes this process's log file from another process's. The desktop uses the process id,
     // which is unique there and is what the desktop tooling globs for. A container must call
@@ -27,7 +29,7 @@ public static class FileLog
     // This comment used to say "Production never reassigns it", which was true and was the bug: a stopped
     // writer was restarted rather than replaced, so every later line threw. See Start.
     private static FileLogWriter _writer =
-        new(LogDir, _instanceId, () => DateTime.Now);
+        new(_logDir, _instanceId, () => DateTime.Now);
 
     private static int _started;
 
@@ -48,20 +50,34 @@ public static class FileLog
     /// leaving the process on the shared file.
     ///
     /// A hosted Gateway needs this because the default discriminator - the process id - is always 1 inside
-    /// a container, so every container computed the same path. Two of them then appended to one file on an
-    /// SMB share mounted <c>nobrl</c>, where the FileShare.Read request is not enforced across clients, and
-    /// clobbered each other mid-record. The token is generated per process rather than read from the
-    /// environment so its uniqueness does not depend on the platform supplying anything.
+    /// a container, so every container computed the same path. Two of them then appended to one file on a
+    /// Server Message Block share mounted <c>nobrl</c>, where the FileShare.Read request is not enforced
+    /// across clients, and clobbered each other mid-record. The token is generated per process rather than
+    /// read from the environment so its uniqueness does not depend on the platform supplying anything.
+    ///
+    /// A caller may also choose a different directory before the writer starts. The hosted Gateway uses
+    /// that seam to keep its process log on the container's temporary disk instead of the durable workload
+    /// share. Durable product state still uses <see cref="CcStorage"/>; a process log is not product state.
     /// </summary>
-    public static void UseUniqueInstanceId()
+    public static void UseUniqueInstanceId() => UseUniqueInstanceId(DefaultLogDir);
+
+    /// <summary>
+    /// Give this process a unique log file in a caller-selected directory. Like the parameterless overload,
+    /// this must be called before <see cref="Start"/>.
+    /// </summary>
+    public static void UseUniqueInstanceId(string logDirectory)
     {
         if (_started != 0)
             throw new InvalidOperationException(
                 "FileLog.UseUniqueInstanceId() must be called before FileLog.Start(); the writer is already " +
                 "running on the shared log file and moving it now would split this process's record in two.");
 
+        if (string.IsNullOrWhiteSpace(logDirectory))
+            throw new ArgumentException("A log directory cannot be blank.", nameof(logDirectory));
+
         _instanceId = Guid.NewGuid().ToString("N")[..12];
-        _writer = new FileLogWriter(LogDir, _instanceId, () => DateTime.Now);
+        _logDir = logDirectory;
+        _writer = new FileLogWriter(_logDir, _instanceId, () => DateTime.Now);
     }
 
     /// <summary>
@@ -129,7 +145,7 @@ public static class FileLog
             return;
 
         if (_writer.IsSpent)
-            _writer = new FileLogWriter(LogDir, _instanceId, () => DateTime.Now);
+            _writer = new FileLogWriter(_logDir, _instanceId, () => DateTime.Now);
 
         _writer.OnSinkHealthChanged = OnSinkHealthChanged;
         _writer.Start();
@@ -174,7 +190,7 @@ public static class FileLog
 
     /// <summary>Returns the current log file path (useful for display).</summary>
     public static string CurrentLogPath =>
-        Path.Combine(LogDir, $"director-{DateTime.Now:yyyy-MM-dd}-{_instanceId}.log");
+        Path.Combine(_logDir, $"director-{DateTime.Now:yyyy-MM-dd}-{_instanceId}.log");
 
     /// <summary>
     /// TEST-ONLY seam (issue #862). Redirects FileLog to a private, throwaway directory for the life

--- a/src/CcDirector.Gateway.UnitTests/Account/GatewayDeviceKeyStoreTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/Account/GatewayDeviceKeyStoreTests.cs
@@ -9,6 +9,7 @@ namespace CcDirector.Gateway.Tests.Account;
 /// install id, that a different install id yields no key, that clearing removes it, and - DT-05 - that the
 /// raw key value is never written to the log even though it is persisted to disk.
 /// </summary>
+[Collection(CcDirector.Gateway.Tests.FileLogCaptureCollection.Name)]
 public sealed class GatewayDeviceKeyStoreTests
 {
     private const string Install = "install-857";

--- a/src/CcDirector.Gateway.UnitTests/FileLogCaptureCollection.cs
+++ b/src/CcDirector.Gateway.UnitTests/FileLogCaptureCollection.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// FileLog.RedirectForTests swaps one process-wide writer, so every test that owns that seam must run with
+/// no other test class beside it. The Gateway unit assembly otherwise runs four classes in parallel.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class FileLogCaptureCollection
+{
+    public const string Name = "FileLog capture";
+}

--- a/src/CcDirector.Gateway.UnitTests/HostedGatewayLoggingTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/HostedGatewayLoggingTests.cs
@@ -1,0 +1,32 @@
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The hosted Gateway's process log is diagnostic output, not durable product state. Issue #2678 found that
+/// keeping it below the Gateway storage root made it most of the Azure Files traffic and let an unrelated
+/// reader break the active file's write lease. These tests pin the location boundary, not a cleanup policy.
+/// </summary>
+public sealed class HostedGatewayLoggingTests
+{
+    [Fact]
+    public void Hosted_process_log_lives_below_the_container_temporary_root()
+    {
+        var temporaryRoot = Path.Combine(Path.GetTempPath(), "hosted-log-root");
+
+        var directory = GatewayEntryPoint.ResolveHostedLogDirectory(temporaryRoot);
+
+        Assert.Equal(
+            Path.Combine(Path.GetFullPath(temporaryRoot), "devthrottle", "logs", "director"),
+            directory);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Hosted_process_log_refuses_an_absent_temporary_root(string temporaryRoot)
+    {
+        Assert.Throws<ArgumentException>(() => GatewayEntryPoint.ResolveHostedLogDirectory(temporaryRoot));
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/SessionKeyRegistryTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionKeyRegistryTests.cs
@@ -15,6 +15,7 @@ namespace CcDirector.Gateway.Tests;
 /// key per session, revoked when the session is reaped, lapsed when nobody revoked it, and a database
 /// failure that denies rather than grants.
 /// </summary>
+[Collection(FileLogCaptureCollection.Name)]
 public sealed class SessionKeyRegistryTests : IDisposable
 {
     private readonly GatewayDbTestHarness _harness = new();
@@ -228,21 +229,27 @@ public sealed class SessionKeyRegistryTests : IDisposable
         var registry = Registry(() => now);
         var session = Guid.NewGuid();
         var hash = GatewaySessionKey.Hash(GatewaySessionKey.Mint());
-        Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, now + SessionKeyRegistry.MaxSessionKeyLifetime));
+        var initialExpiry = now + SessionKeyRegistry.MaxSessionKeyLifetime;
 
-        IReadOnlyList<string> refreshLines;
+        IReadOnlyList<string> registrationLines;
         using (var log = FileLog.RedirectForTests())
         {
+            Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, initialExpiry));
             now = now.AddSeconds(10);
             Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, now + TimeSpan.FromDays(1)));
-            refreshLines = log.DrainAndReadLines();
+            registrationLines = log.DrainAndReadLines();
         }
 
         using var ctx = _harness.Open().CreateUnscopedContext();
         var row = ctx.SessionKeys.Single();
         Assert.Equal(new DateTime(2026, 9, 4, 12, 0, 0, DateTimeKind.Utc), row.IssuedAtUtc);
         Assert.Equal(new DateTime(2026, 9, 5, 0, 0, 0, DateTimeKind.Utc), row.ExpiresAtUtc);
-        Assert.Empty(refreshLines);
+
+        // Presence proves the capture worked; exactly one proves the ten-second refresh added no cap or
+        // success line. Naming the first expiry also distinguishes that control from the later refresh.
+        var recorded = Assert.Single(registrationLines);
+        Assert.Contains($"session={session}", recorded, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains($"expires={initialExpiry:O}", recorded, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.UnitTests/SessionKeyRegistryTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionKeyRegistryTests.cs
@@ -221,6 +221,43 @@ public sealed class SessionKeyRegistryTests : IDisposable
     }
 
     [Fact]
+    public void An_unchanged_roster_refresh_does_not_rewrite_a_long_lived_key()
+    {
+        var now = new DateTime(2026, 9, 4, 12, 0, 0, DateTimeKind.Utc);
+        var registry = Registry(() => now);
+        var session = Guid.NewGuid();
+        var hash = GatewaySessionKey.Hash(GatewaySessionKey.Mint());
+        Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, now + SessionKeyRegistry.MaxSessionKeyLifetime));
+
+        now = now.AddSeconds(10);
+        Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, now + SessionKeyRegistry.MaxSessionKeyLifetime));
+
+        using var ctx = _harness.Open().CreateUnscopedContext();
+        var row = ctx.SessionKeys.Single();
+        Assert.Equal(new DateTime(2026, 9, 4, 12, 0, 0, DateTimeKind.Utc), row.IssuedAtUtc);
+        Assert.Equal(new DateTime(2026, 9, 5, 0, 0, 0, DateTimeKind.Utc), row.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void An_unchanged_key_is_refreshed_before_half_its_lifetime_remains()
+    {
+        var started = new DateTime(2026, 9, 4, 12, 0, 0, DateTimeKind.Utc);
+        var now = started;
+        var registry = Registry(() => now);
+        var session = Guid.NewGuid();
+        var hash = GatewaySessionKey.Hash(GatewaySessionKey.Mint());
+        Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, now + SessionKeyRegistry.MaxSessionKeyLifetime));
+
+        now = started + SessionKeyRegistry.RefreshWhenRemaining + TimeSpan.FromSeconds(1);
+        Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, now + SessionKeyRegistry.MaxSessionKeyLifetime));
+
+        using var ctx = _harness.Open().CreateUnscopedContext();
+        var row = ctx.SessionKeys.Single();
+        Assert.Equal(now, row.IssuedAtUtc);
+        Assert.Equal(now + SessionKeyRegistry.MaxSessionKeyLifetime, row.ExpiresAtUtc);
+    }
+
+    [Fact]
     public void The_gateway_caps_an_expiry_computed_on_the_directors_clock()
     {
         // The expiry arrives from the Director, so it is only as trustworthy as the Director's clock. A

--- a/src/CcDirector.Gateway.UnitTests/SessionKeyRegistryTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionKeyRegistryTests.cs
@@ -1,5 +1,6 @@
 using CcDirector.Core.Security;
 using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Pairing;
 using CcDirector.Gateway.Tests.Data;
 using Xunit;
@@ -229,13 +230,19 @@ public sealed class SessionKeyRegistryTests : IDisposable
         var hash = GatewaySessionKey.Hash(GatewaySessionKey.Mint());
         Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, now + SessionKeyRegistry.MaxSessionKeyLifetime));
 
-        now = now.AddSeconds(10);
-        Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, now + SessionKeyRegistry.MaxSessionKeyLifetime));
+        IReadOnlyList<string> refreshLines;
+        using (var log = FileLog.RedirectForTests())
+        {
+            now = now.AddSeconds(10);
+            Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, now + TimeSpan.FromDays(1)));
+            refreshLines = log.DrainAndReadLines();
+        }
 
         using var ctx = _harness.Open().CreateUnscopedContext();
         var row = ctx.SessionKeys.Single();
         Assert.Equal(new DateTime(2026, 9, 4, 12, 0, 0, DateTimeKind.Utc), row.IssuedAtUtc);
         Assert.Equal(new DateTime(2026, 9, 5, 0, 0, 0, DateTimeKind.Utc), row.ExpiresAtUtc);
+        Assert.Empty(refreshLines);
     }
 
     [Fact]
@@ -255,6 +262,26 @@ public sealed class SessionKeyRegistryTests : IDisposable
         var row = ctx.SessionKeys.Single();
         Assert.Equal(now, row.IssuedAtUtc);
         Assert.Equal(now + SessionKeyRegistry.MaxSessionKeyLifetime, row.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void A_shorter_expiry_on_the_same_key_is_written_immediately()
+    {
+        var started = new DateTime(2026, 9, 4, 12, 0, 0, DateTimeKind.Utc);
+        var now = started;
+        var registry = Registry(() => now);
+        var session = Guid.NewGuid();
+        var hash = GatewaySessionKey.Hash(GatewaySessionKey.Mint());
+        Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, now + SessionKeyRegistry.MaxSessionKeyLifetime));
+
+        now = started.AddSeconds(10);
+        var shorterExpiry = started.AddHours(1);
+        Assert.True(registry.Register(Account, "director-1", session.ToString(), hash, shorterExpiry));
+
+        using var ctx = _harness.Open().CreateUnscopedContext();
+        var row = ctx.SessionKeys.Single();
+        Assert.Equal(now, row.IssuedAtUtc);
+        Assert.Equal(shorterExpiry, row.ExpiresAtUtc);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/GatewayEntryPoint.cs
+++ b/src/CcDirector.Gateway/GatewayEntryPoint.cs
@@ -29,8 +29,10 @@ public static class GatewayEntryPoint
         // Gateway containers at once and they share one storage mount.
         //
         //  - Its own log file. The default discriminator is the process id, which is 1 in EVERY container,
-        //    so both containers computed the same path on the SMB mount and clobbered each other's records
-        //    mid-line. Must be set before FileLog.Start().
+        //    so both containers computed the same path on the Server Message Block mount and clobbered each
+        //    other's records mid-line. The file now lives on the container's temporary disk as well: process
+        //    logging is not durable workload state, and putting it on the shared mount turns every routine
+        //    line into billed network storage traffic. Both settings must be applied before FileLog.Start().
         //  - Standard output as a second sink. The platform captures it per container, and it has no queue
         //    in front of it, so it survives a stalled file share - the failure that erased the startup
         //    record of three deploys and left "no listening ports were detected" with nothing to explain it.
@@ -40,7 +42,7 @@ public static class GatewayEntryPoint
         // containers are running and the logging matters most.
         if (GatewayHostedMode.IsHostedImage)
         {
-            FileLog.UseUniqueInstanceId();
+            FileLog.UseUniqueInstanceId(ResolveHostedLogDirectory(Path.GetTempPath()));
             FileLog.MirrorToConsole = true;
         }
 
@@ -142,5 +144,18 @@ public static class GatewayEntryPoint
 
         FileLog.Stop();
         return 0;
+    }
+
+    /// <summary>
+    /// Locate a hosted process log beneath the container's temporary root. Azure App Service keeps paths
+    /// outside <c>/home</c> and explicitly mounted storage on local host disk, so this path cannot fall back
+    /// into the Gateway's durable data share. The root is supplied to make that boundary directly testable.
+    /// </summary>
+    internal static string ResolveHostedLogDirectory(string temporaryRoot)
+    {
+        if (string.IsNullOrWhiteSpace(temporaryRoot))
+            throw new ArgumentException("A temporary root is required.", nameof(temporaryRoot));
+
+        return Path.Combine(Path.GetFullPath(temporaryRoot), "devthrottle", "logs", "director");
     }
 }

--- a/src/CcDirector.Gateway/Pairing/SessionKeyRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/SessionKeyRegistry.cs
@@ -141,8 +141,6 @@ public sealed class SessionKeyRegistry
             // Director asking for less authority than the maximum is never a problem.
             var ceiling = issued + MaxSessionKeyLifetime;
             var effectiveExpiry = expiresAtUtc > ceiling ? ceiling : expiresAtUtc;
-            if (effectiveExpiry != expiresAtUtc)
-                FileLog.Write($"[SessionKeyRegistry] Register: session={id} asked for expiry {expiresAtUtc:O}, capped to {effectiveExpiry:O} by the Gateway's own clock");
 
             // A roster refresh re-sends every live key every ten seconds. When the identity is unchanged and
             // the existing expiry is still comfortably ahead, accepting it needs no database change:
@@ -185,7 +183,10 @@ public sealed class SessionKeyRegistry
             ctx.SaveChanges();
             transaction.Commit();
 
-            FileLog.Write($"[SessionKeyRegistry] Register: session={id}, director={row.DirectorId}, expires={expiresAtUtc:O} (key value never received)");
+            if (effectiveExpiry != expiresAtUtc)
+                FileLog.Write($"[SessionKeyRegistry] Register: session={id} asked for expiry {expiresAtUtc:O}, capped to {effectiveExpiry:O} by the Gateway's own clock");
+
+            FileLog.Write($"[SessionKeyRegistry] Register: session={id}, director={row.DirectorId}, expires={effectiveExpiry:O} (key value never received)");
             return true;
         }
         catch (Exception ex) when (IsDatabaseFailure(ex))

--- a/src/CcDirector.Gateway/Pairing/SessionKeyRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/SessionKeyRegistry.cs
@@ -54,6 +54,14 @@ public sealed class SessionKeyRegistry
     /// </summary>
     public static readonly TimeSpan MaxSessionKeyLifetime = TimeSpan.FromHours(12);
 
+    /// <summary>
+    /// An unchanged key with more than this much life remaining does not need another database write.
+    /// Directors re-send their live keys with every ten-second roster refresh so a lost registration heals,
+    /// but the credential itself lives for twelve hours. Rewriting the same row and logging the same success
+    /// on every roster refresh produced most of the hosted Gateway's process log without changing authority.
+    /// </summary>
+    internal static readonly TimeSpan RefreshWhenRemaining = MaxSessionKeyLifetime / 2;
+
     private readonly GatewayDatabase _db;
     private readonly Func<DateTime> _clock;
     private readonly bool _isHosted;
@@ -70,14 +78,15 @@ public sealed class SessionKeyRegistry
 
     /// <summary>
     /// Register (or rotate) one session's key. The row is keyed by session id, so a Director that
-    /// re-registers a live session on a tunnel reseed replaces its own row and extends its expiry rather
-    /// than adding a second credential.
+    /// re-registers a live session on a tunnel reseed refreshes its own row when the key is nearing the
+    /// second half of its lifetime rather than adding a second credential. Identical early refreshes are
+    /// accepted without rewriting the row.
     ///
     /// A REVOKED session is NOT resurrected. Revocation is deliberate and final - the session was reaped -
     /// and a reseed that raced the revocation must not undo it. The attempt is refused and logged, never
     /// silently applied.
     /// </summary>
-    /// <returns>True when the row was written; false when the session is revoked or the write was refused.</returns>
+    /// <returns>True when the registration was accepted; false when it was refused.</returns>
     public bool Register(TenantId tenant, string directorId, string sessionId, string keyHash, DateTime expiresAtUtc)
     {
         if (!tenant.IsValid)
@@ -123,21 +132,6 @@ public sealed class SessionKeyRegistry
                 return false;
             }
 
-            // A hash already owned by ANOTHER session is refused rather than stolen. The unique index would
-            // refuse it anyway; catching it here names the reason in the log instead of surfacing a bare
-            // database constraint violation.
-            if (ctx.SessionKeys.AsNoTracking().Any(s => s.KeyHash == hash && s.SessionId != id))
-            {
-                FileLog.Write($"[SessionKeyRegistry] Register REFUSED: the presented key hash is already registered to another session (session={id})");
-                return false;
-            }
-
-            if (row is null)
-            {
-                row = new SessionKeyEntity { SessionId = id };
-                ctx.SessionKeys.Add(row);
-            }
-
             var issued = _clock();
 
             // THE EXPIRY IS THE GATEWAY'S TO DECIDE, NOT THE DIRECTOR'S. It arrives computed from the
@@ -149,6 +143,36 @@ public sealed class SessionKeyRegistry
             var effectiveExpiry = expiresAtUtc > ceiling ? ceiling : expiresAtUtc;
             if (effectiveExpiry != expiresAtUtc)
                 FileLog.Write($"[SessionKeyRegistry] Register: session={id} asked for expiry {expiresAtUtc:O}, capped to {effectiveExpiry:O} by the Gateway's own clock");
+
+            // A roster refresh re-sends every live key every ten seconds. When the identity is unchanged and
+            // the existing expiry is still comfortably ahead, accepting it needs no database change:
+            // IssuedAtUtc and ExpiresAtUtc would only churn the database and emit another success record. A
+            // shorter requested expiry is never coalesced, and a changed hash still rotates immediately.
+            if (row is not null
+                && string.Equals(row.KeyHash, hash, StringComparison.Ordinal)
+                && string.Equals(row.DirectorId, directorId?.Trim() ?? "", StringComparison.OrdinalIgnoreCase)
+                && effectiveExpiry >= row.ExpiresAtUtc
+                && row.ExpiresAtUtc - issued > RefreshWhenRemaining)
+            {
+                transaction.Commit();
+                return true;
+            }
+
+            // A hash already owned by ANOTHER session is refused rather than stolen. The unique index would
+            // refuse it anyway; catching it here names the reason in the log instead of surfacing a bare
+            // database constraint violation. An unchanged registration returned above, so this query runs
+            // only for a new session or a real key rotation.
+            if (ctx.SessionKeys.AsNoTracking().Any(s => s.KeyHash == hash && s.SessionId != id))
+            {
+                FileLog.Write($"[SessionKeyRegistry] Register REFUSED: the presented key hash is already registered to another session (session={id})");
+                return false;
+            }
+
+            if (row is null)
+            {
+                row = new SessionKeyEntity { SessionId = id };
+                ctx.SessionKeys.Add(row);
+            }
 
             row.TenantId = tenant.Value;
             row.DirectorId = directorId?.Trim() ?? "";

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -380,9 +380,11 @@ public sealed class DirectorHub : Hub
         var registered = _sessionKeys.Register(
             tenant, directorId, registration.SessionId, registration.KeyHash, registration.ExpiresAtUtc);
 
-        FileLog.Write($"[DirectorHub] RegisterSessionKey: director={directorId}, session={registration.SessionId}, registered={registered}");
         if (!registered)
+        {
+            FileLog.Write($"[DirectorHub] RegisterSessionKey REFUSED: director={directorId}, session={registration.SessionId}");
             throw new HubException($"the session key for {registration.SessionId} was not registered");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1900

## Root cause

- The hosted Gateway's custom `FileLog` sink does not implement log levels, so changing informational logging settings cannot reduce this output. A live capture contained 138,708 lines and 25.8 megabytes in two hours and fifty minutes, which projects to about 218 megabytes per day.
- Every ten-second roster refresh re-sent every live session key. The Gateway rewrote the same database row and emitted two successful registration lines for each key. Those duplicate successes were 66,287 lines: 47.8 percent of all lines and about 53 percent of the bytes.
- There is no product background reader. The reads in the issue were the investigation itself: another troubleshooting run used Kudu at 20:06 and 20:07 universal time to execute `grep` across the dated log glob and then the exact current and old files in the storage evidence. Azure's one-minute metrics show the matching read spike and Server Message Block lease breaks. Those reads broke the active writer's lease and forced its cached writes across Azure Files, creating the apparent uptime step. Restarting opened a new file and restored the write lease; it did not reset an accumulating product reader.
- The traffic reached Azure Files because `FileLog` inherited its directory from `CcStorage.ToolLogs`, which is the durable mounted share in the hosted image.

## Change

- Configure the hosted image's process log beneath the container's temporary directory before the logger starts. Durable product state remains on Azure Files.
- Accept an unchanged session-key refresh without a database rewrite or success line while more than half of the key lifetime remains. Real rotation, shorter requested expiry, revocation, ownership refusal, and eventual refresh are unchanged.
- Remove the second routine success line from the hub while retaining explicit refusal records.
- Add focused tests for the hosted path boundary and the session-key refresh behavior.

This does not add retention, rotation, or cleanup.

## Verification

- Focused tests on the current head: 4 Core logger tests and 30 Gateway hosted-path, session-key, and log-capture tests passed, 0 failed.
- The full local gate built commit `d8c4e3b48` with 0 warnings and 0 errors, then ran all 11 test projects. Nine projects passed. Gateway reported 2,322 passed, 4 skipped, and exactly the two route-census failures tracked by thefrederiksen/devthrottle_internal#1901; `origin/mission/rules-fix-f` already owns their correction and tenancy proof. Core reported 4,385 passed, 8 skipped, and one transient failure in the unchanged `LifecycleSignalTests.EachRaise_RunsTheHandlerExactlyOnce`; an immediate exact-name rerun passed 1 of 1.
- The hosted continuous check independently passed that lifecycle-signal test and failed only the same two thefrederiksen/devthrottle_internal#1901 route-census assertions.
