### PR TITLE
Publish a plugin marketplace with two plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://code.claude.com/schemas/marketplace.json",
+  "name": "devthrottle",
+  "owner": {
+    "name": "DevThrottle",
+    "url": "https://github.com/thefrederiksen/devthrottle"
+  },
+  "description": "Skills published by DevThrottle: discipline skills about evidence that work anywhere, and the skills for people who run DevThrottle itself.",
+  "version": "1.0.0",
+  "metadata": {
+    "pluginRoot": "./plugins"
+  },
+  "plugins": [
+    {
+      "name": "agent-discipline",
+      "displayName": "Agent Discipline",
+      "source": "./plugins/agent-discipline",
+      "description": "Three skills about evidence: checks that pass because nothing ran, proofs that cover something other than what you changed, and destructive sweeps that delete what they could not identify. No product, no setup, no dependencies.",
+      "version": "1.0.0",
+      "author": {
+        "name": "DevThrottle",
+        "url": "https://devthrottle.com"
+      },
+      "homepage": "https://github.com/thefrederiksen/devthrottle/tree/main/plugins/agent-discipline",
+      "repository": "https://github.com/thefrederiksen/devthrottle",
+      "license": "MIT",
+      "category": "workflow",
+      "keywords": ["verification", "evidence", "code-review", "safety", "testing"]
+    },
+    {
+      "name": "devthrottle",
+      "displayName": "DevThrottle",
+      "source": "./plugins/devthrottle",
+      "description": "For people running DevThrottle: how to install it, and how a session talks to the other sessions running across your machines.",
+      "version": "1.0.0",
+      "author": {
+        "name": "DevThrottle",
+        "url": "https://devthrottle.com"
+      },
+      "homepage": "https://devthrottle.com",
+      "repository": "https://github.com/thefrederiksen/devthrottle",
+      "license": "MIT",
+      "category": "productivity",
+      "keywords": ["devthrottle", "orchestration", "sessions", "multi-agent"]
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,16 +7,12 @@
   },
   "description": "Skills published by DevThrottle: discipline skills about evidence that work anywhere, and the skills for people who run DevThrottle itself.",
   "version": "1.0.0",
-  "metadata": {
-    "pluginRoot": "./plugins"
-  },
   "plugins": [
     {
       "name": "agent-discipline",
       "displayName": "Agent Discipline",
       "source": "./plugins/agent-discipline",
       "description": "Three skills about evidence: checks that pass because nothing ran, proofs that cover something other than what you changed, and destructive sweeps that delete what they could not identify. No product, no setup, no dependencies.",
-      "version": "1.0.0",
       "author": {
         "name": "DevThrottle",
         "url": "https://devthrottle.com"
@@ -32,7 +28,6 @@
       "displayName": "DevThrottle",
       "source": "./plugins/devthrottle",
       "description": "For people running DevThrottle: how to install it, and how a session talks to the other sessions running across your machines.",
-      "version": "1.0.0",
       "author": {
         "name": "DevThrottle",
         "url": "https://devthrottle.com"

--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ not only Claude Code.
 Install guidance and session-to-session messaging. Useful once you have DevThrottle,
 and honestly useless before that, which is why it is the second plugin and not the first.
 
-**Skills never mention the product.** A skill body is loaded straight into your agent as
-instructions; putting a pitch there would be an advert injected into your context, so the
-marketing stays on this page where you chose to read it.
+**The `agent-discipline` skills never mention the product, and no skill here pitches it.**
+A skill body is loaded straight into your agent as instructions, so a pitch there would be
+an advert injected into your context. The two skills above are about DevThrottle because
+documenting it is what they are for -- they tell you how to install it and how to use it,
+and they do not sell it. The selling stays on this page, where you chose to read it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,50 @@ Either gateway needs a DevThrottle login -- Google, GitHub, or email. The email 
   <a href="https://devthrottle.com"><img src="https://img.shields.io/badge/Start%20free-devthrottle.com-2EA44F?style=for-the-badge" alt="Start free at devthrottle.com"></a>
 </p>
 
+## Skills for your agents
+
+This repository is also a Claude Code plugin marketplace. Add it once:
+
+```
+/plugin marketplace add thefrederiksen/devthrottle
+```
+
+Then install either plugin:
+
+```
+/plugin install agent-discipline@devthrottle
+/plugin install devthrottle@devthrottle
+```
+
+### `agent-discipline` -- three skills about evidence
+
+Nothing to sign up for, nothing to install, no mention of any product in the skills
+themselves. They work on the first repository you point them at.
+
+- **`checks-that-fail-open`** -- a check whose pass condition is an ABSENCE certifies a run that never happened. "No errors found" is satisfied by finding nothing because nothing ran. Restate it as a specific presence.
+- **`proof-covers-the-wrong-thing`** -- the harder sibling: the evidence was gathered, the argument is sound, and it is about something adjacent to what you changed. It reads exactly like a proof, because it is one -- of a different claim.
+- **`destructive-sweeps-lean-to-keep`** -- a destructive operation acts only on what it can positively prove is disposable. Enumerate what to DELETE, never what to skip.
+
+These were not written from first principles. Each one is a defect a fleet of unattended
+coding agents hit over and over, in a different medium every time, until somebody put the
+instances side by side and saw one shape. That is the part worth having: the war stories
+are still in the skill bodies, because the shape is easier to recognise from the examples
+than from the rule. **This is what running a lot of agents at once teaches you, and it is
+the reason we built the thing that runs them.**
+
+Each skill carries only the fields in the [agentskills.io](https://agentskills.io)
+specification, so the same files load under other agents that implement the standard --
+not only Claude Code.
+
+### `devthrottle` -- for people who run it
+
+Install guidance and session-to-session messaging. Useful once you have DevThrottle,
+and honestly useless before that, which is why it is the second plugin and not the first.
+
+**Skills never mention the product.** A skill body is loaded straight into your agent as
+instructions; putting a pitch there would be an advert injected into your context, so the
+marketing stays on this page where you chose to read it.
+
 ---
 
 <sub>DevThrottle is open source (MIT) -- this repo is the source, and you're welcome to read it. The Director installs and runs free, with no account; a DevThrottle login is needed only to connect a gateway. The product experience, onboarding, and support live at <a href="https://devthrottle.com">devthrottle.com</a>. It's MIT, so you can always fork it.</sub>

--- a/plugins/agent-discipline/.claude-plugin/plugin.json
+++ b/plugins/agent-discipline/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "agent-discipline",
+  "displayName": "Agent Discipline",
+  "version": "1.0.0",
+  "description": "Three skills about evidence: checks that pass because nothing ran, proofs that cover something other than what you changed, and destructive sweeps that delete what they could not identify.",
+  "author": {
+    "name": "DevThrottle",
+    "url": "https://devthrottle.com"
+  },
+  "homepage": "https://github.com/thefrederiksen/devthrottle/tree/main/plugins/agent-discipline",
+  "repository": "https://github.com/thefrederiksen/devthrottle",
+  "license": "MIT",
+  "keywords": ["verification", "evidence", "code-review", "safety", "testing"]
+}

--- a/plugins/agent-discipline/README.md
+++ b/plugins/agent-discipline/README.md
@@ -1,0 +1,49 @@
+# Agent Discipline
+
+Three skills about evidence. They install into any agent that reads `SKILL.md`, they
+name no product, they need no setup, and they work on the first repository you point
+them at.
+
+```
+/plugin marketplace add thefrederiksen/devthrottle
+/plugin install agent-discipline@devthrottle
+```
+
+## What is in it
+
+**`checks-that-fail-open`** - a check whose pass condition is an ABSENCE certifies a
+run that never happened. Doing nothing at all satisfies "no errors found". Doing
+nothing produces the wrong value against a specific presence. The skill is the repair:
+restate the check as a derived enumeration with a per-item assertion, and treat an
+empty result as a broken instrument rather than a clean run.
+
+**`proof-covers-the-wrong-thing`** - the harder sibling. Here the evidence WAS
+gathered and the argument IS sound, and it is about something adjacent to what you
+changed: the wrong surface, the wrong reader, a different caller than the code, or a
+premise nobody tested. It reads exactly like a proof, because it is one - of a
+different claim.
+
+**`destructive-sweeps-lean-to-keep`** - a destructive operation acts only on what it
+can positively prove is disposable. Enumerate what to DELETE, never what to skip: an
+exclusion list fails open for every shape nobody thought to list, and a false delete
+is unrecoverable while a false keep is merely disk.
+
+## Where they came from
+
+They were written from post-mortems, not from first principles. Each one is a defect
+that was hit repeatedly by a fleet of coding agents running unattended, in different
+media each time, until somebody put the instances side by side and recognised them as
+one shape. The war stories are still in the skill bodies, because the shape is easier
+to recognise from the examples than from the rule.
+
+They are published by [DevThrottle](https://devthrottle.com), which is the tool the
+fleet runs on. The skills themselves mention no product and depend on nothing - if
+you never look at DevThrottle, they still work.
+
+## Portability
+
+Each skill carries only the fields in the [agentskills.io](https://agentskills.io)
+specification - `name`, `description`, `license` - and no host-specific extensions, so
+the same files load under any agent that implements the standard.
+
+MIT licensed.

--- a/plugins/agent-discipline/README.md
+++ b/plugins/agent-discipline/README.md
@@ -1,8 +1,7 @@
 # Agent Discipline
 
-Three skills about evidence. They install into any agent that reads `SKILL.md`, they
-name no product, they need no setup, and they work on the first repository you point
-them at.
+Three skills about evidence. They name no product, they need no setup, and they work on
+the first repository you point them at.
 
 ```
 /plugin marketplace add thefrederiksen/devthrottle
@@ -43,7 +42,7 @@ you never look at DevThrottle, they still work.
 ## Portability
 
 Each skill carries only the fields in the [agentskills.io](https://agentskills.io)
-specification - `name`, `description`, `license` - and no host-specific extensions, so
-the same files load under any agent that implements the standard.
+specification - `name`, `description`, `license` - and no host-specific extensions, so the
+same files load under any agent that implements that standard, not only Claude Code.
 
 MIT licensed.

--- a/plugins/agent-discipline/skills/checks-that-fail-open/SKILL.md
+++ b/plugins/agent-discipline/skills/checks-that-fail-open/SKILL.md
@@ -102,12 +102,12 @@ A wrong conclusion gets argued with. A right conclusion with false evidence gets
 
 ## Applying it to review, which is where it costs most
 
-- Post findings to the pull request **as you go**, and post a **PASS** there too, naming what you checked AND what you could not reach. A pass with no stated scope cannot be judged by anyone who was not there - and everybody who was there is exactly the population that disappears.
-- **Name the artifact, not just "durably".** The tiers are not equal: a pull request comment beats a pushed file beats a committed file beats a local one beats a message. "Durably" with no named target lets someone pick the weakest rung and believe they complied.
+- State a **PASS** as explicitly as a defect, naming what you checked AND what you could not reach. A pass with no stated scope cannot be judged by anyone who was not there - and everybody who was there is exactly the population that disappears. Report it wherever the review was asked for; if you have been asked to publish it somewhere, publish the same scope there.
+- **Name the artifact, not just "durably".** Where a verdict is recorded decides whether it survives, and the tiers are not equal: a comment on the change beats a pushed file beats a committed file beats a local one beats a message that scrolls away. "Durably" with no named target lets someone pick the weakest rung and believe they complied. Do not write to anywhere you were not asked to write - a review that posts itself somewhere unexpected is its own defect.
 - A verdict on file that covers a commit which is no longer the head **is not a verdict on the head**. A verification has a timestamp.
 - **A comment describing a fix is itself a claim, and goes stale like any other text.** A durability rule manufactures this surface: telling a fleet to write everything down produces comment blocks, inventory rows and defect narratives, all of which read as commentary and none of which is exempt. The rule ships with the leg-hunt attached.
 
-## The COUNT-SHAPED check, and three siblings (2026-08-20, new-studio maps)
+## The COUNT-SHAPED check, and three siblings (2026-08-20)
 
 Four more, in one evening, between two sessions. The first three are one shape and it is not
 covered above: it is not an absence, it is a **comparison of two numbers where BOTH SIDES FILTER
@@ -211,7 +211,7 @@ being right while the check was broken look identical in the report. The second 
 being wrong, because being wrong gets fixed. It is the mirror of the RIGHT-claim-on-WRONG-evidence
 section above, seen from the checker's side rather than the author's.
 
-## An extraction whose END is arbitrary (2026-08-21, new-studio train map)
+## An extraction whose END is arbitrary (2026-08-21)
 
 Different from the range anchored on a heading in the list of eight above, and it is worth
 keeping both: there the range failed to match and yielded nothing, which at least LOOKS empty.
@@ -244,7 +244,7 @@ end that means something. `+14` means "as far as I guessed".
 The general form is the same root as everything else here: the window stood in for the document.
 And the tell is the one below - `+14` is a specific value, so it is a hand-kept list of one.
 
-## The CATEGORY standing in for the ANSWER (2026-08-21, new-studio train map)
+## The CATEGORY standing in for the ANSWER (2026-08-21)
 
 A screen pointed at a wide log returned `HTTP 500`. It was not a crash. The renderer had
 DECLINED, deliberately, above a threshold of `len(model.stations) > 60`, and had written the
@@ -322,7 +322,7 @@ which is the opposite of true.
 own earlier write-up** - especially from your own earlier write-up, because that is the copy you
 trust without noticing you are trusting it.
 
-## SELECTING THE WRONG LINE, which returns something complete and false (2026-08-21, new-studio train map)
+## SELECTING THE WRONG LINE, which returns something complete and false (2026-08-21)
 
 Different from the truncated tail in the eight, and the difference is the whole
 point. That one LOST content - `Delivered to <name> (1 session(s)).` wrapped and
@@ -457,10 +457,11 @@ Exit 0 says nothing failed. It does not say your 812 tests ran.
 
 ### The same shape in the skill cache itself
 
-Checking whether an entry had landed, this skill's own local copy at
-`~/.claude/skills/checks-that-fail-open/SKILL.md` was a version behind. Searching
-it for a section that had just been published returned nothing, and the next step
-would have been to report the section missing - from a v4, about a v5.
+Checking whether an entry had landed, the local copy of a shared document -
+this very skill, cached on disk by the agent that had loaded it - was a version
+behind. Searching it for a section that had just been published returned nothing,
+and the next step would have been to report the section missing: from a v4, about
+a v5.
 
 **A local cache of a shared document is a hand-kept copy that looks
 authoritative and carries no version on its face.** Fetch from the source before

--- a/plugins/agent-discipline/skills/checks-that-fail-open/SKILL.md
+++ b/plugins/agent-discipline/skills/checks-that-fail-open/SKILL.md
@@ -1,0 +1,504 @@
+---
+name: checks-that-fail-open
+description: "A check whose pass condition is an ABSENCE certifies a run that never happened. Restate it as a specific PRESENCE - and an empty result is a broken instrument, never a clean run. Use when the task involves: verify, prove it, sweep, grep returned nothing, zero hits, clean run, it passed, no defects, reviewed, delivered, double check, how do we know."
+license: MIT
+---
+
+# Checks That Fail Open
+
+**A check FAILS OPEN when its pass condition is an ABSENCE, and FAILS CLOSED when its pass condition is a specific PRESENCE.**
+
+That is the whole law. Doing nothing at all satisfies an absence. Doing nothing produces the wrong value against a presence.
+
+Written up 2026-08-07 after this fleet hit the same defect eight times in one day, in eight different media, and nobody recognised it as one thing until they were listed side by side. The ninth will be somewhere nobody predicted, which is why this is a skill and not an issue.
+
+## The root
+
+**Every instance is a measurement standing in for the thing it measures.**
+
+| The measurement | What it stood in for |
+|---|---|
+| "Delivered" | received |
+| a working spinner | doing the work you asked for |
+| a count | the list |
+| a tail | the whole output |
+| a comment | the code |
+| ancestry (`git branch --merged`) | the work landed |
+| "no defects posted" | reviewed |
+| "the bad string is gone" | the true string is present |
+| an empty roster row | nothing to say |
+| an error category | the answer the component actually produced |
+
+And the honest reason it goes unnoticed: **the tool usually makes the weaker claim cheap and the stronger claim effortful.** `message send` reports delivery in one command; `message ask` waits for the agent's own answer. Two careful sessions used only the first, all night, without noticing.
+
+## The eight that cost a day
+
+1. **A sweep that searched nothing.** Run by absolute path from outside a repository, `git grep` errored, the return code was ignored, and it printed `files searched: 0 / UNANNOTATED CLAIMS: 0` and exited 0 - certifying the whole repository while searching nothing.
+2. **An `awk` range that never matched.** It printed no delete-shaped calls and looked exactly like proof - inside a writer's own verification of a fix to an overclaim.
+3. **`git grep` with a leading slash, on Windows.** Git Bash rewrites a leading-slash argument to a Windows path before git sees it, so `/docs/start` arrives as `C:/Program Files/Git/docs/start`. **No error, no warning, exit 0.** A sweep run exactly as written in the plan reports a clean pass having searched for the wrong string. Guard with `MSYS_NO_PATHCONV=1`, drop the slash, bracket it as `"[/]docs/start"`, or use ripgrep.
+4. **A guard that cried wolf on prose ABOUT the defect.** A grep for a bad address also matched the comment discussing that address - so it fired on exactly the file it existed to guard, teaching whoever ran it to wave the hit away.
+5. **A range anchored on a heading.** Rename the heading and the range yields nothing, the grep prints zero lines, zero lines contain no bad string - a pass, while the check ran over nothing.
+6. **A review.** Three review seats died in one night; one had completed its review and recorded the verdict NOWHERE. "No defects were posted" is an absence, and is satisfied by a review that never ran.
+7. **A success test reading a truncated tail.** `Delivered to <long name> (1 session(s)).` wraps; `| tail -1` showed only `session.`; the test looking for `Delivered` failed, and four identical messages all landed while the check said none had.
+8. **A shell that ate the content.** A `gh pr comment --body` containing a backticked filename had it command-substituted away. `gh` posted, returned a URL, and exited 0 - and the published sentence was missing the two words it existed for. **A tool that returns a link is not a tool that returned your content.** Use `--body-file` with a quoted heredoc.
+
+## The repair, which is always the same
+
+**Do not fix an absence-shaped check with more care. Restate it as a presence.**
+
+**And the presence must not filter on the property the defect would fail.** This qualifier is
+load-bearing, and it was learned by watching the law applied mechanically produce a new hole.
+Restating "the stylesheet is stamped" as the specific presence
+`count(stamped URLs) == count(stamp placeholders in the template)` is a presence, it is specific,
+and it CANNOT FAIL: add a file that was never stamped at all and both numbers are unchanged. The
+failing case sits outside both sides of the comparison. **A presence filtered on the property
+under test is the same hole with a number in front of it** - see the count-shaped section below.
+
+**The presence that works is a DERIVED enumeration with a per-item assertion**: not "four URLs
+are stamped" but "here is every static URL found ON THE PAGE ITSELF, and each one ends with the
+stamp".
+
+**DERIVED is the whole of it, and it is what reconciles this with "an enumeration is an
+absence claim wearing a list's clothes" under the table.** An enumeration you HAND-KEEP is
+exactly that - it is true only if
+exhaustive and it cannot prove its own exhaustiveness, and the hand-kept list in the
+count-shaped section below went stale exactly that way: it named three files while the
+template stamped four. An enumeration DERIVED
+from the artifact under test - every URL the rendered page actually contains, every input tag
+the template actually declares - is exhaustive by construction, because the thing being checked
+is the thing being enumerated. **If you had to type the list, it will go stale. If the check
+reads the list off the artifact, it cannot.**
+
+| Fails open | Fails closed |
+|---|---|
+| "no bad string in the output" | "exactly these two lines, and here they are" |
+| "zero unannotated claims" | "N files searched, and here they are" |
+| "no defects were posted" | "PASS - here is what I read, and what I could not reach" |
+| "nothing currently writes to it" | "no write route exists - here is the search" |
+| "its only handlers are X, Y, Z" | "no `OnPaste`, no `PasteEvent`, no Ctrl+V branch - here is the search" |
+| "the bad string is gone" | "the corrected string reaches the built artifact" |
+| "`git branch --merged` says merged" | "the changed files are byte-identical to `origin/main`" |
+| "N of them carry the stamp, and N is what I expected" | "here are ALL of them, and each one carries it" |
+
+**An enumeration is an absence claim wearing a list's clothes** - true only if exhaustive, and an enumeration cannot prove its own exhaustiveness. One page asserted five event handlers where there were six: the conclusion was right and the evidence was wrong, which is the worst combination, because it survives review.
+
+## Five rules that fall out of it
+
+1. **State all three arms.** A reader assumes two outcomes. There are three: the expected result is a pass, a bad result is the defect, and **an EMPTY result is a repair job on the instrument - never a clean run.**
+2. **Quote the actual output, never the word "passed".** A load-bearing count is only load-bearing if it is visible in the record.
+3. **Reconcile a sweep against its own expected inventory.** Name what you expect it to find FIRST, run it, then compare. A count with nothing to compare against proves only that the tool ran - and a truncated sweep is indistinguishable from a clean file. One sweep covered 23 of 37 and reported clean; it was caught only because the missing items were known to exist.
+4. **A control proves the check RAN, not that it reached FAR ENOUGH.** A line count is a control for TRUNCATION, not for SCOPE. An event, a callback, a hook, a registration - any fan-out is a REACH problem, and only enumerating the subscribers answers it.
+5. **Run it against a known-BAD input.** A check only ever run against the state you hope passes has demonstrated nothing. Prove it FIRES as well as passes.
+
+## The subtler sibling: a claim that is RIGHT resting on evidence that is WRONG
+
+Harder to catch, because **the conclusion survives scrutiny precisely because it is correct - so nobody re-examines what it stands on.**
+
+Seen four times in one day, every one found only because a reviewer opened the cited range: a correct negative proved by an incomplete enumeration; a correctly narrowed claim citing a comment about a different class; a correct exoneration resting on a comment saying so; and a real experiment with a correct conclusion whose one wrong detail would have argued for the wrong practice **while citing the experiment as proof**.
+
+A wrong conclusion gets argued with. A right conclusion with false evidence gets agreed with, cited, and inherited - and the falsehood travels inside it.
+
+**Agreeing with a conclusion is not a reason to skip its citation - it is the situation where skipping is most likely and most costly.** And when you cannot find evidence for something you believe is true, **say less** rather than reaching for the nearest plausible citation.
+
+## Applying it to review, which is where it costs most
+
+- Post findings to the pull request **as you go**, and post a **PASS** there too, naming what you checked AND what you could not reach. A pass with no stated scope cannot be judged by anyone who was not there - and everybody who was there is exactly the population that disappears.
+- **Name the artifact, not just "durably".** The tiers are not equal: a pull request comment beats a pushed file beats a committed file beats a local one beats a message. "Durably" with no named target lets someone pick the weakest rung and believe they complied.
+- A verdict on file that covers a commit which is no longer the head **is not a verdict on the head**. A verification has a timestamp.
+- **A comment describing a fix is itself a claim, and goes stale like any other text.** A durability rule manufactures this surface: telling a fleet to write everything down produces comment blocks, inventory rows and defect narratives, all of which read as commentary and none of which is exempt. The rule ships with the leg-hunt attached.
+
+## The COUNT-SHAPED check, and three siblings (2026-08-20, new-studio maps)
+
+Four more, in one evening, between two sessions. The first three are one shape and it is not
+covered above: it is not an absence, it is a **comparison of two numbers where BOTH SIDES FILTER
+ON THE PROPERTY THE DEFECT WOULD FAIL**, so the failing case sits outside both sides and is
+invisible to the comparison. The check is a presence, it is specific, and it still cannot fail.
+
+- A hand-kept list naming three stamped static files while the template stamped FOUR. The fourth
+  arrived with a later feature and nobody updated the list; the test passed on the three it knew.
+- `assert page.count(stamp) == template.count(stamp_placeholder)`. Add a fifth static file with
+  NO stamp and both numbers stay four - counts agree, test passes, page ships an unstamped file.
+  **Measured ALIVE** by mutation before the repair.
+- `assert page.count("data-default") >= 2` on a slider-reset control. It counts only the sliders
+  that HAVE a default, so a slider with none is invisible and never gets reset. **Measured ALIVE.**
+
+**One sentence: a test checking a NUMBER ABOUT the thing instead of the thing.** The repair is
+always to enumerate and assert the property of EACH item - every static URL carries the stamp;
+every range input carries a default.
+
+**How the third was found, which is the transferable part.** Not by re-reading, and not by
+grepping for `count(`. By searching the suite for the DEFECT'S SHAPE: *which assertion compares
+two numbers where both sides filter on the property the defect would fail.* Searching by the TOOL
+(`ast.walk`, `rglob`, `count(`) finds duplicates of a mechanism. Searching by the SHAPE finds the
+same defect in code that shares no tool with it - a stamp count and a slider count have nothing
+in common but the shape. **When you fix one instance, search for its shape before you close it.**
+
+Two other count-shaped assertions in the same window were put to the same mutation and CAUGHT it.
+Say so. "I examined three and fixed one" and "I fixed one" are different claims.
+
+### A guard whose blind spot is ALIGNED WITH ITS OWN SUCCESS CONDITION
+
+A syntax-tree guard stopped test files building their own template environment, but scanned only
+`test_*.py`. `conftest.py` is exactly where a helper LANDS when somebody tidies it out of a test
+file - so the guard went blind at precisely the moment its own success condition was being met.
+
+**Ask of any guard: when this succeeds, where does the thing it forbids MOVE TO - and can the
+guard see there?** A blind spot pointed at your own success is worse than a random one, because
+it opens exactly when the guard appears to be working.
+
+### Prose that contradicted the code IN THE SAME BREATH
+
+The skill's closing law - *prose about a rule is not the rule* - has a sharper form. That finder's
+docstring claimed an aliased import was found. True of `import jinja2 as j`; FALSE of
+`from jinja2 import Environment as Env`, which binds a different name it never matched. **Not
+drift. It was never true**, written wrong alongside the code it described, and no suite anywhere
+could have said so.
+
+Unrun prose DRIFTS from the code and someone eventually notices. Prose that was false when written
+has no moment of divergence to notice. **Write the reach as a TEST first and the sentence second.**
+
+The executable form: a test named `..._and_that_is_declined` that asserts the CURRENT behaviour of
+each known gap, plus a note that if it goes red the guard GREW and the note should be deleted
+rather than repaired. **The line for closing a gap versus declining it is ACCIDENT versus
+EVASION** - who would do this, and why - rather than what a parser can reach.
+
+### Reading a tool's PROSE when it has an exit code
+
+Instance 7 above is `| tail -1` truncating a delivery message. This is its general
+form, and it is worth separating because the repair is one word rather than a habit.
+
+Sweeping nine containers to prove a fixed guard fired on the stale ones, the harness
+parsed pytest's own output with `tail -2 | head -1` and read the PROGRESS line
+(`.` / `[100%]`) as the summary. It reported the guard firing on all nine, including
+the three that were correct - which would have sent somebody to "fix" a guard that
+was already right. It did not error. It produced a plausible wrong answer.
+
+It was caught only by contradiction with a full run done minutes earlier. **That is
+not a method, it is luck**, and it does not scale to the checks nobody happens to
+have a contradicting run for.
+
+**The rule: if the tool sets an exit code, read the exit code.** `pytest`, `git`,
+`grep`, `curl`, `docker` all do. Parsing their human-readable output is choosing the
+weaker signal when the stronger one is one character away - the skill's own root,
+that the tool makes the weak claim cheap and the strong claim effortful, except here
+the strong claim is CHEAPER and gets skipped from habit.
+
+| Weak, and what breaks it | Strong |
+|---|---|
+| `grep -c passed` on pytest output | `pytest ...; echo $?` |
+| `tail -1` on anything that wraps | the exit code, or the whole output |
+| "the word ERROR does not appear" | the exit code, plus what it printed |
+| a JSON tool piped through `head` | parse the JSON |
+
+And when there is genuinely no exit code - a message tool, an API that always
+returns 200 - **do not parse the summary line. Read the artifact back.** Fetch the
+published page, re-read the row, list the assets. The write's own report of itself
+is the thing under test, not the evidence for it.
+
+### "Each of N does X" answered by counting matches of ONE SPELLING of X
+
+Checking a claim that all three syntax-tree guards carried a can-it-actually-see-one self-test, a
+session grepped for one spelling and matched one of three - a FALSE NEGATIVE. The other two spell
+the same idea `test_an_assignment_counts_and_an_import_does_not` and
+`test_the_scan_finds_the_imports_that_are_there`.
+
+**When the claim is "each of N does X", ENUMERATE the N and inspect each**, because X is spelled
+differently by whoever wrote it. Counting matches of one spelling is the count-shaped defect again.
+
+And the meta-lesson, which is why that one is in here at all: **a claim that is right by ACCIDENT
+teaches nothing and leaves the broken method in place.** Being right because the check worked and
+being right while the check was broken look identical in the report. The second is worse than
+being wrong, because being wrong gets fixed. It is the mirror of the RIGHT-claim-on-WRONG-evidence
+section above, seen from the checker's side rather than the author's.
+
+## An extraction whose END is arbitrary (2026-08-21, new-studio train map)
+
+Different from the range anchored on a heading in the list of eight above, and it is worth
+keeping both: there the range failed to match and yielded nothing, which at least LOOKS empty.
+Here the range MATCHES and returns text - text that exists nowhere in the file.
+
+```bash
+sed -n "/sized like the content/,+14p" UI_STYLE_GUIDE.md
+```
+
+The start is anchored on structure. The end is `+14`, a distance. Fourteen lines happened to
+cross a section boundary, so the output spliced the tail of one paragraph onto the head of
+another and read as a single fluent sentence:
+
+```text
+...the movement of the element BELOW it, which must be
+already rejects. A single-section screen gets the skeleton...
+```
+
+Both halves are real. The sentence is not. The reader was one message away from reporting a
+freshly-merged document as containing garbled prose, on evidence their own command had
+manufactured.
+
+**An extraction whose end is an arbitrary distance can manufacture a plausible reading that
+exists in no file.** A truncation you can SEE is a nuisance; a splice you cannot see is false
+evidence, and it is worse the more fluent the result.
+
+**Anchor BOTH ends on structure, or read the whole thing.** `sed -n '/^## 8/,/^## 9/p'` has an
+end that means something. `+14` means "as far as I guessed".
+
+The general form is the same root as everything else here: the window stood in for the document.
+And the tell is the one below - `+14` is a specific value, so it is a hand-kept list of one.
+
+## The CATEGORY standing in for the ANSWER (2026-08-21, new-studio train map)
+
+A screen pointed at a wide log returned `HTTP 500`. It was not a crash. The renderer had
+DECLINED, deliberately, above a threshold of `len(model.stations) > 60`, and had written the
+reader a sentence with the fix in it - verbatim from the source and confirmed identical in the
+live response:
+
+```text
+Refusing to lay out 135 stations - the result would be a hairball that
+discredits the data. Fold the activity vocabulary harder (see
+abstract(fold=...)) or restrict object_types.
+```
+
+What reached the reader was `Error: HTTP 500`.
+
+The log was the German Bundestag object-centric dataset, period 20
+(DOI 10.5281/zenodo.16811928, CC-BY 4.0): 62,719 events, 44 object types, 148 event types. The
+135 is what THIS log produced, not a constant.
+
+**A route that turns a deliberate, actionable refusal into a generic failure has thrown away the
+only useful thing on the screen.**
+
+It belongs in this skill because **no check anywhere was failing, and every layer was locally
+correct.** The engine correctly refused and said why. The client correctly declines to render a
+5xx body, because a 5xx body is a stack trace and not a message for a reader. The route
+"correctly" reported an error for an exception. Three right answers compose into a screen that
+tells the reader nothing.
+
+It is the root of this skill with the CATEGORY standing in for the ANSWER. A status code, an
+exception class, an error enum, a log level - each is metadata ABOUT an answer, and a pipeline
+that propagates only the metadata destroys the answer while every component reports success.
+The observable was present; the presence was of the wrong thing.
+
+**The defect lives in the SEAM, and nothing tests seams.** The presence that fails closed is
+end-to-end and is about content, not status: assert that the SENTENCE the component wrote
+reaches the rendered page. Not that the call returned. Not that the status was appropriate.
+
+### The half that transfers furthest: an instance fix is a hand-kept list of one
+
+**That defect had already been fixed once, on that same route, and shipped as done.** On
+2026-08-20, in `def train_map_canvas`, a single `except _trainmap.TooFewObjectTypes` was added,
+returning an `HTMLResponse` with no `status_code` - which is 200. Every other refusal the engine
+can write went on failing for another day, and it surfaced only when somebody finally pointed a
+44-object-type log at the screen - the sample could not produce a refusal at all.
+
+Teaching ONE exception type to answer correctly is **a hand-kept enumeration at its smallest
+possible size**, which this skill already says goes stale and cannot prove its own exhaustiveness.
+At length one it is almost invisible, because it arrives with a passing test beside it and looks
+exactly like a fix. The derived repair drives the exception TYPE through the route, so every
+refusal the engine can write is covered by construction rather than by a list somebody maintains.
+
+**The tell, and it is cheap to check: a fix that names a specific VALUE is a hand-kept list of
+one.** One exception class, one status code, one message string, one column name, one file. When
+you see that shape, the question is not "is this fix correct" - it usually is - but **"what class
+is this an instance of, and what else is in it?"**
+
+Fix the class, or say in the commit that you knowingly fixed one instance and why. An instance fix
+with no such note is indistinguishable from a class fix six weeks later, and the difference is a
+day of somebody else's time.
+
+### A postscript, because it happened while this entry was being written
+
+The four facts above were taken from a chat message and were about to be published unverified -
+into this skill, in the section about correct conclusions resting on evidence nobody checked. They
+were sent back to be read off the branch instead. **Three were right. The wrong one was the
+verbatim quote**, which is the single thing in an entry like this that most needs to be exact.
+
+The parenthetical `(see abstract(fold=...))` had been dropped, and it had been dropped in THREE
+places - the message, the commit message, and the author's own timings document - because it was
+copied forward from the first write-up rather than re-read from the source each time. Quoted
+whole, the sentence carries a second finding for free: a developer-facing API hint sitting in the
+middle of reader-facing prose. Quoted as it had been copied, it reads as clean product writing,
+which is the opposite of true.
+
+**Copying a quotation forward is not quoting. Re-read the source every time, including from your
+own earlier write-up** - especially from your own earlier write-up, because that is the copy you
+trust without noticing you are trusting it.
+
+## SELECTING THE WRONG LINE, which returns something complete and false (2026-08-21, new-studio train map)
+
+Different from the truncated tail in the eight, and the difference is the whole
+point. That one LOST content - `Delivered to <name> (1 session(s)).` wrapped and
+`tail -1` showed `session.`, which is visibly a fragment. This one returns a
+whole line, correctly formatted, that is not the line you wanted and carries no
+warning that it is not.
+
+**Produced deliberately for this entry**, on a real suite with a planted failing
+test, rather than written from memory of it happening:
+
+```
+$ python -m pytest tests/test_train_map_edges.py -q > run.log ; echo $?
+1
+
+$ tail -2 run.log | head -1
+FAILED tests/test_train_map_edges.py::test_deliberately_failing_...
+```
+
+So far so good, by luck. Now the same command on a run that PASSES:
+
+```
+$ python -m pytest tests/test_train_map_edges.py -q > run.log ; echo $?
+0
+
+$ tail -2 run.log | head -1
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+```
+
+**A documentation URL, presented as a test result.** Nothing is malformed. The
+line that `-2` lands on depends on whether pytest emitted a warnings block, so
+the reading's meaning changes with the weather. Search that for `failed`, find
+nothing, call it green - right by accident. Search it for `passed`, find nothing,
+call it red - wrong, on a suite that passed.
+
+### And the short forms are worse - in OPPOSITE directions
+
+All four cases, run rather than reasoned about. Six tests, one `warnings.warn` so
+the warnings block exists, one test deliberately NAMED `test_five_handles_failed_login`,
+and `assert 1 == 2` planted for the failing rows:
+
+```
+case            exit   grep -c passed   grep -c failed   LAST line matching passed|failed
+all pass, -q      0          1                0          6 passed, 1 warning in 0.08s
+all pass, -v      0          1                1  <-!     ====== 6 passed, 1 warning in ...
+one fail, -q      1          1  <-!            1          1 failed, 5 passed, 1 warning ...
+one fail, -v      1          1  <-!            2          ====== 1 failed, 5 passed, ...
+```
+
+**`grep -c passed` is 1 in ALL FOUR.** It does not distinguish anything. The
+summary of a failing run reads `1 failed, 5 passed, 1 warning` - the word `passed`
+is inside the failure - so a grep for the good news matches the bad news, always.
+
+**`grep -c failed` is 1 on a fully PASSING verbose run.** The line it matches is:
+
+```
+test_probe.py::test_five_handles_failed_login PASSED                     [ 83%]
+```
+
+A test NAME. Under `-q` pytest never prints a passing test's name, so there is
+nothing to match and the trap is invisible; under `-v` it fires. Which of the two
+short forms is wrong therefore depends on **a verbosity flag nobody thinks of as
+part of the check** - and one of them is wrong either way.
+
+They fail in opposite directions, which is worse than either alone:
+
+- `grep -c passed` **fails open** - good news on a broken run.
+- `grep -c failed` **false-alarms** - a failure count on a run where everything
+  passed. A team that meets that a few times learns to wave the count away, which
+  is entry 4 of the eight arriving by a different road.
+
+### The cases OUTSIDE those four rows, where every reading says clean
+
+The four rows above all assume the suite RAN. Reproduced across two machines,
+here is what happens when it did not:
+
+```
+case                                 exit   c:passed  c:failed   LAST passed|failed line
+collection error (syntax error)        2        0         0      (empty)
+no tests at all (bare directory)       5        0         0      (empty)
+-k matching nothing, real suite        5        0         0      (empty)
+file present, no test functions        5        0         0      (empty)
+-k matching SOME, real suite           0        1         0      1 passed, 5 deselected
+```
+
+The real summaries are `1 error in 0.31s`, `no tests ran in 0.00s` and
+`6 deselected in 0.01s` - **none of which contains the word `passed` or the word
+`failed`**.
+
+So `grep -c failed` returns **0 - clean** for a suite that never ran. That is this
+document's headline defect, committed by the check people use to police it.
+
+The realistic instance is the third row: a CI step filtering on a test name, the
+test gets renamed, the filter matches nothing, and the step runs zero tests
+forever while every prose reading reports clean. Nobody edits that step again.
+
+The sound form - the last line matching `passed|failed` - returns an **empty
+string** in the first four. That is rule 1 of this document: an empty result is a
+broken instrument, never a clean run. It is sound inside the four rows and SILENT
+outside them, and silence is what a caller reads as fine.
+
+### The exit code, corrected twice
+
+The first version of this entry said the exit code is "0 and 1, correct in all
+four". True of the four cases that had been run, and **too narrow** - which is the
+same defect as everything else here, applied to the advice.
+
+Pytest uses **2** for a collection error and **5** for no-tests-collected. A
+script asking `if exit == 1 then failed` calls a suite that never ran
+not-failed.
+
+**Exit 0 is the only success. Every non-zero is not. Never test for 1.**
+
+**And that is still not sufficient**, which the last row proves:
+
+```
+$ pytest test_probe.py -q -k test_one ; echo $?
+1 passed, 5 deselected in 0.06s
+0
+```
+
+**Exit 0. Five of six tests never ran.** Every check named in this entry passes
+that: exit is 0, `grep -c failed` is 0, and the sound form returns a real summary
+rather than an empty string. A filter whose name has drifted lands here rather
+than on exit 5 the moment it still matches ONE thing.
+
+The complete form is this document's own rule 3 - reconcile a sweep against its
+expected inventory - pointed at its own test suites:
+
+**exit 0 AND the collected count reconciled against what you expected to find.**
+
+Exit 0 says nothing failed. It does not say your 812 tests ran.
+
+### The same shape in the skill cache itself
+
+Checking whether an entry had landed, this skill's own local copy at
+`~/.claude/skills/checks-that-fail-open/SKILL.md` was a version behind. Searching
+it for a section that had just been published returned nothing, and the next step
+would have been to report the section missing - from a v4, about a v5.
+
+**A local cache of a shared document is a hand-kept copy that looks
+authoritative and carries no version on its face.** Fetch from the source before
+saying a section is absent. Same shape as copying a quotation forward: the copy
+you trust without noticing is your own.
+
+---
+
+## Care is not the mechanism. Reproduction is.
+
+Two sessions produced everything in the two 2026-08-21 sections above by refusing
+to take each other's word. Every single finding came from the other one declining
+to accept a report and running it instead:
+
+- three readings reported -> a fourth case found in reproducing them
+- that fourth case reported -> a fifth found, `grep -c passed` constant in all four
+- the four-row table reported -> the cases OUTSIDE the four rows found
+- the exit-code rule recommended -> its own author found it too narrow, and then
+  the reader found a case that defeats the corrected version too
+
+**Both parties were being careful the whole time.** Care is what produces a
+confident wrong reading - a quotation copied forward three times, a `+14` window,
+a grep for one spelling, an exit-code rule true of the cases its author had run.
+None of those is carelessness; each is a competent person going one step less far
+than the step that would have caught it.
+
+The practice that caught them is cheap and unpleasant: **do not accept a reported
+result into anything permanent, and do not accept your own from an earlier
+write-up.** Ask for the command. Run it. Then run the case next to it.
+
+Stated as what it cost rather than as a principle: of eleven findings across one
+evening, ZERO were found by the person who made the mistake, and every one was
+found within minutes of somebody else refusing to take the report on trust.
+
+---
+
+## And the reason this is a skill
+
+**Prose about a rule is not the rule.** A note saying "check both surfaces" cannot check both surfaces. Three times in one night, somebody broke a rule in the same file where they had just written it - because writing the note FEELS like doing the work.
+
+Every law that held that night held because it was a command somebody could run. Every one that failed was prose. **Ship the check, not the reminder.**

--- a/plugins/agent-discipline/skills/destructive-sweeps-lean-to-keep/SKILL.md
+++ b/plugins/agent-discipline/skills/destructive-sweeps-lean-to-keep/SKILL.md
@@ -66,8 +66,9 @@ comment. Never leave them disagreeing.
    deny-list and it is wrong.
 3. **Take the backup in the same breath as the delete**, not as a separate earlier step. A gap between
    snapshot and sweep is a window another writer can fill.
-4. **Check who else is live in the same place.** Read the registry; never broadcast to ask. A shared
-   working tree with another session in it is not yours to reset.
+4. **Check who else is live in the same place.** Establish it by reading - process lists, lock files,
+   whatever inventory of running work you have - rather than by asking around and taking silence for
+   an answer. A working tree with somebody else's work in it is not yours to reset.
 5. **Prefer reversible.** Push a backup ref, move to a quarantine directory, rename rather than remove.
    Something you can undo tomorrow is worth far more than the disk it costs tonight.
 

--- a/plugins/agent-discipline/skills/destructive-sweeps-lean-to-keep/SKILL.md
+++ b/plugins/agent-discipline/skills/destructive-sweeps-lean-to-keep/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: destructive-sweeps-lean-to-keep
+description: "A destructive operation acts only on what it can positively prove is disposable. Enumerate what to DELETE, never what to skip - and refresh the safety signal on every real use. Use when the task involves: sweep, purge, cleanup, delete old, prune, reclaim space, stale files, retention, aged out, rm -rf, git clean, drop the table."
+license: MIT
+---
+
+# Destructive Sweeps Lean To Keep
+
+**A destructive operation acts ONLY on what it can positively identify as safe to delete, refreshes
+its safety signal on every real use, and when in doubt KEEPS.**
+
+Written up 2026-07-20 after one sweep deleted the owner's own recorded audio and, separately, deleted
+an actively-resuming upload mid-use. Both failures came from the same two shapes, and both shapes look
+completely reasonable while you are writing them.
+
+## Why it leans all the way to one side
+
+The two failure directions do not cost the same:
+
+- A false DELETE is **unrecoverable**. Here it was the owner's own recorded audio, gone.
+- A false KEEP is **merely disk**. It accumulates, and a later, more careful pass reclaims it.
+
+Because the costs are asymmetric, the operation must not sit in the comfortable middle of "delete what
+looks stale". It leans all the way toward keeping, and buys the small recoverable cost to avoid the
+large unrecoverable one. A sweep that reclaims 80 percent of what it could have, and has never once
+destroyed something live, is working correctly.
+
+## The two shapes this forbids
+
+### 1. A deny-list where it must be an allow-list
+
+"Delete every aged directory EXCEPT the names I listed" fails OPEN for any shape nobody thought to
+list. It deleted an aged future-partition directory and its sentinel, because no one had thought to
+list them.
+
+**Enumerate what to DELETE, never what to skip.** The correct boundary admits only what it can
+positively prove is disposable: an aged directory whose name IS a canonical 32-hex upload id, and
+nothing else. Malformed names, partials, partition containers, future siblings - all survive, because
+none of them can be PROVEN disposable. Their survival is the boundary working, not the boundary
+leaking.
+
+This is the same shape as the `checks-that-fail-open` skill: a pass condition that is an absence ("not on my
+skip list") is satisfied by anything at all, including things that did not exist when the list was
+written.
+
+### 2. A safety signal the code does not refresh
+
+The sweep judged staleness by last write, and the design comment claimed a live upload resets its own
+clock. A successful re-register and a successful idempotent chunk both wrote nothing - so an actively
+resuming upload aged out and was deleted mid-use.
+
+**The safety signal must be touched on EVERY successful operation**, not only the ones that happen to
+write bytes. And the sweep must not race a resume between its age check and its delete. If that race
+cannot be cheaply proven closed, widen toward KEEP.
+
+Note where the defect actually lived: in a COMMENT asserting a guarantee the code did not implement.
+The author wrote it believing it, which is why the author is the last person able to see it false -
+see the `proof-covers-the-wrong-thing` skill. Make the code deliver what the comment says, or change the
+comment. Never leave them disagreeing.
+
+## Before you run one, in order
+
+1. **Canonicalize before you act.** A destructive boundary needs a positively validated canonical
+   identifier, not a skip-list. The same shape let a non-canonical path traversal escape once already.
+2. **Say out loud what you can PROVE is disposable.** If the sentence needs an "except", it is a
+   deny-list and it is wrong.
+3. **Take the backup in the same breath as the delete**, not as a separate earlier step. A gap between
+   snapshot and sweep is a window another writer can fill.
+4. **Check who else is live in the same place.** Read the registry; never broadcast to ask. A shared
+   working tree with another session in it is not yours to reset.
+5. **Prefer reversible.** Push a backup ref, move to a quarantine directory, rename rather than remove.
+   Something you can undo tomorrow is worth far more than the disk it costs tonight.
+
+## The one-line test
+
+> If this sweep were wrong about one item, could I get it back?
+
+If the answer is no, the boundary must be an allow-list of things positively proven disposable, and
+everything it cannot classify survives.

--- a/plugins/agent-discipline/skills/proof-covers-the-wrong-thing/SKILL.md
+++ b/plugins/agent-discipline/skills/proof-covers-the-wrong-thing/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: proof-covers-the-wrong-thing
+description: "A proof can be valid and still say nothing about what you changed - wrong surface, wrong reader, wrong caller, or an untested premise. Name what your evidence does NOT cover. Use when the task involves: prove it, by construction, root cause, reproduced it, repro, guard-local, skipped test, suite is green, premise, assumption, self review, it is settled."
+license: MIT
+---
+
+# Proof That Covers The Wrong Thing
+
+**A proof can be completely valid and still be silent about the thing you changed.**
+
+The `checks-that-fail-open` skill is about evidence that was never gathered. This is the harder sibling: the
+evidence WAS gathered, the argument IS sound, and it covers something adjacent to the question. It
+reads exactly like a proof, because it is one - of a different claim.
+
+Four shapes, from a single mission on 2026-07-20. Each cost real work: a role change, a restart, and a
+hotfix aimed at a bug the system never had.
+
+## 1. The premise nobody tested - a ruling is not evidence
+
+**A ruling settles what to BUILD. It does not establish the FACTS it rested on.**
+
+A family of routes was ruled a hosted deny at both doors. The ruling rested on a premise - that
+launchers are not a hosted feature - which was *asserted*, never proven. If something hosted genuinely
+depended on them, the ruling was wrong, and that needed to surface in the analysis rather than after it
+shipped.
+
+The reason this needs to be a rule rather than good manners: **a ruling handed over as settled context
+is precisely the thing that stops being tested.** The worker is not careless, it is obedient - and
+obedience to a premise is indistinguishable from verification of it in the written output.
+
+So, at the moment work is delegated, not in a review afterwards:
+
+1. **Name the premise** the work rests on, separately from the instructions.
+2. Require an answer per premise: **VERIFIED against the source**, or **ASSUMED**.
+3. Contradicting evidence is **led with**, never softened into a closing caveat.
+
+**An assumed premise is not a defect. Carrying one silently is.**
+
+The architect who set this ruled it standing with: *"I would rather be corrected twice in an hour than
+have my assumptions calcify into the record."*
+
+## 2. The reader who cannot see it - you cannot verify from inside
+
+**The author is the last person able to see their own prose false.** A comment is the author's INTENT
+written down, and the author reads that intent back out of it no matter what the code says. The reader
+sees the words; the author sees what they MEANT.
+
+This is structural, not a competence gap, and it unifies things that look unrelated: a comment whose
+guarantee the code never delivered; a census exhaustive over its population and blind to what it did
+not ask; a seat that could not step outside the frame it was reasoning inside; a warning whose writer
+felt covered by having written it for other people.
+
+**The verifier and the verified must not be the same reader, the same question set, the same frame, or
+the same author.** Reading your own work harder cannot fix it, because the failure is precisely that
+reading from inside cannot see it. What works is a different reader, made mechanical where possible:
+
+- A comment asserting a guarantee is an ASSERTION. Make the code deliver it, or change the comment.
+- Where the guarantee is load-bearing, write the test that REDDENS when the code stops delivering it.
+- The independent review seat and the audited question set are the same move at larger scale.
+
+This law landed in its own author's lane the night it was written. The class does not spare the person
+naming it, which is the strongest evidence it is structural.
+
+## 3. The surface you did not touch - and skipped is not covered
+
+A value converter was added inside `if (Database.IsNpgsql())` - a Postgres-only change. An unrelated
+test flaked in the same run and was dismissed by a by-construction argument: the change is local to the
+Postgres branch, the default suite runs SQLite, so that model is byte-identical with and without the
+change; a regression is impossible.
+
+**The argument was correct, and it covered the wrong provider.** It proved the SQLite surface was
+unchanged. The change lived on the Npgsql surface, where the proof said nothing - and that is exactly
+where the real regression sat. Two opt-in real-Postgres facts broke. Both continuous-integration jobs
+were green, because neither RUNS those facts without a real Postgres.
+
+> **A skipped test looks like coverage and runs nothing.** A green suite with the relevant facts
+> skipped is a green over a blind spot.
+
+The mechanism that closes it: the facts must be seen to EXECUTE-AND-PASS. **The skip count must drop**
+by the number un-skipped, and each must appear **by name in the passed list**. "I ran them" is refused.
+
+Generally: when a change is provider-, config- or platform-specific, its proof must run on the surface
+it CHANGES. A by-construction argument about the other surface is valid for that surface and must never
+stand in for coverage of the changed one.
+
+## 4. The caller that is not your code - a re-derivation reproduces its own error
+
+A hosted enrolment was returning 503. The cause was diagnosed as an unqualified SELECT resolving via
+`search_path`, reproduced by running an unqualified `psql` query that returned
+`42P01 relation "entitlements" does not exist`. A role change and a container restart were applied, and
+a hotfix was written.
+
+**Every step chased an error the service never emits.** Its data layer already qualified the read, so
+it ran `FROM app.entitlements`, not the bare name the reproduction used. The reproduction produced
+*a* plausible, related-looking 42P01 - not the system's.
+
+> **A hand-run query, a psql session, a second client - each is a DIFFERENT caller than the code, and
+> the error it reproduces is its own.** Reproducing a matching symptom is not observing the system
+> produce it.
+
+What it forces: **when a failure's cause is not directly observed in the failing component's own
+output, the first deliverable is the INSTRUMENT that makes it observable - not a fix.** Plan for a
+READING, not a fix, until the instrument has spoken. And label a guard that changes no behaviour
+honestly: it is a regression guard on a property that already holds, not the fix.
+
+## How to use this
+
+Before calling something proven, answer in one sentence each:
+
+- **What premise is this resting on, and did anyone check it?**
+- **Who read this who is not me?**
+- **Which surface did I change, and did the evidence run there - or was it skipped?**
+- **Did I watch the system produce this, or did I reproduce something that looked like it?**
+
+The useful output is not "it is proven". It is **the sentence naming what your evidence does NOT
+cover.** If you cannot write that sentence, you have not finished looking.

--- a/plugins/devthrottle/.claude-plugin/plugin.json
+++ b/plugins/devthrottle/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "devthrottle",
+  "displayName": "DevThrottle",
+  "version": "1.0.0",
+  "description": "For people running DevThrottle: how to install it, and how a session talks to the other sessions running across your machines.",
+  "author": {
+    "name": "DevThrottle",
+    "url": "https://devthrottle.com"
+  },
+  "homepage": "https://devthrottle.com",
+  "repository": "https://github.com/thefrederiksen/devthrottle",
+  "license": "MIT",
+  "keywords": ["devthrottle", "orchestration", "sessions", "multi-agent"]
+}

--- a/plugins/devthrottle/README.md
+++ b/plugins/devthrottle/README.md
@@ -1,0 +1,26 @@
+# DevThrottle
+
+Skills for people who run [DevThrottle](https://devthrottle.com) - mission control for
+command-line coding agents. Run a fleet of agents at once, each on its own repository,
+from one app, and steer them from your phone.
+
+If you do not run DevThrottle, install
+[`agent-discipline`](../agent-discipline) from the same marketplace instead - it is
+product-free and needs nothing.
+
+```
+/plugin marketplace add thefrederiksen/devthrottle
+/plugin install devthrottle@devthrottle
+```
+
+## What is in it
+
+**`devthrottle-install`** - the documented steps to install DevThrottle and connect a
+gateway. The skill hands the user the steps and stops there. It does not download an
+installer and it does not pipe a remote script into a shell, deliberately.
+
+**`devthrottle-sessions`** - how one session reaches the others: list what is running
+across your machines, name this session, message another one, ask one a question and
+wait for the answer, open a new session, and close one down.
+
+MIT licensed. Source: <https://github.com/thefrederiksen/devthrottle>

--- a/plugins/devthrottle/skills/devthrottle-install/SKILL.md
+++ b/plugins/devthrottle/skills/devthrottle-install/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: devthrottle-install
+description: "Hand the user the documented steps to install or update DevThrottle, and to connect a gateway afterwards. Use when the task involves: install DevThrottle, set up DevThrottle, update DevThrottle, connect a gateway, cc-devthrottle not found, where do the cc tools come from."
+license: MIT
+---
+
+# Installing DevThrottle
+
+**This skill hands the user instructions. It does not install anything.**
+
+Do not download an installer, do not fetch a script, and do not pipe anything into a
+shell on the user's behalf. Print the steps below, let the user run them, and then
+help with what happens next. A coding agent that fetches and executes a remote
+installer is asking the user to trust a chain they cannot see, and there is no
+version of that which is worth the convenience.
+
+## First, check whether it is already installed
+
+```
+cc-devthrottle session whoami
+```
+
+If that prints a session id, DevThrottle is installed and this session is already
+running under it - there is nothing to install. If the command is not found, the
+Director is not installed on this machine, or its tools are not on this shell's PATH.
+
+## Installing is two steps, and only the second one asks who the user is
+
+**Step 1 - install the Director.** The Director is the desktop app that runs and
+watches the agents, and it ships the `cc-*` command line tools. It needs no account
+and no gateway, and it needs no administrator rights - everything lands under the
+user's own profile.
+
+Send the user to the download page and let them run it:
+
+> https://devthrottle.com/download
+
+The Windows installer is a three-screen wizard: Welcome, Install, Complete. There is
+no role to pick and no sign-in to get past. The same assets are published on the
+GitHub releases page if the user would rather take them directly:
+
+> https://github.com/thefrederiksen/devthrottle/releases/latest
+
+macOS installs from the same download page.
+
+**Step 2 - connect a gateway.** A gateway is what makes the machine reachable from
+elsewhere - the phone app, voice control, and cross-machine session messaging. The
+Director asks about it on its own second setup screen, not in the installer, and
+this is the step that asks the user to sign in.
+
+Three answers, and the third is a real one:
+
+| Answer | What it means |
+|---|---|
+| Hosted gateway | DevThrottle runs it. Sign in and the machine is enrolled. |
+| Self-hosted gateway | The user runs the gateway on their own machine and joins it. Windows only, advanced setups. |
+| Not now | Local-only on this machine. Connectable later from Settings. |
+
+Both gateway options need a DevThrottle sign-in. "Not now" needs nothing, and the app
+stays fully usable on that one machine without a gateway.
+
+## Updating
+
+The Director updates itself in place. If the user wants to force it, point them at
+the app's own update action rather than re-running an installer by hand.
+
+## After it is installed
+
+`cc-devthrottle` is on the PATH of every session the Director launches, and it reads
+the session's own credentials from its environment - there is nothing for the user to
+configure and no token for them to paste. `cc-devthrottle actions --json` lists what
+the installed version can do; prefer reading that over guessing at a command.
+
+The reference documentation lives in the repository:
+
+> https://github.com/thefrederiksen/devthrottle

--- a/plugins/devthrottle/skills/devthrottle-sessions/SKILL.md
+++ b/plugins/devthrottle/skills/devthrottle-sessions/SKILL.md
@@ -19,13 +19,16 @@ this shell is not inside a DevThrottle-launched session.
 ## Find out what exists before you act
 
 ```
-cc-devthrottle actions --json     # every verb this installed version supports
+cc-devthrottle actions --json     # the agent-discoverable actions this version exposes
 cc-devthrottle session whoami     # this session's own id, name, machine and repository
 cc-devthrottle session list       # every session across every attached computer
 ```
 
 Read `actions --json` when mapping a request onto a command rather than guessing at a
-flag. It describes the version that is actually installed.
+flag: it describes the version that is actually installed, rather than the version you
+remember. It is the agent-discoverable set, not an exhaustive list of every command -
+`cc-devthrottle <group> --help` is the complete surface, and some commands documented
+below appear only there.
 
 ## Address a session by id prefix or by name
 

--- a/plugins/devthrottle/skills/devthrottle-sessions/SKILL.md
+++ b/plugins/devthrottle/skills/devthrottle-sessions/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: devthrottle-sessions
+description: "Talk to the other DevThrottle sessions running across your machines - list them, rename this one, send a message, ask a question and wait for the answer, open a new session, and close one down. Use when the task involves: message another session, ask another session, list sessions, what sessions are running, spawn a session, rename this session, close this session."
+license: MIT
+---
+
+# Talking to other DevThrottle sessions
+
+A **session** is one running coding agent. DevThrottle keeps every session your
+machines are running attached to one gateway, and `cc-devthrottle` is how a session
+reaches the others - on this computer or on any other computer attached to the same
+gateway.
+
+There is nothing to configure. Every session DevThrottle launches already carries the
+gateway address and its own credential in its environment, so the commands below work
+as written. If one of them says `CC_GATEWAY_URL` or `CC_GATEWAY_SESSION_KEY` is unset,
+this shell is not inside a DevThrottle-launched session.
+
+## Find out what exists before you act
+
+```
+cc-devthrottle actions --json     # every verb this installed version supports
+cc-devthrottle session whoami     # this session's own id, name, machine and repository
+cc-devthrottle session list       # every session across every attached computer
+```
+
+Read `actions --json` when mapping a request onto a command rather than guessing at a
+flag. It describes the version that is actually installed.
+
+## Address a session by id prefix or by name
+
+Every target below accepts a short prefix of a session id, or the session's exact
+display name. If a prefix is ambiguous the command fails and says so - rerun with more
+characters. It never picks one for you.
+
+## Name this session
+
+```
+cc-devthrottle session rename "Frontend review"
+cc-devthrottle session rename 9b2f "API rewrite"
+```
+
+The first form renames the current session; the second renames another one. Name every
+session for the work it is doing. Several sessions often run in the same checkout, and
+an unnamed one shows up as the bare folder name, indistinguishable from its neighbours.
+Leave the repository out of the name - the session list already has a column for it.
+
+## Send a message
+
+```
+cc-devthrottle message send 4c81 "I finished the API layer - the frontend is unblocked."
+cc-devthrottle message send docs "Please refresh the API page when you get a chance."
+cc-devthrottle message send all "Heads up: I am about to rebase our shared branch."
+```
+
+**Every message you send interrupts the session that receives it.** It is typed into
+that agent's composer and starts a turn there. Treat it as a claim on someone else's
+attention and scope it accordingly.
+
+`message send all` reaches only the sessions working alongside you - the same piece of
+work, or the same repository on the same computer. That is the everyday broadcast, and
+it is the right tool for a heads-up about a shared checkout. It does not reach sessions
+in other repositories.
+
+A whole-fleet broadcast interrupts every session on every computer. The gateway refuses
+one unless a person has granted it. If you believe you need one, ask the person running
+the fleet; do not look for a way around the refusal.
+
+## Ask a question and wait for the answer
+
+```
+cc-devthrottle message ask 9b2f "Which database schema is loaded in your checkout?"
+cc-devthrottle message ask docs "What is the title of the API page?" --timeout-ms 60000
+```
+
+`message ask` is always single-target and blocks until the other session answers.
+
+**Prefer `ask` over `send` whenever the answer matters.** `send` reports that a message
+was delivered; delivery is not an answer, and a session that received your message and
+then did nothing looks identical to one that acted on it. If you need to know something,
+ask and read the reply.
+
+## Open a new session
+
+```
+cc-devthrottle session spawn /path/to/repo --name "Frontend review"
+cc-devthrottle session spawn /path/to/repo --purpose "run the test suite" --agent ClaudeCode --prompt "Run the tests and report failures."
+cc-devthrottle session spawn /path/to/repo --name "build" --machine other-computer
+```
+
+Give every spawn a `--name` or a `--purpose`; a spawn with neither is warned about, and
+a name equal to the bare folder name is rejected.
+
+**Spawning is a commitment, not a resource request.** A session you started is yours to
+drive to completion. Before you spawn one, be able to say what specifically has to
+happen for it to be finished - a session with no stated exit does not acquire one on its
+own. Decide up front where its output has to end up, because that decides whether its
+work survives: output left in a throwaway checkout dies with that checkout.
+
+## Close a session down
+
+```
+cc-devthrottle session done            # flag THIS session for removal
+cc-devthrottle session done <target>   # flag another one
+```
+
+`session done` marks a session for graceful removal. It does not kill it mid-turn - the
+session finishes what it is doing and is reaped shortly after. Use it on unattended runs
+so a finished session does not sit idle.
+
+## Check the plumbing
+
+```
+cc-devthrottle selftest
+```
+
+Opens two throwaway local sessions, proves list, send and ask all work end to end, then
+removes them.


### PR DESCRIPTION
Tracking: `thefrederiksen/devthrottle_internal#1677`

Adds `.claude-plugin/marketplace.json` so anyone running Claude Code can do:

```
/plugin marketplace add thefrederiksen/devthrottle
/plugin install agent-discipline@devthrottle
/plugin install devthrottle@devthrottle
```

No new repository, no new surface to maintain. A marketplace is one JSON file.

## What is in it

**`agent-discipline`** - three skills about evidence, useful to a stranger with nothing
installed: `checks-that-fail-open`, `proof-covers-the-wrong-thing`,
`destructive-sweeps-lean-to-keep`. This is the plugin that travels.

**`devthrottle`** - install guidance and session-to-session messaging, for people who
already run it.

## The rule this was built around

**Marketing goes in the README. No skill body pitches the product.** A README is a page
someone chooses to read; a skill body is loaded straight into a stranger's agent as
instructions, and a pitch there is an advert injected into someone else's context. So the
three discipline skills name no product at all, and the README sells. The two skills in the
`devthrottle` plugin do name DevThrottle, because documenting it is what they are for -
they say how to install it and how to use it, and they do not sell it.

Same rule for the install skill: it hands the user the documented steps. It downloads
nothing and pipes nothing into a shell.

## Evidence

Every claim below was checked by enumerating the artifacts, not by looking for the
absence of a problem.

**All five skill bodies, derived from the tree rather than typed out:**

```
plugins/agent-discipline/skills/checks-that-fail-open/SKILL.md
plugins/agent-discipline/skills/destructive-sweeps-lean-to-keep/SKILL.md
plugins/agent-discipline/skills/proof-covers-the-wrong-thing/SKILL.md
plugins/devthrottle/skills/devthrottle-install/SKILL.md
plugins/devthrottle/skills/devthrottle-sessions/SKILL.md
```

**Product mentions in the three discipline skills: zero.** Case-insensitive count per
file of `devthrottle|cc-director|cc-devthrottle|gateway|cockpit|wingman` is `0 0 0`. The
one residual internal word (a war story that said "the gateway" and
`FROM gateway.entitlements`) was reworded to "the service" and `FROM app.entitlements`;
the lesson is unchanged.

**Frontmatter, every skill, listed field by field:**

| file | fields |
|---|---|
| `checks-that-fail-open` | `name`, `description`, `license` |
| `destructive-sweeps-lean-to-keep` | `name`, `description`, `license` |
| `proof-covers-the-wrong-thing` | `name`, `description`, `license` |
| `devthrottle-install` | `name`, `description`, `license` |
| `devthrottle-sessions` | `name`, `description`, `license` |

All five are inside the six agentskills.io specification fields (`name`, `description`,
`license`, `compatibility`, `metadata`, `allowed-tools`). No host-specific extensions
anywhere, so the same files load under other agents that implement the standard.

**Manifests validate:**

```
claude plugin validate .                          -> Validation passed
claude plugin validate ./plugins/agent-discipline -> Validation passed
claude plugin validate ./plugins/devthrottle      -> Validation passed
```

**Both plugins install and every skill loads.** Run against an isolated config directory
so it could not borrow anything already on this machine:

```
claude plugin marketplace add ./     -> Successfully added marketplace: devthrottle
claude plugin install agent-discipline@devthrottle -> Successfully installed
claude plugin install devthrottle@devthrottle      -> Successfully installed

Agent Discipline (agent-discipline) 1.0.0
  Skills (3)  checks-that-fail-open, destructive-sweeps-lean-to-keep, proof-covers-the-wrong-thing
  Always-on:   ~292 tok

DevThrottle (devthrottle) 1.0.0
  Skills (2)  devthrottle-install, devthrottle-sessions
  Always-on:   ~176 tok
```

## What this does NOT yet prove

The install above ran from a local directory. It does not prove the GitHub path
(`/plugin marketplace add thefrederiksen/devthrottle`), which reads the default branch
and therefore cannot pass until this is merged. That proof is run against `main`
immediately after merge and attached to the tracking issue.

## Gates before merge

- [ ] Independent review by a different agent family, recorded on this pull request
- [ ] Owner reads the README marketing copy

Submission to the official directory happens after merge, and is a form at
`https://clau.de/plugin-directory-submission`, not a pull request.



---

**Update.** The independent review is recorded below, with a finding-by-finding response.
Verdict was approve with changes; six of seven findings are fixed in `e46323a4c` and the
seventh is pre-existing copy that is the owner's call. The evidence section above describes
commit `0c88a3fd`; note in particular that its product-mention sweep used a pattern that
omitted host names and so could not have caught the one real hit. It has been re-run with
every product and host name in scope, and fired at a known-bad file first to prove it works.
