### PR TITLE
fix(gateway): a rate-limited narration gets the same bounded retry, and honours the wait it was asked for (#2685)

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
@@ -1943,4 +1943,491 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
 
+    // ---------- The rate-limit arm: an answered "not now" gets the same bounded ladder ----------
+
+    /// <summary>
+    /// A brain that is rate limited for its first <c>refusals</c> asks and answers normally after that -
+    /// the shape of a provider throttling us briefly, which is the case a bounded retry is for. The
+    /// Retry-After it reports is the provider's own hint, or null for a 429 that sent no header.
+    /// </summary>
+    private sealed class RateLimitedThenAnswersBrain : IAgentBrain
+    {
+        private readonly int _refusals;
+        private readonly TimeSpan? _retryAfter;
+        private int _askCount;
+        public RateLimitedThenAnswersBrain(int refusals, TimeSpan? retryAfter = null)
+        {
+            _refusals = refusals;
+            _retryAfter = retryAfter;
+        }
+        public int AskCount => _askCount;
+        public string? SessionId => "rate-limited-brain";
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            var n = Interlocked.Increment(ref _askCount);
+            if (n <= _refusals)
+                throw new WingmanModelRateLimitedException(
+                    "The wingman model call failed: 429 TooManyRequests.", _retryAfter);
+            var wrapped = $"{SessionAskRunner.AnswerBeginMarker}\nnarrated spoken text\n{SessionAskRunner.AnswerEndMarker}";
+            return Task.FromResult(new AskResult { Text = wrapped, ReplySeconds = 0.1 });
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth { IsAlive = true });
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// THE SAME DEFECT THE TIMEOUT HAD, one arm along. A 429 recorded the calm Retrying state and logged
+    /// "this session retries on its own next turn-end / idle sweep". Nothing did: the handler propagated the
+    /// exception out of the narration attempt to a wrapper that scheduled nothing, and the only thing that
+    /// would ever come back was the shared voice sweep. The screen said "retrying automatically, it should
+    /// come through shortly" about a turn no loop was going to touch again.
+    ///
+    /// A provider throttling one call is transient by definition, so it gets the bounded ladder the voice
+    /// path already owns - and this proves it end to end: a refusal that clears produces AUDIO, without a
+    /// sweep, without a new turn, and without anybody pressing anything.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheModelIsRateLimited_TheVoicePathBooksItsOwnReattempt_AndTheTurnIsNarrated()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-429retry-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new RateLimitedThenAnswersBrain(refusals: 1);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 6, 6, 6 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(50));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            // CONTROL, and the exact state the old code stopped at: one refused call, no audio, calm state.
+            Assert.Equal(1, brain.AskCount);
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            // ...and the promise is honest here, because an attempt really is booked.
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+
+            // THE THING THAT DID NOT EXIST: a second attempt, made by the voice path, on its own.
+            Assert.True(await Eventually(() => svc.HasVoice(TenantId.Local, "sid-1")),
+                "the rate limit never led to another attempt - the turn stayed silent");
+            Assert.Equal(2, brain.AskCount);
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// The provider's Retry-After is honoured EXACTLY when it asks for longer than the rung's own backoff -
+    /// waiting as long as we were asked is the one thing a rate limit knows that a timeout does not.
+    ///
+    /// Pinned on the booked delay rather than on how long the test sleeps: a timing assertion for this is
+    /// either flaky or slow, and neither reads as evidence.
+    /// </summary>
+    [Fact]
+    public async Task AProvidersRetryAfter_IsHonoured_WhenItAsksForLongerThanTheRung()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-429after-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            // Real delays, kept SHORT. An earlier draft booked a 45-second re-attempt and returned, leaving
+            // an untracked timer to wake inside the shared test process long after this test had deleted its
+            // own directory (found in review). The numbers only have to differ, not be large.
+            var brain = new RateLimitedThenAnswersBrain(refusals: 5, retryAfter: TimeSpan.FromMilliseconds(300));
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 6 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(20));   // rung 20ms, provider wants 300ms
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(TimeSpan.FromMilliseconds(300), svc.LastBookedRetryDelayForTest);
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // it IS booked, so the promise holds
+            await Task.Delay(600);   // let the one booked re-attempt run, so nothing outlives the test
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// ...and it is NOT honoured below the rung. A provider answering "retry in one second" is describing
+    /// its own window, not licensing us to re-enter a ladder we back off on purpose - calling again a
+    /// second after a 429 is how a rate limit becomes a storm.
+    /// </summary>
+    [Fact]
+    public async Task AProvidersRetryAfter_DoesNotShortenTheRung_WhenItAsksForLess()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-429short-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new RateLimitedThenAnswersBrain(refusals: 5, retryAfter: TimeSpan.FromMilliseconds(10));
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 6 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(300));   // rung 300ms, provider wants 10ms
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(TimeSpan.FromMilliseconds(300), svc.LastBookedRetryDelayForTest);
+            await Task.Delay(600);   // let the one booked re-attempt run, so nothing outlives the test
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// A DELAY WE WILL NOT WAIT OUT IS NOT A RETRY. A provider is free to ask for an hour, and booking that
+    /// would leave "Voice on its way" on a screen for an hour while the service was perfectly satisfied it
+    /// had told the truth - which is the exact sentence this whole area exists to stop. Past the ceiling
+    /// nothing is booked and the screen reports a turn that was not narrated.
+    ///
+    /// Note what is NOT claimed: the session is not given up on. The background sweep still comes back to
+    /// it, so this is a refusal to PROMISE, never a refusal to try again.
+    /// </summary>
+    [Fact]
+    public async Task ARetryAfterBeyondTheCeiling_IsNotBooked_AndTheScreenStopsPromisingAudio()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-429huge-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new RateLimitedThenAnswersBrain(refusals: 5, retryAfter: TimeSpan.FromHours(1));
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 6 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(20), TimeSpan.FromMilliseconds(20));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Null(svc.LastBookedRetryDelayForTest);                      // nothing was booked
+            Assert.True(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // and the screen says so
+
+            // Nothing runs later either - waited many times the (tiny) rung so this is a real absence.
+            await Task.Delay(400);
+            Assert.Equal(1, brain.AskCount);
+
+            // AND THE SENTENCE IS TRUE OF THIS PATH. Asserted as the WHOLE message, not as the absence of
+            // two phrases: an absence check passes on an empty message and passed on the wrong message this
+            // very test was written to catch - it said "the re-attempts for it are used up", which is false
+            // here because the rung is deliberately put back (found in review).
+            var display = VoiceDisplayFold.Fold(
+                voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+                unavailable: svc.VoiceUnavailableFor(TenantId.Local, "sid-1"),
+                nothingToNarrate: false,
+                narrationAbandoned: svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            Assert.Equal("notNarrated", display.Kind);
+            Assert.Equal("This turn has no narration, and nothing further is scheduled to make one. "
+                       + "Read the turn, or ask for the narration again.", display.Message);
+            Assert.Equal("Turn not narrated", display.Label);
+            Assert.True(display.CanGenerate);   // the one action left that can still work
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// A refused rung is PUT BACK, not silently spent. The ceiling declines to book THIS re-attempt; it does
+    /// not shorten the turn's ladder, so a later attempt - the sweep's, or a person pressing Generate - can
+    /// still use the rung if the provider has stopped asking for an unreasonable wait by then.
+    /// </summary>
+    [Fact]
+    public async Task ARungRefusedByTheCeiling_IsStillAvailableToALaterAttempt()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-429rung-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            // Just over the two-minute ceiling, and short enough that the not-before hold it arms expires
+            // inside the test - the hold is what stops the sweep calling the provider again before its own
+            // deadline, so a test that ignored it would be measuring a world that no longer exists.
+            TimeSpan? asked = TimeSpan.FromMilliseconds(2500);
+            var brain = new SwitchableRateLimitBrain(() => asked);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 6 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(50));   // ONE rung
+            svc.UseMaxSingleRetryWaitForTest(TimeSpan.FromSeconds(1));        // ...and a ceiling below the ask
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.True(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // control: refused, nothing booked
+            Assert.Null(svc.LastBookedRetryDelayForTest);
+            Assert.Equal(1, brain.AskCount);
+
+            // WHILE THE HOLD LASTS the model is not called again at all, however often the sweep comes past.
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
+            Assert.Equal(1, brain.AskCount);
+            Assert.Null(svc.LastBookedRetryDelayForTest);
+
+            // Once the provider's own deadline passes, and with it now asking for something reasonable, the
+            // rung is STILL there to spend - the refusal withdrew a promise, it did not shorten the ladder.
+            await Task.Delay(2700);
+            asked = TimeSpan.FromMilliseconds(10);
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
+
+            Assert.Equal(2, brain.AskCount);
+            Assert.Equal(TimeSpan.FromMilliseconds(50), svc.LastBookedRetryDelayForTest);   // rung 50ms beats the 10ms ask
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            await Task.Delay(300);   // let it run, so nothing outlives the test
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>A brain that is always rate limited, with a Retry-After the test can change between
+    /// attempts.</summary>
+    private sealed class SwitchableRateLimitBrain : IAgentBrain
+    {
+        private readonly Func<TimeSpan?> _retryAfter;
+        private int _askCount;
+        public SwitchableRateLimitBrain(Func<TimeSpan?> retryAfter) => _retryAfter = retryAfter;
+        public int AskCount => _askCount;
+        public string? SessionId => "switchable-rate-limit-brain";
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _askCount);
+            throw new WingmanModelRateLimitedException(
+                "The wingman model call failed: 429 TooManyRequests.", _retryAfter());
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth { IsAlive = true });
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// ONE LADDER FOR THE TURN, however it fails. A turn that times out twice and is then rate limited must
+    /// not get a fresh set of re-attempts because the failure changed shape - that would double the spend on
+    /// exactly the turn that is already costing the most, and it is the obvious mistake if the two arms keep
+    /// separate counts.
+    /// </summary>
+    [Fact]
+    public async Task TheRetryLadderIsSharedBetweenANonAnswerAndARateLimit()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-429shared-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            // Times out first, then is rate limited for ever after - so the ladder is climbed by BOTH arms.
+            var brain = new TimesOutThenRateLimitedBrain(timeouts: 1);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 6 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(30), TimeSpan.FromMilliseconds(30));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")),
+                "the shared ladder never ran out - the two failure shapes are keeping separate counts");
+            // The first attempt plus exactly the two rungs, whichever arm spent them. Settled first, so a
+            // rung still sitting on a timer would be counted rather than missed.
+            await Task.Delay(500);
+            Assert.Equal(3, brain.AskCount);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>A brain that times out for its first <c>timeouts</c> asks and is rate limited after that, so
+    /// one turn climbs the ladder through both arms.</summary>
+    private sealed class TimesOutThenRateLimitedBrain : IAgentBrain
+    {
+        private readonly int _timeouts;
+        private int _askCount;
+        public TimesOutThenRateLimitedBrain(int timeouts) => _timeouts = timeouts;
+        public int AskCount => _askCount;
+        public string? SessionId => "timeout-then-429-brain";
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            var n = Interlocked.Increment(ref _askCount);
+            if (n <= _timeouts) throw new TimeoutException("The wingman model call did not answer within 60 seconds.");
+            throw new WingmanModelRateLimitedException("The wingman model call failed: 429 TooManyRequests.", null);
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth { IsAlive = true });
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// A REFUSAL DOES NOT ENTITLE US TO KEEP CALLING. Found in review: the ceiling declines to BOOK a
+    /// re-attempt when a provider asks for longer than this service will hold a promise across, and puts the
+    /// rung back - but the background sweep comes past every 45 seconds, so without a hold it would take the
+    /// rung, be refused, put it back, and call the model again each time. That calls the provider long
+    /// before the deadline it named, which is exactly what Retry-After exists to prevent and how a rate
+    /// limit becomes a storm.
+    /// </summary>
+    [Fact]
+    public async Task AfterTheCeilingRefusesABooking_TheModelIsNotCalledAgainUntilTheProvidersDeadlinePasses()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-429hold-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new SwitchableRateLimitBrain(() => TimeSpan.FromSeconds(30));
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 6 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(20), TimeSpan.FromMilliseconds(20), TimeSpan.FromMilliseconds(20));
+            svc.UseMaxSingleRetryWaitForTest(TimeSpan.FromSeconds(1));   // 30s asked > 1s ceiling -> refused
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.Equal(1, brain.AskCount);                                   // control: it was called once
+            Assert.True(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // control: nothing booked
+
+            // Five sweeps' worth of attempts, all inside the provider's 30-second window.
+            for (var i = 0; i < 5; i++)
+                await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
+
+            Assert.Equal(1, brain.AskCount);   // the provider was not called again, once
+            Assert.Null(svc.LastBookedRetryDelayForTest);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// THE HOLD BELONGS TO THE TURN, so a NEW reply is never held back by the previous turn's refusal. The
+    /// per-session cooldowns this file used to have were removed because one condition silenced work that
+    /// had nothing to do with it; this must not reintroduce that in miniature.
+    /// </summary>
+    [Fact]
+    public async Task TheProvidersHold_DoesNotDelayANewTurnsNarration()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the FIRST reply"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-429holdturn-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var refuse = true;
+            var brain = new RefusesThenNarratesBrain(() => refuse);
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 6, 6 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(20));
+            svc.UseMaxSingleRetryWaitForTest(TimeSpan.FromSeconds(1));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.True(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // control: held off for 10 minutes
+
+            // The agent answers again. The hold was armed against the OLD reply, so this one is narrated at
+            // once - no waiting out somebody else's deadline.
+            refuse = false;
+            conversation.Store(("Text", "the SECOND reply"));
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.True(svc.HasVoice(TenantId.Local, "sid-1"));
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>A brain that is rate limited with a very long Retry-After while the flag says so, and
+    /// narrates normally once it does not.</summary>
+    private sealed class RefusesThenNarratesBrain : IAgentBrain
+    {
+        private readonly Func<bool> _refuse;
+        private int _askCount;
+        public RefusesThenNarratesBrain(Func<bool> refuse) => _refuse = refuse;
+        public int AskCount => _askCount;
+        public string? SessionId => "refuses-then-narrates-brain";
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _askCount);
+            if (_refuse())
+                throw new WingmanModelRateLimitedException(
+                    "The wingman model call failed: 429 TooManyRequests.", TimeSpan.FromMinutes(10));
+            var wrapped = $"{SessionAskRunner.AnswerBeginMarker}\nnarrated spoken text\n{SessionAskRunner.AnswerEndMarker}";
+            return Task.FromResult(new AskResult { Text = wrapped, ReplySeconds = 0.1 });
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth { IsAlive = true });
+        public void Dispose() { }
+    }
+
+    /// <summary>A brain that blocks inside the model call until the test releases it, then fails - so a
+    /// test can hold an attempt open and change the world underneath it, which is the only way to drive the
+    /// interleaving the ownership guards exist for.</summary>
+    private sealed class BlockingThenFailingBrain : IAgentBrain
+    {
+        private readonly SemaphoreSlim _release = new(0);
+        private readonly SemaphoreSlim _entered = new(0);
+        private int _askCount;
+        public int AskCount => _askCount;
+        public string? SessionId => "blocking-brain";
+        /// <summary>Waits until the model call has actually started.</summary>
+        public Task EnteredAsync() => _entered.WaitAsync(TimeSpan.FromSeconds(20));
+        /// <summary>Lets the blocked model call fail.</summary>
+        public void Release() => _release.Release();
+        public async Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _askCount);
+            _entered.Release();
+            await _release.WaitAsync(TimeSpan.FromSeconds(20), ct);
+            throw new TimeoutException("The wingman model call did not answer within 60 seconds.");
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth { IsAlive = true });
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// THE HONESTY INVARIANT, DRIVEN THROUGH THE RACE IT EXISTS FOR. An attempt that is still inside the
+    /// model when a NEW TURN starts must say nothing at all when it finally fails - not "not narrated", not
+    /// a booked re-attempt against a turn that is over.
+    ///
+    /// Found in review, and worth spelling out because the first version of the guard did not catch it. The
+    /// ledger cannot answer "is this mine?" on its own: a cleared entry and a never-created one are the same
+    /// absence, so a late attempt simply created a fresh entry, found nothing pending against it, and
+    /// stamped the terminal sentence onto a turn that had just begun. The reply key does not settle it
+    /// either, because the next turn may carry the same text. A turn epoch does.
+    ///
+    /// The ladder is set to ZERO rungs so the late attempt lands squarely on the abandoning path - the one
+    /// that publishes a verdict, and therefore the one that must be silenced.
+    /// </summary>
+    [Fact]
+    public async Task AnAttemptThatFinishesAfterANewTurnStarted_SaysNothingAtAll()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-epoch-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new BlockingThenFailingBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 6 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest();   // no rungs: a failure lands on the abandoning path
+
+            var attempt = svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            await brain.EnteredAsync();          // the model call is running and holding
+
+            // A new turn starts while that attempt is still inside the model.
+            svc.OnSessionWorking(TenantId.Local, "sid-1");
+
+            brain.Release();                     // ...and only now does the old attempt fail
+            await attempt;
+
+            // It reported NOTHING about the turn that has already moved on.
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+
+            // POSITIVE CONTROL: the same failure DOES speak when no turn has superseded it, so the assertion
+            // above is about the epoch and not about a path that records nothing anyway.
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            brain.Release();
+            Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")),
+                "the control failed: this path records no verdict even without a superseding turn");
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
 }

--- a/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
+++ b/src/CcDirector.Gateway/Wingman/VoiceDisplayFold.cs
@@ -335,8 +335,18 @@ public static class VoiceDisplayFold
     };
 
     /// <summary>
-    /// The verdict for a turn whose narration was ABANDONED (issue #2676): the model did not answer, every
-    /// re-attempt the voice path books has been spent, and no further attempt exists anywhere.
+    /// The verdict for a turn whose narration was ABANDONED (issue #2685): the model leg failed and NO
+    /// further attempt is scheduled for this turn.
+    ///
+    /// THE SENTENCE NAMES NEITHER A CAUSE NOR A COUNT, and both omissions were forced by getting it wrong
+    /// once each. It said "the wingman model did not answer", which became false the day a rate limit -
+    /// an ANSWERED refusal - started arriving here. It then said "the re-attempts for it are used up",
+    /// which is false on the path where a provider asked for a longer wait than this service will hold a
+    /// promise across: that turn's ladder is deliberately left INTACT for a later attempt, and only the
+    /// promise is withdrawn (found in review).
+    ///
+    /// What is true of every path that reaches here, and all the reader needs, is that nothing is coming
+    /// unless they ask. The precise cause is in the log, where the person who can act on it looks.
     ///
     /// Two things separate it from <see cref="GaveUpDisplay"/>, which it sits next to and must not be merged
     /// with. It makes NO claim that anything is still being tried - that sentence is what turned a stalled
@@ -351,8 +361,8 @@ public static class VoiceDisplayFold
         Kind = "notNarrated",
         Tone = "red",
         Label = "Turn not narrated",
-        Message = "The wingman model did not answer, and the retries for this turn are used up, so this turn "
-                + "has no narration. Read the turn, or ask for the narration again.",
+        Message = "This turn has no narration, and nothing further is scheduled to make one. "
+                + "Read the turn, or ask for the narration again.",
         CanGenerate = true,
         WaitedLabel = waited,
     };

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -131,7 +131,25 @@ public sealed class WingmanVoiceService
         /// <param name="ReplyKey">Identity of the reply this budget belongs to.</param>
         /// <param name="Booked">How many re-attempts of the ladder have been spent on that reply.</param>
         /// <param name="Pending">1 while a booked re-attempt is waiting out its backoff, else 0.</param>
-        public sealed record ModelRetryLedger(string ReplyKey, int Booked, int Pending);
+        /// <param name="Reservation">
+        /// Identifies THIS reservation, uniquely and for ever. Found in review, and the reply key alone is
+        /// genuinely not enough: a ledger can be cleared by a new turn and then re-created for the SAME reply
+        /// text, at which point an older attempt's rollback - or an older timer waking up - matches on reply
+        /// key, believes the entry is its own, and rewinds or steals a reservation somebody else is relying
+        /// on. The screen then promises audio backed by a task that will stand down when it fires. A counter
+        /// makes ownership provable rather than probable.
+        /// </param>
+        /// <param name="NotBefore">
+        /// The earliest this session's turn may call the MODEL again, or default when there is no such
+        /// restriction. Set only when a provider's Retry-After was longer than this service will hold a
+        /// promise open: refusing to book a re-attempt does not entitle us to keep calling, and the sweep
+        /// comes past every 45 seconds. Honouring the number we were given is the whole point of reading it.
+        ///
+        /// PER SESSION AND PER TURN, never shared. The fleet-wide cooldowns that used to live in this file
+        /// were removed in July because one session's 429 muted every other session; this reaches nothing
+        /// outside the turn whose own call was refused.
+        /// </param>
+        public sealed record ModelRetryLedger(string ReplyKey, int Booked, int Pending, long Reservation, DateTime NotBefore = default);
 
         /// <summary>Guards <see cref="ModelRetries"/>. A plain lock rather than a concurrent dictionary
         /// because the decision - book the next rung, stand aside for one already booked, or abandon - reads
@@ -141,6 +159,24 @@ public sealed class WingmanVoiceService
 
         /// <summary>The retry ledger, one entry per session with a turn still owed a narration.</summary>
         public readonly Dictionary<string, ModelRetryLedger> ModelRetries = new(StringComparer.Ordinal);
+
+        /// <summary>Hands out the reservation ids above. Read and incremented only under
+        /// <see cref="ModelRetryGate"/>, so a plain field is enough.</summary>
+        public long NextReservation = 1;
+
+        /// <summary>
+        /// Bumped every time a session's turn-scoped voice facts are reset - a new turn, a successful
+        /// narration, voice switched off. An attempt captures it before it calls the model and checks it
+        /// before it writes anything, so a slow attempt cannot report a verdict about a turn that has
+        /// already been superseded.
+        ///
+        /// It exists because "is this ledger mine?" cannot be answered from the ledger alone. A cleared
+        /// entry and a never-created one look identical, so an attempt arriving late after a clear would
+        /// create a fresh entry, find nothing pending against it, and stamp "not narrated" onto a turn that
+        /// had just started (found in review). The reply key does not settle it either - the next turn can
+        /// carry the same reply text. A counter that only ever goes up does.
+        /// </summary>
+        public readonly ConcurrentDictionary<string, long> TurnEpochs = new(StringComparer.Ordinal);
 
         /// <summary>
         /// The model leg did not answer, every re-attempt in the budget has been spent, and NOTHING further
@@ -872,6 +908,34 @@ public sealed class WingmanVoiceService
 
     private TimeSpan[] _modelRetryBackoff = DefaultModelRetryBackoff;
 
+    /// <summary>
+    /// The longest this service will hold one booked re-attempt open, and therefore the longest it will
+    /// promise a reader that audio is coming.
+    ///
+    /// It exists because of the ONE thing a rate limit can do that a timeout cannot: name its own delay. A
+    /// 429 carries the provider's Retry-After, and waiting exactly as long as asked is better than guessing
+    /// - but a provider is free to ask for an hour. Booking that would leave "Voice on its way" on a screen
+    /// for an hour with the service perfectly content that it was telling the truth, which is the sentence
+    /// this whole area of the code exists to stop. Past this ceiling the re-attempt is NOT booked: the turn
+    /// is reported as not narrated, and the log says what was asked for and that we declined to wait it out.
+    ///
+    /// Set just above the ladder's own top rung, so honouring a provider's request is the normal case and
+    /// only an unusually long one is refused. The background sweep still comes back to the session later, so
+    /// refusing to book is a refusal to PROMISE, never a refusal to try again.
+    /// </summary>
+    private static readonly TimeSpan DefaultMaxSingleRetryWait = TimeSpan.FromMinutes(2);
+
+    private TimeSpan _maxSingleRetryWait = DefaultMaxSingleRetryWait;
+
+    /// <summary>Test seam: move the ceiling so a test can exercise the refusal - and the hold it arms -
+    /// without asking a test to wait two minutes. Same code path, same meaning, smaller number.</summary>
+    internal void UseMaxSingleRetryWaitForTest(TimeSpan ceiling) => _maxSingleRetryWait = ceiling;
+
+    /// <summary>Test seam: the delay of the most recently BOOKED re-attempt, or null when none has been
+    /// booked. Exposed so a test can pin that a provider's Retry-After was honoured exactly, rather than
+    /// inferring it from how long a test slept - a timing assertion that is either flaky or slow.</summary>
+    internal TimeSpan? LastBookedRetryDelayForTest { get; private set; }
+
     /// <summary>Test seam: run the bounded model-leg retry on a schedule a test can wait for. Same code
     /// path, same cap semantics (the number of delays IS the cap) - only the delays differ.</summary>
     internal void UseModelRetryBackoffForTest(params TimeSpan[] delays)
@@ -896,7 +960,15 @@ public sealed class WingmanVoiceService
     {
         lock (state.ModelRetryGate) state.ModelRetries.Remove(sid);
         state.NarrationAbandoned.TryRemove(sid, out _);
+        // Everything in flight for the turn just cleared is now speaking about the past. Bumping the epoch
+        // is what tells those attempts so - see TenantVoiceState.TurnEpochs.
+        state.TurnEpochs.AddOrUpdate(sid, 1, (_, n) => n + 1);
     }
+
+    /// <summary>The turn epoch an attempt must still be inside for anything it says to be about the current
+    /// turn. Captured before the model call and checked before any write.</summary>
+    private static long CurrentTurnEpoch(TenantVoiceState state, string sid)
+        => state.TurnEpochs.TryGetValue(sid, out var e) ? e : 0;
 
     /// <summary>
     /// Identity of the reply a retry budget belongs to. Hashed rather than stored whole: the ledger is held
@@ -916,10 +988,15 @@ public sealed class WingmanVoiceService
     /// <summary>
     /// True when an exception from the model (translation) leg means it DID NOT ANSWER - a bounded
     /// <see cref="TimeoutException"/> from <see cref="HostedInferenceBrain"/>, or an
-    /// <see cref="HttpRequestException"/> transport failure - as opposed to an answered failure (402,
-    /// 429, 5xx surface as typed/InvalidOperation exceptions and are handled elsewhere). A caller-cancel
-    /// (shutdown) is excluded: that is not the model's non-answer, it is us stopping. This is the model
-    /// leg's mirror of the "absence of evidence -> Retrying" rule the speech leg already applies.
+    /// <see cref="HttpRequestException"/> transport failure - as opposed to an answered failure (402 and
+    /// 5xx surface as InvalidOperationException and are handled elsewhere). A caller-cancel (shutdown) is
+    /// excluded: that is not the model's non-answer, it is us stopping. This is the model leg's mirror of
+    /// the "absence of evidence -> Retrying" rule the speech leg already applies.
+    ///
+    /// A 429 is deliberately still excluded, but it is no longer handled somewhere ELSE: it has its own
+    /// catch immediately beside this one, and both funnel into the same bounded ladder. They are kept apart
+    /// because the two differ in exactly one respect that matters - a 429 can name its own delay - and
+    /// collapsing them would throw that number away.
     /// </summary>
     private static bool IsModelDidNotAnswer(Exception ex, CancellationToken ct)
         => ex is not WingmanModelRateLimitedException
@@ -1114,12 +1191,24 @@ public sealed class WingmanVoiceService
         }
         catch (WingmanModelRateLimitedException rl)
         {
-            // The provider rate limited THIS call. Nothing fleet-wide happens: this session simply has no
-            // audio this cycle and retries on its own next turn-end / idle sweep. Record Retrying so its
-            // OWN UI says "voice on its way", exactly as the model-leg timeout path does - and it never
-            // reaches across to another session (that coupling was the gate we removed).
+            // A BACKSTOP, AND IT SAYS SO. The narration's own rate-limit arm sits inside GenerateOnceAsync,
+            // beside the reply the ledger is keyed on, and books a re-attempt there; a 429 reaching this far
+            // therefore came from somewhere that arm does not cover, and NOTHING is booked for it.
+            //
+            // This handler used to be where every 429 landed, and it logged "this session retries on its own
+            // next turn-end / idle sweep". Nothing did. That is the same defect the model-leg timeout had
+            // (issue #2676) and it is why the wording here now reports an absence instead of inventing a
+            // retry: a log that claims work nobody is doing is how a stalled session goes unnoticed.
+            //
+            // Nothing fleet-wide happens either way - the shared cooldown that used to mute every session on
+            // one bad call was removed 2026-07-17.
             state.Unavailable[sid] = HostedAiState.Retrying;
-            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} rate limited (429){(rl.RetryAfter is { } ra ? $" (Retry-After {ra.TotalSeconds:F0}s)" : "")}; no audio this cycle, this session retries on its own");
+            // Retrying WITHOUT the abandoned fact would put "voice on its way" back on the screen with
+            // nothing behind it - the exact defect this change removes, reintroduced through the one door
+            // left open (found in review). The guarded form refuses to speak for a turn that already has a
+            // re-attempt booked, so an honest backstop cannot contradict a live promise.
+            MarkAbandonedIfNothingPending(state, sid);
+            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} rate limited (429) OUTSIDE the narration attempt{(rl.RetryAfter is { } ra ? $" (Retry-After {ra.TotalSeconds:F0}s)" : "")}; no audio this cycle and NOTHING is booked here - the next turn-end or sweep is what comes back");
         }
         catch (Exception ex)
         {
@@ -1262,6 +1351,22 @@ public sealed class WingmanVoiceService
             FileLog.Write($"[WingmanVoiceService] GenerateOnce skip (same reply already narrated): sid={sid}");
             return false;   // nothing to do - the provider was not called, so we know nothing new about it
         }
+        // THE PROVIDER'S OWN DEADLINE, HONOURED. When a 429 named a wait longer than this service will hold
+        // a promise across, the re-attempt was refused rather than booked - and refusing to promise does not
+        // entitle us to keep calling. Without this the idle sweep would come past every 45 seconds and call
+        // the model again long before the provider's deadline, which is precisely what Retry-After exists to
+        // prevent and how a rate limit becomes a storm (found in review).
+        //
+        // Checked HERE, after the reply is known, because the hold belongs to a TURN: it is keyed on the
+        // same reply as the retry ledger, so a new turn is never held back by the previous turn's refusal.
+        // It reaches no other session - the fleet-wide cooldowns this file used to have were removed in July
+        // because one session's 429 muted every other session, and nothing here can do that.
+        if (ModelCallHeldOffFor(state, sid, ReplyKey(lastReply)) is { } heldOff)
+        {
+            FileLog.Write($"[WingmanVoiceService] sid={sid}: not calling the model for {heldOff.TotalSeconds:F0}s more - the provider asked us to wait that long and this turn has no re-attempt booked; the screen already reports it as not narrated");
+            return false;   // nothing produced, and deliberately nothing attempted
+        }
+
         // THE COMMIT POINT (issue #2675). Everything above this line is a no-op arm: it reads what is already
         // in memory or in the Gateway's own store, decides there is nothing to make, and returns having spent
         // nothing on the model or the speech provider. From here on the attempt costs the shared, serialized
@@ -1284,6 +1389,9 @@ public sealed class WingmanVoiceService
         // only for a brand-new turn. A background refresh / catch-up stays quiet so a session a phone
         // may be listening to is never flipped yellow mid-play (issue #1322).
         if (showReadingWindow) BeginGenerating(tenant, sid);
+        // CAPTURED BEFORE THE CALL, checked before anything is written about its outcome. A narration takes
+        // as long as the model takes, and a turn can be superseded in that window.
+        var turnEpoch = CurrentTurnEpoch(state, sid);
         try
         {
             WingmanTranslation t;
@@ -1299,10 +1407,6 @@ public sealed class WingmanVoiceService
                 // ServiceDown. Recording Retrying makes the phone show the calm "voice on its way" state
                 // and the voice sweep retries on its own, instead of the session sitting red with no audio
                 // and no reason (the wedge the owner hit: half the fleet stuck, "generate" doing nothing).
-                // A rate-limit (WingmanModelRateLimitedException) is NOT caught here - it stays thrown so
-                // GenerateAsync's handler records THIS session's Retrying state (it does not reach any
-                // other session; the shared cooldown that used to do so is gone).
-                //
                 // AND THE RETRY IS BOOKED HERE, BY THIS LEG (issue #2676). Recording Retrying and returning
                 // is what this arm used to do, and its log line claimed "the session retries on its own" -
                 // which was true of nothing. Nothing on this path scheduled another attempt; the only thing
@@ -1310,8 +1414,30 @@ public sealed class WingmanVoiceService
                 // account's unnarratable sessions were consuming (issue #2675). The leg that failed now owns
                 // the re-attempt, so the promise on the screen is backed by a booked piece of work rather
                 // than by a loop nobody here controls.
-                NoteModelDidNotAnswer(tenant, state, sid, route, lastReply, ex);
+                NoteModelAttemptFailed(tenant, state, sid, route, lastReply, ex, retryAfter: null,
+                    cause: "model did not answer", epoch: turnEpoch);
                 return false;   // nothing produced; the provider was not usefully reached
+            }
+            catch (WingmanModelRateLimitedException rl)
+            {
+                // THE PROVIDER ANSWERED "NOT NOW". Caught HERE, beside the non-answer, because the two need
+                // the same thing from us and used to get opposite treatment: this one propagated out to
+                // GenerateAsync, which recorded the same calm Retrying state and logged "this session
+                // retries on its own next turn-end / idle sweep" - a sentence with nothing behind it, for
+                // exactly the reason the timeout's version of it had nothing behind it. One shared ladder
+                // now answers both, so a turn gets three re-attempts in total however it failed, rather
+                // than a fresh three each time the failure changes shape.
+                //
+                // The one thing a rate limit knows that a timeout does not is HOW LONG to wait, so the
+                // provider's Retry-After is carried in and honoured - up to the point where honouring it
+                // would mean promising an arrival nobody can see the end of. See DefaultMaxSingleRetryWait.
+                //
+                // It is caught here rather than in the wrapper for a second reason: the ledger is keyed on
+                // the reply being narrated, and this is the innermost place that reply is known.
+                NoteModelAttemptFailed(tenant, state, sid, route, lastReply, rl, rl.RetryAfter,
+                    cause: $"model rate limited (429){(rl.RetryAfter is { } ra ? $", provider asked for {ra.TotalSeconds:F0}s" : ", no Retry-After sent")}",
+                    epoch: turnEpoch);
+                return false;   // nothing produced; the provider refused this call
             }
             // Announce a waiting menu AS THE TURN IS READ (issue #2193). A turn that ends on a picker is the
             // one case where the narration alone is misleading: the agent's words are read out, the person
@@ -1359,12 +1485,31 @@ public sealed class WingmanVoiceService
     /// </summary>
     /// <param name="lastReply">The reply this attempt was trying to narrate. It IDENTIFIES the budget - see
     /// <see cref="TenantVoiceState.ModelRetryLedger"/> for why a turn cannot be identified by a transition.</param>
-    private void NoteModelDidNotAnswer(TenantId tenant, TenantVoiceState state, string sid, SessionVerbClient route, string lastReply, Exception ex)
+    /// <param name="retryAfter">
+    /// How long the provider ASKED us to wait, from a 429's Retry-After, or null for a failure that named no
+    /// delay (a timeout, a transport failure, or a 429 that sent no header).
+    ///
+    /// When it is present the booked delay is the LONGER of it and this rung's own backoff. The longer of
+    /// the two rather than the provider's number outright: a provider that answers "retry in one second" is
+    /// describing its own window, not licensing us to re-enter a ladder we back off on purpose, and calling
+    /// again a second after a 429 is how a rate limit becomes a storm.
+    /// </param>
+    /// <param name="cause">Plain words for the log, so a reader can tell a silence from a refusal.</param>
+    /// <param name="epoch">The turn epoch this attempt started in. If the turn has been superseded since -
+    /// a new turn, a successful narration, voice switched off - this attempt says NOTHING, because every
+    /// sentence it could write would be about a turn that is over.</param>
+    private void NoteModelAttemptFailed(TenantId tenant, TenantVoiceState state, string sid, SessionVerbClient route, string lastReply, Exception ex, TimeSpan? retryAfter, string cause, long epoch)
     {
+        if (CurrentTurnEpoch(state, sid) != epoch)
+        {
+            FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {ex.Message} - the turn it was narrating has been superseded, so nothing is recorded and nothing is booked");
+            return;
+        }
         var schedule = _modelRetryBackoff;
         var replyKey = ReplyKey(lastReply);
         bool standAside, abandon;
         int rung;
+        long reservation;
         lock (state.ModelRetryGate)
         {
             // A ledger for a DIFFERENT reply is a different turn's budget and says nothing about this one,
@@ -1372,17 +1517,20 @@ public sealed class WingmanVoiceService
             // having observed a Working transition.
             if (!state.ModelRetries.TryGetValue(sid, out var ledger)
                 || !string.Equals(ledger.ReplyKey, replyKey, StringComparison.Ordinal))
-                ledger = new TenantVoiceState.ModelRetryLedger(replyKey, 0, 0);
+                ledger = new TenantVoiceState.ModelRetryLedger(replyKey, 0, 0, 0);
 
             standAside = ledger.Pending > 0;
             abandon = !standAside && ledger.Booked >= schedule.Length;
             rung = standAside || abandon ? ledger.Booked : ledger.Booked + 1;
-            state.ModelRetries[sid] = standAside || abandon ? ledger : ledger with { Booked = rung, Pending = 1 };
+            reservation = standAside || abandon ? ledger.Reservation : state.NextReservation++;
+            state.ModelRetries[sid] = standAside || abandon
+                ? ledger
+                : ledger with { Booked = rung, Pending = 1, Reservation = reservation };
         }
 
-        // Retrying is the true CAUSE in all three cases - the model did not answer, and nothing here is
-        // evidence of an outage or of an account problem. Only the PROMISE differs, and that is carried by
-        // the abandoned fact beside it, which VoiceDisplayFold reads as a pair.
+        // Retrying is the true CAUSE in all three cases - the model leg failed, and nothing here is evidence
+        // of an outage or of an account problem. Only the PROMISE differs, and that is carried by the
+        // abandoned fact beside it, which VoiceDisplayFold reads as a pair.
         state.Unavailable[sid] = HostedAiState.Retrying;
 
         if (standAside)
@@ -1391,22 +1539,124 @@ public sealed class WingmanVoiceService
             // sweep, or a person pressing Generate. It must not spend a rung of a ladder it does not own,
             // and above all it must not declare the turn abandoned while that task exists.
             state.NarrationAbandoned.TryRemove(sid, out _);
-            FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - Retrying; re-attempt {rung} of {schedule.Length} is already booked, so this attempt spends nothing");
+            FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {ex.Message} - Retrying; re-attempt {rung} of {schedule.Length} is already booked, so this attempt spends nothing");
             return;
         }
         if (!abandon)
         {
+            // The rung's own backoff, or the provider's Retry-After when it asked for longer.
             var delay = schedule[rung - 1];
+            if (retryAfter is { } asked && asked > delay) delay = asked;
+
+            // A DELAY WE WILL NOT WAIT OUT IS NOT A RETRY. Booking it would put "Voice on its way" on the
+            // screen for as long as the provider felt like naming, and a promise nobody can see the end of
+            // is the thing this code exists to stop. So the ladder stops here instead, honestly.
+            if (delay > _maxSingleRetryWait)
+            {
+                ReleaseRefusedReservation(state, sid, replyKey, reservation, rung,
+                    notBefore: DateTime.UtcNow + (retryAfter ?? delay));
+                MarkAbandonedIfNothingPending(state, sid, replyKey);
+                FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {ex.Message} - the provider asked us to wait {delay.TotalSeconds:F0}s, longer than the {_maxSingleRetryWait.TotalSeconds:F0}s this turn will hold a promise open, so NOTHING IS BOOKED, the model is not called again for this turn until the provider's own deadline passes, and the screen reports a turn that was not narrated rather than an arrival with no end in sight");
+                return;
+            }
+
             state.NarrationAbandoned.TryRemove(sid, out _);
-            ScheduleModelRetry(tenant, sid, route, delay, replyKey, rung, schedule.Length);
-            FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - Retrying (audio on its way); re-attempt {rung} of {schedule.Length} is booked for {delay.TotalSeconds:F0}s from now");
+            LastBookedRetryDelayForTest = delay;
+            ScheduleModelRetry(tenant, sid, route, delay, replyKey, reservation, rung, schedule.Length);
+            FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {ex.Message} - Retrying (audio on its way); re-attempt {rung} of {schedule.Length} is booked for {delay.TotalSeconds:F0}s from now{(retryAfter is { } ra ? $" (provider asked for {ra.TotalSeconds:F0}s)" : "")}");
             return;
         }
-        // THE LADDER IS SPENT AND NOTHING IS PENDING. Recorded as its own fact rather than as a new
-        // HostedAiState because it is not a condition of the hosted service - the service's answer is
-        // unchanged, it is OUR attempts that have run out.
-        state.NarrationAbandoned[sid] = 1;
-        FileLog.Write($"[WingmanVoiceService] model did not answer for sid={sid}: {ex.Message} - all {schedule.Length} re-attempt(s) spent and none pending, so THIS TURN WAS NOT NARRATED and nothing further is scheduled; the screen says so instead of promising audio");
+        // THE LADDER IS SPENT. Recorded as its own fact rather than as a new HostedAiState because it is not
+        // a condition of the hosted service - the service's answer is unchanged, it is OUR attempts that have
+        // run out. Published through the same guarded helper as every other abandonment, so it cannot be
+        // stamped onto a turn that has moved on while this attempt was failing.
+        MarkAbandonedIfNothingPending(state, sid, replyKey);
+        FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {ex.Message} - all {schedule.Length} re-attempt(s) spent and none pending, so THIS TURN WAS NOT NARRATED and nothing further is scheduled; the screen says so instead of promising audio");
+    }
+
+    /// <summary>
+    /// Give back a reservation the ceiling refused to book, and record how long the provider asked us to
+    /// wait before calling it again for this turn.
+    ///
+    /// THE RUNG GOES BACK because the refusal is about this MOMENT, not about the turn's budget: the
+    /// provider named a wait we will not hold a promise across, which says nothing about whether a later
+    /// attempt deserves a re-attempt. And <paramref name="notBefore"/> is what stops that generosity turning
+    /// into a stream of calls the provider explicitly asked us not to make - without it the sweep would come
+    /// past every 45 seconds, take the rung, be refused, and put it back, calling the model each time (found
+    /// in review).
+    ///
+    /// Ownership is proven by the RESERVATION, not by the reply key. A ledger cleared and re-created for the
+    /// same reply text is a different reservation, and rewinding it would silently un-book somebody else's
+    /// live re-attempt.
+    /// </summary>
+    private static void ReleaseRefusedReservation(TenantVoiceState state, string sid, string replyKey, long reservation, int rung, DateTime notBefore)
+    {
+        lock (state.ModelRetryGate)
+        {
+            if (!state.ModelRetries.TryGetValue(sid, out var held)
+                || held.Reservation != reservation
+                || !string.Equals(held.ReplyKey, replyKey, StringComparison.Ordinal))
+                return;   // somebody else owns this entry now - leave it entirely alone
+            state.ModelRetries[sid] = held with
+            {
+                Booked = rung - 1,
+                Pending = 0,
+                NotBefore = notBefore > held.NotBefore ? notBefore : held.NotBefore,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Record that this turn's narration was abandoned - BUT ONLY IF the ledger still belongs to this turn
+    /// and nothing is booked against it.
+    ///
+    /// The guard is the invariant this whole area exists to protect, and writing the fact unguarded broke it
+    /// in the one direction nobody would notice (found in review). An attempt that fails slowly can finish
+    /// after a NEW turn has replaced the ledger and booked its own re-attempt; stamping "not narrated" then
+    /// puts the terminal sentence on a turn that is actively being worked on. Absent or mismatched ledger
+    /// means the turn moved on and this attempt has no standing to say anything about it.
+    /// </summary>
+    private static void MarkAbandonedIfNothingPending(TenantVoiceState state, string sid, string replyKey)
+    {
+        lock (state.ModelRetryGate)
+        {
+            if (!state.ModelRetries.TryGetValue(sid, out var held)
+                || !string.Equals(held.ReplyKey, replyKey, StringComparison.Ordinal)
+                || held.Pending > 0)
+                return;
+            state.NarrationAbandoned[sid] = 1;
+        }
+    }
+
+    /// <summary>
+    /// The variant for a caller that does not know which reply it failed on - the wrapper's rate-limit
+    /// backstop. It refuses to speak for any turn with work booked against it, which is the same guarantee
+    /// stated with less information.
+    /// </summary>
+    private static void MarkAbandonedIfNothingPending(TenantVoiceState state, string sid)
+    {
+        lock (state.ModelRetryGate)
+        {
+            if (state.ModelRetries.TryGetValue(sid, out var held) && held.Pending > 0) return;
+            state.NarrationAbandoned[sid] = 1;
+        }
+    }
+
+    /// <summary>
+    /// How long this turn must wait before the model may be called for it again, or null when there is no
+    /// such restriction. Non-null only after a provider asked for a delay this service would not hold a
+    /// promise across - see <see cref="TenantVoiceState.ModelRetryLedger.NotBefore"/>.
+    /// </summary>
+    private static TimeSpan? ModelCallHeldOffFor(TenantVoiceState state, string sid, string replyKey)
+    {
+        lock (state.ModelRetryGate)
+        {
+            if (!state.ModelRetries.TryGetValue(sid, out var held)
+                || !string.Equals(held.ReplyKey, replyKey, StringComparison.Ordinal))
+                return null;
+            var left = held.NotBefore - DateTime.UtcNow;
+            return left > TimeSpan.Zero ? left : null;
+        }
     }
 
     /// <summary>
@@ -1433,7 +1683,7 @@ public sealed class WingmanVoiceService
     /// It re-enters <see cref="GenerateAsync"/> rather than the inner attempt, so every guard on the ordinary
     /// path still applies: coalescing, the identity-aware "already narrated" skip, and the reply read itself.
     /// </summary>
-    private void ScheduleModelRetry(TenantId tenant, string sid, SessionVerbClient route, TimeSpan delay, string replyKey, int attempt, int cap)
+    private void ScheduleModelRetry(TenantId tenant, string sid, SessionVerbClient route, TimeSpan delay, string replyKey, long reservation, int attempt, int cap)
     {
         _ = Task.Run(async () =>
         {
@@ -1445,10 +1695,15 @@ public sealed class WingmanVoiceService
                 // for THIS re-attempt. Releasing it here rather than at the end is what lets this attempt's
                 // own failure book the next rung; leaving it set would make the attempt stand aside from
                 // itself and the ladder would never advance.
+                // Ownership is proven by the RESERVATION this task was booked under, not by the reply key.
+                // The key alone matches a ledger that was cleared and re-created for the same reply text, so
+                // an old timer could take the pending marker off a NEWLY booked re-attempt and leave the
+                // screen promising audio behind a task that would then stand down (found in review).
                 bool stillOurs;
                 lock (state.ModelRetryGate)
                 {
                     stillOurs = state.ModelRetries.TryGetValue(sid, out var ledger)
+                                && ledger.Reservation == reservation
                                 && string.Equals(ledger.ReplyKey, replyKey, StringComparison.Ordinal)
                                 && ledger.Pending > 0;
                     if (stillOurs) state.ModelRetries[sid] = state.ModelRetries[sid] with { Pending = 0 };


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1902.

The model leg's 429 had the defect thefrederiksen/devthrottle_internal#1899 fixed one arm along: it recorded the calm Retrying state and logged "this session retries on its own next turn-end / idle sweep", while scheduling nothing. It survived that change because the right policy for a 429 is not a copy of the timeout's — a rate limit is an ANSWERED refusal and it carries the provider's `Retry-After`, which this code parsed and threw away.

## The same shape, with the one difference a 429 actually has

The 429 is now caught inside `GenerateOnceAsync`, beside the non-answer and beside the reply the retry ledger is keyed on. Both funnel into **one per-turn ladder**: a turn gets three re-attempts in total however it failed, not three per failure shape. A separate count per shape would double the spend on exactly the turn already costing the most.

`Retry-After` is honoured when it asks for **longer** than the rung's own backoff, and ignored when it asks for less. A provider answering "retry in one second" is describing its own window, not licensing us to re-enter a ladder we back off on purpose — calling again a second after a 429 is how a rate limit becomes a storm.

Past a **two-minute ceiling** the re-attempt is not booked at all. A provider is free to ask for an hour, and booking that would leave "Voice on its way" on a screen for an hour with the service perfectly satisfied it was telling the truth. Instead the turn is reported as not narrated — **and the model is not called again for that turn until the provider's own deadline passes**, because refusing to promise does not entitle us to keep calling. The rung goes back rather than being spent: the refusal is about this moment, not about the turn's budget.

The abandoned verdict's sentence now names neither a cause nor a count. It said "the wingman model did not answer", which became false the day an answered refusal started arriving there, and then "the re-attempts for it are used up", which is false on the ceiling path where the ladder is deliberately left intact. What is true of every path is that nothing is coming unless the reader asks.

## Found in review

A different agent family reviewed this before merge and found five defects, two of them in the honesty invariant this area exists to protect. All are fixed here.

- **A ledger entry cannot be identified by its reply key.** A turn can be cleared and a new one carry the same reply text, so a rollback or a waking timer could rewind or steal a reservation somebody else was relying on — leaving the screen promising audio behind a task that would stand down when it fired. Reservations are now numbered.
- **An attempt still inside the model when a new turn started could stamp "not narrated" onto the turn that had just begun.** The ledger cannot answer this on its own: a cleared entry and a never-created one are the same absence. A turn epoch, captured before the model call and checked before any write, can — and a late attempt now says nothing at all.
- **Without the not-before hold, the ceiling's generosity was a loop**: the sweep would take the rung every 45 seconds, be refused, put it back, and call the provider each time, well inside the window it had asked us to wait out.
- **The ceiling test asserted the ABSENCE of two phrases**, which an empty message and the wrong message both satisfy — including the very message the test was written to catch. It now asserts the whole sentence.
- **Three tests booked real 45, 30 and 10 second re-attempts and returned**, leaving untracked timers to wake inside the shared test process after those tests had deleted their own directories. The delays only had to differ, not be large.

## Tests — each confirmed red against the code without it

- A 429 that clears leads to another attempt and **the turn is narrated**, with no sweep, no new turn and nobody pressing anything.
- `Retry-After` is honoured exactly when longer than the rung, and does not shorten it when shorter. Pinned on the booked delay rather than on how long a test sleeps.
- A `Retry-After` beyond the ceiling books nothing, the screen stops promising, and the whole sentence it shows is asserted.
- After such a refusal the model is not called again until the provider's deadline passes — five sweeps' worth of attempts, zero provider calls — while a **new** turn is never held back by the old turn's refusal.
- A refused rung is still available to a later attempt.
- One ladder is shared between a non-answer and a rate limit.
- An attempt that finishes after a new turn started says nothing at all, with a positive control proving the same failure does speak when nothing superseded it.

## Not changed, and worth a look separately

The SPEECH leg's 429 (`TtsAsync`) logs the same false sentence, but it records `ServiceDown`, so its screen shows a red "Voice service down" rather than a calm wait. The log is wrong there; the screen is not.
