### PR TITLE
docs(gateway): the built-in skill tells agents the browser profiles exist

### DIFF
--- a/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
+++ b/src/CcDirector.Gateway/Skills/Content/dev-throttle.skill.md
@@ -25,6 +25,20 @@ All tools are on PATH after install. For exact flags and examples, run any tool 
 ### Web
 `cc-crawl4ai` (clean markdown extraction for RAG), `cc-websiteaudit`, `cc-brandingrecommendations`.
 
+### Browsers you are signed in to
+`cc-devthrottle browser` owns this machine's drivable browser profiles - a real Chrome the user signed into ONCE, which any agent can then drive as the user. `browser-harness` drives the page.
+
+**Never launch a browser yourself** - not `chrome.exe` with a debugging switch, not a hand-written CDP state file, and not `cc-playwright` (retired). Those all succeed into a browser signed in as NOBODY, which surfaces as a login page and tempts the next agent into typing the user's password.
+
+```bash
+cc-devthrottle browser list --json                      # what exists, and whose account each one is
+cc-devthrottle browser start centerconsulting           # launch it if down
+eval "$(cc-devthrottle browser attach 'centerconsulting')"   # BU_NAME / BU_CDP_URL for the harness
+cc-devthrottle browser stop centerconsulting            # done; the login is kept
+```
+
+Pick the profile by its `account` field, never by name or port. **The browsers skill is the full reference** - read it before driving one.
+
 ### Desktop automation
 `cc-click` (Windows UI: click, type, screenshot, OCR), `cc-trisight` (3-tier UI element detection: UIA + OCR + pixel), `cc-computer` (AI desktop agent with screenshot-in-the-loop).
 
@@ -184,6 +198,8 @@ use the identity the preamble gave you. If no user is named (nobody signed in), 
 
 - "What cc-* tools do I have for X?" - look in the tool list above; run the tool with `--help` for syntax.
 - "How do I list / message / create / close sessions?" - use `cc-devthrottle` (details in the fleet-comms skill).
+- "I need a page that requires the user's login" - do NOT launch a browser. `cc-devthrottle browser
+  list --json`, then the **browsers** skill.
 - "Is the app running?" - the Director binds no port, so there is nothing to curl. Read the
   instance registration the running process writes
   (`%LOCALAPPDATA%\cc-director\instances\<slug>\config\director\instances\<directorId>.json`,
@@ -194,10 +210,13 @@ use the identity the preamble gave you. If no user is named (nobody signed in), 
 
 - It does not replace `<tool> --help`, which has the authoritative flags and examples for each tool.
 - It does not replace the **fleet-comms** skill, which is the full reference for `cc-devthrottle`.
+- It does not replace the **browsers** skill, which is the full reference for driving a signed-in browser.
 
 
-**Skill Version:** 6.0 (no Director listener)
-**Last Updated:** 2026-08-03
+**Skill Version:** 6.1 (drivable browser profiles)
+**Last Updated:** 2026-09-06
+**Changes in 6.1:** Added the drivable browser profiles. `cc-devthrottle browser` registers, starts, attaches and stops a real browser the user signed into once, and `browser-harness` drives the page. This is written down because the absence of it caused a live failure on 2026-09-06: with a signed-in `centerconsulting` profile registered and stopped, an agent that never ran `browser list` hand-launched Chrome against a retired `cc-playwright` folder and handed the user a LOGIN page for the site it was asked to work in. Hand-rolling a browser does not fail loudly, it succeeds into the wrong session - so the rule is that the Director owns the profiles and an agent never launches one. Full reference: the **browsers** skill.
+
 **Changes in 6.0:** The remove-the-network-port mission deleted the Director's listener entirely.
 There is no loopback floor, no `/healthz`, no `/fleet/*` relay, no `/reconnect`, no local settings
 routes, and no `CC_DIRECTOR_API` or `CC_DIRECTOR_TOKEN` in any session's environment. Agents reach


### PR DESCRIPTION
## What changed

One file: the shipped built-in `dev-throttle` skill. It listed every `cc-*` tool and never mentioned
that the Director holds **drivable browser profiles** - a real Chrome the user signed into once,
which any agent can then drive as the user. An agent that read this skill end to end came away
believing no such thing existed.

Added:

- a **"Browsers you are signed in to"** section in the tool list - the four commands
  (`list --json` / `start` / `attach` / `stop`), pick-by-`account`, and the explicit "never launch a
  browser yourself"
- a line in *When this skill is the right thing to consult* for "I need a page that requires the
  user's login"
- a line in *What this skill does NOT do*, pointing at the `browsers` skill as the full reference
- the **6.1** changelog entry and version line

## Why now

The gap was paid for on 2026-09-06. With a signed-in `centerconsulting` profile registered and
stopped on this machine, a session that never ran `cc-devthrottle browser list` hand-launched Chrome
against a retired `cc-playwright` folder, hand-wrote a CDP state file (twice), and handed the owner a
**login page** for the site it had been asked to work in.

Nothing errored. That is the whole point, and it is why this belongs in the product rather than in
one repo's notes: hand-rolling a browser does not fail loudly, it succeeds into the wrong session -
and the next move an agent reaches for from a login page is the one it must never make, which is
typing the user's password.

## Scope

Prose only - no code, no behaviour change. The full reference lives in the `browsers` fleet skill
(published separately, live now); this file points at it rather than restating it, so the two cannot
drift into two different sets of instructions.

## How it ships

`BuiltInSkillSeeder` hashes the shipped content and upgrades the built-in when the hash moves, so
this becomes a new published version of `dev-throttle` on the next Gateway start. **Nothing to bump
by hand, and nothing here deploys anything** - it reaches agents when the Gateway is next released
through its own workflow.

## Proof

```
dotnet test CcDirector.Gateway.UnitTests --filter FullyQualifiedName~BuiltInSkill   5 passed
dotnet test CcDirector.Gateway.UnitTests --filter FullyQualifiedName~Skill         64 passed
```

`BuiltInSkillsHaveNoDeadDoorTests` is the one that matters here: it runs over every
`*.skill.md` and fails if shipped prose sends an agent at the deleted Director listener. The new text
adds instructions, so it had to clear that guard rather than merely not break a build - prose is not
compiled, and that test is the only thing in the build that reads it.
