### PR TITLE
fix(gateway): rule on the three Session Rules routes the census never judged (#2679)

### DIFF
--- a/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
+++ b/src/CcDirector.Gateway.Tests/CensusRouteTenancyProbeTests.cs
@@ -54,6 +54,7 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
     private HttpClient _http = null!;
     private string _keyA = "";
     private string _keyB = "";
+    private CcDirector.Core.Tenancy.TenantId _tenantA;
 
     private readonly string _instancesDir =
         Path.Combine(Path.GetTempPath(), "cc-census-" + Guid.NewGuid().ToString("N"));
@@ -80,6 +81,7 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
         var deviceB = HostedTestEnrollment.Enroll(_gateway, "sub-census-b", "census-b@example.com", "dev-cb", "MCB");
         _keyA = deviceA.DeviceKey;
         _keyB = deviceB.DeviceKey;
+        _tenantA = deviceA.Tenant;
 
         Assert.True(_gateway.TenantBoundary.IsHosted, "The harness must be running the HOSTED tenant boundary.");
         Assert.NotEqual(deviceA.Tenant.Value, deviceB.Tenant.Value);
@@ -532,5 +534,147 @@ public sealed class CensusRouteTenancyProbeTests : IAsyncLifetime
         var req = new HttpRequestMessage(new HttpMethod(method), absolute);
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
         return _http.SendAsync(req);
+    }
+
+    // ============================================================ the rules family (session_rules, session_rule_firings)
+
+    /// <summary>
+    /// The THREE context-less Session Rules routes - <c>GET /gateway/rules/{id:guid}</c>,
+    /// <c>DELETE /gateway/rules/{id:guid}</c> and <c>GET /gateway/rules/{id:guid}/firings</c> - executed
+    /// against two accounts.
+    ///
+    /// They arrived on main in the Session Rules mission and were never ruled on, so the census went red
+    /// (issue #2679). The verdict the census now carries is that they are confined by the model rather than
+    /// by anything in the route: both tables are <c>TenantScopedEntity</c>, so
+    /// <c>TenantScopeGuardTests</c> - which reflects the real EF model - proves each carries
+    /// <c>tenant_id</c> and the deny-by-default global query filter. That is a strong argument and it is
+    /// still an argument. This is the execution.
+    ///
+    /// The id is the sharpest possible handle here: a rule id is a Gateway-minted GUID, so the other
+    /// account cannot guess one - but this probe HANDS it to them, which is the only way to ask whether
+    /// anything but the filter was stopping them.
+    ///
+    /// Every refusal is judged twice, because a route that refuses everybody proves nothing about tenancy:
+    /// an independent RE-READ by the owner after the other account's attempt, and a destructibility control
+    /// in which the owner performs the SAME operation successfully.
+    /// </summary>
+    [Fact]
+    public async Task RuleReadFamily_ContextLess_ServesTheOwnerTheExactSeededRule_AndIsANotFoundForTheOtherTenant()
+    {
+        var id = await CreateRule(_keyA, "when the screen says it is rate limited, wait");
+
+        // OWNER CONTROL, on the exact fingerprint rather than a bare 200.
+        var mine = await Json(await Send("GET", $"gateway/rules/{id}", _keyA, null),
+            HttpStatusCode.OK, "owner reads its own rule");
+        Assert.Equal("when the screen says it is rate limited, wait",
+            mine.GetProperty("rule").GetProperty("instruction").GetString());
+
+        // THE OTHER ACCOUNT, handed the id.
+        var theirs = await Send("GET", $"gateway/rules/{id}", _keyB, null);
+        Assert.Equal(HttpStatusCode.NotFound, theirs.StatusCode);
+
+        // ...and it is not in their list either, which is the read that would leak without the filter.
+        var listB = await Json(await Send("GET", "gateway/rules", _keyB, null),
+            HttpStatusCode.OK, "the other account's own rule list");
+        Assert.Empty(listB.GetProperty("rules").EnumerateArray());
+
+        // INDEPENDENT RE-READ: the owner's rule is untouched by the attempt.
+        var again = await Json(await Send("GET", $"gateway/rules/{id}", _keyA, null),
+            HttpStatusCode.OK, "owner re-reads after the other account's attempt");
+        Assert.Equal("when the screen says it is rate limited, wait",
+            again.GetProperty("rule").GetProperty("instruction").GetString());
+    }
+
+    /// <summary>
+    /// DELETE is the destructive half, and the one where a missing filter costs a row rather than a
+    /// secret. The other account is handed the id and asked to delete it; the owner's rule must survive,
+    /// and the owner must then be able to delete it themselves - so the refusal is a refusal and not an
+    /// inert route.
+    /// </summary>
+    [Fact]
+    public async Task RuleDelete_ContextLess_CannotRemoveTheOtherTenantsRule_AndTheOwnerStillCan()
+    {
+        var id = await CreateRule(_keyA, "a rule the other account will try to delete");
+
+        // The other account's delete must not remove it. The route answers with what it deleted, and the
+        // honest answer for a rule it cannot see is "nothing".
+        var attempt = await Json(await Send("DELETE", $"gateway/rules/{id}", _keyB, null),
+            HttpStatusCode.OK, "the other account attempts the delete");
+        Assert.False(attempt.GetProperty("deleted").GetBoolean());
+
+        // INDEPENDENT RE-READ: still there, and still the owner's.
+        var survived = await Json(await Send("GET", $"gateway/rules/{id}", _keyA, null),
+            HttpStatusCode.OK, "owner re-reads after the other account's delete");
+        Assert.Equal("a rule the other account will try to delete",
+            survived.GetProperty("rule").GetProperty("instruction").GetString());
+
+        // DESTRUCTIBILITY CONTROL: the owner CAN delete it, so the refusal above was about tenancy and not
+        // about a route that refuses everyone.
+        var owned = await Json(await Send("DELETE", $"gateway/rules/{id}", _keyA, null),
+            HttpStatusCode.OK, "owner deletes its own rule");
+        Assert.True(owned.GetProperty("deleted").GetBoolean());
+        Assert.Equal(HttpStatusCode.NotFound, (await Send("GET", $"gateway/rules/{id}", _keyA, null)).StatusCode);
+    }
+
+    /// <summary>
+    /// THE FIRING RECORD, which is the product - and the row that cannot be probed honestly without
+    /// seeding, because no route creates a firing. Two empty lists compared against each other pass with
+    /// or without the filter, so the owner's firing is seeded through the store (inside its own tenant
+    /// scope) and the owner's read asserts THAT fingerprint. Only then does the other account's empty list
+    /// carry any weight.
+    /// </summary>
+    [Fact]
+    public async Task RuleFirings_ContextLess_ServeOnlyTheOwningTenants_Record()
+    {
+        var id = await CreateRule(_keyA, "a rule whose record the other account will ask for");
+        _gateway.SeedRuleFiringForTest(_tenantA, Guid.Parse(id), "sess-a", "the owner's own firing", DateTime.UtcNow);
+
+        // OWNER CONTROL on the exact seeded fingerprint.
+        var mine = await Json(await Send("GET", $"gateway/rules/{id}/firings", _keyA, null),
+            HttpStatusCode.OK, "owner reads its own firing record");
+        var firings = mine.GetProperty("firings").EnumerateArray().ToList();
+        Assert.Single(firings);
+        Assert.Equal("the owner's own firing", firings[0].GetProperty("reason").GetString());
+
+        // THE OTHER ACCOUNT, handed the same rule id: an empty record, not the owner's.
+        var theirs = await Json(await Send("GET", $"gateway/rules/{id}/firings", _keyB, null),
+            HttpStatusCode.OK, "the other account asks for that rule's record");
+        Assert.Empty(theirs.GetProperty("firings").EnumerateArray());
+
+        // INDEPENDENT RE-READ: the owner's record is intact.
+        var again = await Json(await Send("GET", $"gateway/rules/{id}/firings", _keyA, null),
+            HttpStatusCode.OK, "owner re-reads its record");
+        Assert.Single(again.GetProperty("firings").EnumerateArray());
+    }
+
+    /// <summary>Create a rule for one account over the real route, and hand back its id. Every field the
+    /// write gate insists on is supplied, so a refusal here is a real defect rather than a malformed
+    /// fixture - and the refusal reason is surfaced, because the store returns it verbatim.</summary>
+    private async Task<string> CreateRule(string key, string instruction)
+    {
+        var body = JsonSerializer.Serialize(new
+        {
+            instruction,
+            screenDescription = "the screen says it is rate limited",
+            triggerWords = new[] { "rate limited" },
+            checks = new object[]
+            {
+                new
+                {
+                    name = "matches_any",
+                    arguments = new Dictionary<string, object>
+                    {
+                        ["text"] = "the screen says it is rate limited",
+                        ["terms"] = new[] { "rate limited" },
+                    },
+                },
+            },
+            scope = "all-sessions",
+            cooldownSeconds = 60,
+            dailyCap = 5,
+        });
+        var created = await Json(await Send("POST", "gateway/rules", key, body),
+            HttpStatusCode.OK, "create a rule");
+        return created.GetProperty("rule").GetProperty("id").GetString()!;
     }
 }

--- a/src/CcDirector.Gateway.Tests/ContextLessRouteCensusTests.cs
+++ b/src/CcDirector.Gateway.Tests/ContextLessRouteCensusTests.cs
@@ -64,6 +64,33 @@ public sealed class ContextLessRouteCensusTests
     ///   /gateway/workflow-runs/{id}                workflow_runs
     ///   /gateway/skills/{id} and its family        skills, skill_versions, skill_files,
     ///                                              skill_tenant_overrides
+    ///   /gateway/rules/{id:guid} (+ /firings)      session_rules, session_rule_firings
+    ///
+    /// THE RULES FAMILY, ruled on here because it shipped without one (issue #2679). The three routes take
+    /// an id and no HttpContext, and nothing in the route confines them - the confinement is in the MODEL,
+    /// which is why reading the endpoint alone cannot settle it:
+    ///
+    ///   - SessionRuleEntity and SessionRuleFiringEntity both derive from GatewayMintedKeyEntity, which
+    ///     derives from TenantScopedEntity. TenantScopeGuardTests reflects the REAL EF model and asserts
+    ///     every such entity carries tenant_id AND the deny-by-default global query filter, so these two
+    ///     are covered by a check that enumerates rather than by a list somebody keeps.
+    ///   - The primary key is a Guid the Gateway MINTS, with a private setter only that base class can
+    ///     write, so there is no caller-supplied key to squat on and no existence oracle - the hazard the
+    ///     guard's third rule exists for.
+    ///   - GatewayDatabase.CreateContext() sets ActiveTenant from the ambient scope the device-key
+    ///     middleware entered, and THROWS on an invalid tenant rather than defaulting, so a rules query
+    ///     cannot run unscoped.
+    ///   - Writes additionally meet GatewayDbContext.SaveChanges, which refuses a row whose TenantId is not
+    ///     the connection's.
+    ///
+    /// EXECUTED, not argued: CensusRouteTenancyProbeTests hands the other account a real rule id and asks
+    /// it to read, delete, and read the firing record. The firing probe seeds a firing through the store
+    /// first, because no route creates one and two empty lists compared against each other would pass with
+    /// the filter removed.
+    ///
+    /// POST /gateway/rules and POST /gateway/rules/{id:guid}/promote are NOT in this census and that is not
+    /// an omission: the first takes no path parameter, and the second takes the HttpContext it needs to
+    /// mint a promotion grant, so neither is context-less.
     ///
     /// Hosted deny (the legacy same-machine discovery plane - not a tenant surface at all; refused on
     /// hosted, gated on the process-level hosted flag and proven by
@@ -74,6 +101,7 @@ public sealed class ContextLessRouteCensusTests
     {
         "DELETE /cron/jobs/{id}",
         "DELETE /directors/{id}/registration",
+        "DELETE /gateway/rules/{id:guid}",
         "DELETE /gateway/skills/{id}",
         "DELETE /gateway/workflows/{id}",
         "DELETE /lists/{name}/consumer",
@@ -81,6 +109,8 @@ public sealed class ContextLessRouteCensusTests
         "GET /cron/jobs/{id}",
         "GET /cron/jobs/{id}/runs",
         "GET /gateway/governance/session-spend/{sessionId}",
+        "GET /gateway/rules/{id:guid}",
+        "GET /gateway/rules/{id:guid}/firings",
         "GET /gateway/skills/{id}",
         "GET /gateway/skills/{id}/body",
         "GET /gateway/skills/{id}/files/{**filePath}",

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -855,6 +855,42 @@ public sealed class GatewayHost : IAsyncDisposable
         _sessionTurns.Append(directorId, batch, DateTime.UtcNow);
     }
 
+    /// <summary>
+    /// Record a rule firing for one account, as the evaluator's own write would.
+    ///
+    /// A test needs this because there is NO ROUTE that creates a firing - the record is written by the
+    /// evaluator, and the only firing route is the READ. Without a seeded firing, a cross-tenant probe of
+    /// <c>GET /gateway/rules/{id}/firings</c> compares one empty list against another and passes whether or
+    /// not the tenant filter is there at all: an absence standing in for a refusal. Seeding one gives the
+    /// owner's read a specific fingerprint to assert, which is what makes the other account's empty list
+    /// mean something.
+    ///
+    /// Enters the tenant's scope itself, so a test cannot write one account's firing into another's
+    /// partition by forgetting to - the same reason <see cref="SeedStoredConversationForTest"/> does.
+    /// </summary>
+    internal Rules.SessionRuleFiring SeedRuleFiringForTest(
+        TenantId tenant, Guid ruleId, string sessionId, string reason, DateTime nowUtc)
+    {
+        using var scope = _tenantBoundary?.EnterScope(tenant);
+        return _sessionRules.RecordFiring(
+            ruleId, sessionId,
+            screenText: "a screen the rule looked at",
+            understanding: "what the rule made of it",
+            // A dry-run rule may not claim to have typed anything, so the decision is the one that records
+            // a rule choosing NOT to act. The store refuses anything outside act/decline/abandoned/refused.
+            decision: "decline",
+            reason: reason,
+            primitiveRuns: Array.Empty<Rules.RulePrimitiveRun>(),
+            typedText: "",
+            outcome: "dry-run",
+            grounding: "seeded by a test",
+            nowUtc: nowUtc);
+    }
+
+    /// <summary>Test-only: the rule store, so a cross-tenant probe can assert against the store the routes
+    /// reach rather than only against what the routes chose to serve.</summary>
+    internal Rules.SessionRuleStore SessionRulesForTest => _sessionRules;
+
     /// <summary>Test-only: the session supervisor (issue #915), so a test can drive a real Working -&gt; idle
     /// transition into the REAL engine. Null until StartAsync builds it.</summary>
     internal Supervision.SessionSupervisor? SessionSupervisorForTest => _sessionSupervisor;

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -867,6 +867,13 @@ public sealed class GatewayHost : IAsyncDisposable
     ///
     /// Enters the tenant's scope itself, so a test cannot write one account's firing into another's
     /// partition by forgetting to - the same reason <see cref="SeedStoredConversationForTest"/> does.
+    ///
+    /// WHAT A PROBE BUILT ON THIS DOES NOT COVER, said here so nobody reads more into a green than it
+    /// carries (raised in review). It writes through the REAL store, so the entity mapping, the tenant
+    /// column, the save guard and the read projection are all the production ones - which is what makes it
+    /// evidence about the query filter. It says NOTHING about whether the evaluator enters the right
+    /// ambient tenant before recording a firing of its own; that is the evaluator's own integration
+    /// question and needs its own test.
     /// </summary>
     internal Rules.SessionRuleFiring SeedRuleFiringForTest(
         TenantId tenant, Guid ruleId, string sessionId, string reason, DateTime nowUtc)
@@ -886,10 +893,6 @@ public sealed class GatewayHost : IAsyncDisposable
             grounding: "seeded by a test",
             nowUtc: nowUtc);
     }
-
-    /// <summary>Test-only: the rule store, so a cross-tenant probe can assert against the store the routes
-    /// reach rather than only against what the routes chose to serve.</summary>
-    internal Rules.SessionRuleStore SessionRulesForTest => _sessionRules;
 
     /// <summary>Test-only: the session supervisor (issue #915), so a test can drive a real Working -&gt; idle
     /// transition into the REAL engine. Null until StartAsync builds it.</summary>


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1901.

`ContextLessRouteCensusTests` has been red on `main` since the Session Rules mission landed on 2 September. It lives in the parked suite, so the fast gate never saw it — it only surfaced when a release-quality run went looking, and it stood between us and a clean release gate. Three routes were live and absent from the ruled list:

```
DELETE /gateway/rules/{id:guid}
GET    /gateway/rules/{id:guid}
GET    /gateway/rules/{id:guid}/firings
```

## Not fixed by adding three lines

The issue and the test's own doc comment both say that would be worse than the red. A row in that file is a **verdict**: which store the route reaches, and what confines it to the caller's tenant. Pasting the strings in turns a tenancy check into a rubber stamp.

**The verdict.** Nothing in these routes confines them — they take an id and no `HttpContext`. The confinement is in the model:

- `SessionRuleEntity` and `SessionRuleFiringEntity` derive from `GatewayMintedKeyEntity : TenantScopedEntity`. `TenantScopeGuardTests` reflects the **real EF model** and asserts every such entity carries `tenant_id` *and* the deny-by-default global query filter — so these two are covered by a check that enumerates rather than by a list somebody maintains.
- The primary key is a Guid the Gateway mints, with a private setter only that base class can write, so there is no caller-supplied key to squat on and no existence oracle — the hazard that guard's third rule exists for.
- `GatewayDatabase.CreateContext()` sets `ActiveTenant` from the ambient scope the device-key middleware entered, and **throws** on an invalid tenant rather than defaulting.
- Writes additionally meet `GatewayDbContext.SaveChanges`, which refuses a row whose `TenantId` is not the connection's.

## Executed, because the family had no probe at all

Three added to `CensusRouteTenancyProbeTests`, in that file's established shape: two accounts minted through the product's own hosted enrollment on one real hosted Gateway, every request over real HTTP through the real auth middleware, the owner control asserting the **exact seeded fingerprint** rather than a bare 200, and every refusal judged by an independent re-read plus a destructibility control — the owner performing the same operation successfully, so a refusal is a refusal and not an inert route.

The other account is **handed** the rule id. A rule id is a minted Guid it could never guess, so handing it over is the only way to ask whether anything but the filter was stopping it.

**The firing probe needed a seed, and that is the interesting part.** No route creates a firing — the record is written by the evaluator, and the only firing route is the read. Without a seeded firing the probe compares one empty list against another and passes whether or not the filter is there at all: an absence standing in for a refusal. A test seam writes the owner's firing through the real store inside its own tenant scope, so the owner's read has a fingerprint to assert and the other account's empty list means something.

## Proved, not asserted

- Remove a census row → both census tests go red.
- Keep the `tenant_id` column and index but remove **only** the query filter from the two rule tables → exactly the three new probes go red, and nothing else.

The blunter mutation — deleting the `ApplyTenantScope` calls outright — was tried first and **rejected as evidence**. It also removes the column, so the EF model will not build and every test in both fixtures dies at `StartAsync`. That proves the application breaks, not that the probe detects a leak.

## Scope

`POST /gateway/rules` and `POST /gateway/rules/{id:guid}/promote` are deliberately not in the census: the first takes no path parameter, the second takes the `HttpContext` it needs to mint a promotion grant. Neither is context-less.

Not taken from `origin/mission/rules-fix-f`, which does carry rows and a verdict for this family. It is 85 commits of in-flight mission work, and its census also lists a `/gateway/rules/draft` route `main` does not have — so merging it would ship a mission, and copying its list would fail the census the other way. The rows here are derived from `main`'s own route table.

## Review

Reviewed by a separate agent family, which found no tenancy or correctness defect and two things worth acting on, both done in the second commit: a test seam I added and never used, and a claim worth narrowing — the firing probe is evidence about the query filter, and says nothing about whether the *evaluator* enters the right ambient tenant before recording a firing of its own. That is its own integration question and the comment now says so.
