### PR TITLE
fix(gateway): the speech leg stops claiming a retry it never books, and gets the same bounded one

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
@@ -2054,15 +2054,23 @@ public sealed class WingmanVoiceServiceTests : IDisposable
             // Real delays, kept SHORT. An earlier draft booked a 45-second re-attempt and returned, leaving
             // an untracked timer to wake inside the shared test process long after this test had deleted its
             // own directory (found in review). The numbers only have to differ, not be large.
-            var brain = new RateLimitedThenAnswersBrain(refusals: 5, retryAfter: TimeSpan.FromMilliseconds(300));
+            var brain = new RateLimitedThenAnswersBrain(refusals: 5, retryAfter: TimeSpan.FromMilliseconds(800));
             var svc = ServiceWithBrainAndTts(brain, new byte[] { 6 }, persistPath, conversation.Reader);
-            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(20));   // rung 20ms, provider wants 300ms
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(20));   // rung 20ms, provider wants 800ms
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
-            Assert.Equal(TimeSpan.FromMilliseconds(300), svc.LastBookedRetryDelayForTest);
+            Assert.Equal(TimeSpan.FromMilliseconds(800), svc.LastBookedRetryDelayForTest);
             Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // it IS booked, so the promise holds
-            await Task.Delay(600);   // let the one booked re-attempt run, so nothing outlives the test
+            Assert.Equal(1, brain.AskCount);
+
+            // The seam records what we DECIDED; the brain shows what we DID - see the speech-leg twin of
+            // this test for why the recorded delay alone is not evidence.
+            await Task.Delay(300);
+            Assert.Equal(1, brain.AskCount);   // 15x the rung has passed and it has not called again
+
+            Assert.True(await Eventually(() => brain.AskCount >= 2),
+                "the booked re-attempt never ran at all - the recorded delay described work nobody did");
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
@@ -2501,7 +2509,10 @@ public sealed class WingmanVoiceServiceTests : IDisposable
     private WingmanVoiceService ServiceWithBrainAndTtsHandler(IAgentBrain brain, HttpMessageHandler handler, string persistPath,
         Func<TenantId, string, CcDirector.Gateway.History.StoredConversation?>? conversationReader = null)
     {
-        var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
+        // The vault lives beside the persist file, INSIDE the directory the test deletes - the older helpers
+        // drop theirs loose in the machine temp directory and never remove it (found in review).
+        var vaultPath = Path.Combine(Path.GetDirectoryName(persistPath)!, "test.vault");
+        Directory.CreateDirectory(Path.GetDirectoryName(persistPath)!);
         var vault = new KeyVault(vaultPath);
         vault.Set("OPENAI_API_KEY", "sk-test");
         vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test");
@@ -2595,14 +2606,24 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
-            var handler = new TtsRateLimitedHandler(refusals: 5, retryAfter: TimeSpan.FromMilliseconds(300));
+            var handler = new TtsRateLimitedHandler(refusals: 5, retryAfter: TimeSpan.FromMilliseconds(800));
             var svc = ServiceWithBrainAndTtsHandler(new RecordingBrain(), handler, persistPath, conversation.Reader);
-            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(20));   // rung 20ms, provider wants 300ms
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(20));   // rung 20ms, provider wants 800ms
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
 
-            Assert.Equal(TimeSpan.FromMilliseconds(300), svc.LastBookedRetryDelayForTest);
-            await Task.Delay(600);   // let the one booked re-attempt run, so nothing outlives the test
+            Assert.Equal(TimeSpan.FromMilliseconds(800), svc.LastBookedRetryDelayForTest);
+            Assert.Equal(1, handler.Calls);
+
+            // THE SEAM RECORDS WHAT WE DECIDED; THE HANDLER SHOWS WHAT WE DID. Found in review: asserting
+            // the recorded delay alone passes if the task is dropped, fires immediately, or fires at the
+            // wrong time. So the wait itself is observed - still one call well past the RUNG, and a second
+            // call after the PROVIDER'S number.
+            await Task.Delay(300);
+            Assert.Equal(1, handler.Calls);   // 15x the rung has passed and it has not called again
+
+            Assert.True(await Eventually(() => handler.Calls >= 2),
+                "the booked re-attempt never ran at all - the recorded delay described work nobody did");
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
@@ -2806,8 +2827,81 @@ public sealed class WingmanVoiceServiceTests : IDisposable
             await Task.Delay(2000);
             Assert.Equal(2, brain.AskCount);
 
-            svc.Unmark(TenantId.Local, "sid-1");   // retire the live reservation so no timer outlives the test
+            // AND THE PRESENCE THAT MAKES THAT ABSENCE MEAN SOMETHING. Found in review: "still two" is also
+            // what a machine too busy to run either timer would report, so on its own it certifies nothing.
+            // The SECOND reservation must still fire - which proves the timers were alive, that the window
+            // the assertion above measured was real, and that standing the orphan down did not cost the turn
+            // its re-attempt. A stall long enough to fake the assertion above would fail this one.
+            Assert.True(await Eventually(() => brain.AskCount >= 3),
+                "the live reservation never fired either - the machinery was asleep, so the count above proved nothing");
+            Assert.Equal(3, brain.AskCount);
+
+            svc.Unmark(TenantId.Local, "sid-1");   // retire the ladder so the next rung's timer stands down
             await Task.Delay(50);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>A speech provider that answers 200 with an EMPTY body - no audio, and no failure status to
+    /// classify it by. The outcome nobody enumerated.</summary>
+    private sealed class TtsEmptyBodyHandler : HttpMessageHandler
+    {
+        private int _calls;
+        public int Calls => _calls;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _calls);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(Array.Empty<byte>()),
+            });
+        }
+    }
+
+    /// <summary>
+    /// NO AUDIO AND NOTHING BOOKED IS THE ABANDONED CASE, WHATEVER PRODUCED IT.
+    ///
+    /// Found in review. The speech leg can return no audio and record NO state at all - a 200 carrying an
+    /// empty body is the reachable one - and that outcome is not any of the three failures the
+    /// classification names. With an earlier attempt having left the calm Retrying standing, the screen went
+    /// back to promising audio with nothing behind it: this change's own defect, arriving through the one
+    /// door its own enumeration did not cover.
+    ///
+    /// The sequence is the one that makes it visible: a first attempt that DOES leave Retrying and a booked
+    /// rung, then an empty-bodied answer once the ladder is spent.
+    /// </summary>
+    [Fact]
+    public async Task ASpeechAnswerWithNoAudioAndNoFailureState_StillStopsThePromise()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-ttsempty-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var handler = new TtsEmptyBodyHandler();
+            var svc = ServiceWithBrainAndTtsHandler(new RecordingBrain(), handler, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest();   // no rungs, so this attempt books nothing
+
+            // Seed the calm promise an earlier attempt would have left behind.
+            svc.NoteRetrying(TenantId.Local, "sid-1");
+            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(1, handler.Calls);                       // control: the speech leg really was called
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));  // and produced nothing
+
+            // The promise is withdrawn, so the screen reports the turn rather than an arrival.
+            Assert.True(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            var display = VoiceDisplayFold.Fold(
+                voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+                unavailable: svc.VoiceUnavailableFor(TenantId.Local, "sid-1"),
+                nothingToNarrate: false,
+                narrationAbandoned: svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            Assert.Equal("notNarrated", display.Kind);
+            Assert.Equal("This turn has no narration, and nothing further is scheduled to make one. "
+                       + "Read the turn, or ask for the narration again.", display.Message);
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }

--- a/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/WingmanVoiceServiceTests.cs
@@ -1820,16 +1820,23 @@ public sealed class WingmanVoiceServiceTests : IDisposable
     }
 
     /// <summary>
-    /// "Nothing further is scheduled" must be TRUE when it is said.
+    /// A CONCURRENT FAILURE SPENDS NOTHING AND CLAIMS NOTHING while a re-attempt is booked.
     ///
     /// A concurrent attempt - the background sweep, or a person pressing Generate - can fail while a booked
-    /// re-attempt is still waiting out its backoff. Counting that failure against the ladder would push the
-    /// count past the cap and declare the turn abandoned while a task genuinely existed: the same false
-    /// sentence this change removes, only inverted (found in review). The concurrent failure must spend
-    /// nothing and claim nothing.
+    /// re-attempt is still waiting out its backoff. Two things must not happen: it must not push the count
+    /// past the cap and declare the turn abandoned while a task genuinely exists, and it must not book a
+    /// SECOND rung on top of the one already pending, which would spend the turn's ladder at twice the rate
+    /// and orphan the first timer.
+    ///
+    /// THE LADDER HAS TWO RUNGS ON PURPOSE. The first version of this test used one, so the concurrent
+    /// failure landed on the abandoning path - where a second guard (the pending check inside the
+    /// abandonment itself) already held the line. The mutation audit caught it: removing the stand-aside
+    /// killed no test at all. With two rungs the concurrent failure lands on the BOOKING path, which is the
+    /// behaviour the stand-aside is actually for, and the attempt count tells the two apart - four calls
+    /// when each rung is spent once, three when the concurrent failure took a rung it did not own.
     /// </summary>
     [Fact]
-    public async Task AConcurrentFailure_WhileAReattemptIsBooked_DoesNotDeclareTheTurnAbandoned()
+    public async Task AConcurrentFailure_WhileAReattemptIsBooked_SpendsNothingAndClaimsNothing()
     {
         var director = new TunnelStub();
         var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
@@ -1839,11 +1846,11 @@ public sealed class WingmanVoiceServiceTests : IDisposable
         {
             var brain = new TimingOutBrain();
             var svc = ServiceWithBrainAndTts(brain, new byte[] { 5 }, persistPath, conversation.Reader);
-            svc.UseModelRetryBackoffForTest(TimeSpan.FromSeconds(3));   // one rung, long enough to still be pending
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
 
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
             Assert.Equal(1, brain.AskCount);
-            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // control: the rung is booked
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // control: rung one is booked
 
             // The sweep comes past and fails too, while that rung is still pending.
             await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: false);
@@ -1852,10 +1859,16 @@ public sealed class WingmanVoiceServiceTests : IDisposable
             Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // and it claimed nothing
             Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
 
-            // POSITIVE CONTROL: the verdict is not simply unreachable - once the booked rung runs and fails,
-            // nothing is pending and the turn IS abandoned.
+            // POSITIVE CONTROL: the verdict is not simply unreachable - once both booked rungs have run and
+            // failed, nothing is pending and the turn IS abandoned.
             Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")),
-                "the abandoned verdict never arrived, so the assertion above proved nothing");
+                "the abandoned verdict never arrived, so the assertions above proved nothing");
+
+            // AND THE LADDER WAS SPENT ONE RUNG AT A TIME: two direct attempts plus the two booked
+            // re-attempts. Three would mean the concurrent failure had taken a rung that was not its own,
+            // orphaning the first timer and burning the turn's budget at twice the rate.
+            await Task.Delay(500);
+            Assert.Equal(4, brain.AskCount);
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }
@@ -2426,6 +2439,375 @@ public sealed class WingmanVoiceServiceTests : IDisposable
             brain.Release();
             Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")),
                 "the control failed: this path records no verdict even without a superseding turn");
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    // ---------- The SPEECH leg: the third place that said "retries on its own" ----------
+
+    /// <summary>
+    /// A speech provider that refuses with 429 for its first <c>refusals</c> calls and returns audio after
+    /// that, optionally carrying a Retry-After. Counts its calls, so a test can prove a SECOND call was
+    /// made rather than inferring it from the audio.
+    /// </summary>
+    private sealed class TtsRateLimitedHandler : HttpMessageHandler
+    {
+        private readonly int _refusals;
+        private readonly TimeSpan? _retryAfter;
+        private int _calls;
+        public int Calls => _calls;
+        public TtsRateLimitedHandler(int refusals, TimeSpan? retryAfter = null)
+        {
+            _refusals = refusals;
+            _retryAfter = retryAfter;
+        }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var n = Interlocked.Increment(ref _calls);
+            if (n > _refusals)
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(new byte[] { 8, 8, 8 }),
+                });
+            var resp = new HttpResponseMessage((HttpStatusCode)429)
+            {
+                Content = new StringContent("{\"error\":\"rate limited\"}", Encoding.UTF8, "application/json"),
+            };
+            if (_retryAfter is { } ra)
+                resp.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(ra);
+            return Task.FromResult(resp);
+        }
+    }
+
+    /// <summary>A speech provider that always answers with the same failing status, counting its calls.</summary>
+    private sealed class TtsAlwaysFailsHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private int _calls;
+        public int Calls => _calls;
+        public TtsAlwaysFailsHandler(HttpStatusCode status) => _status = status;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _calls);
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent("{\"error\":\"upstream\"}", Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    /// <summary>A service whose MODEL answers normally and whose SPEECH leg is the handler under test - the
+    /// shape every narration-path speech test needs, and the one the existing helpers do not build.</summary>
+    private WingmanVoiceService ServiceWithBrainAndTtsHandler(IAgentBrain brain, HttpMessageHandler handler, string persistPath,
+        Func<TenantId, string, CcDirector.Gateway.History.StoredConversation?>? conversationReader = null)
+    {
+        var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
+        var vault = new KeyVault(vaultPath);
+        vault.Set("OPENAI_API_KEY", "sk-test");
+        vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test");
+        return new WingmanVoiceService((_, _, _) => Task.FromResult(brain), vault, Settings, persistPath,
+            ttsHttpClient: new HttpClient(handler), conversationReader: conversationReader);
+    }
+
+    /// <summary>
+    /// THE THIRD FALSE PROMISE, and the one whose SCREEN lied too. The speech leg said "this session retries
+    /// on its own" in three places and scheduled nothing in any of them; two of the three recorded
+    /// ServiceDown, so their screens at least showed a specific red verdict, but the NON-ANSWER arm records
+    /// Retrying - which the fold renders as the calm "Voice is taking a moment, retrying automatically. It
+    /// should come through shortly". A turn with a perfectly good narration text and no audio sat behind
+    /// that sentence with nothing making audio.
+    ///
+    /// The model leg's ladder now covers this leg too. Proved end to end: a speech stall that clears
+    /// produces AUDIO, with no sweep, no new turn, and nobody pressing anything.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheSpeechLegDoesNotAnswer_TheVoicePathBooksItsOwnReattempt_AndTheTurnIsNarrated()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-ttsretry-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            // TtsSynthesis makes its own bounded attempts inside one call, so the handler must refuse
+            // enough times to exhaust those before the call itself fails - which is exactly the failure
+            // this test is about, the whole speech CALL not answering.
+            var handler = new TtsTimeoutHandler(timeouts: 2);
+            var brain = new RecordingBrain();
+            var svc = ServiceWithBrainAndTtsHandler(brain, handler, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(50));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            // CONTROL, and the exact state the old code stopped at: the model answered, the speech leg did
+            // not, no audio, and the calm sentence on the screen.
+            Assert.Equal(1, brain.AskCount);
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+            Assert.Equal(HostedAiState.Retrying, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));   // honest: an attempt IS booked
+
+            // THE THING THAT DID NOT EXIST.
+            Assert.True(await Eventually(() => svc.HasVoice(TenantId.Local, "sid-1")),
+                "the speech-leg stall never led to another attempt - the turn stayed silent behind 'voice on its way'");
+            Assert.Null(svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>A speech 429 is transient by definition, so it gets the same ladder - and the same end to
+    /// end proof, audio arriving with nobody pressing anything.</summary>
+    [Fact]
+    public async Task WhenTheSpeechLegIsRateLimited_TheVoicePathBooksItsOwnReattempt_AndTheTurnIsNarrated()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-tts429-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var handler = new TtsRateLimitedHandler(refusals: 1);
+            var svc = ServiceWithBrainAndTtsHandler(new RecordingBrain(), handler, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(50));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(1, handler.Calls);                       // control: refused once
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+
+            Assert.True(await Eventually(() => svc.HasVoice(TenantId.Local, "sid-1")),
+                "the speech 429 never led to another attempt - the turn stayed silent");
+            Assert.Equal(2, handler.Calls);                       // and exactly one re-attempt made the audio
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// The speech provider's Retry-After is honoured exactly, the same as the model leg's. It was parsed
+    /// into a log line and dropped.
+    /// </summary>
+    [Fact]
+    public async Task ASpeechProvidersRetryAfter_IsHonoured_WhenItAsksForLongerThanTheRung()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-tts429after-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var handler = new TtsRateLimitedHandler(refusals: 5, retryAfter: TimeSpan.FromMilliseconds(300));
+            var svc = ServiceWithBrainAndTtsHandler(new RecordingBrain(), handler, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(20));   // rung 20ms, provider wants 300ms
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(TimeSpan.FromMilliseconds(300), svc.LastBookedRetryDelayForTest);
+            await Task.Delay(600);   // let the one booked re-attempt run, so nothing outlives the test
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// WHERE THE LADDER RUNS OUT, THE SPEECH LEG'S SCREEN STOPS PROMISING TOO. This is the assertion the
+    /// whole change is for: the non-answer arm records Retrying, which renders as the calm "retrying
+    /// automatically, it should come through shortly", and before this that sentence stood for ever with
+    /// nothing making audio.
+    /// </summary>
+    [Fact]
+    public async Task WhenEverySpeechReattemptIsSpent_TheScreenStopsPromisingAudio()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-ttsgiveup-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var handler = new TtsTimeoutHandler(timeouts: int.MaxValue);   // never answers
+            var svc = ServiceWithBrainAndTtsHandler(new RecordingBrain(), handler, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(30), TimeSpan.FromMilliseconds(30));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")),
+                "the speech ladder never ran out, so nothing ever told the reader the turn was not narrated");
+            Assert.False(svc.HasVoice(TenantId.Local, "sid-1"));
+
+            // The WHOLE sentence, not the absence of a phrase.
+            var display = VoiceDisplayFold.Fold(
+                voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+                unavailable: svc.VoiceUnavailableFor(TenantId.Local, "sid-1"),
+                nothingToNarrate: false,
+                narrationAbandoned: svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            Assert.Equal("notNarrated", display.Kind);
+            Assert.Equal("Turn not narrated", display.Label);
+            Assert.Equal("This turn has no narration, and nothing further is scheduled to make one. "
+                       + "Read the turn, or ask for the narration again.", display.Message);
+
+            // NEGATIVE CONTROL: the same facts WITHOUT the abandoned fact are the calm sentence this
+            // change exists to end - so the assertion above is about the fix and not about a state that
+            // renders that way regardless.
+            var promising = VoiceDisplayFold.Fold(
+                voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+                unavailable: svc.VoiceUnavailableFor(TenantId.Local, "sid-1"),
+                nothingToNarrate: false, narrationAbandoned: false);
+            Assert.Equal("retrying", promising.Kind);
+            Assert.Equal("Voice on its way", promising.Label);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// AN ANSWERED 5xx IS NOT RETRIED, and the screen it produces is unchanged. The service told us it is
+    /// failing - a claim the red "Voice service down" panel is right to make, and one a second call seconds
+    /// later has no reason to change. Only its LOG was wrong, and a log is not assertable here; what is
+    /// assertable is that no re-attempt is booked and the verdict is the one it always was.
+    /// </summary>
+    [Theory]
+    [InlineData(500)]
+    [InlineData(502)]
+    [InlineData(503)]
+    public async Task AnAnsweredSpeechFailure_BooksNoReattempt_AndKeepsItsOwnVerdict(int status)
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-tts5xx-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var handler = new TtsAlwaysFailsHandler((HttpStatusCode)status);
+            var svc = ServiceWithBrainAndTtsHandler(new RecordingBrain(), handler, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(20), TimeSpan.FromMilliseconds(20));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(1, handler.Calls);   // control: it was called once
+            await Task.Delay(400);            // many times the rung, so this is a real absence
+            Assert.Equal(1, handler.Calls);   // and never again
+
+            Assert.Null(svc.LastBookedRetryDelayForTest);
+            Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor(TenantId.Local, "sid-1"));
+            var display = VoiceDisplayFold.Fold(
+                voiceMode: true, agentWorking: false, hasAudio: false, generating: false,
+                unavailable: svc.VoiceUnavailableFor(TenantId.Local, "sid-1"),
+                nothingToNarrate: false,
+                narrationAbandoned: svc.NarrationAbandonedFor(TenantId.Local, "sid-1"));
+            Assert.Equal("serviceDown", display.Kind);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// ONE LADDER FOR THE TURN, ACROSS BOTH LEGS. A turn that loses its narration text to a stalled model
+    /// and then its audio to a stalled speech provider has failed twice, not started again. Giving each leg
+    /// its own three re-attempts would spend six on the turn already costing the most, which is the obvious
+    /// mistake if the two legs keep separate counts.
+    /// </summary>
+    [Fact]
+    public async Task TheRetryLadderIsSharedBetweenTheModelLegAndTheSpeechLeg()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-ttsshared-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            // The model stalls once, then answers for ever; the speech leg never answers. So the first
+            // attempt is spent by the MODEL leg and every later one by the SPEECH leg.
+            var brain = new StallsThenAnswersBrain(failures: 1);
+            var handler = new TtsTimeoutHandler(timeouts: int.MaxValue);
+            var svc = ServiceWithBrainAndTtsHandler(brain, handler, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromMilliseconds(30), TimeSpan.FromMilliseconds(30));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+
+            Assert.True(await Eventually(() => svc.NarrationAbandonedFor(TenantId.Local, "sid-1")),
+                "the shared ladder never ran out - the two legs are keeping separate counts");
+
+            // Three narration attempts in total: one that the model lost, and two that reached the speech
+            // leg. Settled first, so a fourth still on a timer is counted rather than missed.
+            await Task.Delay(500);
+            Assert.Equal(3, brain.AskCount);
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    /// <summary>
+    /// THE ON-DEMAND PATH IS UNCHANGED, asserted rather than assumed. StoreSpokenAsync now hands back what
+    /// the speech leg did, and the narration path acts on it - but a caller that does not book must still
+    /// record exactly the state it recorded before, or this change would have quietly turned a specific red
+    /// verdict into a calm wait on the one path that has no re-attempt behind it.
+    /// </summary>
+    [Fact]
+    public async Task TheOnDemandPath_StillRecordsTheSameVerdict_AndBooksNothing()
+    {
+        var handler = new TtsRateLimitedHandler(refusals: int.MaxValue, retryAfter: TimeSpan.FromSeconds(30));
+        var svc = ServiceWithHandler(handler);
+
+        var attempt = await svc.StoreSpokenAsync(TenantId.Local, "sid-429", "spoken", "reply");
+
+        // The verdict the phone reads is the one it always was for an answered refusal.
+        Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor(TenantId.Local, "sid-429"));
+        Assert.False(svc.HasVoice(TenantId.Local, "sid-429"));
+        Assert.False(svc.NarrationAbandonedFor(TenantId.Local, "sid-429"));
+
+        // ...and the outcome it hands back carries what a booking caller would need, which is the whole
+        // point of the return value: the provider's number, and that this one is worth another go.
+        Assert.False(attempt.ProducedAudio);
+        Assert.True(attempt.WorthAnotherAttempt);
+        Assert.Equal(TimeSpan.FromSeconds(30), attempt.RetryAfter);
+
+        // Nothing was booked by this path - one call, and no more.
+        Assert.Equal(1, handler.Calls);
+        await Task.Delay(300);
+        Assert.Equal(1, handler.Calls);
+        Assert.Null(svc.LastBookedRetryDelayForTest);
+    }
+
+    /// <summary>
+    /// AN OLD TIMER CANNOT STEAL A NEWLY BOOKED RE-ATTEMPT.
+    ///
+    /// Found in review, and then found again by the mutation audit: removing the RESERVATION from the
+    /// waking timer's ownership check killed no test at all, so the guard was standing on nothing. The
+    /// reply key cannot answer this, which is the whole point - a turn can be cleared and the next attempt
+    /// carry the SAME reply text, so an old timer matching on text alone believes the new reservation is
+    /// its own, takes the pending marker off it, and runs. The screen is then promising audio behind a
+    /// task that will stand down when it fires.
+    ///
+    /// The window is made wide on purpose. The first re-attempt is booked at t=0 to fire at t=3s; the turn
+    /// is cleared at t=0.05s; a second attempt at t=1.5s books its OWN reservation to fire at t=4.5s. At
+    /// t=3s the first timer wakes into a ledger that matches on reply text and is pending - and must
+    /// recognise that it is not its own.
+    /// </summary>
+    [Fact]
+    public async Task AnOldTimer_CannotStealAReattemptBookedByALaterAttempt()
+    {
+        var director = new TunnelStub();
+        var conversation = StoredConversationStub.Of(("Text", "the reply to narrate"));
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-reservation-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var brain = new TimingOutBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 7 }, persistPath, conversation.Reader);
+            svc.UseModelRetryBackoffForTest(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
+
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.Equal(1, brain.AskCount);   // control: the first attempt ran and booked reservation one
+
+            await Task.Delay(50);
+            svc.OnSessionWorking(TenantId.Local, "sid-1");   // the turn is cleared; that reservation is orphaned
+
+            await Task.Delay(1450);
+            await svc.GenerateAsync(TenantId.Local, "sid-1", RouteFor(director), CancellationToken.None, showReadingWindow: true);
+            Assert.Equal(2, brain.AskCount);   // control: the second attempt ran and booked reservation TWO
+
+            // Past the first timer's deadline and well before the second's. The orphaned timer has woken by
+            // now; if it took the newer reservation for its own it would have run a third attempt here.
+            await Task.Delay(2000);
+            Assert.Equal(2, brain.AskCount);
+
+            svc.Unmark(TenantId.Local, "sid-1");   // retire the live reservation so no timer outlives the test
+            await Task.Delay(50);
         }
         finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ } }
     }

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -1525,11 +1525,35 @@ public sealed class WingmanVoiceService
             // The turn has WORDS at this point - the model answered - so a re-attempt here is cheap in the
             // way that matters: it re-runs the narration from the same reply, and the identity-aware skip
             // means a turn that has since been narrated is left alone.
-            if (!speech.ProducedAudio && speech.WorthAnotherAttempt)
-                NoteNarrationAttemptFailed(tenant, state, sid, route, lastReply,
-                    "the speech provider produced no audio", speech.RetryAfter,
-                    cause: $"speech leg failed{(speech.RetryAfter is { } sra ? $", provider asked for {sra.TotalSeconds:F0}s" : "")}",
-                    epoch: turnEpoch);
+            if (!speech.ProducedAudio)
+            {
+                if (speech.WorthAnotherAttempt)
+                    NoteNarrationAttemptFailed(tenant, state, sid, route, lastReply,
+                        "the speech provider produced no audio", speech.RetryAfter,
+                        cause: $"speech leg failed{(speech.RetryAfter is { } sra ? $", provider asked for {sra.TotalSeconds:F0}s" : "")}",
+                        epoch: turnEpoch);
+                else if (CurrentTurnEpoch(state, sid) == turnEpoch)
+                    // NO AUDIO AND NOTHING BOOKED IS THE ABANDONED CASE, whatever produced it - and this
+                    // arm is the one that catches the outcomes nobody enumerated. Found in review: the
+                    // speech leg can return no audio and record NO state at all (a 200 carrying an empty
+                    // body, or an empty spoken text), and if an earlier attempt had left Retrying standing
+                    // then the screen went back to promising audio with nothing behind it - the very defect
+                    // this change exists to remove, arriving through the one door the classification did
+                    // not name.
+                    //
+                    // Guarded twice over, and by the two different questions that matter. The EPOCH check
+                    // above is what proves this attempt is still speaking about the current turn - which is
+                    // why the ledger-free overload is the right one here: with the turn known to be current,
+                    // an absent ledger entry means no failure has ever been recorded for it, not that the
+                    // turn moved on, and "nothing is pending" is then simply true. The reply-keyed overload
+                    // reads that same absence as "somebody else owns this now" and stays silent, which on
+                    // this path would leave the stale promise exactly where it was.
+                    //
+                    // Harmless where a more specific verdict already applies: an account condition or an
+                    // answered ServiceDown is ranked ahead of this fact by VoiceDisplayFold, so the reader
+                    // still gets the sentence they can act on.
+                    MarkAbandonedIfNothingPending(state, sid);
+            }
             // The model leg ran and answered - TranslateAsync returned rather than throwing
             // WingmanModelRateLimitedException. Reported as true purely so the return honestly says the
             // provider was reached (no caller acts on it now that the shared gate is gone).
@@ -1560,9 +1584,21 @@ public sealed class WingmanVoiceService
     /// again a second after a 429 is how a rate limit becomes a storm.
     /// </param>
     /// <param name="cause">Plain words for the log, so a reader can tell a silence from a refusal.</param>
-    /// <param name="epoch">The turn epoch this attempt started in. If the turn has been superseded since -
-    /// a new turn, a successful narration, voice switched off - this attempt says NOTHING, because every
-    /// sentence it could write would be about a turn that is over.</param>
+    /// <param name="epoch">
+    /// The turn epoch this attempt started in. If the turn has been superseded since - a new turn, a
+    /// successful narration, voice switched off - this method writes NOTHING, because every sentence it
+    /// could write would be about a turn that is over.
+    ///
+    /// WHAT THAT DOES NOT COVER, stated because an earlier version of this comment said a superseded
+    /// attempt "says nothing" full stop, and that was an overclaim (found in review). The guard binds THIS
+    /// method. A slow attempt still passes through <see cref="StoreSpokenAsync"/> first, which records its
+    /// own state and can store audio, and those writes happen before anything here is reached. So a
+    /// narration that was superseded while the speech provider was working can still leave the previous
+    /// turn's clip or its recorded state behind. That window predates this ladder and is bounded by the
+    /// identity-aware regeneration check, which sees a cached reply that is not the current one and
+    /// narrates again; closing it properly means making the store itself epoch-aware, which is a change to
+    /// a method three other callers share and is not attempted here.
+    /// </param>
     private void NoteNarrationAttemptFailed(TenantId tenant, TenantVoiceState state, string sid, SessionVerbClient route, string lastReply, string detail, TimeSpan? retryAfter, string cause, long epoch)
     {
         if (CurrentTurnEpoch(state, sid) != epoch)
@@ -1747,6 +1783,13 @@ public sealed class WingmanVoiceService
     ///
     /// It re-enters <see cref="GenerateAsync"/> rather than the inner attempt, so every guard on the ordinary
     /// path still applies: coalescing, the identity-aware "already narrated" skip, and the reply read itself.
+    ///
+    /// THAT RE-RUNS THE MODEL EVEN WHEN ONLY THE SPEECH LEG FAILED, and it is a deliberate trade rather than
+    /// an oversight (raised in review). Resuming at the speech step would save a model call, and would do it
+    /// by speaking text that was written for a reply this retry has not re-read - so a turn that moved on in
+    /// the meantime would be narrated with the OLD turn's words, which is the failure mode this file has
+    /// spent three issues removing. Re-reading is what makes a re-attempt narrate the CURRENT turn. The cost
+    /// is one extra model call on a speech-only failure, bounded by the same three-rung ladder.
     /// </summary>
     private void ScheduleModelRetry(TenantId tenant, string sid, SessionVerbClient route, TimeSpan delay, string replyKey, long reservation, int attempt, int cap)
     {

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -51,7 +51,41 @@ public sealed class WingmanVoiceService
     /// or the shared <see cref="HostedAiState"/> when hosted AI is unavailable (out of credits, cap
     /// reached, or account setup is incomplete) so the caller can surface it instead of a silent
     /// null. Both null means a generic provider error (logged, no shared state).</summary>
-    private sealed record TtsResult(byte[]? Audio, string? ContentType, HostedAiState? Unavailable, bool ServedViaFallback = false);
+    private sealed record TtsResult(byte[]? Audio, string? ContentType, HostedAiState? Unavailable, bool ServedViaFallback = false, SpeechFailure Failure = SpeechFailure.None, TimeSpan? RetryAfter = null);
+
+    /// <summary>
+    /// What the SPEECH leg did, in the only terms the narration path needs: is this worth another attempt,
+    /// and did the provider name a delay?
+    ///
+    /// It exists because the recorded <see cref="HostedAiState"/> cannot answer that. Two failures that are
+    /// completely different to a retry - a 429 the provider will lift in thirty seconds, and a 5xx it has no
+    /// deadline for - are both an ANSWERED failure and both record <see cref="HostedAiState.ServiceDown"/>,
+    /// so a caller reading the state alone can only guess. Guessing is how the speech leg came to log "this
+    /// session retries on its own" about three different failures while scheduling nothing for any of them.
+    /// </summary>
+    private enum SpeechFailure
+    {
+        /// <summary>Audio was produced, or the failure is the account's (no key, out of credits, cap).</summary>
+        None,
+        /// <summary>The provider refused this call with a 429. Transient by definition, and it may have named
+        /// how long to wait - see <see cref="TtsResult.RetryAfter"/>.</summary>
+        RateLimited,
+        /// <summary>The provider ANSWERED with a failure (a 5xx). It told us it is failing, which is a claim
+        /// about the service the screen is right to make - and not something a re-attempt seconds later has
+        /// any reason to fix, so the narration path does not book one.</summary>
+        AnsweredFailure,
+        /// <summary>The call did not answer at all - the bounded deadline fired, or the transport failed. The
+        /// absence of evidence, and the one speech failure whose screen used to promise audio nobody was
+        /// making.</summary>
+        DidNotAnswer,
+    }
+
+    /// <summary>
+    /// What one call to <see cref="StoreSpokenAsync"/> did, handed back so the narration path can decide
+    /// whether to book a re-attempt. Callers that do not book - the on-demand explain path - ignore it, and
+    /// the state <see cref="StoreSpokenAsync"/> records is unchanged for them.
+    /// </summary>
+    public readonly record struct SpeechAttempt(bool ProducedAudio, TimeSpan? RetryAfter, bool WorthAnotherAttempt);
 
     /// <summary>
     /// ONE tenant's voice state. Every dictionary here is keyed by session id, and the ONLY way to reach one
@@ -1073,10 +1107,15 @@ public sealed class WingmanVoiceService
     /// paths), synthesize its audio, and mark the session as a voice session. Best-effort: if the
     /// audio can't be made (no key / outage) the session is still marked, so turn-end retries.
     /// </summary>
-    public async Task StoreSpokenAsync(TenantId tenant, string sid, string spoken, string reply, CancellationToken ct = default)
+    /// <returns>
+    /// What the speech leg did, so a caller that CAN book a re-attempt knows whether to. Every existing
+    /// caller ignores it and is unaffected: the state this method records is exactly what it recorded
+    /// before, and a caller that does not book leaves the screen saying what it said before.
+    /// </returns>
+    public async Task<SpeechAttempt> StoreSpokenAsync(TenantId tenant, string sid, string spoken, string reply, CancellationToken ct = default)
     {
         Mark(tenant, sid);
-        if (string.IsNullOrWhiteSpace(spoken)) return;
+        if (string.IsNullOrWhiteSpace(spoken)) return new SpeechAttempt(false, null, false);
         var tts = await TtsAsync(tenant, sid, spoken, ct);
         // The "if anything fails, remove the triangle" rule: when synthesis returns null/empty we
         // leave this tenant's Ready map WITHOUT this session, so HasVoice stays false and no triangle shows. Only a
@@ -1094,6 +1133,14 @@ public sealed class WingmanVoiceService
             StateFor(tenant).Unavailable[sid] = unavailable;
             FileLog.Write($"[WingmanVoiceService] voice unavailable tenant={tenant.ToLogString()} sid={sid}: {unavailable}");
         }
+        // WORTH ANOTHER ATTEMPT means transient, and only two of the four speech outcomes are: a refusal
+        // that will be lifted, and a call that never answered. An account condition is the member's to fix
+        // and an answered 5xx is the service telling us it is failing - neither is improved by calling again
+        // in ten seconds, and both already put a specific, actionable sentence on the screen.
+        return new SpeechAttempt(
+            ProducedAudio: tts.Audio is { Length: > 0 },
+            RetryAfter: tts.RetryAfter,
+            WorthAnotherAttempt: tts.Failure is SpeechFailure.RateLimited or SpeechFailure.DidNotAnswer);
     }
 
     /// <summary>Mark a session ready with already-synthesized audio: update the in-memory cache and
@@ -1414,7 +1461,7 @@ public sealed class WingmanVoiceService
                 // account's unnarratable sessions were consuming (issue #2675). The leg that failed now owns
                 // the re-attempt, so the promise on the screen is backed by a booked piece of work rather
                 // than by a loop nobody here controls.
-                NoteModelAttemptFailed(tenant, state, sid, route, lastReply, ex, retryAfter: null,
+                NoteNarrationAttemptFailed(tenant, state, sid, route, lastReply, ex.Message, retryAfter: null,
                     cause: "model did not answer", epoch: turnEpoch);
                 return false;   // nothing produced; the provider was not usefully reached
             }
@@ -1434,7 +1481,7 @@ public sealed class WingmanVoiceService
                 //
                 // It is caught here rather than in the wrapper for a second reason: the ledger is keyed on
                 // the reply being narrated, and this is the innermost place that reply is known.
-                NoteModelAttemptFailed(tenant, state, sid, route, lastReply, rl, rl.RetryAfter,
+                NoteNarrationAttemptFailed(tenant, state, sid, route, lastReply, rl.Message, rl.RetryAfter,
                     cause: $"model rate limited (429){(rl.RetryAfter is { } ra ? $", provider asked for {ra.TotalSeconds:F0}s" : ", no Retry-After sent")}",
                     epoch: turnEpoch);
                 return false;   // nothing produced; the provider refused this call
@@ -1456,7 +1503,7 @@ public sealed class WingmanVoiceService
                 spoken += Speech.SpokenPhrases.WaitingScreenMenuNarrationSuffix.In(_tenantSettings.SpokenLanguage(tenant));
                 FileLog.Write($"[WingmanVoiceService] narration announces a waiting menu (model verdict): sid={sid}");
             }
-            await StoreSpokenAsync(tenant, sid, spoken, lastReply, ct);
+            var speech = await StoreSpokenAsync(tenant, sid, spoken, lastReply, ct);
             // Log the TRUE outcome: StoreSpokenAsync only makes the session playable when the
             // text-to-speech synthesis actually returned audio. Logging "voice ready"
             // unconditionally (the old behavior) hid every failed synthesis behind a success
@@ -1465,6 +1512,24 @@ public sealed class WingmanVoiceService
                 FileLog.Write($"[WingmanVoiceService] voice ready: sid={sid}, spokenLen={spoken.Length}");
             else
                 FileLog.Write($"[WingmanVoiceService] voice NOT ready (text-to-speech produced no audio): sid={sid}, spokenLen={spoken.Length}");
+            // THE SPEECH LEG GETS THE SAME LADDER AS THE MODEL LEG, and for the same reason: it was the
+            // third place in this file that said "this session retries on its own" while scheduling
+            // nothing. Its non-answer arm is the one that mattered most - that arm records Retrying, so
+            // unlike the two answered arms beside it, its SCREEN said "voice on its way" too.
+            //
+            // ONE ladder for the turn, shared with the model leg. A turn that loses its narration text to
+            // a stalled model and then its audio to a stalled speech provider has failed twice, not
+            // started again, and giving each leg its own three re-attempts would spend six on the turn
+            // already costing the most.
+            //
+            // The turn has WORDS at this point - the model answered - so a re-attempt here is cheap in the
+            // way that matters: it re-runs the narration from the same reply, and the identity-aware skip
+            // means a turn that has since been narrated is left alone.
+            if (!speech.ProducedAudio && speech.WorthAnotherAttempt)
+                NoteNarrationAttemptFailed(tenant, state, sid, route, lastReply,
+                    "the speech provider produced no audio", speech.RetryAfter,
+                    cause: $"speech leg failed{(speech.RetryAfter is { } sra ? $", provider asked for {sra.TotalSeconds:F0}s" : "")}",
+                    epoch: turnEpoch);
             // The model leg ran and answered - TranslateAsync returned rather than throwing
             // WingmanModelRateLimitedException. Reported as true purely so the return honestly says the
             // provider was reached (no caller acts on it now that the shared gate is gone).
@@ -1498,11 +1563,11 @@ public sealed class WingmanVoiceService
     /// <param name="epoch">The turn epoch this attempt started in. If the turn has been superseded since -
     /// a new turn, a successful narration, voice switched off - this attempt says NOTHING, because every
     /// sentence it could write would be about a turn that is over.</param>
-    private void NoteModelAttemptFailed(TenantId tenant, TenantVoiceState state, string sid, SessionVerbClient route, string lastReply, Exception ex, TimeSpan? retryAfter, string cause, long epoch)
+    private void NoteNarrationAttemptFailed(TenantId tenant, TenantVoiceState state, string sid, SessionVerbClient route, string lastReply, string detail, TimeSpan? retryAfter, string cause, long epoch)
     {
         if (CurrentTurnEpoch(state, sid) != epoch)
         {
-            FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {ex.Message} - the turn it was narrating has been superseded, so nothing is recorded and nothing is booked");
+            FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {detail} - the turn it was narrating has been superseded, so nothing is recorded and nothing is booked");
             return;
         }
         var schedule = _modelRetryBackoff;
@@ -1539,7 +1604,7 @@ public sealed class WingmanVoiceService
             // sweep, or a person pressing Generate. It must not spend a rung of a ladder it does not own,
             // and above all it must not declare the turn abandoned while that task exists.
             state.NarrationAbandoned.TryRemove(sid, out _);
-            FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {ex.Message} - Retrying; re-attempt {rung} of {schedule.Length} is already booked, so this attempt spends nothing");
+            FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {detail} - Retrying; re-attempt {rung} of {schedule.Length} is already booked, so this attempt spends nothing");
             return;
         }
         if (!abandon)
@@ -1556,14 +1621,14 @@ public sealed class WingmanVoiceService
                 ReleaseRefusedReservation(state, sid, replyKey, reservation, rung,
                     notBefore: DateTime.UtcNow + (retryAfter ?? delay));
                 MarkAbandonedIfNothingPending(state, sid, replyKey);
-                FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {ex.Message} - the provider asked us to wait {delay.TotalSeconds:F0}s, longer than the {_maxSingleRetryWait.TotalSeconds:F0}s this turn will hold a promise open, so NOTHING IS BOOKED, the model is not called again for this turn until the provider's own deadline passes, and the screen reports a turn that was not narrated rather than an arrival with no end in sight");
+                FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {detail} - the provider asked us to wait {delay.TotalSeconds:F0}s, longer than the {_maxSingleRetryWait.TotalSeconds:F0}s this turn will hold a promise open, so NOTHING IS BOOKED, the model is not called again for this turn until the provider's own deadline passes, and the screen reports a turn that was not narrated rather than an arrival with no end in sight");
                 return;
             }
 
             state.NarrationAbandoned.TryRemove(sid, out _);
             LastBookedRetryDelayForTest = delay;
             ScheduleModelRetry(tenant, sid, route, delay, replyKey, reservation, rung, schedule.Length);
-            FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {ex.Message} - Retrying (audio on its way); re-attempt {rung} of {schedule.Length} is booked for {delay.TotalSeconds:F0}s from now{(retryAfter is { } ra ? $" (provider asked for {ra.TotalSeconds:F0}s)" : "")}");
+            FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {detail} - Retrying (audio on its way); re-attempt {rung} of {schedule.Length} is booked for {delay.TotalSeconds:F0}s from now{(retryAfter is { } ra ? $" (provider asked for {ra.TotalSeconds:F0}s)" : "")}");
             return;
         }
         // THE LADDER IS SPENT. Recorded as its own fact rather than as a new HostedAiState because it is not
@@ -1571,7 +1636,7 @@ public sealed class WingmanVoiceService
         // run out. Published through the same guarded helper as every other abandonment, so it cannot be
         // stamped onto a turn that has moved on while this attempt was failing.
         MarkAbandonedIfNothingPending(state, sid, replyKey);
-        FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {ex.Message} - all {schedule.Length} re-attempt(s) spent and none pending, so THIS TURN WAS NOT NARRATED and nothing further is scheduled; the screen says so instead of promising audio");
+        FileLog.Write($"[WingmanVoiceService] {cause} for sid={sid}: {detail} - all {schedule.Length} re-attempt(s) spent and none pending, so THIS TURN WAS NOT NARRATED and nothing further is scheduled; the screen says so instead of promising audio");
     }
 
     /// <summary>
@@ -1827,14 +1892,19 @@ public sealed class WingmanVoiceService
                     return new TtsResult(null, null, HostedAiErrorMapper.Map402(body));
 
                 // A 429 is the provider saying "stop calling" for THIS call. There is no shared gate any
-                // more (removed 2026-07-17): this session simply gets no audio this cycle and retries on
-                // its own next turn-end / idle sweep. It never reaches across to silence another session.
+                // more (removed 2026-07-17): it never reaches across to silence another session.
+                //
+                // IT IS TRANSIENT BY DEFINITION, so the narration path books a re-attempt against the turn's
+                // own bounded ladder and honours the Retry-After carried back here. That number used to be
+                // parsed into a log line and dropped, while this branch claimed the session "retries on its
+                // own next turn-end / idle sweep" - a sentence with nothing behind it, and the last of the
+                // three places in this file that said it (issues #2676 and #2685 were the other two).
                 if ((int)resp.StatusCode == 429)
                 {
                     var retryAfter = RetryAfterHeader.Parse(resp.Headers);
-                    FileLog.Write($"[WingmanVoiceService] tts 429 - no audio for this session this cycle, it retries on its own" +
-                                  $"{(retryAfter is null ? "" : $" (provider Retry-After {retryAfter.Value.TotalSeconds:F0}s)")}");
-                    return new TtsResult(null, null, HostedAiState.ServiceDown);
+                    FileLog.Write($"[WingmanVoiceService] tts 429 sid={sid} - the speech provider refused this call" +
+                                  $"{(retryAfter is null ? " and sent no Retry-After" : $" and asked for {retryAfter.Value.TotalSeconds:F0}s")}; no audio this cycle - whether a re-attempt is booked is decided by the narration path, not here");
+                    return new TtsResult(null, null, HostedAiState.ServiceDown, Failure: SpeechFailure.RateLimited, RetryAfter: retryAfter);
                 }
 
                 // Any other error status means the far end failed, and we KNOW it. This used to return a
@@ -1842,10 +1912,15 @@ public sealed class WingmanVoiceService
                 // a log nobody reads and thrown away three lines from where it was known, so the phone
                 // fell back to "the Gateway has not made one, or this session's computer is offline".
                 // Both false. On 2026-07-15 that cost ~45 minutes of the owner not being able to tell an
-                // outage from a bug. Say what actually happened - this ONE session's ServiceDown - and
-                // let it retry on its own next cycle. No shared cooldown reaches across to other sessions.
-                FileLog.Write($"[WingmanVoiceService] tts {(int)resp.StatusCode} - server answered with a failure; this session has no audio this cycle and retries on its own");
-                return new TtsResult(null, null, HostedAiState.ServiceDown);
+                // outage from a bug. Say what actually happened - this ONE session's ServiceDown. No shared
+                // cooldown reaches across to other sessions.
+                //
+                // NO RE-ATTEMPT IS BOOKED for this one, and the log no longer says one is. The service told
+                // us it is failing, which is a claim the red "Voice service down" screen is right to make
+                // and which a second call seconds later has no reason to change - unlike a refusal that
+                // names its own deadline, or a call that never answered at all.
+                FileLog.Write($"[WingmanVoiceService] tts {(int)resp.StatusCode} sid={sid} - the server answered with a failure; this session has no audio this cycle and NOTHING is booked for it - the next turn-end or sweep is what comes back");
+                return new TtsResult(null, null, HostedAiState.ServiceDown, Failure: SpeechFailure.AnsweredFailure);
             }
             var contentType = resp.Content.Headers.ContentType?.MediaType;
             // The cloud proxy sets this out-of-band header when it quietly failed the primary voice
@@ -1880,8 +1955,8 @@ public sealed class WingmanVoiceService
             // above - keeps ServiceDown, because there the service really did tell us it is failing.)
             // This is per session and touches nothing else: there is no shared gate for a timeout to arm.
             sw.Stop();
-            FileLog.Write($"[WingmanVoiceService] tts did not answer for this narration (elapsedMs={sw.ElapsedMilliseconds}): {ex.Message} - " +
-                          "no answer from the service, so this is Retrying (not down); this session retries on its own");
+            FileLog.Write($"[WingmanVoiceService] tts did not answer for this narration sid={sid} (elapsedMs={sw.ElapsedMilliseconds}): {ex.Message} - " +
+                          "no answer from the service, so this is Retrying (not down); the narration path books the re-attempt");
             // A TimeoutException specifically means the primary went SILENT (the per-attempt deadline
             // fired, no answer). That silent hang is exactly what the cloud proxy's own failover cannot
             // see, so arm this session to route past the primary to the backup on its next turn-end /
@@ -1889,7 +1964,7 @@ public sealed class WingmanVoiceService
             // DIFFERENT fault - the proxy itself was unreachable, which does not implicate the primary -
             // so it does not arm the backup route.
             if (ex is TimeoutException) ArmPreferBackup(tenant, sid);
-            return new TtsResult(null, null, HostedAiState.Retrying);
+            return new TtsResult(null, null, HostedAiState.Retrying, Failure: SpeechFailure.DidNotAnswer);
         }
         // NOTE: no `finally { http.Dispose(); }`. `http` is now either the caller's injected client or
         // the shared static, and disposing EITHER would be wrong - the static must outlive every call


### PR DESCRIPTION
The **speech** leg said "this session retries on its own next turn-end / idle sweep" in three places and scheduled nothing in any of them. It was the last of the three places in this file that said it — the model leg's timeout was thefrederiksen/devthrottle_internal#1899 and its rate limit was thefrederiksen/devthrottle_internal#1902.

## One of the three had a lying screen, not just a lying log

My earlier report of this was too kind to it. The 429 and 5xx arms record `ServiceDown`, so their screens show a specific red "Voice service down" — a claim, but not a promise. The **non-answer arm records `Retrying`**, which the fold renders as "Voice is taking a moment - retrying automatically. It should come through shortly". A turn whose narration text had already been written, whose audio never came, and which nothing was making audio for, sat behind that sentence exactly as thefrederiksen/devthrottle_internal#1899's turns did.

## What changes

The speech leg classifies its own failure, and the narration path books a re-attempt for the two transient ones — a refusal that will be lifted, and a call that never answered. It is the **same per-turn ladder** the model leg uses, not a second one: a turn that loses its narration text to a stalled model and then its audio to a stalled speech provider has failed twice, not started again.

The speech provider's `Retry-After` is honoured the way the model's is — taken when it asks for longer than the rung, ignored when it asks for less, refused past the ceiling. It too was being parsed into a log line and dropped.

An answered 5xx books nothing and keeps its own verdict. The service told us it is failing, which the red panel is right to say and which a second call seconds later has no reason to change. Only its log was wrong.

The on-demand explain path is deliberately unchanged, and that is asserted rather than assumed — without it this change would have quietly turned a specific red verdict into a calm wait on the one path with no re-attempt behind it.

## Found in review

- **A no-audio outcome the classification did not name.** A speech call can produce no audio and record no state at all — a 200 carrying an empty body — and with an earlier attempt having left `Retrying` standing, the screen went back to promising audio with nothing behind it. This change's own defect, through the one door its own enumeration missed. Any attempt that produces no audio and books nothing now withdraws the promise.
- **Two claims of mine were too wide and are narrowed.** The turn epoch's comment said a superseded attempt "says nothing"; the guard binds the ladder, and a slow attempt still passes through `StoreSpokenAsync` first. And the re-attempt re-runs the model even for a speech-only failure — a deliberate trade (resuming at the speech step would speak text written for a reply the retry has not re-read), now written down as one.
- **Two tests were certified by an absence.** The `Retry-After` tests asserted the delay the service *recorded*, which passes if the task is dropped or fires at the wrong time; both now observe the wait itself. `AnOldTimer_CannotSteal` asserted "still two attempts", which is also what a machine too busy to run either timer would report; it now also requires the second reservation to fire.

## The test audit

The ask was for the tests to run and to be correct, and correct is not the same as green. Every test this whole body of work added — **derived** from the test files at the commit it started from, not hand-listed — was put to a mutation audit: each production behaviour re-applied as a mutation, with the rule that a test no mutation kills is not evidence for anything.

The first run reported 5 of 29 surviving. Four were gaps in the *mutation set*; the fifth was real, and a second real one came out of the reverse check (a mutation that killed nothing). Both are fixed:

- The **reservation identity** added to the retry ledger in the thefrederiksen/devthrottle_internal#1902 review had nothing standing against it. `AnOldTimer_CannotStealAReattemptBookedByALaterAttempt` now drives that race.
- `AConcurrentFailure` used a **one-rung** ladder, so the concurrent failure landed on the abandoning path where a second guard already held the line. With two rungs it lands on the booking path, which is what the stand-aside is actually for.

Final: **31 unit tests added, 31 killed, no survivors, no mutation skipped and none silent.** The two sweep tests live in the locked suite the unit harness does not run and were put to their own mutation separately — green on the real code, red against it.

The audit caught itself twice, which is the part worth keeping: once when the test-name parse matched nothing and reported a clean sweep, and once when a mutation's anchor stopped matching after a refactor and was silently skipped. Both would have read as a pass.

## Not changed

Nothing further in this area is knowingly left saying it retries when it does not. The three places that did now either book a re-attempt or say plainly that nothing is booked.
