### PR TITLE
fix(gateway): bound the capture, validate the scope, and shrink what the lookup gives away

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/Api/AdminTurnLogEndpointScopeTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/Api/AdminTurnLogEndpointScopeTests.cs
@@ -1,0 +1,149 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Data;
+using CcDirector.Gateway.Data.Entities;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Tenancy;
+using CcDirector.Gateway.Tests.Data;
+using CcDirector.Gateway.TurnLog;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Api;
+
+/// <summary>
+/// What the capture switch will and will not accept as a scope.
+///
+/// THE ASYMMETRY IS THE POINT, and both halves are here. Switching capture ON must name something real,
+/// because a mistyped scope used to sit in the table looking like a recorded decision while naming nothing
+/// - and under a wider ON, somebody who believed they had switched a machine off would have been captured
+/// anyway. Switching capture OFF is never blocked, whatever it names, because refusing a withdrawal is the
+/// same failure arriving from the other side.
+/// </summary>
+public sealed class AdminTurnLogEndpointScopeTests : IDisposable
+{
+    private const string Token = "test-admin-service-token-77c2";
+
+    private readonly GatewayDbTestHarness _h = new();
+    private GatewayDatabase? _db;
+    private GatewayDatabase Db => _db ??= _h.Open();
+    private readonly string? _prior = Environment.GetEnvironmentVariable(AdminTrialEndpoint.ServiceTokenEnvVar);
+    private readonly List<TurnLogSwitchStore> _stores = new();
+
+    public AdminTurnLogEndpointScopeTests()
+        => Environment.SetEnvironmentVariable(AdminTrialEndpoint.ServiceTokenEnvVar, Token);
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(AdminTrialEndpoint.ServiceTokenEnvVar, _prior);
+        foreach (var s in _stores) s.Dispose();
+        _h.Dispose();
+    }
+
+    private TurnLogSwitchStore NewStore()
+    {
+        var store = new TurnLogSwitchStore(Db);
+        store.Start();
+        _stores.Add(store);
+        return store;
+    }
+
+    private static HttpContext Authorized()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers.Authorization = $"Bearer {Token}";
+        return ctx;
+    }
+
+    private static int StatusOf(IResult result)
+        => result.GetType().GetProperty("StatusCode")?.GetValue(result) as int? ?? StatusCodes.Status200OK;
+
+    private static void Register(DirectorRegistry registry, TenantId tenant, string directorId, string machine)
+        => registry.RegisterFromStream(directorId, machine, "someone", "test", 1, DateTime.UtcNow, tenant);
+
+    private AdminTurnLogEndpoint.SetRequest Req(string account, string machine, bool enabled)
+        => new(account, machine, enabled, "soren@example.com", "a reason that is written down");
+
+    [Fact]
+    public void SwitchingON_AMachineTheGatewayDoesNotKnow_IsRefused()
+    {
+        var tenants = new TenantRegistry(Db);
+        var tenant = tenants.MintOrLookupBySubject("subject-a", "a@example.com");
+        var directors = new DirectorRegistry();
+
+        var result = AdminTurnLogEndpoint.Handle(
+            Authorized(), Req(tenant.Value, "a-typo-nobody-has", enabled: true), NewStore(), tenants, directors);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, StatusOf(result));
+    }
+
+    [Fact]
+    public void SwitchingON_AnAccountTheGatewayDoesNotKnow_IsRefused()
+    {
+        var tenants = new TenantRegistry(Db);
+        var result = AdminTurnLogEndpoint.Handle(
+            Authorized(), Req("no-such-account", TurnLogSwitchEntity.Any, enabled: true),
+            NewStore(), tenants, new DirectorRegistry());
+
+        Assert.Equal(StatusCodes.Status400BadRequest, StatusOf(result));
+    }
+
+    [Fact]
+    public void SwitchingON_AMachineBelongingToADIFFERENTAccount_IsRefused()
+    {
+        var tenants = new TenantRegistry(Db);
+        var mine = tenants.MintOrLookupBySubject("subject-a", "a@example.com");
+        var theirs = tenants.MintOrLookupBySubject("subject-b", "b@example.com");
+        var directors = new DirectorRegistry();
+        Register(directors, theirs, "director-theirs", "THEIR-PC");
+
+        var result = AdminTurnLogEndpoint.Handle(
+            Authorized(), Req(mine.Value, "director-theirs", enabled: true), NewStore(), tenants, directors);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, StatusOf(result));
+    }
+
+    [Fact]
+    public void SwitchingON_ARealAccountAndItsOwnMachine_IsAccepted()
+    {
+        var tenants = new TenantRegistry(Db);
+        var tenant = tenants.MintOrLookupBySubject("subject-a", "a@example.com");
+        var directors = new DirectorRegistry();
+        Register(directors, tenant, "director-1", "THE-PC");
+        var store = NewStore();
+
+        var result = AdminTurnLogEndpoint.Handle(
+            Authorized(), Req(tenant.Value, "director-1", enabled: true), store, tenants, directors);
+
+        Assert.Equal(StatusCodes.Status200OK, StatusOf(result));
+        Assert.True(store.IsEnabled(tenant.Value, "director-1"));
+    }
+
+    [Fact]
+    public void SwitchingOFF_AMachineTheGatewayDoesNotKnow_IsACCEPTED()
+    {
+        // THE OTHER HALF OF THE ASYMMETRY. A withdrawal must never be refused - not for a machine that is
+        // away, not for one whose identifier no longer resolves. Blocking an OFF is the same harm this
+        // validation exists to prevent, arriving from the other side.
+        var tenants = new TenantRegistry(Db);
+        var store = NewStore();
+
+        var result = AdminTurnLogEndpoint.Handle(
+            Authorized(), Req("some-account-long-gone", "some-machine-long-gone", enabled: false),
+            store, tenants, new DirectorRegistry());
+
+        Assert.Equal(StatusCodes.Status200OK, StatusOf(result));
+    }
+
+    [Fact]
+    public void TheGateStillRunsBeforeAnyOfThis()
+    {
+        // Validation must not have become a way to reach the store without the token.
+        var ctx = new DefaultHttpContext();   // no Authorization header
+        var result = AdminTurnLogEndpoint.Handle(
+            ctx, Req("*", "*", enabled: true), NewStore(), new TenantRegistry(Db), new DirectorRegistry());
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, StatusOf(result));
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogRecorderTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogRecorderTests.cs
@@ -440,6 +440,75 @@ public sealed class TurnLogRecorderTests
         Assert.Null(record.Glance.Computer);
     }
 
+    [Fact]
+    public void EnforceRecordCeiling_AnEnormousScrollback_IsTrimmedAndTheScreenIsUntouched()
+    {
+        // Terminal content is UNTRUSTED input - it is whatever a program somebody ran decided to print - so
+        // a record's size must not be settable by that program. The scrollback is the shock absorber; the
+        // live screen is what every judgement reads and is never trimmed.
+        var record = new TurnLogRecord
+        {
+            CapturedAtUtc = new DateTime(2026, 9, 5, 12, 0, 0, DateTimeKind.Utc),
+            Glance = new TurnLogGlance { SessionId = "sid-1", Account = "acct-a", Computer = "PC" },
+            Terminal = new TurnLogTerminal
+            {
+                HasGrid = true,
+                Rows = { "the screen line a judgement reads" },
+                RowCount = 1,
+                Scrollback = Enumerable.Range(0, 4000).Select(i => new string('x', 600)).ToList(),
+                ScrollbackLineCount = 4000,
+            },
+        };
+
+        var trimmed = TurnLogRecorder.EnforceRecordCeiling(record);
+
+        Assert.True(trimmed.Terminal.Scrollback.Count < 4000);
+        Assert.Equal(trimmed.Terminal.Scrollback.Count, trimmed.Terminal.ScrollbackLineCount);
+        Assert.Equal("the screen line a judgement reads", Assert.Single(trimmed.Terminal.Rows));
+        Assert.Contains(trimmed.Gaps, g => g.Part == "scrollback" && g.Reason.Contains("dropped to keep the record under"));
+    }
+
+    [Fact]
+    public void EnforceRecordCeiling_AnOrdinaryRecord_IsReturnedUntouchedAndUnmarked()
+    {
+        var record = new TurnLogRecord
+        {
+            CapturedAtUtc = new DateTime(2026, 9, 5, 12, 0, 0, DateTimeKind.Utc),
+            Glance = new TurnLogGlance { SessionId = "sid-1", Account = "acct-a", Computer = "PC" },
+            Terminal = new TurnLogTerminal { HasGrid = true, Rows = { "small" }, RowCount = 1 },
+        };
+
+        var result = TurnLogRecorder.EnforceRecordCeiling(record);
+
+        Assert.Empty(result.Gaps);
+        Assert.Same(record, result);
+    }
+
+    [Fact]
+    public void OnTurnEnd_MoreTurnsThanCapturesAllowedAtOnce_DropsRatherThanQueueing()
+    {
+        // Every turn end used to start an unbounded task, each holding a screen, thousands of scrollback
+        // lines and a conversation in memory. Dropping loses a turn and says so; queueing would hold them
+        // all and trade a memory problem for a latency one.
+        using var gate = new ManualResetEventSlim(false);
+        var env = new FakeEnvironment { BlockScreenReadOn = gate };
+        using var recorder = new TurnLogRecorder(env);
+
+        // A FIXED number, deliberately NOT derived from MaxConcurrentCaptures. Scaling the input to the
+        // constant under test makes the test vacuous: raise the bound and the input rises with it, so the
+        // bound still bites and the test still passes while proving nothing. Caught by mutation - the first
+        // version of this test went green with the bound raised to a hundred thousand.
+        const int turnsFiredAtOnce = 64;
+        for (var i = 0; i < turnsFiredAtOnce; i++)
+            recorder.OnTurnEnd(Signal());
+
+        // Let the blocked captures finish before the test tears the fake down.
+        var dropped = recorder.DroppedForConcurrency;
+        gate.Set();
+
+        Assert.True(dropped > 0, $"expected some captures to be dropped, but {dropped} were");
+    }
+
     private static HistoryMessageDto Message(string role, string text) => new()
     {
         Role = role,
@@ -457,6 +526,7 @@ public sealed class TurnLogRecorderTests
             = new(true, "transcript-1", Array.Empty<HistoryMessageDto>());
         public Exception? ScreenThrows { get; set; }
         public Exception? SupervisorEnabledThrows { get; set; }
+        public ManualResetEventSlim? BlockScreenReadOn { get; set; }
         public string? MachineNameFromRegistration { get; set; } = "SOREN-NORTH";
         public int MachineNameLookups { get; private set; }
 
@@ -471,6 +541,7 @@ public sealed class TurnLogRecorderTests
 
         public Task<ScreenGridResponse?> ReadScreenAsync(TenantId tenant, string directorId, string sessionId, CancellationToken ct)
         {
+            BlockScreenReadOn?.Wait(TimeSpan.FromSeconds(10));
             ScreenReads++;
             if (ScreenThrows is not null) throw ScreenThrows;
             return Task.FromResult(Grid);

--- a/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogRetentionTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/TurnLog/TurnLogRetentionTests.cs
@@ -1,0 +1,91 @@
+using CcDirector.Gateway.TurnLog;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.TurnLog;
+
+/// <summary>
+/// Retention on the captured records.
+///
+/// THE TEST THAT MATTERS MOST is that a directory it does not understand is LEFT ALONE. The failure mode
+/// of a retention sweep must be "kept too long", never "deleted something we needed" - and a sweep that
+/// guesses what a directory is, or that treats an unparseable name as expired, is how a tidy-up becomes an
+/// incident.
+/// </summary>
+public sealed class TurnLogRetentionTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), "turnlog-retention-tests", Guid.NewGuid().ToString("N"));
+
+    private static readonly DateTime Now = new(2026, 9, 20, 12, 0, 0, DateTimeKind.Utc);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch (IOException) { }
+    }
+
+    private string Day(string name)
+    {
+        var path = Path.Combine(_root, name);
+        Directory.CreateDirectory(Path.Combine(path, "account", "machine"));
+        File.WriteAllText(Path.Combine(path, "account", "machine", "bundle.jsonl.gz"), "x");
+        return path;
+    }
+
+    private TurnLogRetention NewSweep() => new(_root, () => Now);
+
+    [Fact]
+    public void ADayOlderThanTheWindow_IsRemoved()
+    {
+        var old = Day("2026-09-01");   // 19 days before Now
+
+        var removed = NewSweep().Sweep();
+
+        Assert.Equal(1, removed);
+        Assert.False(Directory.Exists(old));
+    }
+
+    [Fact]
+    public void ADayInsideTheWindow_IsKept()
+    {
+        var recent = Day("2026-09-15");   // 5 days before Now
+
+        NewSweep().Sweep();
+
+        Assert.True(Directory.Exists(recent));
+    }
+
+    [Fact]
+    public void ADirectoryWhoseNameIsNotADate_IsLeftALONE()
+    {
+        // The one that matters. An unparseable name is something this sweep does not understand, and it
+        // must not be treated as expired just because it cannot be dated.
+        var strange = Path.Combine(_root, "labelled-keep-forever");
+        Directory.CreateDirectory(strange);
+        File.WriteAllText(Path.Combine(strange, "note.txt"), "x");
+
+        var removed = NewSweep().Sweep();
+
+        Assert.Equal(0, removed);
+        Assert.True(Directory.Exists(strange));
+    }
+
+    [Fact]
+    public void TheBoundaryDayIsKeptRatherThanCut()
+    {
+        // Exactly at the window. Keeping it is the safe side of an off-by-one on a delete.
+        var boundary = Day(Now.Date.AddDays(-TurnLogRetention.KeepFor.TotalDays).ToString("yyyy-MM-dd"));
+
+        NewSweep().Sweep();
+
+        Assert.True(Directory.Exists(boundary));
+    }
+
+    [Fact]
+    public void NoTurnLogDirectoryAtAll_IsNotAnError()
+    {
+        // A Gateway that has never had capture switched on has no directory, and a sweep must not care.
+        var sweep = new TurnLogRetention(Path.Combine(_root, "never-created"), () => Now);
+        Assert.Equal(0, sweep.Sweep());
+    }
+}

--- a/src/CcDirector.Gateway/Api/AdminAccountLookupEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AdminAccountLookupEndpoint.cs
@@ -115,10 +115,11 @@ internal static class AdminAccountLookupEndpoint
             // for an account nobody named.
             if (match.Count > 1)
             {
+                // The COUNT is deliberately not returned. It answered a question nobody needs and told a
+                // caller how many accounts share an address.
                 return Results.Json(new
                 {
                     error = "more than one account is recorded against that email; name the account by ?subject= instead",
-                    count = match.Count,
                 }, statusCode: StatusCodes.Status409Conflict);
             }
             if (match.Count == 1) tenant = new TenantId(match[0].TenantId);
@@ -145,20 +146,27 @@ internal static class AdminAccountLookupEndpoint
         // an account lookup should quietly do on the way past.
         var computers = directors.ListDirectors(found)
             .OrderBy(d => d.MachineName ?? "", StringComparer.OrdinalIgnoreCase)
+            // MINIMISED. The operating-system username was here and is gone: nothing an administrator does
+            // with this needs it, and a lookup that hands back more than the job requires turns a shared
+            // credential into a better reconnaissance tool than it has to be. What is left is what the
+            // capture switch actually takes plus the name a human recognises.
             .Select(d => new
             {
                 director_id = d.DirectorId,
                 machine_name = d.MachineName,
-                user = d.User,
                 last_seen_utc = d.LastSeen,
             })
             .ToList();
+
+        // EVERY LOOKUP IS LOGGED. This route exists to name other people's accounts, so the fact that it
+        // was used is itself worth recording - a shared credential with no trail behind it cannot answer
+        // "who went looking, and when". The tenant is written in its log-safe form, never raw.
+        FileLog.Write($"[AdminAccountLookupEndpoint] account lookup by {(hasSubject ? "subject" : "email")} -> {found.ToLogString()}");
 
         return Results.Json(new
         {
             found = true,
             account = found.Value,
-            email = tenants.EmailForTenant(found),
             computers,
             // Said out loud because an empty list has two meanings and only one of them is a problem: an
             // account that has never connected a computer, and an account whose computers are all currently

--- a/src/CcDirector.Gateway/Api/AdminTrialEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AdminTrialEndpoint.cs
@@ -127,6 +127,11 @@ internal static class AdminTrialEndpoint
     // The wire vocabulary, in one place. These strings are a CONTRACT with the website's admin screen, which
     // says a different sentence for each - so they are named constants rather than literals scattered through
     // the switch below, and renaming one is a change to an interface rather than a tidy-up.
+    /// <summary>The ONE body every unavailable administrator-auth state answers with. Deliberately says
+    /// nothing about which state it is: an unauthenticated caller learning whether a token is configured,
+    /// or whether two tokens collide, is a configuration oracle. The detail lives in the log.</summary>
+    private static readonly object Unavailable = new { error = "the administrator surface is unavailable" };
+
     internal const string OutcomeExtended = "extended";
     internal const string OutcomeNoTrial = "no_trial";
     internal const string OutcomeNotLater = "not_later";
@@ -212,10 +217,12 @@ internal static class AdminTrialEndpoint
         {
             // Fail loud and CLOSED. An unconfigured token is a deployment error, not a reason to serve to
             // anyone who asks, and not a reason to invent an allow-anything mode either.
-            FileLog.Write($"[AdminTrialEndpoint] DENIED: {ServiceTokenEnvVar} is not set on this Gateway - the trial-extension endpoint refuses to serve unguarded");
-            return Results.Json(
-                new { error = $"the admin service token ({ServiceTokenEnvVar}) is not configured on this Gateway" },
-                statusCode: StatusCodes.Status503ServiceUnavailable);
+            FileLog.Write($"[AdminTrialEndpoint] DENIED: {ServiceTokenEnvVar} is not set on this Gateway - the administrator surface refuses to serve unguarded");
+            // ONE EXTERNAL ANSWER FOR EVERY UNAVAILABLE STATE. Saying WHICH misconfiguration it is told an
+            // unauthenticated caller - anybody on the internet - whether this Gateway has an admin token
+            // configured and whether it collides with the report token. That is a configuration oracle, and
+            // the person who needs the detail is reading the log, not the response.
+            return Results.Json(Unavailable, statusCode: StatusCodes.Status503ServiceUnavailable);
         }
 
         // TWO VARIABLE NAMES ARE NOT TWO SECRETS. The separation from the read-only report token is the
@@ -228,14 +235,8 @@ internal static class AdminTrialEndpoint
         var report = Environment.GetEnvironmentVariable(MorningReportEndpoint.ServiceTokenEnvVar);
         if (!string.IsNullOrWhiteSpace(report) && SameSecret(configured, report))
         {
-            FileLog.Write($"[AdminTrialEndpoint] DENIED: {ServiceTokenEnvVar} and {MorningReportEndpoint.ServiceTokenEnvVar} hold the SAME value - the read-only report credential would gain trial-extension authority. Refusing to serve until they differ.");
-            return Results.Json(
-                new
-                {
-                    error = $"{ServiceTokenEnvVar} and {MorningReportEndpoint.ServiceTokenEnvVar} are set to the same value on this Gateway. "
-                          + "They must be different secrets: the report token is read-only and this one hands out paid product.",
-                },
-                statusCode: StatusCodes.Status503ServiceUnavailable);
+            FileLog.Write($"[AdminTrialEndpoint] DENIED: {ServiceTokenEnvVar} and {MorningReportEndpoint.ServiceTokenEnvVar} hold the SAME value - the read-only report credential would gain administrator authority. Refusing to serve until they differ.");
+            return Results.Json(Unavailable, statusCode: StatusCodes.Status503ServiceUnavailable);
         }
 
         if (!PresentedTokenMatches(ctx, configured))

--- a/src/CcDirector.Gateway/Api/AdminTurnLogEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AdminTurnLogEndpoint.cs
@@ -1,6 +1,9 @@
 using System.Text.Json.Serialization;
+using CcDirector.Core.Tenancy;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Data.Entities;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Tenancy;
 using CcDirector.Gateway.TurnLog;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -40,6 +43,47 @@ internal static class AdminTurnLogEndpoint
     /// <summary>The route. Exact-match public in <c>AuthMiddleware</c>; the endpoint carries its own gate.</summary>
     public const string Path = "/gateway/admin/turn-log";
 
+    /// <summary>
+    /// Why an ON decision cannot be recorded, or null when it can. Checks only what the registries can
+    /// answer for certain, and refuses only on a DEFINITE problem - an account nobody has, or a machine
+    /// that belongs to a different account. A machine the Gateway simply does not know right now is
+    /// refused too, because capture cannot reach a computer that is not connected and the far likelier
+    /// explanation for an unknown identifier is a typo; the account lookup exists to supply the real one.
+    /// </summary>
+    private static string? Refuse(
+        TenantRegistry tenants, DirectorRegistry directors, string? account, string? machine)
+    {
+        var any = TurnLogSwitchEntity.Any;
+        var namedAccount = !string.Equals(account, any, StringComparison.Ordinal);
+        var namedMachine = !string.Equals(machine, any, StringComparison.Ordinal);
+
+        TenantId? tenant = null;
+        if (namedAccount)
+        {
+            var known = tenants.ListAll()
+                .Any(t => string.Equals(t.TenantId, account, StringComparison.OrdinalIgnoreCase));
+            if (!known)
+                return $"no account on this Gateway has the identifier \"{account}\". Find it with GET /gateway/admin/accounts?email=...";
+            tenant = new TenantId(account!);
+        }
+
+        if (!namedMachine) return null;
+
+        var owners = tenants.ListAll()
+            .Select(t => new TenantId(t.TenantId))
+            .Where(t => directors.ListDirectors(t)
+                .Any(d => string.Equals(d.DirectorId, machine, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        if (owners.Count == 0)
+            return $"no computer currently connected to this Gateway has the identifier \"{machine}\". Find it with GET /gateway/admin/accounts?email=...";
+
+        if (tenant is { } named && !owners.Any(o => o.Equals(named)))
+            return $"the computer \"{machine}\" does not belong to the account \"{account}\"";
+
+        return null;
+    }
+
     /// <summary>What the caller sends. Every wire name is spelled out: the host binds property names
     /// case-insensitively, which is NOT punctuation-insensitively, so <c>recorded_at_utc</c> does not bind
     /// to <c>RecordedAtUtc</c> by that rule - it binds to nothing and arrives null.</summary>
@@ -53,9 +97,15 @@ internal static class AdminTurnLogEndpoint
     internal const string OutcomeRecorded = "recorded";
     internal const string OutcomeUnknown = "unknown";
 
-    public static void Map(IEndpointRouteBuilder app, TurnLogSwitchStore switches)
+    public static void Map(
+        IEndpointRouteBuilder app,
+        TurnLogSwitchStore switches,
+        TenantRegistry tenants,
+        DirectorRegistry directors)
     {
         ArgumentNullException.ThrowIfNull(switches);
+        ArgumentNullException.ThrowIfNull(tenants);
+        ArgumentNullException.ThrowIfNull(directors);
 
         app.MapGet(Path, (HttpContext ctx) =>
         {
@@ -102,7 +152,7 @@ internal static class AdminTurnLogEndpoint
                     return Results.BadRequest(new { error = "the request body is not readable JSON" });
                 }
 
-                return Handle(ctx, body, switches);
+                return Handle(ctx, body, switches, tenants, directors);
             }
             catch (Exception ex)
             {
@@ -117,7 +167,12 @@ internal static class AdminTurnLogEndpoint
     }
 
     /// <summary>Internal so every refusal can be tested directly, without standing a host up per case.</summary>
-    internal static IResult Handle(HttpContext ctx, SetRequest? body, TurnLogSwitchStore switches)
+    internal static IResult Handle(
+        HttpContext ctx,
+        SetRequest? body,
+        TurnLogSwitchStore switches,
+        TenantRegistry tenants,
+        DirectorRegistry directors)
     {
         if (AdminTrialEndpoint.ServiceTokenDenial(ctx) is { } denial) return denial;
 
@@ -136,6 +191,22 @@ internal static class AdminTurnLogEndpoint
             return Results.BadRequest(new { error = "an actor is required: a capture decision must record who made it" });
         if (string.IsNullOrWhiteSpace(body.Reason))
             return Results.BadRequest(new { error = "a reason is required: for an account that is not yours, this is where the permission is recorded" });
+
+        // A SCOPE THAT NAMES NOTHING REAL IS REFUSED - but ONLY when switching capture ON.
+        //
+        // The endpoint used to persist any non-blank strings. A mistyped account or machine then sat in the
+        // table looking like a recorded decision while naming nothing, which is dangerous in exactly one
+        // direction: somebody who believed they had switched a machine OFF, under a wider ON, would have
+        // been captured anyway. Validating shuts that door.
+        //
+        // OFF IS NEVER BLOCKED, whatever it names. A withdrawal must always be accepted - refusing one
+        // because the machine is currently away, or because the identifier no longer resolves, would be the
+        // same failure this validation exists to prevent, arriving from the other side.
+        if (enabled)
+        {
+            if (Refuse(tenants, directors, body.Account, body.Machine) is { } refusal)
+                return Results.BadRequest(new { error = refusal });
+        }
 
         switches.Set(body.Account, body.Machine, enabled, body.Actor, body.Reason);
         return Results.Json(new { outcome = OutcomeRecorded, enabled });

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -806,6 +806,7 @@ public sealed class GatewayHost : IAsyncDisposable
     // when off, nothing here runs and a turn ends identically.
     private TurnLog.TurnLogRecorder? _turnLogRecorder;
     private TurnLog.TurnLogSwitchStore? _turnLogSwitches;
+    private Timer? _turnLogRetentionTimer;
     private Wingman.WingmanVoiceService? _voiceService;
     // Voice mode is a standing intent, not a one-time action: a tenant that is in voice mode wants EVERY one
     // of its sessions narrating, including the ones that do not exist yet. This timer is how that intent
@@ -2683,6 +2684,17 @@ public sealed class GatewayHost : IAsyncDisposable
             enterTenantScope: tenant => _tenantBoundary.EnterScope(tenant));
         FileLog.Write("[GatewayHost] StartAsync: turn log armed (records nothing unless an administrator has switched a machine on)");
 
+        // Retention on the captured records. Without it the copy on the Gateway is permanent - every screen
+        // and both sides of every conversation, for every account capture was switched on for, on a shared
+        // file system behind a management endpoint. Anything worth keeping has already been pulled daily,
+        // so a bounded window costs nothing and turns an unbounded exposure into a bounded one.
+        var turnLogRetention = new TurnLog.TurnLogRetention(Core.Storage.CcStorage.TurnLog());
+        _turnLogRetentionTimer = new Timer(_ =>
+        {
+            try { turnLogRetention.Sweep(); }
+            catch (Exception ex) { FileLog.Write($"[GatewayHost] turn-log retention sweep FAILED: {ex.Message}"); }
+        }, null, TimeSpan.FromMinutes(5), TimeSpan.FromHours(6));
+
         _turnEndWatcher = new TurnEndWatcher(
             onTurnEnd: signal =>
             {
@@ -3696,7 +3708,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // route is never mapped against a null - a switch screen that answers 503 because the routes were
         // mapped in the wrong order would read as a broken feature rather than as an ordering mistake.
         _turnLogSwitches ??= new TurnLog.TurnLogSwitchStore(_gatewayDb);
-        AdminTurnLogEndpoint.Map(_app, _turnLogSwitches);
+        AdminTurnLogEndpoint.Map(_app, _turnLogSwitches, TenantRegistry, Registry);
         // The bridge between an administrator's world (emails) and the Gateway's (account ids, Directors).
         // Without it the turn-log switch above can only be addressed for the administrator's OWN fleet.
         AdminAccountLookupEndpoint.Map(_app, TenantRegistry, Registry);
@@ -4823,6 +4835,8 @@ public sealed class GatewayHost : IAsyncDisposable
         _turnLogRecorder = null;
         try { _turnLogSwitches?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] turn log switch dispose error: {ex.Message}"); }
         _turnLogSwitches = null;
+        try { _turnLogRetentionTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] turn log retention dispose error: {ex.Message}"); }
+        _turnLogRetentionTimer = null;
         try { _turnEndWatcher?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] watcher dispose error: {ex.Message}"); }
         // Issue #915: cancel any recovery wait in flight, so a Gateway shutdown does not leave a background
         // ladder holding a token and re-sending into a fleet this process no longer owns.

--- a/src/CcDirector.Gateway/TurnLog/TurnLogRecorder.cs
+++ b/src/CcDirector.Gateway/TurnLog/TurnLogRecorder.cs
@@ -65,11 +65,45 @@ public sealed class TurnLogRecorder : IDisposable
     /// </summary>
     public static readonly TimeSpan CaptureTimeout = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// How many captures may be in flight at once, across the whole fleet.
+    ///
+    /// Every turn end used to start an unbounded task. On a busy fleet - or a wildcard switch covering many
+    /// accounts - that is an unbounded number of concurrent tunnel reads, each holding a screen, two
+    /// thousand scrollback lines and a conversation in memory before it compresses them. The log is not
+    /// allowed to be the reason the Gateway struggles, and "it observes, it does not interfere" has to hold
+    /// under load as well as at rest.
+    ///
+    /// Past this, a capture is DROPPED rather than queued. Queueing would trade a memory problem for a
+    /// latency problem and still hold the records; dropping loses that turn and says so. A corpus that is
+    /// missing a turn it names is honest; a Gateway that fell over is not.
+    /// </summary>
+    public const int MaxConcurrentCaptures = 8;
+
+    /// <summary>
+    /// The ceiling on ONE finished record, in bytes of serialized JSON, whatever it is made of.
+    ///
+    /// The conversation already has its own ceiling. This is the backstop for everything else - a terminal
+    /// that emitted an enormous line, a session snapshot that grew, a scrollback of very long rows. Terminal
+    /// content is UNTRUSTED input: it is whatever a program somebody ran decided to print, and a record's
+    /// size should not be settable by that program.
+    ///
+    /// When a record is over, the SCROLLBACK is trimmed first and the trim is recorded. The live screen is
+    /// never trimmed - it is the thing every judgement reads and the reason the record exists at all.
+    /// </summary>
+    public const int MaxRecordBytes = 1024 * 1024;
+
     private readonly ITurnLogEnvironment _env;
     private readonly Func<TenantId, IDisposable>? _enterTenantScope;
     private readonly Func<DateTime> _nowUtc;
     private readonly CancellationTokenSource _stopping = new();
+    private readonly SemaphoreSlim _inFlight = new(MaxConcurrentCaptures, MaxConcurrentCaptures);
+    private long _dropped;
     private bool _disposed;
+
+    /// <summary>How many captures have been dropped because too many were already in flight. Exposed so
+    /// the number is visible rather than inferred from a corpus that is quietly short.</summary>
+    public long DroppedForConcurrency => Interlocked.Read(ref _dropped);
 
     /// <param name="enterTenantScope">Enters the owning account's storage scope for the duration of a
     /// capture. Required on the hosted Gateway and inert on a self-hosted one, which has a single partition.
@@ -102,6 +136,15 @@ public sealed class TurnLogRecorder : IDisposable
         // switch can be asked, and neither costs a round trip.
         if (!_env.IsEnabled(signal.Tenant.Value, signal.DirectorId)) return;
 
+        // BACKPRESSURE BEFORE THE TASK, not inside it. Taking the slot here means a saturated Gateway does
+        // not even allocate the work, and the drop is counted where it can be seen.
+        if (!_inFlight.Wait(0))
+        {
+            var n = Interlocked.Increment(ref _dropped);
+            FileLog.Write($"[TurnLogRecorder] capture DROPPED (already {MaxConcurrentCaptures} in flight; {n} dropped so far) sid={TurnLogSwitchStore.Clean(signal.SessionId)}");
+            return;
+        }
+
         _ = Task.Run(async () =>
         {
             try
@@ -122,6 +165,10 @@ public sealed class TurnLogRecorder : IDisposable
             {
                 // Loud, and it goes no further. The turn is long over.
                 FileLog.Write($"[TurnLogRecorder] capture FAILED sid={TurnLogSwitchStore.Clean(signal.SessionId)}: {ex.Message}");
+            }
+            finally
+            {
+                try { _inFlight.Release(); } catch (ObjectDisposedException) { /* stopping */ }
             }
         });
     }
@@ -289,11 +336,58 @@ public sealed class TurnLogRecorder : IDisposable
             Gaps = gaps,
         };
 
+        record = EnforceRecordCeiling(record);
+
         var path = _env.Write(record);
         if (path is null)
             FileLog.Write($"[TurnLogRecorder] record NOT written sid={TurnLogSwitchStore.Clean(signal.SessionId)} - the writer refused it");
         return path;
     }
+
+    /// <summary>
+    /// Keep one record under <see cref="MaxRecordBytes"/>, trimming the SCROLLBACK and nothing else.
+    ///
+    /// Terminal content is untrusted input - it is whatever a program somebody ran decided to print - so a
+    /// record's size must not be settable by that program. The scrollback is the shock absorber because it
+    /// is the largest part and the least precious: the live screen is what every judgement reads and is
+    /// never touched, and the conversation has already been cut to whole turns by its own ceiling.
+    ///
+    /// A trim is RECORDED. A record that is quietly shorter than it claims teaches the corpus that a
+    /// session printed less than it did.
+    /// </summary>
+    internal static TurnLogRecord EnforceRecordCeiling(TurnLogRecord record)
+    {
+        var size = Measure(record);
+        if (size <= MaxRecordBytes) return record;
+
+        var scrollback = record.Terminal.Scrollback;
+        var kept = scrollback.Count;
+        // Halve the scrollback until it fits, keeping the NEWEST lines - the ones nearest the screen.
+        while (kept > 0 && size > MaxRecordBytes)
+        {
+            kept /= 2;
+            var trimmedTerminal = record.Terminal with
+            {
+                Scrollback = scrollback.Skip(scrollback.Count - kept).ToList(),
+                ScrollbackLineCount = kept,
+            };
+            record = record with { Terminal = trimmedTerminal };
+            size = Measure(record);
+        }
+
+        var dropped = scrollback.Count - kept;
+        var gaps = record.Gaps.ToList();
+        gaps.Add(new TurnLogGap
+        {
+            Part = "scrollback",
+            Reason = $"{dropped} of {scrollback.Count} scrollback line(s) were dropped to keep the record under "
+                   + $"{MaxRecordBytes / 1024} KB - the lines nearest the screen were kept, and the screen itself was not touched",
+        });
+        return record with { Gaps = gaps };
+    }
+
+    private static int Measure(TurnLogRecord record)
+        => System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(record).Length;
 
     private static TurnLogTerminal BuildTerminal(ScreenGridResponse? grid, BufferResponse? scrollback)
     {

--- a/src/CcDirector.Gateway/TurnLog/TurnLogRetention.cs
+++ b/src/CcDirector.Gateway/TurnLog/TurnLogRetention.cs
@@ -1,0 +1,94 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.TurnLog;
+
+/// <summary>
+/// How long captured terminals stay on the Gateway.
+///
+/// WHY THIS EXISTS AT ALL. The corpus is written here and pulled down daily into the repository that keeps
+/// it. Without a sweep, the copy on the Gateway is simply permanent - every screen, every scrollback and
+/// both sides of every conversation, for every account capture was ever switched on for, sitting on a
+/// shared file system behind a management endpoint. A security review named exactly that: the interesting
+/// question about captured content is not only who can reach it, but how long it is there to be reached.
+/// A retention window turns an unbounded exposure into a bounded one, and it costs nothing, because
+/// anything worth keeping has already been pulled.
+///
+/// IT DELETES BY DAY, WHOLE DIRECTORIES AT A TIME, and only ones whose name is a date it can parse. A
+/// sweep that guesses what a directory is, or that deletes the newest thing it finds, is how a retention
+/// job becomes an outage. Anything it does not understand is left alone and named in the log rather than
+/// removed - the failure mode of this class must be "kept too long", never "deleted something we needed".
+///
+/// THE WINDOW IS DELIBERATELY LONGER THAN THE PULL CADENCE. The pull runs daily; two weeks means a pull
+/// can fail, and be noticed and fixed, without the records it was going to collect being deleted underneath
+/// it. Shortening this to the pull cadence would make one missed job a permanent hole.
+/// </summary>
+public sealed class TurnLogRetention
+{
+    /// <summary>How long a day's records stay on the Gateway. Fourteen days: long enough that a failed
+    /// daily pull can be noticed and fixed before anything is lost, short enough that the copy sitting on
+    /// the Gateway is a working buffer rather than an archive.</summary>
+    public static readonly TimeSpan KeepFor = TimeSpan.FromDays(14);
+
+    private readonly string _root;
+    private readonly Func<DateTime> _nowUtc;
+
+    public TurnLogRetention(string root, Func<DateTime>? nowUtc = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(root);
+        _root = root;
+        _nowUtc = nowUtc ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// Delete every day older than the window. Answers how many day-directories were removed.
+    ///
+    /// Never throws: a retention sweep that takes the Gateway down with it is worse than one that runs
+    /// late. Every refusal and every failure is logged, because a sweep that silently does nothing looks
+    /// exactly like a sweep that had nothing to do.
+    /// </summary>
+    public int Sweep()
+    {
+        if (!Directory.Exists(_root)) return 0;
+
+        var cutoff = DateOnly.FromDateTime(_nowUtc().Date.Add(-KeepFor));
+        var removed = 0;
+
+        foreach (var dayDir in SafeDirectories(_root))
+        {
+            var name = Path.GetFileName(dayDir);
+
+            // ONLY A DIRECTORY WHOSE NAME IS A DATE. Anything else is something this sweep does not
+            // understand, and it is left where it is.
+            if (!DateOnly.TryParseExact(name, "yyyy-MM-dd", out var day))
+            {
+                FileLog.Write($"[TurnLogRetention] leaving {name}: not a day directory, so this sweep will not judge it");
+                continue;
+            }
+
+            if (day >= cutoff) continue;
+
+            try
+            {
+                Directory.Delete(dayDir, recursive: true);
+                removed++;
+                FileLog.Write($"[TurnLogRetention] removed {name} (older than {KeepFor.TotalDays:F0} days)");
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[TurnLogRetention] could NOT remove {name}: {ex.Message} - it stays, and this is not fatal");
+            }
+        }
+
+        return removed;
+    }
+
+    private static IEnumerable<string> SafeDirectories(string root)
+    {
+        try { return Directory.GetDirectories(root); }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[TurnLogRetention] could not list {root}: {ex.Message}");
+            return Array.Empty<string>();
+        }
+    }
+}


### PR DESCRIPTION
Round two from the security review - the defects and cheap hardening, leaving the two findings that need a decision.

- **Capture is bounded.** Eight concurrent captures; the rest dropped and counted. Queueing would trade a memory problem for a latency one and still hold the records.
- **A record has a ceiling** whatever it is made of - one megabyte, scrollback trimmed newest-first and the trim recorded, screen never touched. Terminal content is untrusted input and must not set its own record size.
- **Records expire on the Gateway** after fourteen days. Longer than the daily pull, so one missed job is not a permanent hole. Only day-named directories are swept; anything else is left alone and logged.
- **An ON that names nothing real is refused**; an **OFF is never blocked**. A mistyped scope used to look like a recorded decision while protecting nothing.
- **The lookup gives away less** - no OS username, no echoed email, no duplicate count - and every lookup is logged.
- **One external answer for every unavailable auth state**, with the detail in the log rather than in a response to a stranger.

**One test nearly shipped proving nothing.** The concurrency test derived its input from the constant under test, so raising the bound raised the input and the bound still bit - it went green with the bound at 100,000. Caught by mutation, not by reading. Fixed to a literal.

Four mutations applied, run, watched go red, reverted. Gate: 4,916 tests, every suite Completed.