### PR TITLE
feat(gateway): an administrator can find an account and its computers by email

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/Api/AdminAccountLookupEndpointTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/Api/AdminAccountLookupEndpointTests.cs
@@ -1,0 +1,195 @@
+using System.Text.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Api;
+
+/// <summary>
+/// The administrator account lookup - the bridge between an administrator's world (emails) and the
+/// Gateway's (account ids and Directors).
+///
+/// THE TESTS THAT MATTER MOST are the refusals. This route exists so a capability can be pointed at
+/// somebody else's account, and the ways it can point at the WRONG one are the ways real harm happens:
+/// naming two accounts at once, an address recorded against more than one account, and an account that
+/// simply is not here. Each of those has to be a plain refusal rather than a confident answer about
+/// somebody nobody named.
+/// </summary>
+public sealed class AdminAccountLookupEndpointTests : IDisposable
+{
+    private const string Token = "test-admin-service-token-a4f1";
+
+    private readonly GatewayDbTestHarness _h = new();
+    private GatewayDatabase? _db;
+    private GatewayDatabase Db => _db ??= _h.Open();
+    private readonly string? _priorAdmin = Environment.GetEnvironmentVariable(AdminTrialEndpoint.ServiceTokenEnvVar);
+
+    public AdminAccountLookupEndpointTests()
+        => Environment.SetEnvironmentVariable(AdminTrialEndpoint.ServiceTokenEnvVar, Token);
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(AdminTrialEndpoint.ServiceTokenEnvVar, _priorAdmin);
+        _h.Dispose();
+    }
+
+    private TenantRegistry NewTenants() => new(Db);
+
+    private static DirectorRegistry NewDirectors() => new();
+
+    private static HttpContext Authorized()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers.Authorization = $"Bearer {Token}";
+        return ctx;
+    }
+
+    private static JsonElement Body(IResult result)
+    {
+        // Results.Json carries the value; read it back the way a caller would see it.
+        var valueProp = result.GetType().GetProperty("Value");
+        var value = valueProp?.GetValue(result);
+        return JsonSerializer.SerializeToElement(value);
+    }
+
+    [Fact]
+    public void NamingBothAnEmailAndASubject_IsRefused()
+    {
+        // Preferring one silently would let a caller that resolved an address to the wrong subject act on
+        // an account it never named, and the reply would look perfectly correct.
+        var result = AdminAccountLookupEndpoint.Handle(
+            NewTenants(), NewDirectors(), "someone@example.com", "subject-1");
+
+        Assert.Equal(StatusCodes.Status400BadRequest, StatusOf(result));
+    }
+
+    [Fact]
+    public void NamingNeither_IsRefused()
+    {
+        var result = AdminAccountLookupEndpoint.Handle(NewTenants(), NewDirectors(), "", "");
+        Assert.Equal(StatusCodes.Status400BadRequest, StatusOf(result));
+    }
+
+    [Fact]
+    public void AnAccountThatIsNotHere_IsAPlainNegativeAndNotAnError()
+    {
+        // "Nobody by that name" and "the lookup broke" are different facts. An administrator told the
+        // second when it was the first would go looking for a fault that does not exist.
+        var result = AdminAccountLookupEndpoint.Handle(
+            NewTenants(), NewDirectors(), "nobody@example.com", null);
+
+        Assert.Equal(StatusCodes.Status404NotFound, StatusOf(result));
+        var body = Body(result);
+        Assert.False(body.GetProperty("found").GetBoolean());
+        Assert.Equal("email", body.GetProperty("searched_by").GetString());
+    }
+
+    [Fact]
+    public void AnAccountFoundByEmail_AnswersItsAccountIdAndItsComputers()
+    {
+        var tenants = NewTenants();
+        var tenant = tenants.MintOrLookupBySubject("subject-mario", "mario@example.com");
+
+        var directors = NewDirectors();
+        Register(directors, tenant, "director-1", "OFFICEPC");
+        Register(directors, tenant, "director-2", "LAPTOP");
+
+        var result = AdminAccountLookupEndpoint.Handle(tenants, directors, "mario@example.com", null);
+
+        var body = Body(result);
+        Assert.True(body.GetProperty("found").GetBoolean());
+        Assert.Equal(tenant.Value, body.GetProperty("account").GetString());
+        var computers = body.GetProperty("computers").EnumerateArray().ToList();
+        Assert.Equal(2, computers.Count);
+        // Ordered by machine name so an administrator reads a stable list.
+        Assert.Equal("LAPTOP", computers[0].GetProperty("machine_name").GetString());
+        Assert.Equal("OFFICEPC", computers[1].GetProperty("machine_name").GetString());
+    }
+
+    [Fact]
+    public void TheEmailIsMatchedWithoutRegardToCase()
+    {
+        var tenants = NewTenants();
+        var tenant = tenants.MintOrLookupBySubject("subject-mario", "Mario.D@Example.com");
+
+        var result = AdminAccountLookupEndpoint.Handle(tenants, NewDirectors(), "mario.d@example.com", null);
+
+        Assert.Equal(tenant.Value, Body(result).GetProperty("account").GetString());
+    }
+
+    [Fact]
+    public void AnEmailRecordedAgainstTwoAccounts_IsRefusedRatherThanGuessed()
+    {
+        // The dangerous one. Picking the first would answer confidently with an account nobody named, and
+        // the caller would then switch capture on for a stranger while believing it had asked about Mario.
+        var tenants = NewTenants();
+        tenants.MintOrLookupBySubject("subject-one", "shared@example.com");
+        tenants.MintOrLookupBySubject("subject-two", "shared@example.com");
+
+        var result = AdminAccountLookupEndpoint.Handle(tenants, NewDirectors(), "shared@example.com", null);
+
+        Assert.Equal(StatusCodes.Status409Conflict, StatusOf(result));
+    }
+
+    [Fact]
+    public void AnAccountFoundBySubject_AnswersTheSameAccount()
+    {
+        var tenants = NewTenants();
+        var tenant = tenants.MintOrLookupBySubject("subject-mario", "mario@example.com");
+
+        var result = AdminAccountLookupEndpoint.Handle(tenants, NewDirectors(), null, "subject-mario");
+
+        Assert.Equal(tenant.Value, Body(result).GetProperty("account").GetString());
+    }
+
+    [Fact]
+    public void ItReturnsOnlyTHATAccountsComputers()
+    {
+        // The whole point of this route is to name somebody else's account. If it leaked a third party's
+        // machines while doing it, the bridge would be worse than the gap it closes.
+        var tenants = NewTenants();
+        var mario = tenants.MintOrLookupBySubject("subject-mario", "mario@example.com");
+        var other = tenants.MintOrLookupBySubject("subject-other", "other@example.com");
+
+        var directors = NewDirectors();
+        Register(directors, mario, "director-mario", "OFFICEPC");
+        Register(directors, other, "director-other", "SOMEONE-ELSE-PC");
+
+        var body = Body(AdminAccountLookupEndpoint.Handle(tenants, directors, "mario@example.com", null));
+
+        var names = body.GetProperty("computers").EnumerateArray()
+            .Select(c => c.GetProperty("machine_name").GetString()).ToList();
+        Assert.Equal(new[] { "OFFICEPC" }, names);
+    }
+
+    [Fact]
+    public void AnAccountWithNoConnectedComputer_SaysSoRatherThanImplyingItHasNone()
+    {
+        // An empty list has two meanings and only one is a problem: never connected a computer, or its
+        // computers are away right now. This route only sees what the Gateway holds at this instant.
+        var tenants = NewTenants();
+        tenants.MintOrLookupBySubject("subject-mario", "mario@example.com");
+
+        var body = Body(AdminAccountLookupEndpoint.Handle(tenants, NewDirectors(), "mario@example.com", null));
+
+        Assert.Empty(body.GetProperty("computers").EnumerateArray());
+        Assert.False(string.IsNullOrWhiteSpace(body.GetProperty("computers_note").GetString()));
+    }
+
+    private static int StatusOf(IResult result)
+    {
+        var prop = result.GetType().GetProperty("StatusCode");
+        return prop?.GetValue(result) as int? ?? StatusCodes.Status200OK;
+    }
+
+    private static void Register(DirectorRegistry registry, TenantId tenant, string directorId, string machine)
+        => registry.RegisterFromStream(
+            directorId, machine, user: "someone", version: "test", pid: 1,
+            startedAt: DateTime.UtcNow, tenant: tenant);
+}

--- a/src/CcDirector.Gateway/Api/AdminAccountLookupEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AdminAccountLookupEndpoint.cs
@@ -1,0 +1,172 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Tenancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The administrator account lookup:
+///
+///   GET /gateway/admin/accounts?email=someone@example.com   ->  { account, email, computers: [...] }
+///   GET /gateway/admin/accounts?subject=&lt;account subject&gt;
+///
+/// WHY IT EXISTS. Every administrator surface we have speaks EMAILS and website member ids, and every
+/// Gateway capability that acts on an account - the turn-log capture switch is the first, and it will not
+/// be the last - is keyed on the Gateway's own account identifier or on a Director id. Nothing bridged the
+/// two. The result was an administrator screen with an "Account" box that could not be filled in for
+/// anybody except the administrator's own fleet, because the only way to learn an account identifier was to
+/// already be inside that account. A capability nobody can address is not a capability.
+///
+/// It also answers the question that comes immediately after "who is this?": WHICH COMPUTERS. An account is
+/// not a useful unit for capture - a person has machines, and a decision to record one machine is very
+/// different from a decision to record all of them. So the lookup returns the Directors the Gateway
+/// currently knows for that account, each with the machine name a human recognises and the identifier the
+/// switch actually takes.
+///
+/// IT IS A LOOKUP, NOT A DIRECTORY. It answers about ONE account named by the caller. There is deliberately
+/// no "list every account" leg: an administrator surface that enumerates the customer base invites being
+/// used as one, and every legitimate use here starts from a person somebody has already identified on the
+/// website.
+///
+/// AUTHORIZATION is the same administrator service token the trial and turn-log surfaces carry, called
+/// rather than copied so there is one definition of who may act as an administrator here. See
+/// <see cref="AdminTurnLogEndpoint"/> for why one secret guards one screen.
+///
+/// IT RETURNS NO TERMINAL CONTENT AND NO SESSION CONTENT - an account identifier, an email the Gateway
+/// already recorded at mint time, and the machines. Nothing here reads anybody's work.
+/// </summary>
+internal static class AdminAccountLookupEndpoint
+{
+    /// <summary>The route. Exact-match public in <c>AuthMiddleware</c>; the endpoint carries its own gate.</summary>
+    public const string Path = "/gateway/admin/accounts";
+
+    public static void Map(
+        IEndpointRouteBuilder app,
+        TenantRegistry tenants,
+        DirectorRegistry directors)
+    {
+        ArgumentNullException.ThrowIfNull(tenants);
+        ArgumentNullException.ThrowIfNull(directors);
+
+        app.MapGet(Path, (HttpContext ctx) =>
+        {
+            try
+            {
+                if (AdminTrialEndpoint.ServiceTokenDenial(ctx) is { } gate) return gate;
+
+                var email = ctx.Request.Query["email"].ToString().Trim();
+                var subject = ctx.Request.Query["subject"].ToString().Trim();
+                return Handle(tenants, directors, email, subject);
+            }
+            catch (Exception ex)
+            {
+                // UNKNOWN, not "no such account". Telling an administrator an account does not exist
+                // because a query threw would have them conclude somebody was never a customer.
+                FileLog.Write($"[AdminAccountLookupEndpoint] GET {Path} FAILED ({ex.GetType().Name}): {ex.Message}");
+                return Results.Json(new { error = "the lookup could not be completed" },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+        });
+
+        FileLog.Write($"[AdminAccountLookupEndpoint] mapped {Path} (service-token authorized)");
+    }
+
+    /// <summary>Internal so every branch is testable without standing a host up.</summary>
+    internal static IResult Handle(
+        TenantRegistry tenants,
+        DirectorRegistry directors,
+        string? email,
+        string? subject)
+    {
+        var hasEmail = !string.IsNullOrWhiteSpace(email);
+        var hasSubject = !string.IsNullOrWhiteSpace(subject);
+
+        // EXACTLY ONE. Accepting both and preferring one silently would let a caller that resolved an email
+        // to the wrong subject act on an account it never named, and the reply would look correct.
+        if (hasEmail == hasSubject)
+        {
+            return Results.BadRequest(new
+            {
+                error = "name exactly one account: either ?email= or ?subject=",
+            });
+        }
+
+        TenantId? tenant = null;
+        if (hasSubject)
+        {
+            tenant = tenants.LookupBySubject(subject!.Trim());
+        }
+        else
+        {
+            // The Gateway records the account email when it mints a tenant, so this resolves without the
+            // website. Compared case-insensitively because an address is not case-sensitive to a human and
+            // an administrator will type it as they read it.
+            var match = tenants.ListAll()
+                .Where(t => !string.IsNullOrWhiteSpace(t.Email))
+                .Where(t => string.Equals(t.Email, email!.Trim(), StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            // AMBIGUITY IS REFUSED, NOT GUESSED. Two tenants recorded against one address is a state we
+            // should not paper over by picking the first - acting on the wrong one would switch capture on
+            // for an account nobody named.
+            if (match.Count > 1)
+            {
+                return Results.Json(new
+                {
+                    error = "more than one account is recorded against that email; name the account by ?subject= instead",
+                    count = match.Count,
+                }, statusCode: StatusCodes.Status409Conflict);
+            }
+            if (match.Count == 1) tenant = new TenantId(match[0].TenantId);
+        }
+
+        if (tenant is not { IsValid: true } found)
+        {
+            // A plain, honest negative. It says what was searched so an administrator can tell "this person
+            // has never run a Director" from "I typed the address wrong".
+            return Results.Json(new
+            {
+                found = false,
+                searched_by = hasSubject ? "subject" : "email",
+                message = "no account on this Gateway matches that. An account appears here once it has run "
+                        + "something - a member who has only ever signed in to the website has no account here yet.",
+            }, statusCode: StatusCodes.Status404NotFound);
+        }
+
+        // The machines, read through the registry's PER-TENANT listing rather than the fleet-wide one.
+        // That is deliberate and it is the narrower capability: the tenant has already been resolved from
+        // the account the caller named, and the registry then filters on its own key. The fleet-wide
+        // accessor exists and takes a SystemScope token, and this route does not hold one - so it cannot
+        // read across accounts even by mistake, and adding a general cross-tenant reader is not something
+        // an account lookup should quietly do on the way past.
+        var computers = directors.ListDirectors(found)
+            .OrderBy(d => d.MachineName ?? "", StringComparer.OrdinalIgnoreCase)
+            .Select(d => new
+            {
+                director_id = d.DirectorId,
+                machine_name = d.MachineName,
+                user = d.User,
+                last_seen_utc = d.LastSeen,
+            })
+            .ToList();
+
+        return Results.Json(new
+        {
+            found = true,
+            account = found.Value,
+            email = tenants.EmailForTenant(found),
+            computers,
+            // Said out loud because an empty list has two meanings and only one of them is a problem: an
+            // account that has never connected a computer, and an account whose computers are all currently
+            // away. This route only sees the ones the Gateway is holding right now.
+            computers_note = computers.Count == 0
+                ? "no computer for this account is currently connected to the Gateway, so none can be listed. "
+                + "That is not the same as the account having none."
+                : null,
+        });
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -3697,6 +3697,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // mapped in the wrong order would read as a broken feature rather than as an ordering mistake.
         _turnLogSwitches ??= new TurnLog.TurnLogSwitchStore(_gatewayDb);
         AdminTurnLogEndpoint.Map(_app, _turnLogSwitches);
+        // The bridge between an administrator's world (emails) and the Gateway's (account ids, Directors).
+        // Without it the turn-log switch above can only be addressed for the administrator's OWN fleet.
+        AdminAccountLookupEndpoint.Map(_app, TenantRegistry, Registry);
 
         // "DevThrottle emails me" relay (issue #1318 consumer): POST /account/email. A session or scheduled
         // run passes a subject + body (+ optional attachments); the Gateway injects its own stored account

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -194,6 +194,11 @@ internal static class AuthMiddleware
         // the decisions behind it; it never reads or returns captured terminal content, so an exempted route
         // here cannot be used to dredge anybody's screen out of the corpus.
         Api.AdminTurnLogEndpoint.Path,
+        // The administrator account lookup, exempt for the same reason and behind the same gate. It answers
+        // about ONE account the caller names - there is no leg that enumerates accounts - and it returns no
+        // session or terminal content, only an account id, the email already recorded at mint time, and the
+        // machines.
+        Api.AdminAccountLookupEndpoint.Path,
     };
 
     /// <summary>


### PR DESCRIPTION
Every administrator surface speaks **emails**; every Gateway capability that acts on an account is keyed on the **account identifier or a Director id**. Nothing bridged the two, and it showed the first time anyone tried to use one: the turn-log capture switch has an Account box that cannot be filled in for anybody but your own fleet, because the only way to learn an account id was to already be inside that account.

```
GET /gateway/admin/accounts?email=someone@example.com
GET /gateway/admin/accounts?subject=<account subject>
```

Answers the account identifier, the email the Gateway recorded at mint time, and the **computers** - because a person has machines, and recording one machine is a different decision from recording all of them.

**It refuses rather than guesses, and each refusal is a real harm avoided:**
- email **and** subject together -> 400. Preferring one silently lets a caller act on an account it never named, with an answer that looks correct.
- one email against two accounts -> 409, not the first match. Picking one answers confidently about a stranger.
- account not here -> plain 404 saying what was searched, so "never ran anything" is distinguishable from a typo.
- a failure -> 503, never "no such account", which would read as "never a customer".

**A lookup, not a directory.** One account, named by the caller; no leg enumerates accounts. Machines are read through the registry's per-tenant accessor, not the fleet-wide one - that takes a SystemScope token this route does not hold, so it cannot read across accounts even by mistake. No session or terminal content is returned.

Three mutations applied, run, watched go red, reverted: ambiguity taking the first match; both parameters allowed with email preferred; a missing account reported as found.

Gate: 4,896 tests, every suite Completed. Parked suites not run - lock held by another worktree - and this is a new, additive route.