### PR TITLE
fix(gateway): a withdrawn capture decision now actually stops capture

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogSwitchStoreTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogSwitchStoreTests.cs
@@ -64,6 +64,77 @@ public sealed class TurnLogSwitchStoreTests : IDisposable
     }
 
     [Fact]
+    public void Set_TheSaveSucceedsButTheReREADFails_TheOFFStillTakesEffect()
+    {
+        // THE SECURITY REVIEW'S FINDING, and the worst one in this class. Set used to commit the row and
+        // then call Refresh() to make it take effect. Refresh swallows a failed read and keeps whatever it
+        // already had - so a committed OFF could be thrown away by a database blip while the endpoint
+        // answered "recorded", and an administrator was told capture had stopped when it had not.
+        var store = NewStore();
+        store.Set("acct-a", TurnLogSwitchEntity.Any, enabled: true, actor: "soren", reason: "on first");
+        Assert.True(store.IsEnabled("acct-a", "director-1"));
+
+        // From here every re-read fails.
+        store.ReaderForTest = () => throw new InvalidOperationException("the database is unreachable");
+
+        store.Set("acct-a", TurnLogSwitchEntity.Any, enabled: false, actor: "soren", reason: "they withdrew");
+
+        Assert.False(store.IsEnabled("acct-a", "director-1"));
+    }
+
+    [Fact]
+    public void IsEnabled_TheDecisionsCannotBeReREADForTooLong_CaptureSTOPS()
+    {
+        // A cache trusted forever is a way for a withdrawal never to arrive: every instance would go on
+        // capturing from the last answer it held for as long as the outage lasted. Losing records during an
+        // outage is a gap in a corpus; capturing somebody who withdrew is a broken promise.
+        var now = new DateTime(2026, 9, 5, 12, 0, 0, DateTimeKind.Utc);
+        using var store = new TurnLogSwitchStore(Db, () => now);
+        store.Set("acct-a", TurnLogSwitchEntity.Any, enabled: true, actor: "soren", reason: "on");
+        store.Start();
+        Assert.True(store.IsEnabled("acct-a", "director-1"));
+
+        // The clock moves past the window with no successful read in between.
+        now = now.Add(TurnLogSwitchStore.MaxTrustedStaleness).AddSeconds(1);
+        store.ReaderForTest = () => throw new InvalidOperationException("still unreachable");
+        store.Refresh();
+
+        Assert.False(store.IsEnabled("acct-a", "director-1"));
+    }
+
+    [Theory]
+    [InlineData("DIRECTOR-2")]
+    [InlineData("director-2")]
+    [InlineData("Director-2")]
+    public void IsEnabled_AnOffRowWrittenInANYCase_StillProtectsThatMachine(string offSpelling)
+    {
+        // The pushed roster keys Directors case-insensitively, so an ordinal comparison here let a
+        // deliberate OFF sit in the table looking recorded while a wider ON went on capturing the machine
+        // it was meant to protect. For a privacy switch the comparison has to be the looser one.
+        var store = NewStore();
+        store.Set("acct-a", TurnLogSwitchEntity.Any, enabled: true, actor: "soren", reason: "the account");
+        store.Set("acct-a", offSpelling, enabled: false, actor: "soren", reason: "not this machine");
+
+        Assert.False(store.IsEnabled("acct-a", "director-2"));
+        Assert.False(store.IsEnabled("acct-a", "DIRECTOR-2"));
+        Assert.True(store.IsEnabled("acct-a", "director-9"));
+    }
+
+    [Fact]
+    public void Clean_StripsControlCharactersSoAnIdentifierCannotForgeALogLine()
+    {
+        // A session or machine identifier is caller-supplied text that reaches a line-oriented log, so an
+        // embedded newline lets a caller forge an entry that reads exactly like one of ours.
+        var forged = "sid-1" + (char)10 + "2026-09-05 00:00:00 [TurnLogSwitchStore] capture ON for everything";
+
+        var cleaned = TurnLogSwitchStore.Clean(forged);
+
+        Assert.DoesNotContain(((char)10).ToString(), cleaned);
+        Assert.DoesNotContain(((char)13).ToString(), cleaned);
+        Assert.True(cleaned.Length <= 80);
+    }
+
+    [Fact]
     public void IsEnabled_NobodyHasDecidedAnything_IsOff()
     {
         var store = NewStore();

--- a/src/CcDirector.Gateway/TurnLog/GatewayTurnLogEnvironment.cs
+++ b/src/CcDirector.Gateway/TurnLog/GatewayTurnLogEnvironment.cs
@@ -99,7 +99,7 @@ internal sealed class GatewayTurnLogEnvironment : ITurnLogEnvironment
     {
         var path = _writer.Append(record);
         if (path is not null)
-            FileLog.Write($"[TurnLogRecorder] recorded a turn end sid={record.Glance.SessionId} gather={record.Moment.GatherMs}ms gaps={record.Gaps.Count}");
+            FileLog.Write($"[TurnLogRecorder] recorded a turn end sid={TurnLogSwitchStore.Clean(record.Glance.SessionId)} gather={record.Moment.GatherMs}ms gaps={record.Gaps.Count}");
         return path;
     }
 }

--- a/src/CcDirector.Gateway/TurnLog/TurnLogRecorder.cs
+++ b/src/CcDirector.Gateway/TurnLog/TurnLogRecorder.cs
@@ -116,12 +116,12 @@ public sealed class TurnLogRecorder : IDisposable
             }
             catch (OperationCanceledException)
             {
-                FileLog.Write($"[TurnLogRecorder] capture timed out sid={signal.SessionId} - no record written");
+                FileLog.Write($"[TurnLogRecorder] capture timed out sid={TurnLogSwitchStore.Clean(signal.SessionId)} - no record written");
             }
             catch (Exception ex)
             {
                 // Loud, and it goes no further. The turn is long over.
-                FileLog.Write($"[TurnLogRecorder] capture FAILED sid={signal.SessionId}: {ex.Message}");
+                FileLog.Write($"[TurnLogRecorder] capture FAILED sid={TurnLogSwitchStore.Clean(signal.SessionId)}: {ex.Message}");
             }
         });
     }
@@ -291,7 +291,7 @@ public sealed class TurnLogRecorder : IDisposable
 
         var path = _env.Write(record);
         if (path is null)
-            FileLog.Write($"[TurnLogRecorder] record NOT written sid={signal.SessionId} - the writer refused it");
+            FileLog.Write($"[TurnLogRecorder] record NOT written sid={TurnLogSwitchStore.Clean(signal.SessionId)} - the writer refused it");
         return path;
     }
 

--- a/src/CcDirector.Gateway/TurnLog/TurnLogSwitchStore.cs
+++ b/src/CcDirector.Gateway/TurnLog/TurnLogSwitchStore.cs
@@ -41,6 +41,20 @@ public sealed class TurnLogSwitchStore : IDisposable
     /// </summary>
     public static readonly TimeSpan RefreshEvery = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// How stale the decisions may get before capture STOPS.
+    ///
+    /// The cache exists so the turn-end path never waits on a database, and that is worth keeping. But a
+    /// cache that is trusted forever is a way for a withdrawal never to take effect: if the database is
+    /// unreachable, every instance would go on capturing from the last answer it happened to hold, for as
+    /// long as the outage lasted, while an administrator who switched capture off had been told it stopped.
+    ///
+    /// So the answer expires. Past this, IsEnabled says NO for everything until a read succeeds again. That
+    /// direction is deliberate and it is not symmetric: losing some records during a database outage is a
+    /// gap in a corpus, and capturing somebody who withdrew is a broken promise.
+    /// </summary>
+    public static readonly TimeSpan MaxTrustedStaleness = TimeSpan.FromMinutes(5);
+
     private readonly GatewayDatabase _db;
     private readonly Func<DateTime> _nowUtc;
     private readonly object _gate = new();
@@ -53,6 +67,17 @@ public sealed class TurnLogSwitchStore : IDisposable
     /// records, and the cost of being wrong the other way is recording somebody who was switched off.
     /// </summary>
     private volatile IReadOnlyList<TurnLogSwitchEntity> _cached = Array.Empty<TurnLogSwitchEntity>();
+
+    /// <summary>When the decisions were last read successfully. MinValue means never - which reads as off.</summary>
+    private DateTime _lastGoodReadUtc = DateTime.MinValue;
+
+    /// <summary>
+    /// Test seam: where <see cref="Refresh"/> gets its rows. Exists so a test can make the re-read FAIL
+    /// while the write succeeds, which is the exact shape of the defect this class had - a committed OFF
+    /// that a failed refresh quietly discarded, leaving capture on and the caller told it had stopped.
+    /// Production never sets it.
+    /// </summary>
+    internal Func<IReadOnlyList<TurnLogSwitchEntity>>? ReaderForTest { get; set; }
 
     public TurnLogSwitchStore(GatewayDatabase db, Func<DateTime>? nowUtc = null)
     {
@@ -88,6 +113,12 @@ public sealed class TurnLogSwitchStore : IDisposable
     {
         if (string.IsNullOrWhiteSpace(account) || string.IsNullOrWhiteSpace(machine)) return false;
 
+        // AN ANSWER WE CANNOT REFRESH IS NOT AN ANSWER. See MaxTrustedStaleness: past the window this
+        // stops capturing rather than trusting whatever it last held.
+        DateTime lastGood;
+        lock (_gate) lastGood = _lastGoodReadUtc;
+        if (lastGood == DateTime.MinValue || _nowUtc() - lastGood > MaxTrustedStaleness) return false;
+
         var rows = _cached;
         if (rows.Count == 0) return false;
 
@@ -95,9 +126,15 @@ public sealed class TurnLogSwitchStore : IDisposable
         var on = false;
         foreach (var row in rows)
         {
-            var accountMatches = string.Equals(row.Account, account, StringComparison.Ordinal)
+            // CASE-INSENSITIVE, to match how a Director id is keyed where it actually lives: the pushed
+            // roster stores Directors in a case-insensitive map (PushedSessionStore). Comparing ordinally
+            // here meant a switch row whose identifier differed only in case matched nothing - so a
+            // deliberate OFF for one machine could sit in the table looking recorded while a wider ON went
+            // on capturing it. For a privacy switch the comparison has to be the LOOSER one, so that an OFF
+            // catches every spelling of the thing it is trying to protect.
+            var accountMatches = string.Equals(row.Account, account, StringComparison.OrdinalIgnoreCase)
                                  || string.Equals(row.Account, any, StringComparison.Ordinal);
-            var machineMatches = string.Equals(row.Machine, machine, StringComparison.Ordinal)
+            var machineMatches = string.Equals(row.Machine, machine, StringComparison.OrdinalIgnoreCase)
                                  || string.Equals(row.Machine, any, StringComparison.Ordinal);
             if (!accountMatches || !machineMatches) continue;
 
@@ -160,12 +197,35 @@ public sealed class TurnLogSwitchStore : IDisposable
                 existing.RecordedUtc = _nowUtc();
             }
             ctx.SaveChanges();
+
+            // APPLY IT TO THE CACHE HERE, FROM THE VALUE WE JUST COMMITTED - not by re-reading. Set used to
+            // call Refresh() and rely on that; Refresh swallows a failed read and keeps whatever it already
+            // had, so a committed OFF could be discarded by a database blip while the endpoint answered
+            // "recorded". An administrator would have been told capture had stopped when it had not. The
+            // decision is authoritative the moment it commits, and the serving answer now moves with it
+            // inside the same lock.
+            var updated = _cached.Where(r =>
+                    !(string.Equals(r.Account, account, StringComparison.OrdinalIgnoreCase)
+                      && string.Equals(r.Machine, machine, StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+            updated.Add(new TurnLogSwitchEntity
+            {
+                Account = account,
+                Machine = machine,
+                Enabled = enabled,
+                Actor = actor,
+                Reason = reason,
+                RecordedUtc = _nowUtc(),
+            });
+            _cached = updated;
+            _lastGoodReadUtc = _nowUtc();
         }
 
-        // Take effect NOW rather than at the next tick. Someone who switches capture off is entitled to
-        // have it stop, not to wait out a refresh interval they cannot see.
+        // Still re-read, so this instance also picks up anything another instance changed. It is now an
+        // optimisation rather than the thing the decision depends on, and its failure cannot lose the
+        // decision above.
         Refresh();
-        FileLog.Write($"[TurnLogSwitchStore] capture {(enabled ? "ON" : "OFF")} for machine={machine} (scope recorded)");
+        FileLog.Write($"[TurnLogSwitchStore] capture {(enabled ? "ON" : "OFF")} for machine={Clean(machine)} (scope recorded)");
     }
 
     /// <summary>
@@ -180,14 +240,35 @@ public sealed class TurnLogSwitchStore : IDisposable
         {
             lock (_gate)
             {
-                using var ctx = _db.CreateUnscopedContext();
-                _cached = ctx.TurnLogSwitches.AsNoTracking().ToList();
+                if (ReaderForTest is { } read)
+                {
+                    _cached = read();
+                }
+                else
+                {
+                    using var ctx = _db.CreateUnscopedContext();
+                    _cached = ctx.TurnLogSwitches.AsNoTracking().ToList();
+                }
+                _lastGoodReadUtc = _nowUtc();
             }
         }
         catch (Exception ex)
         {
             FileLog.Write($"[TurnLogSwitchStore] Refresh FAILED - the previous decisions still stand: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// An identifier as it is safe to put in a log line. Caller-supplied text reaches the log, and the log
+    /// is line-oriented, so an embedded newline lets a caller forge an entry that looks like ours. Control
+    /// characters are stripped and the value is capped rather than escaped, because a log line is for
+    /// reading and an identifier that needs escaping is already wrong.
+    /// </summary>
+    internal static string Clean(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return "(none)";
+        var safe = new string(value.Where(ch => !char.IsControl(ch)).ToArray());
+        return safe.Length <= 80 ? safe : safe[..80];
     }
 
     public void Dispose()

--- a/src/CcDirector.Gateway/TurnLog/TurnLogWriter.cs
+++ b/src/CcDirector.Gateway/TurnLog/TurnLogWriter.cs
@@ -119,7 +119,8 @@ public sealed class TurnLogWriter
     /// accounts' records into one bundle, so two different accounts' terminals would land in one file - a
     /// failure of the isolation this feature has to keep rather than a tidiness problem. A short hash of the
     /// ORIGINAL value, ordinal and case-sensitive, makes the mapping one-to-one again while the readable
-    /// stem keeps a human able to find the directory they want.
+    /// stem keeps a human able to find the directory they want. The digest is 128 bits: at 32 it was only
+    /// unlikely to collide by accident, which is not the same claim.
     /// </summary>
     internal static string Sanitize(string value)
     {
@@ -132,8 +133,13 @@ public sealed class TurnLogWriter
         if (cleaned.Length > 48) cleaned = cleaned[..48];
         if (cleaned.Length == 0) cleaned = "unnamed";
 
+        // SIXTEEN BYTES, not four. The comment above used to claim the mapping was one-to-one; with a
+        // 32-bit tag it was not, it was merely unlikely to collide by accident - and these segments carry
+        // ACCOUNT identifiers, so a collision co-mingles two accounts' terminals in one bundle. A value
+        // somebody chose to collide is a different problem from a value that happens to, and 32 bits is
+        // within reach of the first. 128 bits is not.
         var digest = Convert.ToHexString(
-            SHA256.HashData(Encoding.UTF8.GetBytes(value)), 0, 4).ToLowerInvariant();
+            SHA256.HashData(Encoding.UTF8.GetBytes(value)), 0, 16).ToLowerInvariant();
         return cleaned + "-" + digest;
     }
 }


### PR DESCRIPTION
From an adversarial security review of the administrator surface. Eleven issues came back; these are the four that were **defects in this code**, and two of them fail in the direction that matters - capture continuing after somebody switched it off.

**A committed OFF could be thrown away by a database blip.** `Set` committed the row then called `Refresh` to make it take effect; `Refresh` swallows a failed read and keeps what it held. So an OFF could commit, the re-read fail, the cache go on saying ON, and the endpoint answer `recorded`. The administrator is told capture stopped when it has not. The committed decision is now applied to the serving cache inside the same lock, and the re-read is an optimisation rather than the thing the decision depends on.

**A cache trusted forever is a withdrawal that never arrives.** With the database unreachable every instance would keep capturing from its last answer for the length of the outage. The answer now expires after five minutes and capture stops until a read succeeds. Asymmetric on purpose: lost records are a gap in a corpus; capturing someone who withdrew is a broken promise.

**An OFF in the wrong case protected nothing.** Matching was ordinal while the pushed roster keys Directors case-insensitively, so a deliberate OFF could sit in the table looking recorded while a wider ON kept capturing that machine.

**Two overstated claims fixed:** the writer's path digest was 32 bits under a comment claiming a one-to-one mapping - on segments carrying *account* identifiers, where a collision co-mingles two accounts' terminals; now 128 bits with an honest comment. And caller-supplied identifiers reached a line-oriented log unescaped, so a newline could forge an entry.

Four mutations applied, run, watched go red, reverted. Gate: 4,902 tests, every suite Completed.