### PR TITLE
The mobile ring names the desk and the Cockpit separately

### DIFF
--- a/apps/cockpit/src/throttle/YourThrottleContract.test.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleContract.test.tsx
@@ -86,7 +86,9 @@ function overviewFromDom(container: HTMLElement) {
   const [voiceRing, phoneRing] = heroes;
   const legend = (ring: Element) => Array.from(ring.querySelectorAll(".thr-hero-leg b")).map((b) => count(b.textContent));
   const [voiceTurns, typedTurns] = legend(voiceRing);
-  const [phoneTurns, phoneRemainder] = legend(phoneRing);
+  // The phone ring names its other side surface by surface now (owner's ask, 2026-09-06), so the legend is
+  // the phone count followed by one count per remaining surface that has a turn.
+  const [phoneTurns, ...restOfPhoneRing] = legend(phoneRing);
   const sub = container.querySelector(".thr-panel-sub")!.textContent ?? "";
   const denominator = count(/^(\S+) turns across every surface$/.exec(sub)?.[1]);
   const segments = Array.from(container.querySelectorAll(".thr-split-seg")).map((seg) => {
@@ -100,7 +102,8 @@ function overviewFromDom(container: HTMLElement) {
   }));
   return {
     denominator,
-    voiceTurns, typedTurns, phoneTurns, phoneRemainder,
+    voiceTurns, typedTurns, phoneTurns,
+    restOfPhoneRing,
     voiceShare: arcShare(voiceRing), phoneShare: arcShare(phoneRing),
     voicePercent: percent(voiceRing.querySelector(".thr-ring-pct")!.textContent),
     phonePercent: percent(phoneRing.querySelector(".thr-ring-pct")!.textContent),
@@ -162,7 +165,9 @@ describe("the Your Throttle contract, on the rendered Cockpit page - the whole a
       expect(overview).toEqual({
         denominator: expected.denominator,
         voiceTurns: expected.voiceTurns, typedTurns: expected.typedTurns,
-        phoneTurns: expected.phoneTurns, phoneRemainder: expected.phoneRemainder,
+        phoneTurns: expected.phoneTurns,
+        // Each remaining surface with a turn, named on its own - never one added-up "Desktop + Cockpit".
+        restOfPhoneRing: expected.surfaces.filter((s) => s.surface !== "phone" && s.turns > 0).map((s) => s.turns),
         voiceShare: expected.voiceShare, phoneShare: expected.phoneShare,
         voicePercent: expected.voicePercent, phonePercent: expected.phonePercent,
         segments: expected.segments.map((s) => ({ label: s.label, turns: s.turns, percent: s.percent, share: s.share, printed: s.share !== null && s.share * 100 >= 8 ? s.percent : null })),

--- a/apps/cockpit/src/throttle/YourThrottleView.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleView.tsx
@@ -254,10 +254,12 @@ function OverviewTab({ summary, data }: { summary: ThrottleSummary; data: Thrott
           accentVar="--thr-mobile"
           centerCaption="from phone"
           primary={{ label: "Phone", count: summary.turnsBySurface.phone }}
-          secondary={{
-            label: "Desktop + Cockpit",
-            count: summary.phoneRemainder,
-          }}
+          // The other side of this ring, BROKEN OUT (owner's ask, 2026-09-06). It used to read
+          // "Desktop + Cockpit 257", which answers the ring's question and hides the one underneath it:
+          // how much of the desk is the Cockpit. Every surface that has a turn is named on its own, so
+          // the parts still add to the ring's other side and nothing is folded away.
+          rest={summary.surfaces.filter((s) => s.surface !== "phone" && s.turns > 0)
+            .map((s) => ({ label: s.label, count: s.turns }))}
         />
       </div>
 
@@ -321,6 +323,7 @@ function HeroRing({
   centerCaption,
   primary,
   secondary,
+  rest,
   note,
 }: {
   title: string;
@@ -329,13 +332,20 @@ function HeroRing({
   accentVar: string;
   centerCaption: string;
   primary: { label: string; count: number };
-  secondary: { label: string; count: number };
+  /** The single remainder, for a ring whose other side is one thing ("Typed"). */
+  secondary?: { label: string; count: number };
+  /** The remainder BROKEN OUT, for a ring whose other side is several things - each named with its own
+   *  count so the reader sees what the ring's one number is hiding. Exactly one of these two is given. */
+  rest?: { label: string; count: number }[];
   note?: string;
 }) {
   const R = 42;
   const C = 2 * Math.PI * R;
   const filled = share === null ? 0 : share * C;
   const pctText = formatPercent(percent);
+  // The ring's other side, as the label a screen reader hears: one thing, or the parts named.
+  const others = rest ?? (secondary === undefined ? [] : [secondary]);
+  const othersTotal = others.reduce((t, e) => t + e.count, 0);
 
   return (
     <section className="thr-hero">
@@ -343,7 +353,7 @@ function HeroRing({
       <div
         className="thr-ring"
         role="img"
-        aria-label={`${title}: ${primary.label} ${pctText} (${primary.count} of ${primary.count + secondary.count} turns)`}
+        aria-label={`${title}: ${primary.label} ${pctText} (${primary.count} of ${primary.count + othersTotal} turns)`}
       >
         <svg
           viewBox="0 0 100 100"
@@ -370,11 +380,13 @@ function HeroRing({
           {primary.label}
           <b>{primary.count.toLocaleString()}</b>
         </span>
-        <span className="thr-hero-leg">
-          <span className="thr-dot thr-dot-muted" />
-          {secondary.label}
-          <b>{secondary.count.toLocaleString()}</b>
-        </span>
+        {(rest ?? (secondary === undefined ? [] : [secondary])).map((entry) => (
+          <span key={entry.label} className="thr-hero-leg">
+            <span className="thr-dot thr-dot-muted" />
+            {entry.label}
+            <b>{entry.count.toLocaleString()}</b>
+          </span>
+        ))}
       </div>
       {note !== undefined && <div className="thr-hero-note">{note}</div>}
     </section>

--- a/apps/mobile/src/pages/YourThrottle.tsx
+++ b/apps/mobile/src/pages/YourThrottle.tsx
@@ -124,7 +124,10 @@ export function YourThrottle() {
               percent={summary.phonePercent}
               color={RING_MOBILE}
               primary={{ label: "Phone", count: summary.turnsBySurface.phone }}
-              secondary={{ label: "Desk + Cockpit", count: summary.phoneRemainder }}
+              // Broken out, exactly as on the Cockpit (owner's ask, 2026-09-06): the desk and the Cockpit
+              // are named separately rather than added together, so the two surfaces say the same thing.
+              rest={summary.surfaces.filter((s) => s.surface !== "phone" && s.turns > 0)
+                .map((s) => ({ label: s.label, count: s.turns }))}
             />
           </div>
 
@@ -210,6 +213,7 @@ function MetricRing({
   color,
   primary,
   secondary,
+  rest,
   note,
 }: {
   title: string;
@@ -217,20 +221,25 @@ function MetricRing({
   percent: number | null;
   color: string;
   primary: { label: string; count: number };
-  secondary: { label: string; count: number };
+  /** The single remainder, for a ring whose other side is one thing ("Typed"). */
+  secondary?: { label: string; count: number };
+  /** The remainder broken out, each surface named with its own count. */
+  rest?: { label: string; count: number }[];
   note?: string;
 }) {
   const R = 42;
   const C = 2 * Math.PI * R;
   const filled = share === null ? 0 : share * C;
   const pctText = formatPercent(percent);
+  const others = rest ?? (secondary === undefined ? [] : [secondary]);
+  const othersTotal = others.reduce((t, e) => t + e.count, 0);
 
   return (
     <section className="mthr-metric">
       <div
         className="mthr-ring"
         role="img"
-        aria-label={`${title}: ${primary.label} ${pctText} (${primary.count} of ${primary.count + secondary.count} turns)`}
+        aria-label={`${title}: ${primary.label} ${pctText} (${primary.count} of ${primary.count + othersTotal} turns)`}
       >
         <svg viewBox="0 0 100 100" className="mthr-ring-svg" style={{ ["--mthr-arc" as string]: color } as CSSProperties}>
           <circle className="mthr-ring-track" cx="50" cy="50" r={R} />
@@ -245,10 +254,12 @@ function MetricRing({
             <span className="mthr-dot" style={{ background: color }} />
             {primary.label} <b>{primary.count.toLocaleString()}</b>
           </span>
-          <span className="mthr-leg">
-            <span className="mthr-dot mthr-dot-muted" />
-            {secondary.label} <b>{secondary.count.toLocaleString()}</b>
-          </span>
+          {others.map((entry) => (
+            <span key={entry.label} className="mthr-leg">
+              <span className="mthr-dot mthr-dot-muted" />
+              {entry.label} <b>{entry.count.toLocaleString()}</b>
+            </span>
+          ))}
         </div>
         {note !== undefined && <div className="mthr-metric-note">{note}</div>}
       </div>

--- a/apps/mobile/src/pages/YourThrottleContract.test.tsx
+++ b/apps/mobile/src/pages/YourThrottleContract.test.tsx
@@ -77,7 +77,8 @@ function pageFromDom(container: HTMLElement) {
   const [voiceRing, phoneRing] = metrics;
   const legend = (ring: Element) => Array.from(ring.querySelectorAll(".mthr-leg b")).map((b) => count(b.textContent));
   const [voiceTurns, typedTurns] = legend(voiceRing);
-  const [phoneTurns, phoneRemainder] = legend(phoneRing);
+  // Broken out surface by surface, exactly as on the Cockpit (owner's ask, 2026-09-06).
+  const [phoneTurns, ...restOfPhoneRing] = legend(phoneRing);
   const segments = Array.from(container.querySelectorAll(".mthr-split-seg")).map((seg) => {
     const title = /^(.+): (\d+) \((.+)\)$/.exec(seg.getAttribute("title") ?? "");
     return { label: title?.[1], turns: count(title?.[2]), percent: percent(title?.[3]), share: round10(pct(seg) / 100) };
@@ -88,7 +89,8 @@ function pageFromDom(container: HTMLElement) {
   }));
   return {
     denominator: count(container.querySelector(".mthr-stat-value")!.textContent),
-    voiceTurns, typedTurns, phoneTurns, phoneRemainder,
+    voiceTurns, typedTurns, phoneTurns,
+    restOfPhoneRing,
     voiceShare: arcShare(voiceRing), phoneShare: arcShare(phoneRing),
     voicePercent: percent(voiceRing.querySelector(".mthr-ring-pct")!.textContent),
     phonePercent: percent(phoneRing.querySelector(".mthr-ring-pct")!.textContent),
@@ -119,7 +121,8 @@ describe("the Your Throttle contract, on the rendered phone page - the whole ans
       expect(pageFromDom(container)).toEqual({
         denominator: expected.denominator,
         voiceTurns: expected.voiceTurns, typedTurns: expected.typedTurns,
-        phoneTurns: expected.phoneTurns, phoneRemainder: expected.phoneRemainder,
+        phoneTurns: expected.phoneTurns,
+        restOfPhoneRing: expected.surfaces.filter((s) => s.surface !== "phone" && s.turns > 0).map((s) => s.turns),
         voiceShare: expected.voiceShare, phoneShare: expected.phoneShare,
         voicePercent: expected.voicePercent, phonePercent: expected.phonePercent,
         segments: expected.segments.map((s) => ({ label: s.label, turns: s.turns, percent: s.percent, share: s.share })),


### PR DESCRIPTION
The "Mobile vs desktop" ring answers how much you drive from the phone, and its other side read
**"Desktop + Cockpit 257"** - which answers the ring's question and hides the one underneath it: how much
of the desk is actually the Cockpit.

Now every surface with a turn is named on its own beneath the ring, on the Cockpit page and on the phone,
so the two surfaces still say the same thing. The unknown surface keeps its own entry when it has turns,
so the parts still account for the whole instead of quietly dropping the ones nobody could place.

No server change: the per-surface counts were already on the served headline, so the ring reads fields it
already had rather than subtracting anything.

Both rendered-page contracts read the legend back off the real DOM. They were watched failing on the old
combined entry before they were updated, which is the evidence they are not vacuous.

Local gate green. Four web workspaces green, typecheck clean.