### PR TITLE
fix(gateway): a turn record now says which computer the turn happened on

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogRecorderTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogRecorderTests.cs
@@ -393,6 +393,53 @@ public sealed class TurnLogRecorderTests
         Parts = new List<HistoryPartDto> { new() { Kind = "ToolResult", Text = text, ToolId = id } },
     };
 
+    [Fact]
+    public async Task CaptureAsync_TheRawPushHasNoMachineName_ItIsFilledFromTheDirectorRegistration()
+    {
+        // A Director pushes its sessions with an empty machine name; the Gateway fills it in when it SERVES
+        // the session list. A capture reads the pushed snapshot, one layer earlier, so it sees the blank -
+        // and every record on the fleet said its computer was "unknown" while the Gateway knew all along.
+        var env = new FakeEnvironment();
+        env.Session!.MachineName = "";
+        var recorder = new TurnLogRecorder(env);
+
+        await recorder.CaptureAsync(Signal(), CancellationToken.None);
+
+        var record = Assert.Single(env.Written);
+        Assert.Equal("SOREN-NORTH", record.Glance.Computer);
+        Assert.Equal("SOREN-NORTH", record.Session!.MachineName);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_TheSessionAlreadyCarriesAMachineName_TheRegistrationIsNotConsulted()
+    {
+        // The Director's own answer wins, exactly as it does in the session listing. Asking the
+        // registration anyway would let a re-registered Director rename a machine under a session that had
+        // already told us what it was.
+        var env = new FakeEnvironment();
+        env.Session!.MachineName = "SOREN-SOUTH";
+        var recorder = new TurnLogRecorder(env);
+
+        await recorder.CaptureAsync(Signal(), CancellationToken.None);
+
+        var record = Assert.Single(env.Written);
+        Assert.Equal("SOREN-SOUTH", record.Glance.Computer);
+        Assert.Equal(0, env.MachineNameLookups);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_NeitherTheSessionNorTheRegistrationKnowsTheMachine_TheRecordSaysNothingRatherThanGuessing()
+    {
+        var env = new FakeEnvironment { MachineNameFromRegistration = null };
+        env.Session!.MachineName = "";
+        var recorder = new TurnLogRecorder(env);
+
+        await recorder.CaptureAsync(Signal(), CancellationToken.None);
+
+        var record = Assert.Single(env.Written);
+        Assert.Null(record.Glance.Computer);
+    }
+
     private static HistoryMessageDto Message(string role, string text) => new()
     {
         Role = role,
@@ -410,6 +457,8 @@ public sealed class TurnLogRecorderTests
             = new(true, "transcript-1", Array.Empty<HistoryMessageDto>());
         public Exception? ScreenThrows { get; set; }
         public Exception? SupervisorEnabledThrows { get; set; }
+        public string? MachineNameFromRegistration { get; set; } = "SOREN-NORTH";
+        public int MachineNameLookups { get; private set; }
 
         public int ScreenReads { get; private set; }
         public int ScrollbackReads { get; private set; }
@@ -446,6 +495,12 @@ public sealed class TurnLogRecorderTests
         }
 
         public bool? IsVoiceSession(TenantId tenant, string sessionId) => false;
+
+        public string? ResolveMachineName(TenantId tenant, string directorId)
+        {
+            MachineNameLookups++;
+            return MachineNameFromRegistration;
+        }
 
         public string? Write(TurnLogRecord record)
         {

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -2672,7 +2672,11 @@ public sealed class GatewayHost : IAsyncDisposable
             // wrong account.
             conversation: ReadTurnLogConversation,
             settings: _tenantSettingsResolver,
-            isVoiceSession: (tenant, sessionId) => _voiceService?.IsVoiceSession(tenant, sessionId) ?? false),
+            isVoiceSession: (tenant, sessionId) => _voiceService?.IsVoiceSession(tenant, sessionId) ?? false,
+            // The SAME source the session listing uses to fill this in (see GatewayEndpoints, where a
+            // Director-supplied name wins and an empty one is enriched from the registration). A capture
+            // reads the raw pushed snapshot, which never passes through that step.
+            machineName: (tenant, directorId) => Registry.Get(tenant, directorId)?.MachineName),
             // Every read the capture makes is partitioned, exactly as the supervisor's are. Without this the
             // capture runs with no tenant in scope, every read is denied, and the corpus fills with records
             // whose screen and conversation are permanently missing.

--- a/src/CcDirector.Gateway/TurnLog/GatewayTurnLogEnvironment.cs
+++ b/src/CcDirector.Gateway/TurnLog/GatewayTurnLogEnvironment.cs
@@ -32,6 +32,7 @@ internal sealed class GatewayTurnLogEnvironment : ITurnLogEnvironment
     private readonly Func<TenantId, string, StoredConversationSnapshot?> _conversation;
     private readonly TenantSettingsResolver _settings;
     private readonly Func<TenantId, string, bool> _isVoiceSession;
+    private readonly Func<TenantId, string, string?> _machineName;
 
     public GatewayTurnLogEnvironment(
         TurnLogSwitchStore switches,
@@ -40,7 +41,8 @@ internal sealed class GatewayTurnLogEnvironment : ITurnLogEnvironment
         Func<TenantId, string, SessionDto?> locate,
         Func<TenantId, string, StoredConversationSnapshot?> conversation,
         TenantSettingsResolver settings,
-        Func<TenantId, string, bool> isVoiceSession)
+        Func<TenantId, string, bool> isVoiceSession,
+        Func<TenantId, string, string?> machineName)
     {
         _switches = switches ?? throw new ArgumentNullException(nameof(switches));
         _writer = writer ?? throw new ArgumentNullException(nameof(writer));
@@ -49,6 +51,7 @@ internal sealed class GatewayTurnLogEnvironment : ITurnLogEnvironment
         _conversation = conversation ?? throw new ArgumentNullException(nameof(conversation));
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         _isVoiceSession = isVoiceSession ?? throw new ArgumentNullException(nameof(isVoiceSession));
+        _machineName = machineName ?? throw new ArgumentNullException(nameof(machineName));
     }
 
     /// <inheritdoc />
@@ -87,6 +90,9 @@ internal sealed class GatewayTurnLogEnvironment : ITurnLogEnvironment
 
     /// <inheritdoc />
     public bool? IsVoiceSession(TenantId tenant, string sessionId) => _isVoiceSession(tenant, sessionId);
+
+    /// <inheritdoc />
+    public string? ResolveMachineName(TenantId tenant, string directorId) => _machineName(tenant, directorId);
 
     /// <inheritdoc />
     public string? Write(TurnLogRecord record)

--- a/src/CcDirector.Gateway/TurnLog/ITurnLogEnvironment.cs
+++ b/src/CcDirector.Gateway/TurnLog/ITurnLogEnvironment.cs
@@ -17,8 +17,24 @@ public interface ITurnLogEnvironment
     /// <summary>Whether capture is switched on for this account and machine.</summary>
     bool IsEnabled(string account, string machine);
 
-    /// <summary>The session as the Gateway holds it, whole. Null when the session cannot be located.</summary>
+    /// <summary>
+    /// The session as the Gateway holds it, whole. Null when the session cannot be located.
+    ///
+    /// The returned object is the CALLER'S to modify - implementations hand back a snapshot, never the
+    /// stored instance - so the recorder may fill in fields the raw push leaves empty without disturbing
+    /// anything else reading the roster.
+    /// </summary>
     SessionDto? LocateSession(TenantId tenant, string sessionId);
+
+    /// <summary>
+    /// The name of the computer a Director runs on, from that Director's own registration. Null when the
+    /// Director is not currently registered.
+    ///
+    /// It exists because a Director pushes its sessions with an EMPTY machine name and the Gateway fills it
+    /// in from the registration when it SERVES the session list. Anything reading the raw pushed snapshot -
+    /// which is what a turn-end capture does - is one layer earlier than that, and sees the blank.
+    /// </summary>
+    string? ResolveMachineName(TenantId tenant, string directorId);
 
     /// <summary>The live terminal grid. Null when it cannot be read.</summary>
     Task<ScreenGridResponse?> ReadScreenAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct);

--- a/src/CcDirector.Gateway/TurnLog/TurnLogRecorder.cs
+++ b/src/CcDirector.Gateway/TurnLog/TurnLogRecorder.cs
@@ -138,6 +138,26 @@ public sealed class TurnLogRecorder : IDisposable
         var gaps = new List<TurnLogGap>();
 
         var session = _env.LocateSession(signal.Tenant, signal.SessionId);
+
+        // FILL IN THE MACHINE NAME THE RAW PUSH LEAVES EMPTY. A Director sends its sessions without one and
+        // the Gateway fills it from the Director's registration when it serves the session list; a capture
+        // reads the pushed snapshot, which is one layer earlier, so it sees the blank. Left alone, every
+        // record on the fleet says its computer is "unknown" and the bundles land in a directory of that
+        // name - a corpus that cannot say which machine a turn happened on, while the Gateway knew all
+        // along. The snapshot is the caller's to modify by contract, so nothing else is disturbed.
+        if (session is not null && string.IsNullOrWhiteSpace(session.MachineName))
+        {
+            try
+            {
+                var resolved = _env.ResolveMachineName(signal.Tenant, signal.DirectorId);
+                if (!string.IsNullOrWhiteSpace(resolved)) session.MachineName = resolved!;
+            }
+            catch (Exception ex)
+            {
+                gaps.Add(new TurnLogGap { Part = "machine-name", Reason = ex.Message });
+            }
+        }
+
         if (session is null)
         {
             // We keep going deliberately. A session that has already gone - deleted, or its Director dropped


### PR DESCRIPTION
Every record so far claimed its computer was `unknown`, and the bundles landed in a directory of that name - a corpus that could not say which machine a turn happened on, while the Gateway knew all along.

**The name was never missing.** A Director pushes its sessions with an empty machine name, and the Gateway fills it in from the Director's registration when it *serves* the session list. A turn-end capture reads the pushed snapshot, one layer earlier, so it saw the blank.

The capture now does the same fill-in from the same source with the same precedence: the session's own answer wins, and the registration is consulted only when there is nothing to overwrite - otherwise a re-registered Director could rename a machine under a session that had already said what it was.

Nothing shared is disturbed: the roster hands back a clone, and the environment contract now says so explicitly instead of leaving the next caller to discover it.

Three mutations applied, run, watched go red, reverted: fill-in removed; resolved name thrown away; registration allowed to override a name the session already gave.

Gate: every suite Completed. Gateway.UnitTests is 3,585 passing run alone and breaches the 120s ceiling only under parallel load. Parked suites not run - the lock is held by another worktree - and this change is confined to the recorder and its wiring.