### PR TITLE
feat(director): the Director installs the launcher's staged update (issue #2719, Phase 0)

### DIFF
--- a/scripts/launcher-swap-proof.ps1
+++ b/scripts/launcher-swap-proof.ps1
@@ -1,0 +1,216 @@
+<#
+.SYNOPSIS
+    The end-to-end proof of the Director installing the launcher's staged update (issue #2719,
+    Phase 0), on an ISOLATED storage root, with REAL launcher binaries and a REAL running launcher.
+
+.DESCRIPTION
+    Phase 0's unit tests drive the whole pass through fakes for the process list, the stop and the
+    start. That is right for the decisions and says nothing about the three production delegates that
+    touch the machine: DefaultStopProcess, DefaultStartLauncher (including the CC_DIRECTOR_ROOT scrub
+    and the --managed argument), and the witness reading a genuinely new process. Until this script
+    ran, none of those had ever executed against a real launcher.
+
+    WHY AN ISOLATED ROOT AND NOT THIS MACHINE'S LAUNCHER. On Windows the installed launcher is the
+    parent of the Director, and on this account that Director carries the live fleet. Swapping it
+    would put the one unproven invariant - a launcher swap must not orphan its Director - directly
+    underneath every running session. The owner's standing instruction is to ask before anything stops
+    or replaces the running launcher, and that question is unanswered.
+
+    So the rig builds its own world. A launcher started with CC_DIRECTOR_ROOT pointing elsewhere
+    serves THAT root completely: it registers under it, derives its own root key from it, and its
+    instance guard refuses to act on a Director that is not its own (established 2026-09-06, recorded
+    on issue #2719). The rig asserts that separation rather than assuming it - the driver refuses to
+    run against the real root, and checks afterwards that the machine's real launcher did not move.
+
+    WHAT THIS DOES NOT PROVE. The rig's launcher supervises no Director, so a launcher that is a LIVE
+    DIRECTOR'S PARENT has still never been swapped. The no-orphan invariant is asserted only through
+    a fake, in LauncherUpdateOwnerTests. Say so wherever this run is quoted.
+
+.PARAMETER Root
+    The isolated storage root. Must NOT be this machine's real cc-director root; the driver refuses.
+
+.PARAMETER OldVersion
+    The version stamped into the build that starts out installed.
+
+.PARAMETER NewVersion
+    The version stamped into the build that is staged, and which must end up running and commandable.
+
+.PARAMETER KeepRoot
+    Leave the isolated root and its launcher in place after the run, for inspection.
+
+.EXAMPLE
+    .\scripts\launcher-swap-proof.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$Root = (Join-Path $env:LOCALAPPDATA "cc-director-launcher-proof"),
+    [string]$OldVersion = "2.0.4",
+    [string]$NewVersion = "2.0.99",
+    [switch]$KeepRoot
+)
+
+$ErrorActionPreference = "Stop"
+$repo = Split-Path -Parent $PSScriptRoot
+
+function Say([string]$text) { Write-Host "[launcher-swap-proof] $text" }
+
+# ---------------------------------------------------------------------------
+# 0. Refuse the real root here as well as in the driver. Two refusals, because
+#    this script starts and stops launcher processes before the driver ever runs.
+# ---------------------------------------------------------------------------
+$realRoot = Join-Path $env:LOCALAPPDATA "cc-director"
+if ($Root.TrimEnd('\') -ieq $realRoot.TrimEnd('\')) {
+    throw "REFUSING: $Root is this machine's REAL cc-director root. This script stops launchers."
+}
+$launcherDir = Join-Path $Root "launcher"
+$stagedDir   = Join-Path $Root "state\staged"
+$setupDir    = Join-Path $Root "config\setup"
+
+# ---------------------------------------------------------------------------
+# 1. Two real launcher builds, differing only in the version they stamp. The
+#    staged one has to be genuinely NEWER or FindStagedUpdate correctly declines.
+# ---------------------------------------------------------------------------
+$buildRoot = Join-Path $env:TEMP "launcher-swap-proof-builds"
+$oldBuild  = Join-Path $buildRoot "old\cc-launcher.exe"
+$newBuild  = Join-Path $buildRoot "new\cc-launcher.exe"
+
+function Publish-Launcher([string]$version, [string]$outDir) {
+    if (Test-Path (Join-Path $outDir "cc-launcher.exe")) {
+        $stamped = [System.Diagnostics.FileVersionInfo]::GetVersionInfo((Join-Path $outDir "cc-launcher.exe")).ProductVersion
+        if ($stamped -and $stamped.StartsWith($version)) { Say "reusing $version at $outDir"; return }
+    }
+    Say "publishing launcher $version -> $outDir"
+    & dotnet publish (Join-Path $repo "src\CcDirector.Launcher\CcDirector.Launcher.csproj") `
+        -c Release -f net10.0-windows -r win-x64 --self-contained true `
+        -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true `
+        -p:Version=$version -p:InformationalVersion=$version `
+        -o $outDir --nologo -v q
+    if ($LASTEXITCODE -ne 0) { throw "publishing the launcher at $version failed" }
+}
+
+Publish-Launcher $OldVersion (Split-Path -Parent $oldBuild)
+Publish-Launcher $NewVersion (Split-Path -Parent $newBuild)
+
+# ---------------------------------------------------------------------------
+# 2. Lay out the isolated install: the old build installed, the new one staged,
+#    and a manifest that says what is installed.
+# ---------------------------------------------------------------------------
+function Stop-RigLaunchers([string]$dir) {
+    # Only processes running from the RIG's launcher directory. Never a name-wide
+    # sweep: this machine's real launcher is also called cc-launcher.
+    Get-Process -Name "cc-launcher" -ErrorAction SilentlyContinue | ForEach-Object {
+        $path = $null
+        try { $path = $_.MainModule.FileName } catch { }
+        if ($path -and $path.StartsWith($dir, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Say "stopping leftover rig launcher pid $($_.Id)"
+            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Stop-RigLaunchers $launcherDir
+if (Test-Path $Root) { Remove-Item -Recurse -Force $Root }
+New-Item -ItemType Directory -Force -Path $launcherDir, $stagedDir, $setupDir | Out-Null
+
+Copy-Item $oldBuild (Join-Path $launcherDir "cc-launcher.exe") -Force
+Copy-Item $newBuild (Join-Path $stagedDir  "cc-launcher.exe") -Force
+@{ "cc-launcher" = $OldVersion } | ConvertTo-Json | Set-Content -Path (Join-Path $setupDir "installed.json") -Encoding utf8
+
+Say "isolated root laid out at $Root (installed $OldVersion, staged $NewVersion)"
+
+# ---------------------------------------------------------------------------
+# 3. Start the rig's launcher, pointed at the isolated root.
+#
+#    CC_DIRECTOR_ROOT is set DELIBERATELY here - it is what makes the launcher
+#    serve the rig's world instead of the machine's. That is the exact opposite
+#    of what the Director's own DefaultStartLauncher does, which REMOVES the
+#    variable so a launcher it starts cannot inherit a Director's instance home.
+#    Both are correct: this script is the installer of the rig's world, and the
+#    variable is how a world is named.
+# ---------------------------------------------------------------------------
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = (Join-Path $launcherDir "cc-launcher.exe")
+$psi.WorkingDirectory = $launcherDir
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+# Windows PowerShell 5.1 runs on .NET Framework, whose ProcessStartInfo has no ArgumentList - the
+# single Arguments string is the only form available here.
+$psi.Arguments = "--managed"
+$psi.EnvironmentVariables["CC_DIRECTOR_ROOT"] = $Root
+$rig = [System.Diagnostics.Process]::Start($psi)
+Say "started the rig launcher: pid $($rig.Id)"
+
+# It unpacks a single-file binary before it registers anything, so give it real time.
+$registration = Join-Path $Root "config\launcher\launcher.json"
+$deadline = (Get-Date).AddSeconds(120)
+while ((Get-Date) -lt $deadline -and -not (Test-Path $registration)) { Start-Sleep -Milliseconds 500 }
+if (-not (Test-Path $registration)) {
+    Stop-RigLaunchers $launcherDir
+    throw "the rig launcher never registered at $registration"
+}
+Say "the rig launcher registered: $(Get-Content $registration -Raw)"
+
+# ---------------------------------------------------------------------------
+# 4. The proof itself.
+# ---------------------------------------------------------------------------
+#    THE DRIVER'S OUTPUT IS REDIRECTED TO FILES, AND THAT IS NOT TIDINESS. The swap starts a launcher
+#    that is meant to STAY RUNNING, and a child started without redirection inherits the console
+#    handles - so the pipeline reading this script's output waits on the launcher, not on the driver,
+#    and the script hangs after printing PASS. Observed on 2026-09-06: the first two runs terminated
+#    only because the started launcher exited immediately (it was the second-instance failure the rig
+#    was there to find), and the first SUCCESSFUL run hung for ten minutes with the proof already
+#    passed. Handing the driver file handles instead means the launcher inherits those, and Start-Process
+#    -Wait waits only on the driver.
+$proofOut = Join-Path $env:TEMP "launcher-swap-proof.out.txt"
+$proofErr = Join-Path $env:TEMP "launcher-swap-proof.err.txt"
+# Deleted BEFORE the run: a verdict left by a previous run must never be read as this run's result.
+$proofVerdict = Join-Path $env:TEMP "launcher-swap-proof.verdict.txt"
+if (Test-Path $proofVerdict) { Remove-Item -Force $proofVerdict }
+try {
+    $driver = Start-Process -FilePath "dotnet" -PassThru -NoNewWindow `
+        -RedirectStandardOutput $proofOut -RedirectStandardError $proofErr `
+        -ArgumentList @(
+            "run", "--project",
+            (Join-Path $repo "scripts\launcher-swap-proof\LauncherSwapProof.csproj"),
+            "--no-build", "--", $Root, $NewVersion)
+
+    # POLL, DO NOT WAIT ON THE STREAMS. -Wait (and WaitForExit) on a process with redirected output
+    # waits for those streams to CLOSE, and the launcher the swap started inherited them - so the
+    # script blocked on a launcher that is supposed to keep running, with the proof already passed.
+    # HasExited asks about the process and nothing else.
+    while (-not $driver.HasExited) { Start-Sleep -Milliseconds 500 }
+    if (Test-Path $proofOut) { Get-Content $proofOut | ForEach-Object { Write-Host $_ } }
+    if (Test-Path $proofErr) { Get-Content $proofErr | ForEach-Object { Write-Host $_ } }
+
+    # Refresh before reading: a process object obtained from Start-Process -PassThru without -Wait
+    # caches its state, and ExitCode came back EMPTY without this - which the check below then read as
+    # "not zero" and reported as a FAILED proof on a run that had passed. An unreadable exit code is
+    # undecidable, and undecidable is not a pass either, so it is raised rather than defaulted.
+    # THE VERDICT IS THE FILE THE DRIVER WROTE, not the exit code. Windows PowerShell's
+    # Start-Process -PassThru without -Wait does not retain the process handle, so ExitCode reads back
+    # EMPTY - and this script duly reported a FAILED proof on a run that had passed. -Wait is not
+    # available either: with redirected output it waits for the streams to close, and the launcher this
+    # proof deliberately leaves running has inherited them.
+    #
+    # The check is a PRESENCE: the file must exist and must say PASS. A missing file is a broken
+    # instrument, never a clean run.
+    if (-not (Test-Path $proofVerdict)) {
+        throw "the proof driver wrote no verdict at $proofVerdict, so the result is UNKNOWN - which is not a pass."
+    }
+    $verdict = (Get-Content $proofVerdict -Raw).Trim()
+    $proofExit = if ($verdict -eq "PASS") { 0 } else { 1 }
+    Say "verdict: $verdict"
+}
+finally {
+    if (-not $KeepRoot) {
+        Stop-RigLaunchers $launcherDir
+        Start-Sleep -Seconds 2
+        if (Test-Path $Root) { Remove-Item -Recurse -Force $Root -ErrorAction SilentlyContinue }
+        Say "torn down"
+    } else {
+        Say "left in place at $Root (-KeepRoot)"
+    }
+}
+
+if ($proofExit -ne 0) { Write-Error "THE PROOF FAILED (exit $proofExit)"; exit $proofExit }
+Say "PROOF PASSED"

--- a/scripts/launcher-swap-proof.ps1
+++ b/scripts/launcher-swap-proof.ps1
@@ -6,9 +6,9 @@
 .DESCRIPTION
     Phase 0's unit tests drive the whole pass through fakes for the process list, the stop and the
     start. That is right for the decisions and says nothing about the three production delegates that
-    touch the machine: DefaultStopProcess, DefaultStartLauncher (including the CC_DIRECTOR_ROOT scrub
-    and the --managed argument), and the witness reading a genuinely new process. Until this script
-    ran, none of those had ever executed against a real launcher.
+    touch the machine: DefaultStopProcess, DefaultStartLauncher (including the CC_DIRECTOR_ROOT it
+    hands the child) and the witness reading a genuinely new process. Until this script ran, none of
+    those had ever executed against a real launcher - and the first run found a real defect.
 
     WHY AN ISOLATED ROOT AND NOT THIS MACHINE'S LAUNCHER. On Windows the installed launcher is the
     parent of the Director, and on this account that Director carries the live fleet. Swapping it
@@ -27,7 +27,8 @@
     a fake, in LauncherUpdateOwnerTests. Say so wherever this run is quoted.
 
 .PARAMETER Root
-    The isolated storage root. Must NOT be this machine's real cc-director root; the driver refuses.
+    The isolated storage root. It must be provably disposable - see Assert-Disposable below, which
+    refuses anything this script cannot prove it owns.
 
 .PARAMETER OldVersion
     The version stamped into the build that starts out installed.
@@ -51,32 +52,101 @@ param(
 
 $ErrorActionPreference = "Stop"
 $repo = Split-Path -Parent $PSScriptRoot
+$sep = [System.IO.Path]::DirectorySeparatorChar
 
 function Say([string]$text) { Write-Host "[launcher-swap-proof] $text" }
 
 # ---------------------------------------------------------------------------
-# 0. Refuse the real root here as well as in the driver. Two refusals, because
-#    this script starts and stops launcher processes before the driver ever runs.
+# 0. THE DELETION BOUNDARY, AND IT IS AN ALLOW-LIST.
+#
+#    This script recursively removes $Root and stops processes, so what it may
+#    act on has to be POSITIVELY PROVEN disposable - never merely "not on a list
+#    of things I thought of".
+#
+#    The first version compared uncanonicalized strings against one default path
+#    and deleted anything that was not it. That is a deny-list and it failed open
+#    for every shape nobody listed: "<real root>\." passes a string compare and
+#    resolves to the real root; so does an ancestor such as %LOCALAPPDATA%, a
+#    child such as "<real root>\config", and any installation not at the default
+#    path. Every one of them would have been deleted before the driver's own
+#    refusal ever ran.
+#
+#    What is admitted now: a CANONICAL path, inside the scratch parent, carrying
+#    this script's marker in its leaf name, which either does not exist yet or
+#    carries the sentinel file this script writes. Anything that cannot be
+#    classified survives - that is the boundary working, not the boundary leaking.
 # ---------------------------------------------------------------------------
-$realRoot = Join-Path $env:LOCALAPPDATA "cc-director"
-if ($Root.TrimEnd('\') -ieq $realRoot.TrimEnd('\')) {
-    throw "REFUSING: $Root is this machine's REAL cc-director root. This script stops launchers."
+$RigMarker    = "cc-director-launcher-proof"
+$SentinelName = ".launcher-swap-proof-owns-this-directory"
+
+$Root          = [System.IO.Path]::GetFullPath($Root).TrimEnd($sep)
+$scratchParent = [System.IO.Path]::GetFullPath($env:LOCALAPPDATA).TrimEnd($sep)
+$realRoot      = [System.IO.Path]::GetFullPath((Join-Path $env:LOCALAPPDATA "cc-director")).TrimEnd($sep)
+
+function Assert-Disposable([string]$path) {
+    if ($path -ieq $scratchParent) {
+        throw "REFUSING: $path is the scratch PARENT itself, not a directory this script owns."
+    }
+    if (-not $path.StartsWith($scratchParent + $sep, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "REFUSING: $path is not inside $scratchParent, so this script does not own it."
+    }
+    # The real root, anything inside it, and any ancestor of it are all off limits.
+    if ($path -ieq $realRoot -or
+        $path.StartsWith($realRoot + $sep, [System.StringComparison]::OrdinalIgnoreCase) -or
+        $realRoot.StartsWith($path + $sep, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "REFUSING: $path is this machine's REAL cc-director root, is inside it, or is an ancestor of it."
+    }
+    if ((Split-Path -Leaf $path) -notlike "*$RigMarker*") {
+        throw "REFUSING: $path does not carry this script's marker '$RigMarker' in its leaf name."
+    }
+    # A directory that already exists must PROVE it is one of ours before it is deleted. One with no
+    # sentinel belongs to somebody else, whatever its name says.
+    if ((Test-Path $path) -and -not (Test-Path (Join-Path $path $SentinelName))) {
+        throw "REFUSING: $path exists but carries no $SentinelName, so this script did not create it."
+    }
 }
-$launcherDir = Join-Path $Root "launcher"
-$stagedDir   = Join-Path $Root "state\staged"
-$setupDir    = Join-Path $Root "config\setup"
+
+Assert-Disposable $Root
+
+$launcherDir  = Join-Path $Root "launcher"
+$stagedDir    = Join-Path $Root "state\staged"
+$setupDir     = Join-Path $Root "config\setup"
+$sentinel     = Join-Path $Root $SentinelName
+
+# Every artifact of THIS run is named for this run. Two runs side by side previously shared one
+# output file and one verdict file in %TEMP%, so a failing run could read another run's PASS.
+$runId        = [Guid]::NewGuid().ToString("N").Substring(0, 8)
+$runDir       = Join-Path $env:TEMP "launcher-swap-proof-$runId"
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+$proofOut     = Join-Path $runDir "out.txt"
+$proofErr     = Join-Path $runDir "err.txt"
+$proofVerdict = Join-Path $runDir "verdict.txt"
 
 # ---------------------------------------------------------------------------
 # 1. Two real launcher builds, differing only in the version they stamp. The
 #    staged one has to be genuinely NEWER or FindStagedUpdate correctly declines.
+#
+#    THE BUILDS ARE KEYED TO THE SOURCE TREE. Reuse used to be decided by the
+#    version string alone, so a run could PASS against binaries published from an
+#    older tree - a proof of code that is no longer the code. The build directory
+#    now carries the tree's own identity, so a changed tree cannot reuse the
+#    previous tree's launchers.
 # ---------------------------------------------------------------------------
-$buildRoot = Join-Path $env:TEMP "launcher-swap-proof-builds"
+Push-Location $repo
+try {
+    $treeId = (& git rev-parse --short HEAD).Trim()
+    if ((& git status --porcelain).Length -gt 0) { $treeId = "$treeId-dirty-$runId" }
+}
+finally { Pop-Location }
+
+$buildRoot = Join-Path $env:TEMP "launcher-swap-proof-builds\$treeId"
 $oldBuild  = Join-Path $buildRoot "old\cc-launcher.exe"
 $newBuild  = Join-Path $buildRoot "new\cc-launcher.exe"
 
 function Publish-Launcher([string]$version, [string]$outDir) {
-    if (Test-Path (Join-Path $outDir "cc-launcher.exe")) {
-        $stamped = [System.Diagnostics.FileVersionInfo]::GetVersionInfo((Join-Path $outDir "cc-launcher.exe")).ProductVersion
+    $exe = Join-Path $outDir "cc-launcher.exe"
+    if (Test-Path $exe) {
+        $stamped = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($exe).ProductVersion
         if ($stamped -and $stamped.StartsWith($version)) { Say "reusing $version at $outDir"; return }
     }
     Say "publishing launcher $version -> $outDir"
@@ -91,26 +161,41 @@ function Publish-Launcher([string]$version, [string]$outDir) {
 Publish-Launcher $OldVersion (Split-Path -Parent $oldBuild)
 Publish-Launcher $NewVersion (Split-Path -Parent $newBuild)
 
+# THE DRIVER IS BUILT FROM THIS TREE, EVERY RUN. It used to be invoked with --no-build against a
+# project deliberately outside the solution, which nothing here ever built: on a clean checkout the
+# rig could not start at all, and after one build it could PASS using a stale assembly while the
+# current source carried a regression. A proof that can run against code which is not the code under
+# test is not a proof.
+Say "building the proof driver from this tree"
+& dotnet build (Join-Path $repo "scripts\launcher-swap-proof\LauncherSwapProof.csproj") --nologo -v q
+if ($LASTEXITCODE -ne 0) { throw "building the proof driver failed" }
+
 # ---------------------------------------------------------------------------
 # 2. Lay out the isolated install: the old build installed, the new one staged,
 #    and a manifest that says what is installed.
 # ---------------------------------------------------------------------------
 function Stop-RigLaunchers([string]$dir) {
-    # Only processes running from the RIG's launcher directory. Never a name-wide
-    # sweep: this machine's real launcher is also called cc-launcher.
+    # Only processes running from the RIG's launcher directory, matched on that directory PLUS A
+    # SEPARATOR. A bare prefix also matches a sibling such as "<dir>-old", which is somebody else's
+    # process - the same rule, and the same reason, as InstalledLauncherProcesses.Ours in the product.
+    $prefix = $dir.TrimEnd($sep) + $sep
     Get-Process -Name "cc-launcher" -ErrorAction SilentlyContinue | ForEach-Object {
         $path = $null
         try { $path = $_.MainModule.FileName } catch { }
-        if ($path -and $path.StartsWith($dir, [System.StringComparison]::OrdinalIgnoreCase)) {
+        if ($path -and $path.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
             Say "stopping leftover rig launcher pid $($_.Id)"
             Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
         }
     }
 }
 
+Assert-Disposable $Root
 Stop-RigLaunchers $launcherDir
 if (Test-Path $Root) { Remove-Item -Recurse -Force $Root }
 New-Item -ItemType Directory -Force -Path $launcherDir, $stagedDir, $setupDir | Out-Null
+# The sentinel goes down FIRST, so a run interrupted at any later point leaves a directory the NEXT
+# run can prove is its own rather than one it must refuse.
+Set-Content -Path $sentinel -Value "created by scripts/launcher-swap-proof.ps1" -Encoding utf8
 
 Copy-Item $oldBuild (Join-Path $launcherDir "cc-launcher.exe") -Force
 Copy-Item $newBuild (Join-Path $stagedDir  "cc-launcher.exe") -Force
@@ -121,12 +206,11 @@ Say "isolated root laid out at $Root (installed $OldVersion, staged $NewVersion)
 # ---------------------------------------------------------------------------
 # 3. Start the rig's launcher, pointed at the isolated root.
 #
-#    CC_DIRECTOR_ROOT is set DELIBERATELY here - it is what makes the launcher
-#    serve the rig's world instead of the machine's. That is the exact opposite
-#    of what the Director's own DefaultStartLauncher does, which REMOVES the
-#    variable so a launcher it starts cannot inherit a Director's instance home.
-#    Both are correct: this script is the installer of the rig's world, and the
-#    variable is how a world is named.
+#    CC_DIRECTOR_ROOT is set here for the same reason the product sets it: it
+#    NAMES the world the launcher is to serve. The product's own start passes
+#    the install's shared root; this script passes the rig's. (It used to REMOVE
+#    the variable and rely on the process default - that is the defect this rig
+#    found, written up in BuildLauncherStartInfo.)
 # ---------------------------------------------------------------------------
 $psi = New-Object System.Diagnostics.ProcessStartInfo
 $psi.FileName = (Join-Path $launcherDir "cc-launcher.exe")
@@ -152,45 +236,34 @@ Say "the rig launcher registered: $(Get-Content $registration -Raw)"
 
 # ---------------------------------------------------------------------------
 # 4. The proof itself.
+#
+#    THE DRIVER'S OUTPUT IS REDIRECTED TO FILES, AND THAT IS NOT TIDINESS. The
+#    swap starts a launcher that is MEANT to stay running, and a child started
+#    without redirection inherits the console handles - so a pipeline reading
+#    this script's output waits on the launcher rather than on the driver, and
+#    the script hangs after printing PASS. Observed 2026-09-06: the first
+#    successful run hung for ten minutes with the proof already passed.
 # ---------------------------------------------------------------------------
-#    THE DRIVER'S OUTPUT IS REDIRECTED TO FILES, AND THAT IS NOT TIDINESS. The swap starts a launcher
-#    that is meant to STAY RUNNING, and a child started without redirection inherits the console
-#    handles - so the pipeline reading this script's output waits on the launcher, not on the driver,
-#    and the script hangs after printing PASS. Observed on 2026-09-06: the first two runs terminated
-#    only because the started launcher exited immediately (it was the second-instance failure the rig
-#    was there to find), and the first SUCCESSFUL run hung for ten minutes with the proof already
-#    passed. Handing the driver file handles instead means the launcher inherits those, and Start-Process
-#    -Wait waits only on the driver.
-$proofOut = Join-Path $env:TEMP "launcher-swap-proof.out.txt"
-$proofErr = Join-Path $env:TEMP "launcher-swap-proof.err.txt"
-# Deleted BEFORE the run: a verdict left by a previous run must never be read as this run's result.
-$proofVerdict = Join-Path $env:TEMP "launcher-swap-proof.verdict.txt"
-if (Test-Path $proofVerdict) { Remove-Item -Force $proofVerdict }
 try {
     $driver = Start-Process -FilePath "dotnet" -PassThru -NoNewWindow `
         -RedirectStandardOutput $proofOut -RedirectStandardError $proofErr `
         -ArgumentList @(
             "run", "--project",
             (Join-Path $repo "scripts\launcher-swap-proof\LauncherSwapProof.csproj"),
-            "--no-build", "--", $Root, $NewVersion)
+            "--no-build", "--", $Root, $NewVersion, $proofVerdict)
 
     # POLL, DO NOT WAIT ON THE STREAMS. -Wait (and WaitForExit) on a process with redirected output
-    # waits for those streams to CLOSE, and the launcher the swap started inherited them - so the
-    # script blocked on a launcher that is supposed to keep running, with the proof already passed.
-    # HasExited asks about the process and nothing else.
+    # waits for those streams to CLOSE, and the launcher the swap started inherited them. HasExited
+    # asks about the process and nothing else.
     while (-not $driver.HasExited) { Start-Sleep -Milliseconds 500 }
     if (Test-Path $proofOut) { Get-Content $proofOut | ForEach-Object { Write-Host $_ } }
     if (Test-Path $proofErr) { Get-Content $proofErr | ForEach-Object { Write-Host $_ } }
 
-    # Refresh before reading: a process object obtained from Start-Process -PassThru without -Wait
-    # caches its state, and ExitCode came back EMPTY without this - which the check below then read as
-    # "not zero" and reported as a FAILED proof on a run that had passed. An unreadable exit code is
-    # undecidable, and undecidable is not a pass either, so it is raised rather than defaulted.
     # THE VERDICT IS THE FILE THE DRIVER WROTE, not the exit code. Windows PowerShell's
     # Start-Process -PassThru without -Wait does not retain the process handle, so ExitCode reads back
     # EMPTY - and this script duly reported a FAILED proof on a run that had passed. -Wait is not
-    # available either: with redirected output it waits for the streams to close, and the launcher this
-    # proof deliberately leaves running has inherited them.
+    # available either, for the stream reason above. The file is named for THIS run, so a verdict left
+    # by a concurrent run cannot be read as this one's.
     #
     # The check is a PRESENCE: the file must exist and must say PASS. A missing file is a broken
     # instrument, never a clean run.
@@ -205,12 +278,15 @@ finally {
     if (-not $KeepRoot) {
         Stop-RigLaunchers $launcherDir
         Start-Sleep -Seconds 2
+        # Re-asserted rather than assumed: the checks at the top ran before the run and this deletes
+        # after it. Nothing here is cheaper than being sure.
+        Assert-Disposable $Root
         if (Test-Path $Root) { Remove-Item -Recurse -Force $Root -ErrorAction SilentlyContinue }
         Say "torn down"
     } else {
-        Say "left in place at $Root (-KeepRoot)"
+        Say "left in place at $Root (-KeepRoot); artifacts in $runDir"
     }
 }
 
-if ($proofExit -ne 0) { Write-Error "THE PROOF FAILED (exit $proofExit)"; exit $proofExit }
+if ($proofExit -ne 0) { Write-Error "THE PROOF FAILED (exit $proofExit) - see $proofOut"; exit $proofExit }
 Say "PROOF PASSED"

--- a/scripts/launcher-swap-proof.ps1
+++ b/scripts/launcher-swap-proof.ps1
@@ -193,8 +193,12 @@ Assert-Disposable $Root
 Stop-RigLaunchers $launcherDir
 if (Test-Path $Root) { Remove-Item -Recurse -Force $Root }
 New-Item -ItemType Directory -Force -Path $launcherDir, $stagedDir, $setupDir | Out-Null
-# The sentinel goes down FIRST, so a run interrupted at any later point leaves a directory the NEXT
-# run can prove is its own rather than one it must refuse.
+# The sentinel goes down as early as it can - immediately after the directories exist, before any
+# binary is copied - so a run interrupted after THIS LINE leaves a directory the next run can prove is
+# its own. It is not "any later point": between the New-Item above and this line there is a window in
+# which the directory exists with no sentinel, and a run killed inside it leaves something the next run
+# REFUSES and a person has to remove by hand. That is the safe direction (refuse, never delete) and it
+# is stated rather than glossed, because the window is real.
 Set-Content -Path $sentinel -Value "created by scripts/launcher-swap-proof.ps1" -Encoding utf8
 
 Copy-Item $oldBuild (Join-Path $launcherDir "cc-launcher.exe") -Force

--- a/scripts/launcher-swap-proof.ps1
+++ b/scripts/launcher-swap-proof.ps1
@@ -201,7 +201,20 @@ Copy-Item $oldBuild (Join-Path $launcherDir "cc-launcher.exe") -Force
 Copy-Item $newBuild (Join-Path $stagedDir  "cc-launcher.exe") -Force
 @{ "cc-launcher" = $OldVersion } | ConvertTo-Json | Set-Content -Path (Join-Path $setupDir "installed.json") -Encoding utf8
 
-Say "isolated root laid out at $Root (installed $OldVersion, staged $NewVersion)"
+# THE RIG'S WORLD MUST NOT REACH THE INTERNET. A launcher serving this root runs its OWN periodic
+# auto-update, and it does not care that it is in a test rig: on 2026-09-07 the rig's 2.0.4 launcher
+# reached GitHub, downloaded the real 2.0.6 release, overwrote the 2.0.99 build this script had
+# staged, and installed itself over the rig's own installed binary. The proof then reported "nothing
+# is staged" - a FAIL that said nothing whatever about the code under test, and which could as
+# easily have been a PASS measured against binaries this script never put there.
+#
+# A rig that races the real release feed is not a controlled experiment. Switched off in the config
+# the launcher reads, and again through the environment variable, because the launcher started by
+# the SWAP inherits its environment from the driver rather than from this script.
+@{ autoUpdate = @{ enabled = $false } } | ConvertTo-Json |
+    Set-Content -Path (Join-Path $Root "config\config.json") -Encoding utf8
+
+Say "isolated root laid out at $Root (installed $OldVersion, staged $NewVersion); auto-update OFF"
 
 # ---------------------------------------------------------------------------
 # 3. Start the rig's launcher, pointed at the isolated root.
@@ -221,6 +234,7 @@ $psi.CreateNoWindow = $true
 # single Arguments string is the only form available here.
 $psi.Arguments = "--managed"
 $psi.EnvironmentVariables["CC_DIRECTOR_ROOT"] = $Root
+$psi.EnvironmentVariables["CC_AUTOUPDATE"] = "0"
 $rig = [System.Diagnostics.Process]::Start($psi)
 Say "started the rig launcher: pid $($rig.Id)"
 
@@ -244,6 +258,8 @@ Say "the rig launcher registered: $(Get-Content $registration -Raw)"
 #    the script hangs after printing PASS. Observed 2026-09-06: the first
 #    successful run hung for ten minutes with the proof already passed.
 # ---------------------------------------------------------------------------
+# Inherited by the driver, and so by the launcher the SWAP starts.
+$env:CC_AUTOUPDATE = "0"
 try {
     $driver = Start-Process -FilePath "dotnet" -PassThru -NoNewWindow `
         -RedirectStandardOutput $proofOut -RedirectStandardError $proofErr `

--- a/scripts/launcher-swap-proof/LauncherSwapProof.csproj
+++ b/scripts/launcher-swap-proof/LauncherSwapProof.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    THE DRIVER for scripts/launcher-swap-proof.ps1 - the end-to-end proof of the Director installing
+    the launcher's update, run against an ISOLATED storage root with REAL launcher binaries.
+
+    It is a console project on purpose and it is NOT in cc-director.sln and NOT in the project list
+    scripts/test-local.ps1 runs. A rig that needs two published launchers and a live process is not a
+    unit test, and putting it in the suite as a test that skips itself would put a check that cannot
+    fail into the gate - which reads exactly like coverage and is not.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>launcher-swap-proof</AssemblyName>
+    <RootNamespace>CcDirector.Proof.LauncherSwap</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\cc-director-setup-engine\CcDirector.Setup.Engine.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/scripts/launcher-swap-proof/Program.cs
+++ b/scripts/launcher-swap-proof/Program.cs
@@ -10,9 +10,9 @@ namespace CcDirector.Proof.LauncherSwap;
 /// WHY A RIG AND NOT A TEST. Every scenario in LauncherUpdateOwnerTests drives the pass through fakes
 /// for the process list, the stop and the start - which is right for the decisions, and says nothing
 /// at all about the three production delegates that actually touch the machine. DefaultStopProcess,
-/// DefaultStartLauncher (including the CC_DIRECTOR_ROOT scrub and the --managed argument) and the
-/// witness reading a genuinely new process had never once executed against a real launcher. This runs
-/// them.
+/// DefaultStartLauncher (including the CC_DIRECTOR_ROOT it hands the child and the --managed argument)
+/// and the witness reading a genuinely new process had never once executed against a real launcher.
+/// This runs them - and the first run found a real defect in exactly that environment handling.
 ///
 /// WHAT IT PROVES AND WHAT IT DOES NOT - read this before quoting it as the end-to-end proof:
 ///
@@ -42,12 +42,18 @@ public static class Program
     {
         if (args.Length < 1)
         {
-            Console.Error.WriteLine("usage: launcher-swap-proof <isolated-root> [expected-new-version]");
+            Console.Error.WriteLine("usage: launcher-swap-proof <isolated-root> [expected-new-version] [verdict-file]");
             return 2;
         }
 
         var root = Path.GetFullPath(args[0]);
         var expectedNewVersion = args.Length > 1 ? args[1] : null;
+        // Named by the CALLER, so each run has its own. A single shared path in the temporary
+        // directory meant two runs side by side could overwrite one another's answer, and a failing
+        // run could read another run's PASS.
+        _verdictPath = args.Length > 2 && !string.IsNullOrWhiteSpace(args[2])
+            ? Path.GetFullPath(args[2])
+            : Path.Combine(Path.GetTempPath(), "launcher-swap-proof.verdict.txt");
 
         var realRoot = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "cc-director");
@@ -167,8 +173,8 @@ public static class Program
     {
         try
         {
-            File.WriteAllText(VerdictPath, verdict);
-            Console.WriteLine($"verdict written to {VerdictPath}");
+            File.WriteAllText(_verdictPath, verdict);
+            Console.WriteLine($"verdict written to {_verdictPath}");
         }
         catch (Exception ex)
         {
@@ -176,10 +182,9 @@ public static class Program
         }
     }
 
-    /// <summary>Where the verdict is written. The script deletes it before a run, so a stale PASS from
-    /// a previous run cannot be read as this one's result.</summary>
-    public static string VerdictPath =>
-        Path.Combine(Path.GetTempPath(), "launcher-swap-proof.verdict.txt");
+    /// <summary>Where the verdict is written - supplied per run by the calling script, so a verdict
+    /// from a concurrent run can never be read as this one's result.</summary>
+    private static string _verdictPath = "";
 
     private static void Report(LauncherWitnessReading r)
     {

--- a/scripts/launcher-swap-proof/Program.cs
+++ b/scripts/launcher-swap-proof/Program.cs
@@ -1,0 +1,193 @@
+using CcDirector.Setup.Engine;
+
+namespace CcDirector.Proof.LauncherSwap;
+
+/// <summary>
+/// THE END-TO-END PROOF of the Director installing the launcher's staged update (issue #2719,
+/// Phase 0), driven against an ISOLATED storage root with REAL launcher binaries and a REAL running
+/// launcher process.
+///
+/// WHY A RIG AND NOT A TEST. Every scenario in LauncherUpdateOwnerTests drives the pass through fakes
+/// for the process list, the stop and the start - which is right for the decisions, and says nothing
+/// at all about the three production delegates that actually touch the machine. DefaultStopProcess,
+/// DefaultStartLauncher (including the CC_DIRECTOR_ROOT scrub and the --managed argument) and the
+/// witness reading a genuinely new process had never once executed against a real launcher. This runs
+/// them.
+///
+/// WHAT IT PROVES AND WHAT IT DOES NOT - read this before quoting it as the end-to-end proof:
+///
+///   PROVED HERE: an installed launcher running from an isolated root is stopped for real, its binary
+///   is replaced for real, a new process is started for real by DefaultStartLauncher, and the new
+///   build is WITNESSED - registered, alive, and holding a live command surface at the isolated
+///   root's own signal names.
+///
+///   NOT PROVED HERE: the case that actually matters most on a real machine - a launcher that is the
+///   PARENT of a live Director. On Windows the installed launcher is the Director's parent process,
+///   so the swap stops this process's own parent, and the no-orphan invariant (the Director keeps
+///   running across the swap and the new launcher re-adopts it rather than starting a second one) is
+///   the whole reason the stop refuses to kill a process tree. The rig's launcher supervises no
+///   Director, so that invariant is NOT exercised by this program. It is asserted only by
+///   LauncherUpdateOwnerTests, through a fake.
+///
+/// The isolation itself rests on a fact established on 2026-09-06 and recorded on issue #2719: a
+/// launcher started with CC_DIRECTOR_ROOT pointing elsewhere serves THAT root completely - it
+/// registers under it, derives its own root key from it, and its instance guard positively refuses to
+/// act on a Director that is not its own. That is what lets this run beside a live fleet. The rig
+/// asserts that separation rather than assuming it: it refuses to start if the root it was given is
+/// the real one, and it checks afterwards that the machine's real launcher was left untouched.
+/// </summary>
+public static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        if (args.Length < 1)
+        {
+            Console.Error.WriteLine("usage: launcher-swap-proof <isolated-root> [expected-new-version]");
+            return 2;
+        }
+
+        var root = Path.GetFullPath(args[0]);
+        var expectedNewVersion = args.Length > 1 ? args[1] : null;
+
+        var realRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "cc-director");
+        if (string.Equals(Path.TrimEndingDirectorySeparator(root),
+                          Path.TrimEndingDirectorySeparator(realRoot), StringComparison.OrdinalIgnoreCase))
+        {
+            // The one refusal that matters. This program stops launchers and replaces binaries; pointed
+            // at the real root it would do that to the launcher supervising the live fleet.
+            Console.Error.WriteLine($"REFUSING: {root} is this machine's REAL cc-director root.");
+            return 2;
+        }
+
+        var realLauncherBefore = new LauncherWitness(realRoot).Read();
+
+        var witness = new LauncherWitness(root);
+        var owner = new LauncherUpdateOwner(
+            root,
+            // The rig's launcher supervises no Director, so there is no instance for this to be about.
+            // Stated rather than defaulted, and reported below so nobody reads it as the no-orphan
+            // invariant having been exercised.
+            directorStillHoldsItsInstance: () => true,
+            witnessTimeout: TimeSpan.FromMinutes(2));
+
+        Console.WriteLine($"root         = {root}");
+        Console.WriteLine($"signal       = {witness.CommandSignalName}");
+
+        var before = witness.Read();
+        Console.WriteLine("--- BEFORE ---");
+        Report(before);
+        var staged = owner.FindStagedUpdate(out var why);
+        Console.WriteLine($"staged       = {staged?.Version ?? "(none)"} why=[{why}]");
+
+        if (!before.Witnessed)
+        {
+            Console.Error.WriteLine("FAIL: the rig's own launcher is not witnessed before the swap, so the swap "
+                                    + "would be measured from a broken starting point.");
+            WriteVerdict("FAIL: the rig's own launcher was not witnessed before the swap");
+            return 1;
+        }
+        if (staged is null)
+        {
+            Console.Error.WriteLine("FAIL: nothing is staged, so there is no swap to prove.");
+            WriteVerdict("FAIL: nothing was staged, so there was no swap to prove");
+            return 1;
+        }
+
+        Console.WriteLine("--- SWAPPING (real stop, real binary replacement, real start) ---");
+        var result = await owner.RunOnceAsync();
+        Console.WriteLine($"decision     = {result.Decision}");
+        Console.WriteLine($"message      = {result.Message}");
+        foreach (var step in result.Steps) Console.WriteLine($"  step: {step}");
+
+        var after = witness.Read();
+        Console.WriteLine("--- AFTER ---");
+        Report(after);
+
+        var failures = new List<string>();
+
+        if (result.Decision != LauncherUpdateDecision.Applied)
+            failures.Add($"decision was {result.Decision}, expected Applied");
+
+        if (!after.Witnessed)
+            failures.Add("the new launcher is NOT witnessed - the whole point is that a started process is "
+                         + "not the proof; it must be registered, alive AND commandable");
+
+        if (after.CommandSurface != LauncherCommandSurface.Present)
+            failures.Add($"the new launcher's command surface is {after.CommandSurface}, expected Present");
+
+        if (after.Pid == before.Pid)
+            failures.Add($"the launcher process id did not change ({after.Pid}) - nothing was actually replaced");
+
+        if (expectedNewVersion is not null
+            && (after.Version is null || !after.Version.StartsWith(expectedNewVersion, StringComparison.Ordinal)))
+            failures.Add($"the running launcher reports {after.Version ?? "(none)"}, expected {expectedNewVersion}");
+
+        // THE ISOLATION ASSERTION. The rig runs beside a live fleet, so "it worked" is not enough - it
+        // must also be true that nothing outside the isolated root moved.
+        var realLauncherAfter = new LauncherWitness(realRoot).Read();
+        Console.WriteLine("--- THE MACHINE'S REAL LAUNCHER (must be untouched) ---");
+        Report(realLauncherAfter);
+        if (realLauncherBefore.Pid != realLauncherAfter.Pid || realLauncherBefore.Version != realLauncherAfter.Version)
+            failures.Add($"THE REAL LAUNCHER MOVED: was pid {realLauncherBefore.Pid} {realLauncherBefore.Version}, "
+                         + $"now pid {realLauncherAfter.Pid} {realLauncherAfter.Version}. The isolation this rig "
+                         + "depends on does not hold - STOP and write that up; it is a bigger finding than the "
+                         + "proof would have been.");
+
+        Console.WriteLine();
+        Console.WriteLine("NOT PROVED BY THIS RUN: the rig's launcher supervised no Director, so a launcher that is "
+                          + "a LIVE DIRECTOR'S PARENT has still never been swapped, and the no-orphan invariant is "
+                          + "asserted only through a fake.");
+
+        if (failures.Count > 0)
+        {
+            Console.Error.WriteLine();
+            foreach (var f in failures) Console.Error.WriteLine($"FAIL: {f}");
+            WriteVerdict("FAIL: " + string.Join(" | ", failures));
+            return 1;
+        }
+
+        Console.WriteLine("PASS: the launcher was stopped, replaced and restarted, and the NEW build was witnessed "
+                          + "alive and commandable on the isolated root.");
+        WriteVerdict("PASS");
+        return 0;
+    }
+
+    /// <summary>
+    /// The verdict, written where the calling script can read it.
+    ///
+    /// The exit code alone was not enough, and the reason is a Windows PowerShell quirk with teeth:
+    /// Start-Process -PassThru WITHOUT -Wait returns a process object that does not retain the handle,
+    /// so ExitCode reads back EMPTY once the process is gone - and -Wait cannot be used, because with
+    /// redirected output it waits for the streams to close and the launcher this proof deliberately
+    /// leaves running has inherited them. So the run reported a FAILED proof on a run that passed.
+    /// A file the driver writes on its way out is decided by the driver, not by how it was invoked.
+    /// </summary>
+    private static void WriteVerdict(string verdict)
+    {
+        try
+        {
+            File.WriteAllText(VerdictPath, verdict);
+            Console.WriteLine($"verdict written to {VerdictPath}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"could not write the verdict file: {ex.Message}");
+        }
+    }
+
+    /// <summary>Where the verdict is written. The script deletes it before a run, so a stale PASS from
+    /// a previous run cannot be read as this one's result.</summary>
+    public static string VerdictPath =>
+        Path.Combine(Path.GetTempPath(), "launcher-swap-proof.verdict.txt");
+
+    private static void Report(LauncherWitnessReading r)
+    {
+        Console.WriteLine($"registered   = {r.Registered}");
+        Console.WriteLine($"alive        = {r.ProcessAlive} (pid {r.Pid})");
+        Console.WriteLine($"version      = {r.Version ?? "(none)"}");
+        Console.WriteLine($"surface      = {r.CommandSurface}");
+        Console.WriteLine($"WITNESSED    = {r.Witnessed}");
+        Console.WriteLine($"detail       = {r.Detail}");
+    }
+}

--- a/scripts/mutation/launcher-update-mutations.py
+++ b/scripts/mutation/launcher-update-mutations.py
@@ -1,0 +1,219 @@
+"""
+THE MUTATION PROOF FOR ISSUE #2719 PHASE 0, WITH A COMPILE GATE.
+
+Run it from the repository root:  python scripts/mutation/launcher-update-mutations.py
+
+WHY THE COMPILE GATE EXISTS, AND WHY IT IS THE POINT OF THIS FILE.
+
+The first harness used for this branch decided "survived" from the ABSENCE of failure lines in the
+test output. A mutant that does not COMPILE produces no failing test - which is indistinguishable
+from a mutant no test caught. It duly reported a SURVIVOR on a mutation that had never run at all,
+and the mutation in question was `if (p.Pid <= 0)` changed to `if (false)`, which the compiler
+rejects as unreachable code.
+
+That is the same defect this mission hit at two other altitudes on the same day: could-not-read
+reported as nothing-is-there, and did-not-run reported as came-back-clean. A pass condition that is
+an ABSENCE is satisfied by a broken instrument.
+
+So a mutant counts here only if the product project BUILDS, and there are THREE outcomes, never two:
+
+    KILLED   - it built, and at least one test failed
+    SURVIVED - it built, every test passed. A REAL DEFECT IN THE TESTS.
+    BROKEN   - it did not build, or no test summary line was observed. Neither killed nor survived;
+               the mutation must be rewritten before it means anything.
+
+The gate has been run against a known-bad input rather than trusted: with the non-compiling mutant
+above, this harness reports BROKEN and the old absence-based reading reports SURVIVED, on the same
+mutant, in the same run.
+
+Every claim of the form "each new test dies to the defect it names" on pull request #2728 was
+produced by this file. Re-run it before trusting that claim again - and if you add a test to this
+area, add the mutation that should kill it, so the two lists stay reconciled in both directions.
+"""
+
+"""
+Mutation harness with a COMPILE GATE.
+
+The previous harness decided "survived" from the ABSENCE of failure lines in the test output.
+A mutant that does not COMPILE produces no failing test, which is indistinguishable from a mutant
+no test caught - so it reported a survivor on a mutation that had never run at all.
+
+Here a mutant counts only if the product project BUILDS. Three outcomes, never two:
+    KILLED  - it built, and at least one test failed
+    SURVIVED- it built, and every test passed          <- a real defect in the tests
+    BROKEN  - it did not build; neither killed nor survived, and the mutation must be rewritten
+"""
+import io, subprocess, os, sys, json
+
+REPO = r"D:\ReposFred\devthrottle-launcher-update"
+ENGINE_SRC = r"tools\cc-director-setup-engine\CcDirector.Setup.Engine.csproj"
+ENGINE_TESTS = r"tools\cc-director-setup-engine.Tests\CcDirector.Setup.Engine.Tests.csproj"
+LAUNCHER_SRC = r"src\CcDirector.Launcher\CcDirector.Launcher.csproj"
+LAUNCHER_TESTS = r"src\CcDirector.Launcher.Tests\CcDirector.Launcher.Tests.csproj"
+
+OWNER = r"tools\cc-director-setup-engine\LauncherUpdateOwner.cs"
+WITNESS = r"tools\cc-director-setup-engine\LauncherWitness.cs"
+PROCS = r"tools\cc-director-setup-engine\InstalledLauncherProcesses.cs"
+STOP = r"tools\cc-director-setup-engine\SingleProcessStop.cs"
+LOCK = r"tools\cc-director-setup-engine\BinarySwapLock.cs"
+DIRUPD = r"src\CcDirector.Launcher\DirectorUpdateOwner.cs"
+
+E = (ENGINE_SRC, ENGINE_TESTS)
+L = (LAUNCHER_SRC, LAUNCHER_TESTS)
+
+# (label, (src_proj, test_proj), file, find, replace, expected_test_substring)
+MUTATIONS = [
+ ("the shortcut accepts a merely-alive launcher", E, OWNER,
+  "var witnessedTheInstalledLauncher =\n            reading.Witnessed && ours.Count == 1 && ours[0].Pid == reading.Pid;",
+  "var witnessedTheInstalledLauncher =\n            reading.ProcessAlive;",
+  "AlreadyTheStagedVersionButCANNOTBeCommanded"),
+
+ ("the shortcut ignores WHICH process was witnessed", E, OWNER,
+  "reading.Witnessed && ours.Count == 1 && ours[0].Pid == reading.Pid;",
+  "reading.Witnessed;",
+  "AWITNESSEDLauncherThatIsNotTheINSTALLEDOne"),
+
+ ("the shortcut never fires at all", E, OWNER,
+  "if (witnessedTheInstalledLauncher && VersionsMatch(staged.Version, reading.Version))",
+  "if (!witnessedTheInstalledLauncher && VersionsMatch(staged.Version, reading.Version))",
+  "AND_COMMANDABLE_InstallsNothing"),
+
+ ("a not-observable platform is no longer refused", E, OWNER,
+  "if (reading.CommandSurface == LauncherCommandSurface.NotObservable)",
+  "if (reading.CommandSurface == LauncherCommandSurface.Absent)",
+  "WhereTheCommandSurfaceCannotBeObserved"),
+
+ ("the swap takes a lock nobody else takes", E, OWNER,
+  'who: "launcher-update",\n            name: SwapLockName);',
+  'who: "launcher-update",\n            name: SwapLockName + "-unshared");',
+  "WhileAnotherBinarySwapHoldsTheMachineWideLock"),
+
+ ("the orphaned Director is a plain success again", E, OWNER,
+  "SelfUpdateOutcome.Updated when !stillOurs => LauncherUpdateDecision.AppliedButThisDirectorLostItsInstance,\n            SelfUpdateOutcome.Updated => LauncherUpdateDecision.Applied,",
+  "SelfUpdateOutcome.Updated => LauncherUpdateDecision.Applied,",
+  "ThatIsItsOwnDecision"),
+
+ ("the after-the-swap reading is not reported", E, OWNER,
+  'steps.Add($"after the swap: {_witness.Read().Detail}");',
+  'steps.Add("after the swap: done");',
+  "AfterARollback"),
+
+ ("the started launcher is not told which root to serve", E, OWNER,
+  'psi.Environment["CC_DIRECTOR_ROOT"] = layout.LocalRoot;',
+  'psi.Environment.Remove("CC_DIRECTOR_ROOT");',
+  "IsTOLDWhichRootToServe"),
+
+ ("the unreadable sentinel is handed to the stop again", E, OWNER,
+  "if (p.Pid <= 0)",
+  "if (p.Pid < 0)",
+  "IsNeverHandedToTheStop"),
+
+ ("an unreadable list is reported as an empty one", E, OWNER,
+  'return [new LauncherProcess(0, "the process list is unreadable")];',
+  "return [];",
+  "IsNotAnEmptyOne"),
+
+ ("the witness accepts a not-observable surface", E, WITNESS,
+  "public bool Witnessed => Registered && ProcessAlive && CommandSurface == LauncherCommandSurface.Present;",
+  "public bool Witnessed => Registered && ProcessAlive && CommandSurface != LauncherCommandSurface.Absent;",
+  "ThatIsNOTAWITNESS"),
+
+ ("an unreadable process is dropped instead of refused", E, PROCS,
+  "if (unreadable.Count > 0)\n            throw new InvalidOperationException(",
+  "if (unreadable.Count > 99)\n            throw new InvalidOperationException(",
+  "MakesTheMachineUNDECIDABLE"),
+
+ ("a null main module is fail-open again", E, PROCS,
+  "if (hasExited == true) return UnreadableVerdict.CannotBeOurs;",
+  "if (hasExited != true) return UnreadableVerdict.CannotBeOurs;",
+  "IsUndecidableOnlyWhenItCouldBeOurs"),
+
+ ("an unreadable session is assumed not ours", E, PROCS,
+  "if (sessionId is null) return UnreadableVerdict.CouldBeOurs;",
+  "if (sessionId is null) return UnreadableVerdict.CannotBeOurs;",
+  "IsUndecidableOnlyWhenItCouldBeOurs"),
+
+ ("every unreadable process is undecidable regardless of session", E, PROCS,
+  "return sessionId == ourSession ? UnreadableVerdict.CouldBeOurs : UnreadableVerdict.CannotBeOurs;",
+  "return UnreadableVerdict.CouldBeOurs;",
+  "IsUndecidableOnlyWhenItCouldBeOurs"),
+
+ ("the single kill becomes a tree kill", E, STOP,
+  "process.Kill(entireProcessTree: false);",
+  "process.Kill(entireProcessTree: true);",
+  "KillsOneProcess_NeverATree"),
+
+ ("a kill is put back into the swap's own file", E, OWNER,
+  "    private List<LauncherProcess> OursNow()",
+  "    private static bool StopHard(System.Diagnostics.Process p) { p.Kill(entireProcessTree: true); return true; }\n\n    private List<LauncherProcess> OursNow()",
+  "ExpressesNoProcessKillAtAll"),
+
+ ("the two owners take different locks", L, DIRUPD,
+  "internal string SwapLockName { get; init; } = BinarySwapLock.Name;",
+  'internal string SwapLockName { get; init; } = @"Global\\a-different-lock";',
+  "TheTwoOwnersDefaultToTheSameMachineWideLock"),
+
+ ("the lock stops being machine-wide", L, LOCK,
+  'public const string Name = @"Global\\cc-director-binary-swap";',
+  'public const string Name = @"Local\\cc-director-binary-swap";',
+  "TheLockIsMachineWide"),
+]
+
+def run(cmd, timeout=1200):
+    return subprocess.run(cmd, cwd=REPO, capture_output=True, text=True, timeout=timeout)
+
+results = []
+for label, (src_proj, test_proj), relpath, find, replace, expect in MUTATIONS:
+    path = os.path.join(REPO, relpath)
+    original = io.open(path, encoding="utf-8").read()
+
+    if find not in original:
+        results.append((label, "ANCHOR-MISSING", "", ""))
+        print(f"[ANCHOR-MISSING] {label}"); sys.stdout.flush(); continue
+
+    io.open(path, "w", encoding="utf-8", newline="").write(original.replace(find, replace, 1))
+    try:
+        # ---- THE COMPILE GATE. A mutant that does not build is a broken instrument. ----
+        build = run(["dotnet", "build", src_proj, "--nologo", "-v", "q"])
+        if build.returncode != 0:
+            err = [l for l in (build.stdout + build.stderr).splitlines() if "error CS" in l]
+            results.append((label, "BROKEN", "did not compile", err[0][:150] if err else ""))
+            print(f"[BROKEN - DID NOT COMPILE] {label}\n    {err[0][:150] if err else ''}")
+            sys.stdout.flush(); continue
+
+        test = run(["dotnet", "test", test_proj, "--nologo", "-v", "q"])
+        text = test.stdout + test.stderr
+        # If the TEST project itself failed to build, that is also a broken instrument.
+        if "error CS" in text:
+            err = [l for l in text.splitlines() if "error CS" in l]
+            results.append((label, "BROKEN", "test project did not compile", err[0][:150]))
+            print(f"[BROKEN - TEST PROJECT DID NOT COMPILE] {label}\n    {err[0][:150]}")
+            sys.stdout.flush(); continue
+
+        failed = sorted({ln.split("[FAIL]")[0].strip().split(".")[-1] for ln in text.splitlines() if "[FAIL]" in ln})
+        # A positive presence check: a summary line must exist, or we did not observe a run.
+        ran = "Passed!" in text or "Failed!" in text
+        if not ran:
+            results.append((label, "BROKEN", "no test summary line - the run was not observed", ""))
+            print(f"[BROKEN - NO RUN OBSERVED] {label}"); sys.stdout.flush(); continue
+
+        if failed:
+            hit = any(expect in f for f in failed)
+            results.append((label, "KILLED" if hit else "KILLED-BY-OTHER", "; ".join(failed)[:200], expect))
+            print(f"[{'KILLED' if hit else 'KILLED BUT NOT BY THE EXPECTED TEST'}] {label}\n    {failed}")
+        else:
+            results.append((label, "SURVIVED", "", expect))
+            print(f"[*** SURVIVED ***] {label}  (expected {expect} to die)")
+        sys.stdout.flush()
+    finally:
+        io.open(path, "w", encoding="utf-8", newline="").write(original)
+
+print("\n================ SUMMARY ================")
+for label, verdict, detail, expect in results:
+    print(f"{verdict:<22} {label}")
+counts = {}
+for _, v, _, _ in results:
+    counts[v] = counts.get(v, 0) + 1
+print("\ncounts:", json.dumps(counts, indent=None))
+io.open(os.path.join(r"C:\Users\soren\AppData\Local\Temp\claude\D--ReposFred-devthrottle\b24f87d3-e91b-434f-bf16-d00e58b25903\scratchpad", "mutation-results.json"), "w", encoding="utf-8").write(
+    json.dumps([{"label": a, "verdict": b, "detail": c, "expected": d} for a, b, c, d in results], indent=2))

--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -503,6 +503,16 @@ public partial class App : Application
                             outcome = await Updater.CheckAndStageAsync();
                             var toolResult = await new CcDirector.Setup.Engine.ToolUpdater(layout).RefreshAsync();
                             FileLog.Write($"[App] tool auto-update: updated={toolResult.Updated}, failed={toolResult.Failed}");
+
+                            // The launcher's own update, which the Director owns (issue #2719). The
+                            // mirror of the launcher owning the Director's: whatever replaces a binary
+                            // has to outlive the process being replaced, and the launcher cannot
+                            // honestly swap itself. Nothing owned this before, so a machine whose
+                            // launcher fell behind became permanently uncommandable - and could not be
+                            // fixed remotely, because the thing that would receive the fix was the
+                            // broken thing. A Director update still reaches it, which is why this runs
+                            // here.
+                            await RunLauncherUpdatePassAsync();
                         }
                         catch (Exception ex)
                         {
@@ -631,6 +641,11 @@ public partial class App : Application
                         .GetAwaiter().GetResult();
                     FileLog.Write($"[CcDirector] on-demand update check concluded: "
                                   + $"{outcome?.ToString() ?? "the updater has not started yet"}");
+                    // "Check for updates now" covers the machine's launcher too, not only this
+                    // Director. A machine whose launcher is too old to be commanded is exactly the
+                    // machine somebody is standing at when they ask for this, and the periodic loop
+                    // does not run at all on a development build.
+                    RunLauncherUpdatePassAsync().GetAwaiter().GetResult();
                 });
 
             log($"Lifecycle signals listening for directorId={directorId}");
@@ -642,6 +657,59 @@ public partial class App : Application
             log($"Lifecycle signals FAILED to start: {ex.Message}. This Director cannot be stopped or "
                 + "asked to check for updates from outside itself; closing its window still works.");
         }
+    }
+
+    /// <summary>
+    /// One pass of the Director's ownership of the LAUNCHER's update (issue #2719): install a staged
+    /// cc-launcher build over the installed one, and confirm the new launcher is alive AND commandable
+    /// before believing it.
+    ///
+    /// THE ROOT IS THE SHARED ONE. This Director's own storage is redirected to its instance home, so
+    /// the layout must be built from <see cref="InstanceContext.SharedRoot"/>. Resolved the ordinary
+    /// way it would look for a staged launcher under <c>instances/&lt;slug&gt;/state</c> - a directory
+    /// no installer has ever written - and report "nothing staged" for ever, on every machine.
+    ///
+    /// Never throws: this is called from a background loop and from a signal handler.
+    /// </summary>
+    private static async Task RunLauncherUpdatePassAsync()
+    {
+        try
+        {
+            var directorId = DirectorIdStore.LoadOrCreate();
+            var owner = new CcDirector.Setup.Engine.LauncherUpdateOwner(
+                InstanceContext.SharedRoot,
+                directorStillHoldsItsInstance: () => DirectorStillHoldsItsInstance(directorId));
+
+            var result = await owner.RunOnceAsync();
+            if (result.Decision != CcDirector.Setup.Engine.LauncherUpdateDecision.NothingStaged)
+                FileLog.Write($"[App] launcher update pass: {result.Decision} - {result.Message}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[App] launcher update pass FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Is this Director still the live owner of its instance - the check that a launcher swap did not
+    /// take it with it, or leave a second Director holding the same home? Read from the registration
+    /// this process writes about itself, so a yes means THIS process id is still the registered owner
+    /// and not merely that some Director is.
+    /// </summary>
+    private static bool DirectorStillHoldsItsInstance(string directorId)
+    {
+        var path = Path.Combine(InstanceRegistration.InstancesDirectory, $"{directorId}.json");
+        if (!File.Exists(path)) return false;
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        foreach (var property in doc.RootElement.EnumerateObject())
+        {
+            if (property.Name.Equals("pid", StringComparison.OrdinalIgnoreCase)
+                && property.Value.ValueKind == JsonValueKind.Number
+                && property.Value.TryGetInt32(out var pid))
+                return pid == Environment.ProcessId;
+        }
+        return false;
     }
 
     private void StartControlApi(Action<string> log)

--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -503,22 +503,29 @@ public partial class App : Application
                             outcome = await Updater.CheckAndStageAsync();
                             var toolResult = await new CcDirector.Setup.Engine.ToolUpdater(layout).RefreshAsync();
                             FileLog.Write($"[App] tool auto-update: updated={toolResult.Updated}, failed={toolResult.Failed}");
-
-                            // The launcher's own update, which the Director owns (issue #2719). The
-                            // mirror of the launcher owning the Director's: whatever replaces a binary
-                            // has to outlive the process being replaced, and the launcher cannot
-                            // honestly swap itself. Nothing owned this before, so a machine whose
-                            // launcher fell behind became permanently uncommandable - and could not be
-                            // fixed remotely, because the thing that would receive the fix was the
-                            // broken thing. A Director update still reaches it, which is why this runs
-                            // here.
-                            await RunLauncherUpdatePassAsync();
                         }
                         catch (Exception ex)
                         {
                             outcome = UpdatePhase.Failed;
                             FileLog.Write($"[App] auto-update cycle FAILED: {ex.Message}");
                         }
+
+                        // The launcher's own update, which the Director owns (issue #2719). The mirror
+                        // of the launcher owning the Director's: whatever replaces a binary has to
+                        // outlive the process being replaced, and the launcher cannot honestly swap
+                        // itself. Nothing owned this before, so a machine whose launcher fell behind
+                        // became permanently uncommandable - and could not be fixed remotely, because
+                        // the thing that would receive the fix was the broken thing. A Director update
+                        // still reaches it, which is why this runs here.
+                        //
+                        // IT HAS ITS OWN try, DELIBERATELY. Inside the one above, a failure in the
+                        // Director's own check or the tool refresh - a network timeout, most likely -
+                        // skipped this entirely. That is precisely backwards: a launcher build is
+                        // ALREADY DOWNLOADED and needs no network at all to install, and the machines
+                        // whose launcher is stale are exactly the machines with something else wrong.
+                        // A stranded launcher update is the failure this whole change exists to end,
+                        // so it does not share a failure path with the network.
+                        await RunLauncherUpdatePassAsync();
                     }
 
                     // Tool reconcile is governed by its OWN switch (tools.autoUpdate.enabled), independent

--- a/src/CcDirector.Core.Tests/LifecycleSignalTests.cs
+++ b/src/CcDirector.Core.Tests/LifecycleSignalTests.cs
@@ -37,6 +37,41 @@ public sealed class LifecycleSignalTests
     }
 
     [Fact]
+    public void HasListener_AnswersWithoutRaisingAnything()
+    {
+        // The question a capability check has to be able to ask. Raising the signal to find out whether
+        // anybody is there would restart a Director or quit a launcher as a side effect of asking, so
+        // this must answer AND leave the listener unfired.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var name = UniqueName();
+        Assert.False(LifecycleSignal.HasListener(name));
+
+        var fired = 0;
+        using (var listener = LifecycleSignal.Listen(name, () => Interlocked.Increment(ref fired)))
+        {
+            Assert.True(LifecycleSignal.HasListener(name));
+            Thread.Sleep(200);
+            Assert.Equal(0, Volatile.Read(ref fired));
+        }
+
+        Assert.False(LifecycleSignal.HasListener(name));
+    }
+
+    [Fact]
+    public void HasListener_WhereItCannotBeObserved_SaysSoRatherThanInventingANo()
+    {
+        // Unix has no named event: the mechanism is a request file a listener polls, and nothing on disk
+        // says whether anybody is polling. A false there would be an invented answer, so it is null.
+        if (OperatingSystem.IsWindows()) return;
+
+        var name = UniqueName();
+        using var listener = LifecycleSignal.Listen(name, () => { });
+
+        Assert.Null(LifecycleSignal.HasListener(name));
+    }
+
+    [Fact]
     public void RaisingASignalNobodyListensFor_ReportsItWasNotDelivered()
     {
         // Windows can say this outright - no kernel object of that name exists. The Unix arm writes a

--- a/src/CcDirector.Core/Lifecycle/LifecycleSignal.cs
+++ b/src/CcDirector.Core/Lifecycle/LifecycleSignal.cs
@@ -101,6 +101,43 @@ public static class LifecycleSignal
         }
     }
 
+    /// <summary>
+    /// Is anything listening for <paramref name="name"/> right now - asked WITHOUT asking it to do
+    /// anything?
+    ///
+    /// This exists because the only other way to find out was <see cref="Raise"/>, and raising a
+    /// signal to see whether somebody is there restarts a Director or quits a launcher as a side
+    /// effect of the question. A capability check may not have consequences.
+    ///
+    /// THE ANSWER IS A TRI-STATE AND THAT IS NOT A HEDGE. On Windows a named event either exists in
+    /// this logon session or it does not, so true and false are both facts. On Unix the mechanism is a
+    /// request FILE that the listener polls (see the class comment): there is no listener registry to
+    /// consult, and the absence of a request file says nothing at all about whether anybody is
+    /// watching for one. Returning false there would be an invented no, so the answer is null - NOT
+    /// OBSERVABLE - and a caller has to decide what to do about a question this platform cannot
+    /// answer, rather than being handed a confident wrong one.
+    /// </summary>
+    /// <returns>True/false on Windows; null on Unix, where a listener cannot be observed at all.</returns>
+    public static bool? HasListener(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("A signal name is required", nameof(name));
+        if (!OperatingSystem.IsWindows()) return null;
+
+        try
+        {
+            if (!EventWaitHandle.TryOpenExisting(WindowsPrefix + name, out var handle) || handle is null)
+                return false;
+            // Opened, never set: this asks who is there, it does not ask them to act.
+            handle.Dispose();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LifecycleSignal] HasListener FAILED: name={name}: {ex.Message}");
+            return null;
+        }
+    }
+
     [SupportedOSPlatform("windows")]
     private static bool RaiseWindows(string name)
     {

--- a/src/CcDirector.Core/Lifecycle/LifecycleSignal.cs
+++ b/src/CcDirector.Core/Lifecycle/LifecycleSignal.cs
@@ -116,6 +116,13 @@ public static class LifecycleSignal
     /// watching for one. Returning false there would be an invented no, so the answer is null - NOT
     /// OBSERVABLE - and a caller has to decide what to do about a question this platform cannot
     /// answer, rather than being handed a confident wrong one.
+    ///
+    /// WHAT A TRUE PROVES. That the named handle EXISTS - the listener got far enough to arm it. It
+    /// does NOT prove the thread waiting on that handle is still pumping, so a process that armed its
+    /// signals and then wedged answers true here. Closing that gap would mean raising the signal and
+    /// watching for the effect, which is exactly the destructive question this method exists to avoid.
+    /// Callers get the honest weaker fact; anything that needs "is it being serviced" has to accept
+    /// the consequences of asking.
     /// </summary>
     /// <returns>True/false on Windows; null on Unix, where a listener cannot be observed at all.</returns>
     public static bool? HasListener(string name)

--- a/src/CcDirector.Launcher.Tests/BothUpdateOwnersTakeTheSameLockTests.cs
+++ b/src/CcDirector.Launcher.Tests/BothUpdateOwnersTakeTheSameLockTests.cs
@@ -1,0 +1,47 @@
+using CcDirector.Launcher;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Launcher.Tests;
+
+/// <summary>
+/// THE FACT A TEST SEAM COULD OTHERWISE COST.
+///
+/// This install has two update owners and each stops the other's process: the launcher installs the
+/// Director's update, and the Director installs the launcher's. They are kept apart by ONE machine-wide
+/// lock, and "one" is the whole mechanism - two owners taking two differently-named mutexes exclude
+/// nothing at all while looking, in every log and every test, exactly like a lock that works.
+///
+/// Both owners let a test override the lock's name, because the alternative was tests taking the real
+/// machine-wide lock and failing each other across projects and worktrees for a reason in neither
+/// branch. That seam is what makes this assertion necessary rather than obvious: the property that
+/// matters is no longer visible at the call site, so it is asserted here instead - the DEFAULT each
+/// owner ships with, compared against the other's, not merely against a string this file also spells.
+///
+/// This is the only project that can see both types; the setup engine cannot reference the launcher.
+/// </summary>
+public class BothUpdateOwnersTakeTheSameLockTests
+{
+    [Fact]
+    public void TheTwoOwnersDefaultToTheSameMachineWideLock()
+    {
+        var launcherInstallingTheDirectorsUpdate = new DirectorUpdateOwner(new DirectorSupervisor()).SwapLockName;
+        var directorInstallingTheLaunchersUpdate =
+            new LauncherUpdateOwner(TestRoot(), directorStillHoldsItsInstance: () => true).SwapLockName;
+
+        Assert.Equal(launcherInstallingTheDirectorsUpdate, directorInstallingTheLaunchersUpdate);
+        Assert.Equal(BinarySwapLock.Name, launcherInstallingTheDirectorsUpdate);
+    }
+
+    [Fact]
+    public void TheLockIsMachineWide_NotSessionScoped()
+    {
+        // A Director and the launcher supervising it need not share a logon session, and an unqualified
+        // mutex name is session-scoped - so a lock that looked identical would still fail to exclude
+        // exactly the pair it exists for.
+        Assert.StartsWith(@"Global\", BinarySwapLock.Name, StringComparison.Ordinal);
+    }
+
+    private static string TestRoot()
+        => Path.Combine(Path.GetTempPath(), "cc-swap-lock-" + Guid.NewGuid().ToString("N"));
+}

--- a/src/CcDirector.Launcher/DirectorUpdateOwner.cs
+++ b/src/CcDirector.Launcher/DirectorUpdateOwner.cs
@@ -26,6 +26,11 @@ public enum DirectorUpdateDecision
     HeldBecauseBusy,
     /// <summary>An update is staged but the Director could not be asked whether it is busy, so it waits.</summary>
     HeldBecauseUnknown,
+    /// <summary>
+    /// An update is staged, but another binary swap is already running on this machine - a Director
+    /// installing the launcher's own update, or a second launcher. Nothing was touched.
+    /// </summary>
+    HeldBecauseAnotherSwapIsRunning,
     /// <summary>An update is staged but the Director is not running, and it is not this loop's business to start one.</summary>
     HeldBecauseDirectorNotRunning,
     /// <summary>The staged update is one that already failed to start and was pinned away from.</summary>
@@ -87,6 +92,13 @@ public sealed class DirectorUpdateOwner
         // answers anything, and this has to be long enough that a slow machine is not called a failure.
         _healthTimeout = healthTimeout ?? TimeSpan.FromMinutes(3);
     }
+
+    /// <summary>
+    /// The machine-wide lock this swap takes. <see cref="BinarySwapLock.Name"/> in production, always;
+    /// a test overrides it so it can hold a lock of its own without contending with everything else on
+    /// the machine. See the parameter note on <see cref="BinarySwapLock.RunExclusivelyAsync"/>.
+    /// </summary>
+    public string SwapLockName { get; init; } = BinarySwapLock.Name;
 
     /// <summary>
     /// Decide whether a staged update may be installed right now: only when one is staged AND the
@@ -206,6 +218,28 @@ public sealed class DirectorUpdateOwner
                       + $"target={staged.InstallTarget}, sessions=0, currentVersion="
                       + $"{(status.Version.Length > 0 ? status.Version : "unknown")}");
 
+        // THE SWAP IS EXCLUSIVE, MACHINE-WIDE (issue #2719). The Director now owns the LAUNCHER's
+        // update, which stops and replaces this process while it runs - so the two owners stop each
+        // other's process and each one destroys the other's evidence. Taken here, BEFORE the staged
+        // record is cleared: clearing it and then finding the lock held would throw away the record of
+        // a download for a pass that did nothing. See BinarySwapLock for both directions of the race.
+        return await BinarySwapLock.RunExclusivelyAsync(
+            () => SwapAsync(staged, conflictNote, ct),
+            whenBusy: why =>
+            {
+                FileLog.Write($"[DirectorUpdateOwner] {staged.Version} is staged, but {why}");
+                return Record(staged, DirectorUpdateDecision.HeldBecauseAnotherSwapIsRunning, conflictNote + why);
+            },
+            who: "director-update",
+            name: SwapLockName);
+    }
+
+    /// <summary>
+    /// The swap itself, run while <see cref="BinarySwapLock"/> is held: claim the staged record, stop,
+    /// replace, start, and wait for the new version to answer.
+    /// </summary>
+    private async Task<DirectorUpdateDecision> SwapAsync(StagedDirectorUpdate staged, string conflictNote, CancellationToken ct)
+    {
         // Claim it BEFORE anything is started, so no Director that comes up during this can hand itself
         // to its own swap. See the class comment - the alternative is a rollback loop into a dead build.
         ClearStagedRecord(staged);

--- a/src/CcDirector.Launcher/DirectorUpdateOwner.cs
+++ b/src/CcDirector.Launcher/DirectorUpdateOwner.cs
@@ -97,8 +97,13 @@ public sealed class DirectorUpdateOwner
     /// The machine-wide lock this swap takes. <see cref="BinarySwapLock.Name"/> in production, always;
     /// a test overrides it so it can hold a lock of its own without contending with everything else on
     /// the machine. See the parameter note on <see cref="BinarySwapLock.RunExclusivelyAsync"/>.
+    ///
+    /// INTERNAL, so the override is reachable only from the test assemblies. Public, it was a knob a
+    /// production caller could turn - and two owners on two names exclude nothing at all while looking,
+    /// in every log and every test, exactly like a lock that works. The guarantee should not rest on
+    /// nobody happening to set it.
     /// </summary>
-    public string SwapLockName { get; init; } = BinarySwapLock.Name;
+    internal string SwapLockName { get; init; } = BinarySwapLock.Name;
 
     /// <summary>
     /// Decide whether a staged update may be installed right now: only when one is staged AND the

--- a/src/CcDirector.Launcher/Program.cs
+++ b/src/CcDirector.Launcher/Program.cs
@@ -202,7 +202,20 @@ public static class Program
         // so both waits certify the process they actually started - never whatever else wrote the file.
         var relaunchedPid = 0;
 
-        var result = new LauncherSelfUpdate().ApplyAsync(
+        // THE THIRD SWAP ROUTE, AND IT TAKES THE SAME MACHINE-WIDE LOCK (issue #2719).
+        //
+        // This helper replaces the launcher binary, and since Phase 0 the DIRECTOR also replaces that
+        // same binary through LauncherUpdateOwner. Two swaps overlapping on one target is not a near
+        // miss: both write the same target, the same .new and the same .old, so the second swap can
+        // delete the FIRST swap's real backup and leave a copy of the new build in its place. If that
+        // build then fails its health check, the rollback faithfully "restores" the bad build - and
+        // the machine ends up on it with no way back.
+        //
+        // It WAITS for the lock rather than skipping, unlike the two periodic owners. This process was
+        // started for the single purpose of performing one swap and has no next cycle to return on;
+        // skipping would silently drop the update it exists to apply.
+        var result = BinarySwapLock.RunExclusivelyAsync<SelfUpdateResult>(
+            work: () => new LauncherSelfUpdate().ApplyAsync(
             target, stagedSelf, version,
             stopLauncher: () =>
             {
@@ -268,7 +281,11 @@ public static class Program
                     && CcDirector.Core.Configuration.LauncherDiscovery.IsRunning(fact);
                 return Task.FromResult(healthy);
             },
-            healthTimeout: TimeSpan.FromSeconds(30)).GetAwaiter().GetResult();
+            healthTimeout: TimeSpan.FromSeconds(30)),
+            whenBusy: why => new SelfUpdateResult(SelfUpdateOutcome.Failed,
+                $"The launcher self-update did not run: {why}", Array.Empty<string>()),
+            who: "launcher-self-update",
+            waitFor: TimeSpan.FromMinutes(5)).GetAwaiter().GetResult();
 
         FileLog.Write($"[Program] self-update outcome={result.Outcome}: {result.Message}");
         foreach (var step in result.Steps) FileLog.Write($"[Program]   {step}");

--- a/tools/cc-director-setup-engine.Tests/InstalledLauncherProcessesTests.cs
+++ b/tools/cc-director-setup-engine.Tests/InstalledLauncherProcessesTests.cs
@@ -1,0 +1,44 @@
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// Which launcher processes belong to an install - and, the part that matters here, what happens when
+/// one of them cannot be read at all.
+/// </summary>
+public class InstalledLauncherProcessesTests
+{
+    [Fact]
+    public void EverythingReadable_IsTheAnswer()
+    {
+        var readable = new[] { new LauncherProcess(1, "/opt/cc-director/launcher/cc-launcher --managed") };
+
+        Assert.Same(readable, InstalledLauncherProcesses.Resolve(readable, []));
+    }
+
+    [Fact]
+    public void AProcessThatCouldNotBeRead_MakesTheMachineUNDECIDABLE_NotEmpty()
+    {
+        // THE KNOWN-BAD INPUT. A cc-launcher process is running and its command line could not be read,
+        // so whether it belongs to this install is unknown. Returning the short list would answer "not
+        // ours", which both callers turn into "nothing to stop" - so the uninstaller would certify a
+        // clean machine over a live launcher, and the Director's swap would replace a binary out from
+        // under a running process. The only honest answer is that the question could not be answered.
+        var readable = new[] { new LauncherProcess(1, "/opt/cc-director/launcher/cc-launcher --managed") };
+
+        var refused = Assert.Throws<InvalidOperationException>(
+            () => InstalledLauncherProcesses.Resolve(readable, ["4242 (Access is denied)"]));
+
+        Assert.Contains("could not be read", refused.Message);
+        Assert.Contains("4242", refused.Message);
+    }
+
+    [Fact]
+    public void AnUnreadableProcessIsRefusedEvenWhenNothingElseIsRunning()
+    {
+        // The dangerous shape specifically: nothing readable, one unreadable. Dropped, this is an empty
+        // machine - the most reassuring answer there is, and the wrong one.
+        Assert.Throws<InvalidOperationException>(
+            () => InstalledLauncherProcesses.Resolve([], ["4242 (Access is denied)"]));
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/InstalledLauncherProcessesTests.cs
+++ b/tools/cc-director-setup-engine.Tests/InstalledLauncherProcessesTests.cs
@@ -33,6 +33,33 @@ public class InstalledLauncherProcessesTests
         Assert.Contains("4242", refused.Message);
     }
 
+    [Theory]
+    // A live process in OUR session whose path could not be read might be ours: undecidable.
+    [InlineData(null, false, 1, 1, InstalledLauncherProcesses.UnreadableVerdict.CouldBeOurs)]
+    // Its session could not even be read, so it cannot be ruled out either.
+    [InlineData(null, false, null, 1, InstalledLauncherProcesses.UnreadableVerdict.CouldBeOurs)]
+    // Another logon session cannot be running this per-user install's binary.
+    [InlineData(null, false, 2, 1, InstalledLauncherProcesses.UnreadableVerdict.CannotBeOurs)]
+    // It has exited; it is not running from anywhere.
+    [InlineData(null, true, 1, 1, InstalledLauncherProcesses.UnreadableVerdict.CannotBeOurs)]
+    // It was readable after all - the caller keeps it, this path is not about it.
+    [InlineData("/opt/cc-director/launcher/cc-launcher", false, 1, 1, InstalledLauncherProcesses.UnreadableVerdict.CannotBeOurs)]
+    internal void AProcessWhosePathCannotBeRead_IsUndecidableOnlyWhenItCouldBeOurs(
+        string? commandLine, bool hasExited, int? sessionId, int ourSession,
+        InstalledLauncherProcesses.UnreadableVerdict expected)
+    {
+        // THE SHAPE THAT RAISED NO EXCEPTION. A null main module used to be coalesced to an empty
+        // command line, which Ours then drops for having no matching prefix - the exact fail-open the
+        // throw exists to close, surviving in the one case that does not throw.
+        //
+        // And the opposite over-correction is guarded here too: treating EVERY unreadable process as
+        // possibly ours is far too broad, because the enumeration is machine-wide while the install is
+        // per-user. One other signed-in user's launcher would otherwise make this user's update
+        // undecidable on every pass, for ever, with nothing wrong on this user's machine.
+        Assert.Equal(expected,
+            InstalledLauncherProcesses.Classify(commandLine, hasExited, sessionId, ourSession));
+    }
+
     [Fact]
     public void AnUnreadableProcessIsRefusedEvenWhenNothingElseIsRunning()
     {

--- a/tools/cc-director-setup-engine.Tests/LauncherSwapNeverKillsATreeTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherSwapNeverKillsATreeTests.cs
@@ -1,0 +1,72 @@
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// THE ONE RULE IN THE LAUNCHER SWAP THAT NO BEHAVIOURAL TEST CAN REACH: it must never kill a process
+/// TREE.
+///
+/// On Windows the launcher is the Director's parent process, and the Director is the process performing
+/// the swap. A tree kill aimed at the launcher would therefore end the swap halfway through, with the
+/// launcher binary already renamed aside and nothing left running to put it back or to start what was
+/// installed. The uninstaller kills trees on purpose - the whole install is going away there - so the
+/// two stops look alike and the wrong one is one word away.
+///
+/// WHAT THIS PROVES AND WHAT IT DOES NOT. It reads one file and asserts a call, so it catches the edit
+/// that is actually likely: somebody with a launcher that will not die flipping the flag to make it die.
+/// It does NOT catch the same kill moved into a helper elsewhere, which is the known weakness of every
+/// source-text guard (see NoListenerDependencyGuardTests, which chose a dependency assertion for exactly
+/// that reason). A dependency assertion cannot help here, because what has to be asserted is the VALUE
+/// OF AN ARGUMENT, and both values come from the same method on the same type. Proved against a
+/// known-bad input before it was trusted: with entireProcessTree flipped to true, this test fails and
+/// every other test in this project still passes.
+/// </summary>
+public class LauncherSwapNeverKillsATreeTests
+{
+    [Fact]
+    public void TheDirectorsLauncherSwap_KillsOneProcess_NeverATree()
+    {
+        var source = File.ReadAllText(OwnerSourcePath());
+
+        Assert.Contains("entireProcessTree: false", source);
+        Assert.DoesNotContain("entireProcessTree: true", source);
+    }
+
+    [Fact]
+    public void TheUninstallersStop_IsAllowedToKillATree_AndIsADifferentFile()
+    {
+        // Stated so the difference is deliberate rather than accidental: if these two ever end up in one
+        // place, the reason the Director's swap must not do this is the thing that gets lost.
+        var uninstall = File.ReadAllText(Path.Combine(RepoRoot(), "tools", "cc-director-setup-engine", "LauncherStopper.cs"));
+
+        Assert.Contains("entireProcessTree: true", uninstall);
+    }
+
+    private static string OwnerSourcePath()
+        => Path.Combine(RepoRoot(), "tools", "cc-director-setup-engine", "LauncherUpdateOwner.cs");
+
+    /// <summary>
+    /// The repository this test file was compiled from, checked against markers so a path that exists
+    /// but is not this repository fails loudly instead of being read as though it were the product.
+    /// </summary>
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        // this file: <repo>/tools/cc-director-setup-engine.Tests/LauncherSwapNeverKillsATreeTests.cs
+        var dir = Path.GetDirectoryName(thisFile)!;
+        var root = Path.GetFullPath(Path.Combine(dir, "..", ".."));
+
+        foreach (var marker in new[]
+                 {
+                     Path.Combine("tools", "cc-director-setup-engine", "LauncherUpdateOwner.cs"),
+                     Path.Combine("tools", "cc-director-setup-engine", "LauncherStopper.cs"),
+                 })
+        {
+            Assert.True(File.Exists(Path.Combine(root, marker)),
+                $"Resolved the repository root to {root}, but it does not contain {marker}. This guard was "
+                + "built from a tree it can no longer find, so it is not reading the product.");
+        }
+
+        return root;
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/LauncherSwapNeverKillsATreeTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherSwapNeverKillsATreeTests.cs
@@ -13,24 +13,52 @@ namespace CcDirector.Setup.Engine.Tests;
 /// installed. The uninstaller kills trees on purpose - the whole install is going away there - so the
 /// two stops look alike and the wrong one is one word away.
 ///
-/// WHAT THIS PROVES AND WHAT IT DOES NOT. It reads one file and asserts a call, so it catches the edit
-/// that is actually likely: somebody with a launcher that will not die flipping the flag to make it die.
-/// It does NOT catch the same kill moved into a helper elsewhere, which is the known weakness of every
-/// source-text guard (see NoListenerDependencyGuardTests, which chose a dependency assertion for exactly
-/// that reason). A dependency assertion cannot help here, because what has to be asserted is the VALUE
-/// OF AN ARGUMENT, and both values come from the same method on the same type. Proved against a
-/// known-bad input before it was trusted: with entireProcessTree flipped to true, this test fails and
-/// every other test in this project still passes.
+/// WHAT THIS PROVES AND WHAT IT DOES NOT. This began as a source-text scan of ONE file for ONE
+/// spelling of the argument, which is the weakest kind of proof: it saw the edit it was written for and
+/// nothing else, and in particular it could not see the same kill moved into a helper. The kill has
+/// since been moved deliberately - it lives in SingleProcessStop, a type whose entire purpose is the
+/// single-process form - which turns the weak assertion into a strong one. The file that performs the
+/// swap now contains NO process kill at all, so what is asserted about it is a complete absence for
+/// that file rather than the absence of one string, and there is no argument in it left to flip.
+///
+/// The residual limit, stated rather than hidden: this still cannot see a kill written into some third
+/// file and called from the swap. What it can see is that the swap's own file expresses none, and that
+/// the one type it delegates to expresses only the single-process form. Proved against known-bad
+/// inputs before it was trusted: with entireProcessTree flipped to true in SingleProcessStop, and
+/// separately with a Kill call put back into LauncherUpdateOwner, the matching test fails and every
+/// other test in this project still passes.
 /// </summary>
 public class LauncherSwapNeverKillsATreeTests
 {
     [Fact]
-    public void TheDirectorsLauncherSwap_KillsOneProcess_NeverATree()
+    public void TheFileThatPerformsTheSwap_ExpressesNoProcessKillAtAll()
     {
+        // The strong form. Not "it does not say entireProcessTree: true" - it does not kill anything,
+        // so the argument that could be got wrong is not written here to get wrong.
         var source = File.ReadAllText(OwnerSourcePath());
+
+        Assert.DoesNotContain(".Kill(", source);
+        Assert.DoesNotContain("entireProcessTree", source);
+    }
+
+    [Fact]
+    public void TheOnlyKillInTheSwapPath_KillsOneProcess_NeverATree()
+    {
+        var source = File.ReadAllText(SingleProcessStopSourcePath());
 
         Assert.Contains("entireProcessTree: false", source);
         Assert.DoesNotContain("entireProcessTree: true", source);
+        // One kill, not one correct kill beside another.
+        Assert.Equal(1, CountOccurrences(source, ".Kill("));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+            count++;
+        return count;
     }
 
     [Fact]
@@ -46,6 +74,9 @@ public class LauncherSwapNeverKillsATreeTests
     private static string OwnerSourcePath()
         => Path.Combine(RepoRoot(), "tools", "cc-director-setup-engine", "LauncherUpdateOwner.cs");
 
+    private static string SingleProcessStopSourcePath()
+        => Path.Combine(RepoRoot(), "tools", "cc-director-setup-engine", "SingleProcessStop.cs");
+
     /// <summary>
     /// The repository this test file was compiled from, checked against markers so a path that exists
     /// but is not this repository fails loudly instead of being read as though it were the product.
@@ -60,6 +91,7 @@ public class LauncherSwapNeverKillsATreeTests
                  {
                      Path.Combine("tools", "cc-director-setup-engine", "LauncherUpdateOwner.cs"),
                      Path.Combine("tools", "cc-director-setup-engine", "LauncherStopper.cs"),
+                     Path.Combine("tools", "cc-director-setup-engine", "SingleProcessStop.cs"),
                  })
         {
             Assert.True(File.Exists(Path.Combine(root, marker)),

--- a/tools/cc-director-setup-engine.Tests/LauncherUpdateOwnerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherUpdateOwnerTests.cs
@@ -211,9 +211,11 @@ public class LauncherUpdateOwnerTests : IDisposable
     [Fact]
     public async Task ARunningLauncherThatIsAlreadyTheStagedVersion_AND_COMMANDABLE_InstallsNothing()
     {
+        // pid 1001 is BOTH what the registration names and the process running from the install
+        // directory - the shortcut requires that they are the same process.
         WriteRegistration(1001, StagedVersion);
         var stopped = new List<int>();
-        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true, stopped: stopped,
+        var owner = Owner([InstalledLauncher(1001)], newBuildIsCommandable: true, stopped: stopped,
             oldBuildListens: true);
 
         var result = await owner.RunOnceAsync();
@@ -242,6 +244,32 @@ public class LauncherUpdateOwnerTests : IDisposable
 
         Assert.Equal(LauncherUpdateDecision.Applied, result.Decision);
         Assert.Equal(new[] { 1001 }, stopped);
+        Assert.Equal("launcher-NEW", File.ReadAllText(_target));
+    }
+
+    [Fact]
+    public async Task AWITNESSEDLauncherThatIsNotTheINSTALLEDOne_DoesNotGetItsVersionRecorded()
+    {
+        // THE SECOND HALF OF THE SAME DEFECT. "Witnessed" says a launcher is registered, alive and
+        // commandable - it does NOT say the installed BINARY is that version. The witness reads the
+        // registration at the shared root, and any launcher can write it: one run from a repository
+        // checkout, or from the staging directory, pointed at this root. Such a launcher is witnessed
+        // while the installed file is still the old build.
+        //
+        // Record on that and the damage outlives the pass: InstalledStateReader prefers the recorded
+        // version over the older file stamp, so the staged build stops looking newer and the installed
+        // binary can never be repaired. The registration here names a process that is NOT the one
+        // running from the install directory, which is exactly that machine.
+        WriteRegistration(7777, StagedVersion);
+        var running = new List<LauncherProcess> { InstalledLauncher(1001) };
+        var owner = Owner(running, newBuildIsCommandable: true, oldBuildListens: true);
+
+        var result = await owner.RunOnceAsync();
+
+        // The shortcut must NOT fire. What proves that is the install actually happening: the binary
+        // on disk is the new one. (Recording the version afterwards is then correct and expected -
+        // the defect was recording it INSTEAD of installing.)
+        Assert.NotEqual(LauncherUpdateDecision.NothingStaged, result.Decision);
         Assert.Equal("launcher-NEW", File.ReadAllText(_target));
     }
 

--- a/tools/cc-director-setup-engine.Tests/LauncherUpdateOwnerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherUpdateOwnerTests.cs
@@ -1,0 +1,292 @@
+using System.Text.Json;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// The Director installing the launcher's staged update. Every test here drives the whole pass through
+/// fakes for the three things that touch the machine - the process list, the stop, and the start - so
+/// the rollback, the refusals and the witness are all exercised without a launcher anywhere.
+///
+/// The fake START rewrites the registration file, because that is what a real launcher does when it
+/// comes up, and it is the only way the witness can tell a build that arrived from one that did not.
+/// </summary>
+public class LauncherUpdateOwnerTests : IDisposable
+{
+    private readonly string _root;
+    private readonly InstallLayout _layout;
+    private readonly string _target;
+    private readonly string _staged;
+    private readonly string _registration;
+
+    private const string InstalledVersion = "1.9.8";
+    private const string StagedVersion = "2.0.4";
+
+    public LauncherUpdateOwnerTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cc-luo-" + Guid.NewGuid().ToString("N"));
+        _layout = new InstallLayout(_root);
+        _target = _layout.PathFor(ComponentRegistry.Launcher);
+        _staged = Path.Combine(_root, "state", "staged", "cc-launcher.exe");
+        _registration = LauncherWitness.RegistrationPathFor(_root);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(_target)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(_staged)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(_registration)!);
+
+        File.WriteAllText(_target, "launcher-OLD");
+        File.WriteAllText(_staged, "launcher-NEW");
+        var manifest = InstalledManifest.Load(_layout);
+        manifest.Set(ComponentRegistry.Launcher.Id, InstalledVersion);
+        manifest.Save(_layout);
+
+        WriteRegistration(1001, InstalledVersion);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    private void WriteRegistration(int pid, string version)
+        => File.WriteAllText(_registration, JsonSerializer.Serialize(new { pid, version }));
+
+    /// <summary>The launcher this machine is running, as the process list would report it.</summary>
+    private LauncherProcess InstalledLauncher(int pid = 1001)
+        => new(pid, Path.Combine(_layout.LauncherDir, "cc-launcher.exe") + " --managed");
+
+    /// <summary>
+    /// An owner wired to fakes. <paramref name="newBuildIsCommandable"/> decides what the started
+    /// launcher turns out to be: a build that can be told things, or one that comes up perfectly and
+    /// listens for nothing - which is the failure this whole thing exists to catch.
+    /// </summary>
+    private LauncherUpdateOwner Owner(
+        List<LauncherProcess> running,
+        bool newBuildIsCommandable,
+        List<int>? stopped = null,
+        List<string>? quitRequests = null,
+        bool directorSurvives = true,
+        bool oldBuildListens = false)
+    {
+        var startedNewBuild = false;
+
+        var witness = new LauncherWitness(_root)
+        {
+            RegistrationPath = _registration,
+            ProcessIsAlive = _ => running.Count > 0,
+            // Before the swap the old launcher answers (or does not); afterwards the new one does,
+            // according to what this test says the new build is.
+            HasListener = _ => startedNewBuild ? newBuildIsCommandable : oldBuildListens,
+        };
+
+        return new LauncherUpdateOwner(
+            _root,
+            directorStillHoldsItsInstance: () => directorSurvives,
+            witness: witness,
+            apply: new LauncherSelfUpdate(_layout, unlockTimeout: TimeSpan.FromSeconds(1)),
+            witnessTimeout: TimeSpan.FromMilliseconds(400))
+        {
+            ReadVersionOnDisk = path => path == _staged ? StagedVersion : null,
+            ListLauncherProcesses = () => running.ToList(),
+            RequestQuit = root => { quitRequests?.Add(root); return false; },
+            StopProcess = pid =>
+            {
+                stopped?.Add(pid);
+                running.RemoveAll(p => p.Pid == pid);
+                return true;
+            },
+            StartLauncher = _ =>
+            {
+                startedNewBuild = true;
+                running.Add(InstalledLauncher(2002));
+                WriteRegistration(2002, StagedVersion);
+                return 2002;
+            },
+            GracefulStopTimeout = TimeSpan.FromMilliseconds(200),
+            StopSettleTimeout = TimeSpan.FromMilliseconds(200),
+        };
+    }
+
+    [Fact]
+    public void StagedBuildPath_IsUnderTheSharedRoot()
+    {
+        // Resolved through the calling process's own storage instead, this points into a Director's
+        // instance home and finds nothing, for ever, on every machine.
+        var owner = new LauncherUpdateOwner(_root, () => true);
+
+        Assert.Equal(Path.Combine(_root, "state", "staged", "cc-launcher.exe"), owner.StagedBuildPath);
+    }
+
+    [Fact]
+    public void FindStagedUpdate_FindsANewerBuild_AndSaysWhyWhenThereIsNone()
+    {
+        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true);
+
+        var found = owner.FindStagedUpdate(out var why);
+        Assert.NotNull(found);
+        Assert.Equal(StagedVersion, found!.Version);
+        Assert.Equal(_target, found.InstallTarget);
+        Assert.Equal("", why);
+
+        File.Delete(_staged);
+        Assert.Null(owner.FindStagedUpdate(out var missing));
+        Assert.Contains("no launcher build is staged", missing);
+    }
+
+    [Fact]
+    public void FindStagedUpdate_RefusesABuildThatIsNotNewer_AndOneThatWillNotSayWhatItIs()
+    {
+        var older = new LauncherUpdateOwner(_root, () => true) { ReadVersionOnDisk = _ => "1.9.7" };
+        Assert.Null(older.FindStagedUpdate(out var why));
+        Assert.Contains("not newer", why);
+
+        var silent = new LauncherUpdateOwner(_root, () => true) { ReadVersionOnDisk = _ => null };
+        Assert.Null(silent.FindStagedUpdate(out var noVersion));
+        Assert.Contains("does not declare a version", noVersion);
+    }
+
+    [Fact]
+    public void FindStagedUpdate_SkipsABuildThatIsPinned()
+    {
+        var pins = new UpdatePins();
+        pins.Pin(ComponentRegistry.Launcher.Id, StagedVersion);
+        PinStore.Save(_layout, pins);
+
+        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true);
+
+        Assert.Null(owner.FindStagedUpdate(out var why));
+        Assert.StartsWith("pinned", why);
+    }
+
+    [Fact]
+    public async Task NoLauncherRunning_HoldsAndTouchesNothing()
+    {
+        var owner = Owner([], newBuildIsCommandable: true);
+
+        var result = await owner.RunOnceAsync();
+
+        Assert.Equal(LauncherUpdateDecision.HeldBecauseLauncherNotRunning, result.Decision);
+        Assert.Equal("launcher-OLD", File.ReadAllText(_target));
+    }
+
+    [Fact]
+    public async Task MoreThanOneInstalledLauncher_IsUndecidable_AndTouchesNothing()
+    {
+        var owner = Owner([InstalledLauncher(1001), InstalledLauncher(1002)], newBuildIsCommandable: true);
+
+        var result = await owner.RunOnceAsync();
+
+        Assert.Equal(LauncherUpdateDecision.HeldBecauseUndecidable, result.Decision);
+        Assert.Contains("1001, 1002", result.Message);
+        Assert.Equal("launcher-OLD", File.ReadAllText(_target));
+    }
+
+    [Fact]
+    public async Task ALauncherFromSomewhereElse_IsNotOurs()
+    {
+        // A developer's launcher run from a repository checkout. It is not under the install directory,
+        // so it is not counted, not stopped, and not replaced.
+        var stopped = new List<int>();
+        var owner = Owner([new LauncherProcess(9, @"D:\repos\devthrottle\bin\cc-launcher.exe")],
+            newBuildIsCommandable: true, stopped: stopped);
+
+        var result = await owner.RunOnceAsync();
+
+        Assert.Equal(LauncherUpdateDecision.HeldBecauseLauncherNotRunning, result.Decision);
+        Assert.Empty(stopped);
+        Assert.Equal("launcher-OLD", File.ReadAllText(_target));
+    }
+
+    [Fact]
+    public async Task ARunningLauncherThatIsAlreadyTheStagedVersion_InstallsNothing()
+    {
+        WriteRegistration(1001, StagedVersion);
+        var stopped = new List<int>();
+        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true, stopped: stopped);
+
+        var result = await owner.RunOnceAsync();
+
+        Assert.Equal(LauncherUpdateDecision.NothingStaged, result.Decision);
+        Assert.Empty(stopped);
+        Assert.Equal("launcher-OLD", File.ReadAllText(_target));
+        // ...and the manifest is corrected, so the record and the running build stop disagreeing.
+        Assert.Equal(StagedVersion, InstalledManifest.Load(_layout).Get(ComponentRegistry.Launcher.Id));
+    }
+
+    [Fact]
+    public async Task ACommandableNewBuild_IsInstalled_AndRecorded()
+    {
+        var stopped = new List<int>();
+        var quits = new List<string>();
+        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true, stopped: stopped, quitRequests: quits);
+
+        var result = await owner.RunOnceAsync();
+
+        Assert.Equal(LauncherUpdateDecision.Applied, result.Decision);
+        Assert.Equal("launcher-NEW", File.ReadAllText(_target));
+        Assert.Equal(StagedVersion, InstalledManifest.Load(_layout).Get(ComponentRegistry.Launcher.Id));
+        Assert.False(PinStore.Load(_layout).IsPinned(ComponentRegistry.Launcher.Id, StagedVersion));
+        // Asked politely first, and only then insisted on the one process id.
+        Assert.Equal(new[] { _root }, quits);
+        Assert.Equal(new[] { 1001 }, stopped);
+        Assert.Contains(result.Steps, s => s.Contains("still holds its instance"));
+    }
+
+    [Fact]
+    public async Task ANewBuildThatComesUpAndListensForNOTHING_IsRolledBackAndPinned()
+    {
+        // THE TEST THIS CLASS EXISTS FOR. The started process is alive, registered, and reports the new
+        // version - everything a liveness check looks at - and it holds no command surface. That is a
+        // failed update, and calling it a success is how a machine becomes uncommandable in silence.
+        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: false);
+
+        var result = await owner.RunOnceAsync();
+
+        Assert.Equal(LauncherUpdateDecision.RolledBack, result.Decision);
+        Assert.Equal("launcher-OLD", File.ReadAllText(_target));
+        Assert.True(PinStore.Load(_layout).IsPinned(ComponentRegistry.Launcher.Id, StagedVersion));
+    }
+
+    [Fact]
+    public async Task WhenTheDirectorNoLongerHoldsItsInstance_TheResultSaysSo()
+    {
+        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true, directorSurvives: false);
+
+        var result = await owner.RunOnceAsync();
+
+        Assert.Equal(LauncherUpdateDecision.Applied, result.Decision);
+        Assert.Contains("NO LONGER HOLDS ITS INSTANCE", result.Message);
+        Assert.Contains(result.Steps, s => s.Contains("NO LONGER HOLDS ITS INSTANCE"));
+    }
+
+    [Fact]
+    public void StopInstalledLauncher_NeverStopsThisVeryProcess()
+    {
+        // Belt and braces on the no-orphan rule: even if the process list somehow named this process,
+        // the Director performing the swap is not something the swap may stop.
+        var stopped = new List<int>();
+        var running = new List<LauncherProcess> { InstalledLauncher(Environment.ProcessId) };
+        var owner = Owner(running, newBuildIsCommandable: true, stopped: stopped);
+
+        owner.StopInstalledLauncher();
+
+        Assert.Empty(stopped);
+    }
+
+    [Fact]
+    public void StopInstalledLauncher_AnUnreadableProcessList_IsNotAnEmptyOne()
+    {
+        // "Nothing left running" has to be observed. A list that could not be read is not evidence of
+        // an empty machine, and reporting it as a clean stop would let the swap run over a live launcher.
+        var owner = new LauncherUpdateOwner(_root, () => true)
+        {
+            ListLauncherProcesses = () => throw new InvalidOperationException("cannot list processes"),
+            RequestQuit = _ => false,
+            StopProcess = _ => true,
+            GracefulStopTimeout = TimeSpan.FromMilliseconds(50),
+            StopSettleTimeout = TimeSpan.FromMilliseconds(50),
+        };
+
+        Assert.False(owner.StopInstalledLauncher());
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/LauncherUpdateOwnerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherUpdateOwnerTests.cs
@@ -456,6 +456,30 @@ public class LauncherUpdateOwnerTests : IDisposable
     }
 
     [Fact]
+    public void StopInstalledLauncher_AnUnreadableProcessList_IsNeverHandedToTheStop()
+    {
+        // The comment on the unreadable-list sentinel said it "yields a process id nothing can stop".
+        // It did not: the sentinel's pid 0 went straight to the stop, and on Windows pid 0 resolves to
+        // the System Idle Process, so CloseMainWindow and Kill were attempted on it. The attempt fails
+        // and is caught, so nothing was harmed - but a sentence describing something the code does not
+        // do is exactly the defect this test exists to prevent coming back.
+        var stopped = new List<int>();
+        var owner = new LauncherUpdateOwner(_root, () => true)
+        {
+            ListLauncherProcesses = () => throw new InvalidOperationException("cannot list processes"),
+            RequestQuit = _ => false,
+            StopProcess = pid => { stopped.Add(pid); return true; },
+            GracefulStopTimeout = TimeSpan.FromMilliseconds(50),
+            StopSettleTimeout = TimeSpan.FromMilliseconds(50),
+        };
+
+        var clean = owner.StopInstalledLauncher();
+
+        Assert.Empty(stopped);      // nothing was asked to stop - least of all pid 0
+        Assert.False(clean);        // and the stop is still not called clean
+    }
+
+    [Fact]
     public void StopInstalledLauncher_AnUnreadableProcessList_IsNotAnEmptyOne()
     {
         // "Nothing left running" has to be observed. A list that could not be read is not evidence of

--- a/tools/cc-director-setup-engine.Tests/LauncherUpdateOwnerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherUpdateOwnerTests.cs
@@ -19,6 +19,16 @@ public class LauncherUpdateOwnerTests : IDisposable
     private readonly string _staged;
     private readonly string _registration;
 
+    /// <summary>
+    /// This test class's own machine-wide lock. The real one is shared with the launcher's Director
+    /// update owner and with every other Director on the machine, so taking it here would make one
+    /// test project fail another - including the one running from a different worktree in the same
+    /// gate. That both PRODUCTION owners take the real one is asserted separately, by
+    /// BothUpdateOwnersTakeTheSameLockTests in CcDirector.Launcher.Tests - the one project that can
+    /// see both owners at once.
+    /// </summary>
+    private readonly string _swapLockName = @"Local\cc-director-binary-swap-test-" + Guid.NewGuid().ToString("N");
+
     private const string InstalledVersion = "1.9.8";
     private const string StagedVersion = "2.0.4";
 
@@ -86,6 +96,7 @@ public class LauncherUpdateOwnerTests : IDisposable
             apply: new LauncherSelfUpdate(_layout, unlockTimeout: TimeSpan.FromSeconds(1)),
             witnessTimeout: TimeSpan.FromMilliseconds(400))
         {
+            SwapLockName = _swapLockName,
             ReadVersionOnDisk = path => path == _staged ? StagedVersion : null,
             ListLauncherProcesses = () => running.ToList(),
             RequestQuit = root => { quitRequests?.Add(root); return false; },
@@ -198,11 +209,12 @@ public class LauncherUpdateOwnerTests : IDisposable
     }
 
     [Fact]
-    public async Task ARunningLauncherThatIsAlreadyTheStagedVersion_InstallsNothing()
+    public async Task ARunningLauncherThatIsAlreadyTheStagedVersion_AND_COMMANDABLE_InstallsNothing()
     {
         WriteRegistration(1001, StagedVersion);
         var stopped = new List<int>();
-        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true, stopped: stopped);
+        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true, stopped: stopped,
+            oldBuildListens: true);
 
         var result = await owner.RunOnceAsync();
 
@@ -211,6 +223,44 @@ public class LauncherUpdateOwnerTests : IDisposable
         Assert.Equal("launcher-OLD", File.ReadAllText(_target));
         // ...and the manifest is corrected, so the record and the running build stop disagreeing.
         Assert.Equal(StagedVersion, InstalledManifest.Load(_layout).Get(ComponentRegistry.Launcher.Id));
+    }
+
+    [Fact]
+    public async Task ARunningLauncherThatIsAlreadyTheStagedVersionButCANNOTBeCommanded_IsReplacedAnyway()
+    {
+        // THE TEST THAT USED TO SAY THE OPPOSITE. This shortcut asked only whether the process was
+        // ALIVE and reported the staged version, and then wrote that version into the installed
+        // manifest - so a launcher that is the right version and can be told nothing was blessed, the
+        // record was made to agree with it, and the pass reported nothing to do for ever. That is the
+        // machine this whole change exists for, certified as healthy by the thing meant to catch it.
+        WriteRegistration(1001, StagedVersion);
+        var stopped = new List<int>();
+        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true, stopped: stopped,
+            oldBuildListens: false);
+
+        var result = await owner.RunOnceAsync();
+
+        Assert.Equal(LauncherUpdateDecision.Applied, result.Decision);
+        Assert.Equal(new[] { 1001 }, stopped);
+        Assert.Equal("launcher-NEW", File.ReadAllText(_target));
+    }
+
+    [Fact]
+    public async Task AVersionThatWasNeverWitnessed_IsNeverRecordedAsInstalled()
+    {
+        // The half of the same defect that outlives the pass: the shortcut did not merely decline to
+        // act, it WROTE the unwitnessed version into the manifest. The manifest is what FindStagedUpdate
+        // compares against, so once written, the staged build stops being "newer" and the retry that
+        // would have fixed the machine can never happen again.
+        WriteRegistration(1001, StagedVersion);
+        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: false, oldBuildListens: false);
+
+        _ = await owner.RunOnceAsync();
+
+        // The swap ran and rolled back, so what is installed is still the old build - and the manifest
+        // must say so rather than claiming the version nothing ever proved.
+        Assert.Equal("launcher-OLD", File.ReadAllText(_target));
+        Assert.NotEqual(StagedVersion, InstalledManifest.Load(_layout).Get(ComponentRegistry.Launcher.Id));
     }
 
     [Fact]
@@ -248,15 +298,119 @@ public class LauncherUpdateOwnerTests : IDisposable
     }
 
     [Fact]
-    public async Task WhenTheDirectorNoLongerHoldsItsInstance_TheResultSaysSo()
+    public async Task AfterARollback_TheMachineIsReportedAsWHATITIS_NotMerelyAsRestored()
     {
+        // A rollback that puts the file back and leaves the machine uncommandable is only half an
+        // answer, and the half it reports is the reassuring one. What the rollback restores here is a
+        // launcher that listens for nothing - which is the state the whole change exists to end - so
+        // the reading taken after the swap must say so rather than the result implying a machine
+        // returned to health. The rollback IS the right action; this asserts it is not oversold.
+        var running = new List<LauncherProcess> { InstalledLauncher() };
+        var owner = Owner(running, newBuildIsCommandable: false, oldBuildListens: false);
+
+        var result = await owner.RunOnceAsync();
+
+        Assert.Equal(LauncherUpdateDecision.RolledBack, result.Decision);
+        var afterTheSwap = Assert.Single(result.Steps, s => s.StartsWith("after the swap:", StringComparison.Ordinal));
+        Assert.Contains("nothing is listening", afterTheSwap);
+    }
+
+    [Fact]
+    public async Task WhereTheCommandSurfaceCannotBeObserved_NothingIsSwappedAtAll()
+    {
+        // On a platform that cannot be asked who is listening, EVERY swap would install, fail to
+        // certify for the whole witness timeout, roll back, and PIN a build that was probably fine.
+        // Refusing up front, naming the platform fact, is the honest form of the same answer - and it
+        // is the deliberate resolution of letting the witness pass on a live registration alone, which
+        // would have reintroduced liveness-only proof on the one platform nobody watches.
+        var stopped = new List<int>();
+        var running = new List<LauncherProcess> { InstalledLauncher() };
+        var owner = new LauncherUpdateOwner(
+            _root,
+            directorStillHoldsItsInstance: () => true,
+            witness: new LauncherWitness(_root)
+            {
+                RegistrationPath = _registration,
+                ProcessIsAlive = _ => true,
+                HasListener = _ => null,      // the Unix answer: not observable
+            },
+            apply: new LauncherSelfUpdate(_layout, unlockTimeout: TimeSpan.FromSeconds(1)),
+            witnessTimeout: TimeSpan.FromMilliseconds(400))
+        {
+            SwapLockName = _swapLockName,
+            ReadVersionOnDisk = path => path == _staged ? StagedVersion : null,
+            ListLauncherProcesses = () => running.ToList(),
+            StopProcess = pid => { stopped.Add(pid); return true; },
+        };
+
+        var result = await owner.RunOnceAsync();
+
+        Assert.Equal(LauncherUpdateDecision.HeldBecauseTheCommandSurfaceCannotBeObserved, result.Decision);
+        Assert.Contains("cannot be observed on this platform", result.Message);
+        Assert.Empty(stopped);
+        Assert.Equal("launcher-OLD", File.ReadAllText(_target));
+    }
+
+    [Fact]
+    public async Task WhileAnotherBinarySwapHoldsTheMachineWideLock_NothingIsTouched()
+    {
+        // The launcher may at that moment be installing the DIRECTOR's staged update, which stops this
+        // process mid-swap. Held from outside, this pass must do nothing at all - not stop the
+        // launcher, not replace the binary - and must say which state it was in.
+        var stopped = new List<int>();
+        var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true, stopped: stopped);
+
+        using var heldByAnotherSwap = new Mutex(initiallyOwned: false, _swapLockName, out _);
+        Assert.True(heldByAnotherSwap.WaitOne(TimeSpan.FromSeconds(5)), "could not take the lock to set the test up");
+        try
+        {
+            var result = await owner.RunOnceAsync();
+
+            Assert.Equal(LauncherUpdateDecision.HeldBecauseAnotherSwapIsRunning, result.Decision);
+            Assert.Contains("another binary swap is already running", result.Message);
+            Assert.Empty(stopped);
+            Assert.Equal("launcher-OLD", File.ReadAllText(_target));
+        }
+        finally { heldByAnotherSwap.ReleaseMutex(); }
+    }
+
+    [Fact]
+    public async Task WhenTheDirectorNoLongerHoldsItsInstance_ThatIsItsOwnDecision_NotAnAppliedWithANote()
+    {
+        // The no-orphan check used to return Applied with a longer message, so a caller switching on
+        // the decision - which is what a caller does - read the worst outcome this class can produce as
+        // a success, with the warning riding in a string nothing inspects.
         var owner = Owner([InstalledLauncher()], newBuildIsCommandable: true, directorSurvives: false);
 
         var result = await owner.RunOnceAsync();
 
-        Assert.Equal(LauncherUpdateDecision.Applied, result.Decision);
+        Assert.Equal(LauncherUpdateDecision.AppliedButThisDirectorLostItsInstance, result.Decision);
+        Assert.NotEqual(LauncherUpdateDecision.Applied, result.Decision);
         Assert.Contains("NO LONGER HOLDS ITS INSTANCE", result.Message);
         Assert.Contains(result.Steps, s => s.Contains("NO LONGER HOLDS ITS INSTANCE"));
+    }
+
+    [Fact]
+    public void TheStartedLauncher_IsTOLDWhichRootToServe_NotMerelyDeniedTheWrongOne()
+    {
+        // FOUND BY THE END-TO-END RIG, NOT BY READING. This removed CC_DIRECTOR_ROOT from the child's
+        // environment, reasoning that a launcher must not inherit a Director's instance home. True, and
+        // not enough: removing the variable does not name the right root, it only stops naming a wrong
+        // one, and the child then falls back on the process default - which equals this install's root
+        // only when the install sits at the default path.
+        //
+        // On 2026-09-06 scripts/launcher-swap-proof.ps1 swapped a launcher on an isolated root and the
+        // new build resolved to the MACHINE'S root instead, found the real launcher there, and exited
+        // as a second instance. It never registered where the witness looked, so the witness refused,
+        // the swap rolled back, and a good build was PINNED - four starts across two runs, all four the
+        // same. An install away from the default path would have been left permanently refusing its own
+        // launcher update, with the log blaming the build.
+        var psi = LauncherUpdateOwner.BuildLauncherStartInfo(_layout);
+
+        Assert.Equal(_root, psi.Environment["CC_DIRECTOR_ROOT"]);
+        Assert.Equal(_target, psi.FileName);
+        Assert.Contains(LauncherTrayInstaller.InstalledArguments, psi.ArgumentList);
+        Assert.False(psi.UseShellExecute);
     }
 
     [Fact]

--- a/tools/cc-director-setup-engine.Tests/LauncherWitnessTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherWitnessTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// The witness has one job: refuse to call a launcher healthy on the strength of a process existing.
+/// The machine this was written for was running a launcher that was registered, alive, heartbeating,
+/// and unable to receive a single command - so every test here is written around that shape.
+/// </summary>
+public class LauncherWitnessTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _registration;
+
+    public LauncherWitnessTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "cc-lwit-" + Guid.NewGuid().ToString("N"));
+        _registration = LauncherWitness.RegistrationPathFor(_root);
+        Directory.CreateDirectory(Path.GetDirectoryName(_registration)!);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    private void WriteRegistration(int pid, string? version)
+    {
+        var payload = version is null
+            ? JsonSerializer.Serialize(new { pid })
+            : JsonSerializer.Serialize(new { pid, version });
+        File.WriteAllText(_registration, payload);
+    }
+
+    private LauncherWitness Witness(bool? listener, Func<int, bool>? alive = null,
+        IReadOnlyList<LauncherProcess>? running = null) =>
+        new(_root)
+        {
+            RegistrationPath = _registration,
+            ProcessIsAlive = alive ?? (_ => true),
+            HasListener = _ => listener,
+            ListLauncherProcesses = () => running ?? [],
+        };
+
+    [Fact]
+    public void RegistrationPath_IsUnderTheRootItWasGiven()
+    {
+        // The whole reason the root is a parameter: inside a Director the default path resolves to the
+        // instance home, where no launcher has ever written, and the answer is "not installed" for ever.
+        Assert.Equal(Path.Combine(_root, "config", "launcher", "launcher.json"),
+            LauncherWitness.RegistrationPathFor(_root));
+    }
+
+    [Fact]
+    public void NoRegistration_IsNotWitnessed()
+    {
+        var reading = Witness(listener: true).Read();
+
+        Assert.False(reading.Registered);
+        Assert.False(reading.Witnessed);
+        Assert.Null(new LauncherWitness(_root)
+        {
+            RegistrationPath = _registration,
+            HasListener = _ => true,
+        }.WitnessedVersion());
+    }
+
+    [Fact]
+    public void AliveAndListening_IsWitnessed_AndReportsItsVersion()
+    {
+        WriteRegistration(4242, "2.0.4");
+
+        var reading = Witness(listener: true).Read();
+
+        Assert.True(reading.Witnessed);
+        Assert.Equal("2.0.4", reading.Version);
+        Assert.Equal(LauncherCommandSurface.Present, reading.CommandSurface);
+        Assert.Equal("2.0.4", Witness(listener: true).WitnessedVersion());
+    }
+
+    [Fact]
+    public void AliveButNothingListening_IsNOTWitnessed()
+    {
+        // The 2026-09-06 machine, exactly: a launcher that is up and cannot be told anything. Every
+        // check that asks "did a process start" says yes about it, which is why this one may not.
+        WriteRegistration(4242, "1.9.8");
+
+        var reading = Witness(listener: false).Read();
+
+        Assert.True(reading.Registered);
+        Assert.True(reading.ProcessAlive);
+        Assert.False(reading.Witnessed);
+        Assert.Equal(LauncherCommandSurface.Absent, reading.CommandSurface);
+        Assert.Contains("cannot be told anything", reading.Detail);
+        Assert.Null(Witness(listener: false).WitnessedVersion());
+    }
+
+    [Fact]
+    public void RegistrationNamingADeadProcess_IsNotWitnessed()
+    {
+        WriteRegistration(4242, "2.0.4");
+
+        var reading = Witness(listener: true, alive: _ => false).Read();
+
+        Assert.True(reading.Registered);
+        Assert.False(reading.ProcessAlive);
+        Assert.False(reading.Witnessed);
+    }
+
+    [Fact]
+    public void WhereAListenerCannotBeObserved_TheRegistrationIsTheWholeWitness()
+    {
+        // Unix: the signal is a request file that a listener polls, so there is nothing to consult and
+        // a "no" would be invented. The reading says so in its own words rather than pretending.
+        WriteRegistration(4242, "2.0.4");
+
+        var reading = Witness(listener: null).Read();
+
+        Assert.Equal(LauncherCommandSurface.NotObservable, reading.CommandSurface);
+        Assert.True(reading.Witnessed);
+        Assert.Contains("cannot be observed on this platform", reading.Detail);
+    }
+
+    [Fact]
+    public void ALauncherRegisteredUNDERANOTHERROOT_IsNamedAsThat_NotAsNoLauncher()
+    {
+        // The 2026-09-06 second defect: a launcher started with a Director's CC_DIRECTOR_ROOT inherited
+        // takes the instance home for the machine root, so it registers and listens under that root.
+        // From here it looks like an empty machine, and "no launcher" would send the next person hunting
+        // for a process that is plainly running.
+        File.Delete(_registration);
+        var running = new[] { new LauncherProcess(30736, Path.Combine(_root, "launcher", "cc-launcher.exe") + " --managed") };
+
+        var reading = Witness(listener: false, running: running).Read();
+
+        Assert.False(reading.Witnessed);
+        Assert.Contains("30736", reading.Detail);
+        Assert.Contains("different storage root", reading.Detail);
+    }
+
+    [Fact]
+    public void WithNoLauncherRunningAtAll_TheReadingDoesNotInventOne()
+    {
+        File.Delete(_registration);
+
+        var reading = Witness(listener: false).Read();
+
+        Assert.False(reading.Witnessed);
+        Assert.DoesNotContain("different storage root", reading.Detail);
+    }
+
+    [Fact]
+    public void TheSignalItAsksAbout_IsTheRestartTheDirectorOne()
+    {
+        // Named for the root, so a test rig and the installed launcher never answer for each other.
+        var name = new LauncherWitness(_root).CommandSignalName;
+
+        Assert.Equal(CcDirector.Core.Lifecycle.LifecycleSignalNames.LauncherRestartDirector(_root), name);
+        Assert.Contains("launcher-restart-director", name);
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/LauncherWitnessTests.cs
+++ b/tools/cc-director-setup-engine.Tests/LauncherWitnessTests.cs
@@ -109,16 +109,26 @@ public class LauncherWitnessTests : IDisposable
     }
 
     [Fact]
-    public void WhereAListenerCannotBeObserved_TheRegistrationIsTheWholeWitness()
+    public void WhereAListenerCannotBeObserved_ThatIsNOTAWITNESS()
     {
         // Unix: the signal is a request file that a listener polls, so there is nothing to consult and
-        // a "no" would be invented. The reading says so in its own words rather than pretending.
+        // a "no" would be invented. The reading says so in its own words rather than pretending - and
+        // it does NOT count as witnessed.
+        //
+        // THIS TEST ASSERTED THE OPPOSITE. Accepting NotObservable was reasoned as "a listener genuinely
+        // cannot be observed here, so refusing would refuse for ever" - but what it actually did was let
+        // a live registration ALONE pass, which is precisely the liveness-only proof this class exists
+        // to forbid, reintroduced on the one platform where nobody would see it. A witness that cannot
+        // fail on a platform is not a witness on that platform. The refusal for ever is the honest
+        // answer, and it is the caller's job to say so plainly rather than the boolean's job to hide it:
+        // LauncherUpdateOwner declines to swap at all where this is the reading.
         WriteRegistration(4242, "2.0.4");
 
         var reading = Witness(listener: null).Read();
 
         Assert.Equal(LauncherCommandSurface.NotObservable, reading.CommandSurface);
-        Assert.True(reading.Witnessed);
+        Assert.False(reading.Witnessed);
+        Assert.Null(Witness(listener: null).WitnessedVersion());
         Assert.Contains("cannot be observed on this platform", reading.Detail);
     }
 

--- a/tools/cc-director-setup-engine/BinarySwapLock.cs
+++ b/tools/cc-director-setup-engine/BinarySwapLock.cs
@@ -20,11 +20,17 @@ namespace CcDirector.Setup.Engine;
 ///
 /// The same lock also keeps two DIRECTORS sharing one install from swapping the one launcher at once.
 ///
-/// It is a machine-wide named mutex, taken WITHOUT WAITING - the same shape and the same reasoning as
-/// <see cref="ToolReconciler.HeavyRepairMutexName"/>. Never blocking is the point: both owners run on
-/// periodic loops, so a pass that cannot have the lock has nothing to gain by queueing behind one. It
+/// It is a machine-wide named mutex, the same shape and the same reasoning as
+/// <see cref="ToolReconciler.HeavyRepairMutexName"/>. THE TWO PERIODIC OWNERS DO NOT WAIT FOR IT: each
+/// runs on a loop, so a pass that cannot have the lock has nothing to gain by queueing behind one - it
 /// says why it did nothing and looks again on its next cycle, by which time the other swap has either
 /// finished or failed and said so.
+///
+/// ONE CALLER DOES WAIT, AND IT IS NOT AN EXCEPTION TO THE REASONING BUT AN APPLICATION OF IT. The
+/// launcher's detached self-update helper is not a periodic pass; it is a process started to perform
+/// exactly one swap, with no next cycle to return on, so skipping would silently drop the update it
+/// exists to apply. It passes a bounded wait through <c>waitFor</c>. Nothing waits unbounded, and
+/// nothing waits on the thread that asked - see the thread note on the method.
 ///
 /// WHAT THIS DOES NOT COVER, AND CANNOT. A launcher old enough to predate this code takes no lock, so
 /// the exclusion only holds once both sides are running a build that has it. That is inherent to

--- a/tools/cc-director-setup-engine/BinarySwapLock.cs
+++ b/tools/cc-director-setup-engine/BinarySwapLock.cs
@@ -56,6 +56,16 @@ public static class BinarySwapLock
     /// <param name="work">The swap. Runs only when the lock was taken.</param>
     /// <param name="whenBusy">The answer to give when another swap is already running.</param>
     /// <param name="who">A short label for the log, so it says which owner was held off.</param>
+    /// <param name="waitFor">
+    /// How long to wait for the lock before giving up. Null means DO NOT WAIT, which is right for the
+    /// two periodic owners: a pass that cannot have the lock has nothing to gain by queueing, because
+    /// it will look again on its next cycle anyway.
+    ///
+    /// The detached launcher self-update helper is the exception and passes a bounded wait. It is not
+    /// a periodic pass - it is a process launched for the single purpose of performing one swap, and
+    /// it has no next cycle to come back on. Skipping there would mean the update it was started to
+    /// apply simply does not happen.
+    /// </param>
     /// <param name="name">
     /// The mutex to take. Defaults to <see cref="Name"/>, which is the whole point - both owners take
     /// the SAME one or the lock excludes nothing.
@@ -69,7 +79,7 @@ public static class BinarySwapLock
     /// quietly cost.
     /// </param>
     public static Task<T> RunExclusivelyAsync<T>(
-        Func<Task<T>> work, Func<string, T> whenBusy, string who, string? name = null)
+        Func<Task<T>> work, Func<string, T> whenBusy, string who, string? name = null, TimeSpan? waitFor = null)
     {
         ArgumentNullException.ThrowIfNull(work);
         ArgumentNullException.ThrowIfNull(whenBusy);
@@ -86,13 +96,17 @@ public static class BinarySwapLock
             try
             {
                 mutex = new Mutex(initiallyOwned: false, mutexName, out _);
-                try { held = mutex.WaitOne(TimeSpan.Zero); }
+                var patience = waitFor ?? TimeSpan.Zero;
+                try { held = mutex.WaitOne(patience); }
                 catch (AbandonedMutexException) { held = true; }   // a prior holder died; we own it now
 
                 if (!held)
                 {
+                    var waited = patience == TimeSpan.Zero
+                        ? ""
+                        : $" after waiting {patience.TotalSeconds:F0}s";
                     var message = "another binary swap is already running on this machine "
-                                  + "(a Director update or a launcher update); nothing was touched.";
+                                  + $"(a Director update or a launcher update){waited}; nothing was touched.";
                     FileLog.Write($"[BinarySwapLock] {who} held off: {message}");
                     completion.SetResult(whenBusy(message));
                     return;

--- a/tools/cc-director-setup-engine/BinarySwapLock.cs
+++ b/tools/cc-director-setup-engine/BinarySwapLock.cs
@@ -1,0 +1,123 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// THE MACHINE-WIDE LOCK THAT KEEPS TWO BINARY SWAPS APART.
+///
+/// This install has two update owners, and each one stops the other's process. The launcher owns the
+/// Director's update (<c>DirectorUpdateOwner</c>): it stops the Director, swaps its binary, starts it
+/// and waits for the new version to answer. The Director owns the launcher's update
+/// (<see cref="LauncherUpdateOwner"/>): it stops the launcher, swaps ITS binary, starts it and waits
+/// for the new build to be witnessed. Each is correct alone, and they were uncoordinated.
+///
+/// Overlapped, they destroy each other's evidence and can leave the machine on a half-installed pair.
+/// The Director begins swapping the launcher; the launcher, in the same seconds, decides the Director
+/// is idle and stops it - killing the process that has already renamed the launcher binary aside, with
+/// nothing left running to put it back or to start what was installed. The mirror is no better: the
+/// Director stops the launcher mid-Director-swap, and the swap's own witness dies with it, so a
+/// perfectly good build is rolled back and pinned for a reason that has nothing to do with the build.
+///
+/// The same lock also keeps two DIRECTORS sharing one install from swapping the one launcher at once.
+///
+/// It is a machine-wide named mutex, taken WITHOUT WAITING - the same shape and the same reasoning as
+/// <see cref="ToolReconciler.HeavyRepairMutexName"/>. Never blocking is the point: both owners run on
+/// periodic loops, so a pass that cannot have the lock has nothing to gain by queueing behind one. It
+/// says why it did nothing and looks again on its next cycle, by which time the other swap has either
+/// finished or failed and said so.
+///
+/// WHAT THIS DOES NOT COVER, AND CANNOT. A launcher old enough to predate this code takes no lock, so
+/// the exclusion only holds once both sides are running a build that has it. That is inherent to
+/// shipping a lock into a pair of processes that update each other - and it is the ordinary case for
+/// the very machines this exists for, whose launcher is the stale one. The Director's side is still
+/// worth taking on its own: it makes two Directors safe immediately, and it makes the pair safe from
+/// the first launcher that carries it.
+/// </summary>
+public static class BinarySwapLock
+{
+    /// <summary>
+    /// The one name both owners take. Global so it spans logon sessions on a machine where a Director
+    /// and a launcher may not share one; the same convention as the tool reconcile's mutex.
+    /// </summary>
+    public const string Name = @"Global\cc-director-binary-swap";
+
+    /// <summary>
+    /// Run <paramref name="work"/> while holding the lock, or return <paramref name="whenBusy"/>'s
+    /// answer without running it at all when another swap holds it.
+    ///
+    /// A WINDOWS NAMED MUTEX HAS THREAD AFFINITY: only the thread that took it may release it. The
+    /// guarded work is asynchronous and an await resumes on whatever thread the runtime picks, so
+    /// taking the mutex, awaiting, and releasing inline released it from a different thread and threw
+    /// "Object synchronization method was called from an unsynchronized block of code" - which the
+    /// caller's catch then reported as a FAILED update of a swap that had actually succeeded
+    /// (issue #1045, in the tool reconcile). So the whole critical section runs start to finish on one
+    /// dedicated thread, exactly as <see cref="ToolReconciler"/> does it.
+    /// </summary>
+    /// <param name="work">The swap. Runs only when the lock was taken.</param>
+    /// <param name="whenBusy">The answer to give when another swap is already running.</param>
+    /// <param name="who">A short label for the log, so it says which owner was held off.</param>
+    /// <param name="name">
+    /// The mutex to take. Defaults to <see cref="Name"/>, which is the whole point - both owners take
+    /// the SAME one or the lock excludes nothing.
+    ///
+    /// It is a parameter only so that a test can hold a lock of its own and prove the held-off path
+    /// without stopping every other process on the machine that is legitimately swapping a binary -
+    /// and, more practically, without two test projects running side by side in one gate contending
+    /// for a real machine-wide lock and failing each other for a reason that is not in either branch.
+    /// Production callers never pass it; that both of them do not is asserted by
+    /// <c>BothUpdateOwnersTakeTheSameLockTests</c>, which is the fact a test seam here could otherwise
+    /// quietly cost.
+    /// </param>
+    public static Task<T> RunExclusivelyAsync<T>(
+        Func<Task<T>> work, Func<string, T> whenBusy, string who, string? name = null)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        ArgumentNullException.ThrowIfNull(whenBusy);
+        var mutexName = string.IsNullOrWhiteSpace(name) ? Name : name;
+
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Background, so a wedged swap can never keep the process alive; created per call, so it holds
+        // no other lock and cannot deadlock against anything.
+        var thread = new Thread(() =>
+        {
+            Mutex? mutex = null;
+            var held = false;
+            try
+            {
+                mutex = new Mutex(initiallyOwned: false, mutexName, out _);
+                try { held = mutex.WaitOne(TimeSpan.Zero); }
+                catch (AbandonedMutexException) { held = true; }   // a prior holder died; we own it now
+
+                if (!held)
+                {
+                    var message = "another binary swap is already running on this machine "
+                                  + "(a Director update or a launcher update); nothing was touched.";
+                    FileLog.Write($"[BinarySwapLock] {who} held off: {message}");
+                    completion.SetResult(whenBusy(message));
+                    return;
+                }
+
+                // Blocking is correct on this thread: it exists only to own the mutex.
+                completion.SetResult(work().GetAwaiter().GetResult());
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            finally
+            {
+                if (held)
+                {
+                    try { mutex!.ReleaseMutex(); }
+                    catch (Exception ex) { FileLog.Write($"[BinarySwapLock] releasing FAILED: {ex.Message}"); }
+                }
+                mutex?.Dispose();
+            }
+        })
+        { IsBackground = true, Name = $"binary-swap-lock-{who}" };
+
+        thread.Start();
+        return completion.Task;
+    }
+}

--- a/tools/cc-director-setup-engine/CcDirector.Setup.Engine.csproj
+++ b/tools/cc-director-setup-engine/CcDirector.Setup.Engine.csproj
@@ -12,6 +12,14 @@
   <ItemGroup>
     <!-- Expose internals (e.g. ProcessRunner) to the engine test project for direct unit testing. -->
     <InternalsVisibleTo Include="CcDirector.Setup.Engine.Tests" />
+    <!--
+      BothUpdateOwnersTakeTheSameLockTests lives in the launcher's test project, because that is the
+      only project that can see the Director's launcher-update owner AND the launcher's Director-update
+      owner at once, and what it asserts is that the two default to the SAME machine-wide lock. The
+      lock-name override those owners expose is internal so no production caller can select a different
+      one; this is how the guard still reads it.
+    -->
+    <InternalsVisibleTo Include="CcDirector.Launcher.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/cc-director-setup-engine/InstallLayout.cs
+++ b/tools/cc-director-setup-engine/InstallLayout.cs
@@ -58,14 +58,29 @@ public sealed class InstallLayout
 
     private static string HomeDir => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
+    /// <summary>
+    /// The configuration directory of this install - the parent of every per-tool config folder, and
+    /// the same directory <c>CcStorage.Config()</c> resolves to for a process whose storage home is
+    /// <see cref="LocalRoot"/>. Named here so the paths under it are composed from ONE definition
+    /// rather than from a "config" string repeated at each site.
+    /// </summary>
+    public string ConfigDir => Path.Combine(LocalRoot, "config");
+
     /// <summary>Per-user install bookkeeping (installed-version manifest, pins) - NOT user data.</summary>
-    public string SetupStateDir => Path.Combine(LocalRoot, "config", "setup");
+    public string SetupStateDir => Path.Combine(ConfigDir, "setup");
 
     /// <summary>The installed-version manifest: component id -> the version actually placed on disk.</summary>
     public string InstalledManifestPath => Path.Combine(SetupStateDir, "installed.json");
 
     /// <summary>The shared app config (%LOCALAPPDATA%\cc-director\config\config.json), incl. the autoUpdate section.</summary>
-    public string ConfigPath => Path.Combine(LocalRoot, "config", "config.json");
+    public string ConfigPath => Path.Combine(ConfigDir, "config.json");
+
+    /// <summary>
+    /// Where the launcher serving this install registers what it is: its version, its process id and
+    /// its interface state. Written by the running launcher (<c>LauncherDiscovery</c>) and read by
+    /// anything that needs to know which launcher is on this machine.
+    /// </summary>
+    public string LauncherRegistrationPath => Path.Combine(ConfigDir, "launcher", "launcher.json");
 
     /// <summary>The Gateway tray app's binaries.</summary>
     public string GatewayDir => Path.Combine(LocalRoot, "gateway");

--- a/tools/cc-director-setup-engine/InstalledLauncherProcesses.cs
+++ b/tools/cc-director-setup-engine/InstalledLauncherProcesses.cs
@@ -15,6 +15,39 @@ namespace CcDirector.Setup.Engine;
 public static class InstalledLauncherProcesses
 {
     /// <summary>
+    /// The answer to "which launcher processes are on this machine", given what could be read and what
+    /// could not.
+    ///
+    /// A LAUNCHER WE COULD NOT READ IS NOT A LAUNCHER THAT IS NOT THERE. The enumeration used to
+    /// swallow a per-process failure and carry on with a shorter list, which reads downstream as "that
+    /// process is somebody else's" - and both callers treat "not ours" as "nothing to stop". So a
+    /// launcher whose command line could not be read would be left running while the uninstaller's stop
+    /// reported a clean machine, and while the Director's swap replaced the binary out from under it.
+    ///
+    /// There is no honest partial answer, because the question is exactly WHICH processes are ours and
+    /// one that cannot be placed makes that undecidable. Both callers already handle an unreadable list
+    /// correctly - the stop refuses to certify, the update owner holds the pass - so the way to reach
+    /// that handling is to say the list could not be read.
+    ///
+    /// Separated from the enumeration so it can be driven with a known-bad input, which a real
+    /// unreadable process cannot be manufactured to provide.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Anything at all could not be read.</exception>
+    public static IReadOnlyList<LauncherProcess> Resolve(
+        IReadOnlyList<LauncherProcess> readable, IReadOnlyList<string> unreadable)
+    {
+        ArgumentNullException.ThrowIfNull(readable);
+        ArgumentNullException.ThrowIfNull(unreadable);
+
+        if (unreadable.Count > 0)
+            throw new InvalidOperationException(
+                $"{unreadable.Count} cc-launcher process(es) could not be read, so which processes belong to "
+                + $"this install cannot be established: {string.Join("; ", unreadable)}");
+
+        return readable;
+    }
+
+    /// <summary>
     /// The launcher processes running from <paramref name="launcherDir"/>.
     ///
     /// Matched on the command line beginning with that directory plus a separator - a bare prefix
@@ -41,20 +74,34 @@ public static class InstalledLauncherProcesses
     /// scoping). Windows reads the main module; macOS and Linux ask ps, whose output is NOT quoted, so
     /// the whole argument string is kept and callers compare prefixes rather than parsing an
     /// executable out of it.
+    ///
+    /// THROWS rather than returning a shorter list when a cc-launcher process cannot be read at all -
+    /// see the comment at that throw. Callers must treat the exception as "undecidable", never as
+    /// "none running".
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// A cc-launcher process is running whose command line could not be read, so which processes
+    /// belong to this install cannot be established.
+    /// </exception>
     public static IReadOnlyList<LauncherProcess> List()
     {
         var found = new List<LauncherProcess>();
 
         if (OperatingSystem.IsWindows())
         {
+            var unreadable = new List<string>();
             foreach (var p in Process.GetProcessesByName("cc-launcher"))
             {
                 try { found.Add(new LauncherProcess(p.Id, p.MainModule?.FileName ?? "")); }
-                catch (Exception ex) { EngineLog.Write($"[InstalledLauncherProcesses] pid={p.Id}: {ex.Message}"); }
+                catch (Exception ex)
+                {
+                    EngineLog.Write($"[InstalledLauncherProcesses] pid={p.Id}: {ex.Message}");
+                    unreadable.Add($"{p.Id} ({ex.Message})");
+                }
                 finally { p.Dispose(); }
             }
-            return found;
+
+            return Resolve(found, unreadable);
         }
 
         var psi = new ProcessStartInfo("/bin/ps") { RedirectStandardOutput = true, UseShellExecute = false };

--- a/tools/cc-director-setup-engine/InstalledLauncherProcesses.cs
+++ b/tools/cc-director-setup-engine/InstalledLauncherProcesses.cs
@@ -14,6 +14,63 @@ namespace CcDirector.Setup.Engine;
 /// </summary>
 public static class InstalledLauncherProcesses
 {
+    /// <summary>What a cc-launcher process whose path could not be read has to be treated as.</summary>
+    internal enum UnreadableVerdict
+    {
+        /// <summary>It could plausibly be ours, so the machine is undecidable until it can be read.</summary>
+        CouldBeOurs,
+
+        /// <summary>It cannot be ours - it has exited, or it belongs to another logon session.</summary>
+        CannotBeOurs,
+    }
+
+    /// <summary>
+    /// A cc-launcher process whose path could not be read: undecidable if it could plausibly be OURS,
+    /// and ignored if it could not. Pure, so it can be driven with the inputs a real machine will not
+    /// produce on demand.
+    ///
+    /// A NULL MODULE IS UNREADABLE, NOT AN EMPTY COMMAND LINE. The enumeration used to coalesce null
+    /// to "", which <see cref="Ours"/> then drops for having no matching prefix - the exact fail-open
+    /// the throw exists to close, surviving in the one shape that raises no exception.
+    ///
+    /// WHY THE SESSION IS CONSULTED. Making every unreadable process undecidable is right for one that
+    /// might be ours and far too broad for one that cannot be. The enumeration is machine-wide, while
+    /// the install is per-user under that user's own local application data - so on a machine with
+    /// several people signed in, ONE other user's launcher (whose module a non-elevated read is
+    /// refused) would make this user's launcher update undecidable on every pass, for ever, with
+    /// nothing wrong on this user's machine at all.
+    ///
+    /// The residual limit, stated rather than hidden: the SAME user signed in twice has two sessions
+    /// and could genuinely be running our binary in the other one. That case is missed. Narrowing
+    /// further needs the process's owning account, which is not readable cheaply.
+    /// </summary>
+    internal static UnreadableVerdict Classify(string? commandLine, bool? hasExited, int? sessionId, int ourSession)
+    {
+        if (!string.IsNullOrEmpty(commandLine)) return UnreadableVerdict.CannotBeOurs;  // it was readable
+        if (hasExited == true) return UnreadableVerdict.CannotBeOurs;                   // simply gone
+        if (sessionId is null) return UnreadableVerdict.CouldBeOurs;                    // cannot even place it
+        return sessionId == ourSession ? UnreadableVerdict.CouldBeOurs : UnreadableVerdict.CannotBeOurs;
+    }
+
+    /// <summary>Read a process property that may throw, as an absence rather than an exception.</summary>
+    private static T? TryRead<T>(Func<T?> read) where T : struct
+    {
+        try { return read(); }
+        catch { return null; }
+    }
+
+    /// <summary>Log the verdict, and add to the undecidable list only when it could be ours.</summary>
+    private static void Note(int pid, UnreadableVerdict verdict, string why, List<string> unreadable)
+    {
+        if (verdict == UnreadableVerdict.CouldBeOurs)
+        {
+            EngineLog.Write($"[InstalledLauncherProcesses] pid={pid}: {why}; it could be ours, so the machine is undecidable");
+            unreadable.Add($"{pid} ({why})");
+            return;
+        }
+        EngineLog.Write($"[InstalledLauncherProcesses] pid={pid}: {why}, but it cannot be ours (exited, or another logon session)");
+    }
+
     /// <summary>
     /// The answer to "which launcher processes are on this machine", given what could be read and what
     /// could not.
@@ -90,13 +147,26 @@ public static class InstalledLauncherProcesses
         if (OperatingSystem.IsWindows())
         {
             var unreadable = new List<string>();
+            var ourSession = Process.GetCurrentProcess().SessionId;
+
             foreach (var p in Process.GetProcessesByName("cc-launcher"))
             {
-                try { found.Add(new LauncherProcess(p.Id, p.MainModule?.FileName ?? "")); }
+                try
+                {
+                    var path = p.MainModule?.FileName;
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        found.Add(new LauncherProcess(p.Id, path));
+                        continue;
+                    }
+
+                    var verdict = Classify(path, TryRead<bool>(() => p.HasExited), TryRead<int>(() => p.SessionId), ourSession);
+                    Note(p.Id, verdict, "its main module could not be named", unreadable);
+                }
                 catch (Exception ex)
                 {
-                    EngineLog.Write($"[InstalledLauncherProcesses] pid={p.Id}: {ex.Message}");
-                    unreadable.Add($"{p.Id} ({ex.Message})");
+                    var verdict = Classify(null, TryRead<bool>(() => p.HasExited), TryRead<int>(() => p.SessionId), ourSession);
+                    Note(p.Id, verdict, ex.Message, unreadable);
                 }
                 finally { p.Dispose(); }
             }

--- a/tools/cc-director-setup-engine/InstalledLauncherProcesses.cs
+++ b/tools/cc-director-setup-engine/InstalledLauncherProcesses.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// Which launcher processes on this machine belong to an install, and how to enumerate them.
+///
+/// It is one class because two different jobs have to agree about it exactly. The uninstaller
+/// (<see cref="LauncherStopper"/>) stops every launcher of the install it is removing, and the
+/// Director's ownership of the launcher's update (<see cref="LauncherUpdateOwner"/>) stops the one
+/// launcher whose binary it is about to replace. If those two ever disagreed about what "ours" means,
+/// one of them would act on a process the other says is somebody else's - a developer's launcher run
+/// from a repository checkout, or a second install serving a different storage root.
+/// </summary>
+public static class InstalledLauncherProcesses
+{
+    /// <summary>
+    /// The launcher processes running from <paramref name="launcherDir"/>.
+    ///
+    /// Matched on the command line beginning with that directory plus a separator - a bare prefix
+    /// would also match a sibling like "&lt;launcherDir&gt;-dev", which is somebody else's launcher.
+    /// The WHOLE command line is compared rather than a parsed executable because macOS <c>ps</c>
+    /// does not quote paths and the installed launcher lives under a path containing a space.
+    /// </summary>
+    public static List<LauncherProcess> Ours(string launcherDir, IEnumerable<LauncherProcess> all)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(launcherDir);
+        ArgumentNullException.ThrowIfNull(all);
+
+        var dir = launcherDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var prefixes = new[] { dir + Path.DirectorySeparatorChar, dir + Path.AltDirectorySeparatorChar };
+
+        return all
+            .Where(p => !string.IsNullOrEmpty(p.CommandLine)
+                        && prefixes.Any(prefix => p.CommandLine.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Every cc-launcher process, with its full command line (unfiltered - <see cref="Ours"/> does the
+    /// scoping). Windows reads the main module; macOS and Linux ask ps, whose output is NOT quoted, so
+    /// the whole argument string is kept and callers compare prefixes rather than parsing an
+    /// executable out of it.
+    /// </summary>
+    public static IReadOnlyList<LauncherProcess> List()
+    {
+        var found = new List<LauncherProcess>();
+
+        if (OperatingSystem.IsWindows())
+        {
+            foreach (var p in Process.GetProcessesByName("cc-launcher"))
+            {
+                try { found.Add(new LauncherProcess(p.Id, p.MainModule?.FileName ?? "")); }
+                catch (Exception ex) { EngineLog.Write($"[InstalledLauncherProcesses] pid={p.Id}: {ex.Message}"); }
+                finally { p.Dispose(); }
+            }
+            return found;
+        }
+
+        var psi = new ProcessStartInfo("/bin/ps") { RedirectStandardOutput = true, UseShellExecute = false };
+        psi.ArgumentList.Add("-axo");
+        psi.ArgumentList.Add("pid=,args=");
+        using var ps = Process.Start(psi)
+                       ?? throw new InvalidOperationException("could not run /bin/ps");
+        var output = ps.StandardOutput.ReadToEnd();
+        ps.WaitForExit(5000);
+
+        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = line.TrimStart();
+            var space = trimmed.IndexOf(' ');
+            if (space <= 0) continue;
+            if (!int.TryParse(trimmed[..space], out var pid)) continue;
+
+            var commandLine = trimmed[(space + 1)..].Trim();
+            if (!commandLine.Contains("cc-launcher", StringComparison.Ordinal)) continue;
+            found.Add(new LauncherProcess(pid, commandLine));
+        }
+        return found;
+    }
+}

--- a/tools/cc-director-setup-engine/InstalledStateReader.cs
+++ b/tools/cc-director-setup-engine/InstalledStateReader.cs
@@ -104,7 +104,15 @@ public sealed class InstalledStateReader
     /// carries neither, so it reads as null ("present but version unknown", which the
     /// planner answers by re-applying the release so the version gets recorded).
     /// </summary>
-    private static string? DefaultReadVersion(string path)
+    private static string? DefaultReadVersion(string path) => ReadVersionFromDisk(path);
+
+    /// <summary>
+    /// The version a build on disk declares about ITSELF, for any path - not only a component's
+    /// installed location. Public because a build that has been downloaded but not yet installed has
+    /// no manifest entry to be looked up in, and the file's own stamp is then the only thing that can
+    /// say what it is (the staged launcher <see cref="LauncherUpdateOwner"/> is about to install).
+    /// </summary>
+    public static string? ReadVersionFromDisk(string path)
     {
         if (OperatingSystem.IsWindows())
         {

--- a/tools/cc-director-setup-engine/LauncherStopper.cs
+++ b/tools/cc-director-setup-engine/LauncherStopper.cs
@@ -140,23 +140,17 @@ public sealed class LauncherStopper
     }
 
     /// <summary>
-    /// The launcher processes that belong to THIS install. Matched on the command line beginning with
-    /// the install-owned launcher directory plus a separator - a bare prefix would also match a sibling
-    /// like "&lt;LauncherDir&gt;-dev", which is somebody else's launcher.
+    /// The launcher processes that belong to THIS install. The scoping rule itself lives in
+    /// <see cref="InstalledLauncherProcesses.Ours"/>, because the Director's ownership of the
+    /// launcher's update has to answer the same question the same way.
     /// </summary>
     private List<LauncherProcess> Ours(out bool listed)
     {
-        var dir = _layout.LauncherDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var prefixes = new[] { dir + Path.DirectorySeparatorChar, dir + Path.AltDirectorySeparatorChar };
-
         try
         {
             var all = ListLauncherProcesses();
             listed = true;
-            return all
-                .Where(p => !string.IsNullOrEmpty(p.CommandLine)
-                            && prefixes.Any(prefix => p.CommandLine.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
-                .ToList();
+            return InstalledLauncherProcesses.Ours(_layout.LauncherDir, all);
         }
         catch (Exception ex)
         {
@@ -193,47 +187,8 @@ public sealed class LauncherStopper
         }
     }
 
-    /// <summary>
-    /// Every cc-launcher process, with its full command line. Windows reads the main module; macOS and
-    /// Linux ask ps, whose output is NOT quoted - so the whole argument string is kept and the caller
-    /// compares prefixes rather than trying to parse an executable out of it.
-    /// </summary>
-    private static IReadOnlyList<LauncherProcess> DefaultListLauncherProcesses()
-    {
-        var found = new List<LauncherProcess>();
-
-        if (OperatingSystem.IsWindows())
-        {
-            foreach (var p in Process.GetProcessesByName("cc-launcher"))
-            {
-                try { found.Add(new LauncherProcess(p.Id, p.MainModule?.FileName ?? "")); }
-                catch (Exception ex) { EngineLog.Write($"[LauncherStopper] pid={p.Id}: {ex.Message}"); }
-                finally { p.Dispose(); }
-            }
-            return found;
-        }
-
-        var psi = new ProcessStartInfo("/bin/ps") { RedirectStandardOutput = true, UseShellExecute = false };
-        psi.ArgumentList.Add("-axo");
-        psi.ArgumentList.Add("pid=,args=");
-        using var ps = Process.Start(psi)
-                       ?? throw new InvalidOperationException("could not run /bin/ps");
-        var output = ps.StandardOutput.ReadToEnd();
-        ps.WaitForExit(5000);
-
-        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-        {
-            var trimmed = line.TrimStart();
-            var space = trimmed.IndexOf(' ');
-            if (space <= 0) continue;
-            if (!int.TryParse(trimmed[..space], out var pid)) continue;
-
-            var commandLine = trimmed[(space + 1)..].Trim();
-            if (!commandLine.Contains("cc-launcher", StringComparison.Ordinal)) continue;
-            found.Add(new LauncherProcess(pid, commandLine));
-        }
-        return found;
-    }
+    /// <summary>Every cc-launcher process on the machine - see <see cref="InstalledLauncherProcesses.List"/>.</summary>
+    private static IReadOnlyList<LauncherProcess> DefaultListLauncherProcesses() => InstalledLauncherProcesses.List();
 
     /// <summary>
     /// Ask, then insist. The real orphan ignored a polite termination request, so a stop that stops at

--- a/tools/cc-director-setup-engine/LauncherUpdateOwner.cs
+++ b/tools/cc-director-setup-engine/LauncherUpdateOwner.cs
@@ -97,8 +97,17 @@ public sealed record LauncherUpdateResult(LauncherUpdateDecision Decision, strin
 /// Second, THE SWAP MUST NEVER TAKE THE DIRECTOR WITH IT. On Windows the launcher is the Director's
 /// parent process, so stopping it with a process-TREE kill would kill the very process performing the
 /// swap. Nothing here ever kills a tree; it asks politely first, and insists on one process id at a
-/// time. The Director keeps running across the whole swap and the new launcher re-adopts it - the
-/// launcher never starts a Director that already holds its instance.
+/// time.
+///
+/// WHAT IS INTENDED TO FOLLOW FROM THAT, AND HAS NOT BEEN OBSERVED: the Director keeps running across
+/// the whole swap, and the new launcher re-adopts it rather than starting a second one, because a
+/// launcher does not start a Director that already holds its instance. THAT IS THE DESIGN, NOT A
+/// MEASUREMENT. It has never been exercised on any machine - the end-to-end rig
+/// (scripts/launcher-swap-proof.ps1) swaps a launcher that supervises no Director, and the only place
+/// the invariant is asserted at all is LauncherUpdateOwnerTests, through a fake. The pass checks
+/// afterwards whether this Director still holds its instance and reports
+/// <see cref="LauncherUpdateDecision.AppliedButThisDirectorLostItsInstance"/> when it does not, which
+/// is how the untested case announces itself rather than passing silently.
 ///
 /// AND THE ROOT IS THE SHARED ONE. A Director redirects its data tree to its instance home, so a
 /// layout resolved by <see cref="InstallLayout.Default"/> inside a Director points at
@@ -477,6 +486,20 @@ public sealed class LauncherUpdateOwner
                 // Cannot happen with a correctly scoped list, and is asserted anyway: this process is a
                 // Director, and a Director that stopped itself here would leave the swap unfinished.
                 FileLog.Write("[LauncherUpdateOwner] REFUSING to stop this very process.");
+                continue;
+            }
+
+            if (p.Pid <= 0)
+            {
+                // THE UNREADABLE-LIST SENTINEL, and this is what makes the sentence above OursNow true.
+                // That comment says an unreadable list "yields a process id nothing can stop" - but
+                // without this the sentinel's pid 0 went straight to the stop, which on Windows resolves
+                // pid 0 to the System Idle Process and attempts CloseMainWindow and Kill on it. The
+                // attempt fails and is caught, so nothing was harmed; the sentence was still describing
+                // something the code did not do. The sentinel exists to keep the wait from concluding a
+                // clean stop, never to be stopped.
+                FileLog.Write("[LauncherUpdateOwner] the process list is unreadable; there is no process to stop, "
+                              + "and the stop will not be reported clean.");
                 continue;
             }
 

--- a/tools/cc-director-setup-engine/LauncherUpdateOwner.cs
+++ b/tools/cc-director-setup-engine/LauncherUpdateOwner.cs
@@ -174,8 +174,13 @@ public sealed class LauncherUpdateOwner
     /// The machine-wide lock this swap takes. <see cref="BinarySwapLock.Name"/> in production, always;
     /// a test overrides it so it can hold a lock of its own without contending with everything else on
     /// the machine. See the parameter note on <see cref="BinarySwapLock.RunExclusivelyAsync"/>.
+    ///
+    /// INTERNAL, so the override is reachable only from the test assemblies. Public, it was a knob a
+    /// production caller could turn - and two owners on two names exclude nothing at all while looking,
+    /// in every log and every test, exactly like a lock that works. The guarantee should not rest on
+    /// nobody happening to set it.
     /// </summary>
-    public string SwapLockName { get; init; } = BinarySwapLock.Name;
+    internal string SwapLockName { get; init; } = BinarySwapLock.Name;
 
     /// <summary>How long to wait for the stopped launcher's processes to go before insisting.</summary>
     public TimeSpan GracefulStopTimeout { get; init; } = TimeSpan.FromSeconds(15);
@@ -253,27 +258,6 @@ public sealed class LauncherUpdateOwner
                 LauncherUpdateDecision.HeldBecauseTheCommandSurfaceCannotBeObserved, notObservable);
         }
 
-        // ALREADY THE RIGHT BUILD - BUT ONLY IF IT CAN BE COMMANDED. This asked whether the running
-        // process was ALIVE and reported the staged version, and then wrote that version into the
-        // installed manifest. A launcher that is the right version and holds no command surface is
-        // exactly the machine this whole change exists for, and that shortcut blessed it: the manifest
-        // then agreed with the binary, so the pass reported nothing to do for ever and the machine
-        // stayed uncommandable in silence. The version is recorded only when it was WITNESSED, and an
-        // unwitnessed match falls through to the swap, which is the retry that fixes it.
-        if (reading.Witnessed && VersionsMatch(staged.Version, reading.Version))
-        {
-            FileLog.Write($"[LauncherUpdateOwner] the running launcher already reports {reading.Version} and is "
-                          + "commandable; nothing to install.");
-            RecordInstalledVersion(staged.Version);
-            return LauncherUpdateResult.Of(LauncherUpdateDecision.NothingStaged,
-                $"The running launcher already reports {reading.Version} and can be commanded.");
-        }
-
-        if (reading.ProcessAlive && VersionsMatch(staged.Version, reading.Version))
-            FileLog.Write($"[LauncherUpdateOwner] the running launcher already reports {reading.Version}, but it is "
-                          + $"NOT witnessed ({reading.Detail}). Reinstalling it rather than recording a version that "
-                          + "was never proved commandable.");
-
         List<LauncherProcess> ours;
         try
         {
@@ -285,6 +269,41 @@ public sealed class LauncherUpdateOwner
             return LauncherUpdateResult.Of(LauncherUpdateDecision.HeldBecauseUndecidable,
                 $"The process list could not be read, so which process the launcher is could not be established: {ex.Message}");
         }
+
+        // ALREADY THE RIGHT BUILD - BUT ONLY IF IT CAN BE COMMANDED, AND ONLY IF IT IS THE INSTALLED
+        // ONE. Two defects have lived in this shortcut and they compound.
+        //
+        // The first: it asked whether the running process was ALIVE and reported the staged version,
+        // and then wrote that version into the installed manifest. A launcher that is the right
+        // version and holds no command surface is exactly the machine this whole change exists for,
+        // and the shortcut blessed it - after which the manifest agreed with the binary and the pass
+        // reported nothing to do, for ever.
+        //
+        // The second: WITNESSED alone does not say the INSTALLED BINARY is that version. The witness
+        // reads the registration at the shared root, and any launcher can write it - one run from a
+        // repository checkout, or from the staging directory, pointed at this root. Such a launcher is
+        // registered, alive and commandable while the installed file is still the old build, so the
+        // shortcut would record a version that is not on disk. InstalledStateReader then prefers that
+        // newer recorded version over the older file stamp, the staged build stops looking newer, and
+        // the installed binary can never be repaired. So the process the witness saw must be the one
+        // running from the INSTALL directory: exactly one of ours, and it must be that same process id.
+        var witnessedTheInstalledLauncher =
+            reading.Witnessed && ours.Count == 1 && ours[0].Pid == reading.Pid;
+
+        if (witnessedTheInstalledLauncher && VersionsMatch(staged.Version, reading.Version))
+        {
+            FileLog.Write($"[LauncherUpdateOwner] the installed launcher (pid {reading.Pid}) already reports "
+                          + $"{reading.Version} and is commandable; nothing to install.");
+            RecordInstalledVersion(staged.Version);
+            return LauncherUpdateResult.Of(LauncherUpdateDecision.NothingStaged,
+                $"The running launcher already reports {reading.Version} and can be commanded.");
+        }
+
+        if (reading.ProcessAlive && VersionsMatch(staged.Version, reading.Version))
+            FileLog.Write($"[LauncherUpdateOwner] the registered launcher already reports {reading.Version}, but it "
+                          + $"is not both witnessed and the installed process (witnessed={reading.Witnessed}, "
+                          + $"registered pid={reading.Pid}, installed launcher processes={ours.Count}). Not recording "
+                          + "a version that was never proved to be the one on disk.");
 
         if (ours.Count == 0)
         {

--- a/tools/cc-director-setup-engine/LauncherUpdateOwner.cs
+++ b/tools/cc-director-setup-engine/LauncherUpdateOwner.cs
@@ -22,11 +22,38 @@ public enum LauncherUpdateDecision
     /// <summary>A newer build is staged but which process the launcher IS could not be established, so nothing was touched.</summary>
     HeldBecauseUndecidable,
 
+    /// <summary>
+    /// A newer build is staged, but on this platform a launcher cannot be observed to hold a command
+    /// surface at all, so no swap could ever be certified. Nothing was touched. See
+    /// <see cref="LauncherWitnessReading.Witnessed"/>: this is Windows-only until the launcher
+    /// publishes its own capability.
+    /// </summary>
+    HeldBecauseTheCommandSurfaceCannotBeObserved,
+
+    /// <summary>
+    /// A newer build is staged, but another binary swap is already running on this machine - the
+    /// launcher installing the Director's update, or a second Director installing the launcher's.
+    /// Nothing was touched; the next pass looks again.
+    /// </summary>
+    HeldBecauseAnotherSwapIsRunning,
+
     /// <summary>The staged build is one that already failed to come up and was pinned away from.</summary>
     SkippedPinnedBadVersion,
 
     /// <summary>The update was applied and the new launcher was witnessed alive and commandable.</summary>
     Applied,
+
+    /// <summary>
+    /// The launcher was replaced and witnessed, AND THIS DIRECTOR NO LONGER HOLDS ITS INSTANCE. The
+    /// swap stopped a process that on Windows is this Director's parent, so the one thing that had to
+    /// stay true did not: either this process was taken with it, or the new launcher started a second
+    /// Director over the same home.
+    ///
+    /// It is its own answer and not an <see cref="Applied"/> with a longer sentence, because a caller
+    /// that switches on the decision would otherwise read the worst outcome this class can produce as
+    /// a success - and the message that carried the warning is the part nothing switches on.
+    /// </summary>
+    AppliedButThisDirectorLostItsInstance,
 
     /// <summary>The update was applied, the new launcher was never witnessed, and the previous build was put back.</summary>
     RolledBack,
@@ -127,8 +154,12 @@ public sealed class LauncherUpdateOwner
     public Func<string, bool> RequestQuit { get; init; } =
         root => LifecycleSignal.Raise(LifecycleSignalNames.LauncherShutdown(root));
 
-    /// <summary>Stop ONE process id, escalating from polite to insistent. NEVER a process tree.</summary>
-    public Func<int, bool> StopProcess { get; init; } = DefaultStopProcess;
+    /// <summary>
+    /// Stop ONE process id, escalating from polite to insistent. NEVER a process tree - the rule lives
+    /// in <see cref="SingleProcessStop"/>, which is the only place in the swap path that kills
+    /// anything, so this file contains no kill to get wrong.
+    /// </summary>
+    public Func<int, bool> StopProcess { get; init; } = SingleProcessStop.Stop;
 
     /// <summary>Start the installed launcher in managed mode. Returns the process id, or 0 when it could not be started.</summary>
     public Func<InstallLayout, int> StartLauncher { get; init; } = DefaultStartLauncher;
@@ -138,6 +169,13 @@ public sealed class LauncherUpdateOwner
     /// a test supplies one, because a fake build has no version resource to read.
     /// </summary>
     public Func<string, string?> ReadVersionOnDisk { get; init; } = InstalledStateReader.ReadVersionFromDisk;
+
+    /// <summary>
+    /// The machine-wide lock this swap takes. <see cref="BinarySwapLock.Name"/> in production, always;
+    /// a test overrides it so it can hold a lock of its own without contending with everything else on
+    /// the machine. See the parameter note on <see cref="BinarySwapLock.RunExclusivelyAsync"/>.
+    /// </summary>
+    public string SwapLockName { get; init; } = BinarySwapLock.Name;
 
     /// <summary>How long to wait for the stopped launcher's processes to go before insisting.</summary>
     public TimeSpan GracefulStopTimeout { get; init; } = TimeSpan.FromSeconds(15);
@@ -195,13 +233,46 @@ public sealed class LauncherUpdateOwner
         // loop reopens - the same rule the launcher applies to a closed Director, for the same reason:
         // starting an application somebody deliberately closed is not an update.
         var reading = _witness.Read();
-        if (reading.ProcessAlive && VersionsMatch(staged.Version, reading.Version))
+
+        // WHERE A LAUNCHER CANNOT BE WITNESSED, NOTHING IS SWAPPED. On a platform whose command surface
+        // cannot be observed at all, every swap this class performed would install the new build, fail
+        // to certify it for the whole witness timeout, roll it back and PIN it - churning the machine
+        // and permanently blacklisting a build that was probably fine. Refusing up front, and saying
+        // which platform fact caused it, is the honest form of the same answer. See
+        // LauncherWitnessReading.Witnessed for why the alternative - letting the witness pass on a live
+        // registration alone - is the liveness-only proof this whole class exists to forbid.
+        if (reading.CommandSurface == LauncherCommandSurface.NotObservable)
         {
-            FileLog.Write($"[LauncherUpdateOwner] the running launcher already reports {reading.Version}; nothing to install.");
+            var notObservable =
+                $"{staged.Version} is staged, but whether a launcher holds a command surface cannot be "
+                + "observed on this platform, so a swap could never be certified. The Director's "
+                + "ownership of the launcher's update is Windows-only until the launcher publishes its "
+                + "own capability.";
+            FileLog.Write($"[LauncherUpdateOwner] {notObservable}");
+            return LauncherUpdateResult.Of(
+                LauncherUpdateDecision.HeldBecauseTheCommandSurfaceCannotBeObserved, notObservable);
+        }
+
+        // ALREADY THE RIGHT BUILD - BUT ONLY IF IT CAN BE COMMANDED. This asked whether the running
+        // process was ALIVE and reported the staged version, and then wrote that version into the
+        // installed manifest. A launcher that is the right version and holds no command surface is
+        // exactly the machine this whole change exists for, and that shortcut blessed it: the manifest
+        // then agreed with the binary, so the pass reported nothing to do for ever and the machine
+        // stayed uncommandable in silence. The version is recorded only when it was WITNESSED, and an
+        // unwitnessed match falls through to the swap, which is the retry that fixes it.
+        if (reading.Witnessed && VersionsMatch(staged.Version, reading.Version))
+        {
+            FileLog.Write($"[LauncherUpdateOwner] the running launcher already reports {reading.Version} and is "
+                          + "commandable; nothing to install.");
             RecordInstalledVersion(staged.Version);
             return LauncherUpdateResult.Of(LauncherUpdateDecision.NothingStaged,
-                $"The running launcher already reports {reading.Version}.");
+                $"The running launcher already reports {reading.Version} and can be commanded.");
         }
+
+        if (reading.ProcessAlive && VersionsMatch(staged.Version, reading.Version))
+            FileLog.Write($"[LauncherUpdateOwner] the running launcher already reports {reading.Version}, but it is "
+                          + $"NOT witnessed ({reading.Detail}). Reinstalling it rather than recording a version that "
+                          + "was never proved commandable.");
 
         List<LauncherProcess> ours;
         try
@@ -236,6 +307,24 @@ public sealed class LauncherUpdateOwner
         FileLog.Write($"[LauncherUpdateOwner] installing launcher {staged.Version}: staged={staged.StagedBuild}, "
                       + $"target={staged.InstallTarget}, running={reading.Detail}");
 
+        // THE SWAP IS EXCLUSIVE, MACHINE-WIDE. The launcher may at this very moment be installing the
+        // DIRECTOR's staged update - which stops this process, mid-swap, with the launcher binary
+        // already renamed aside. See BinarySwapLock for both directions of that race and for what the
+        // lock does not cover.
+        return await BinarySwapLock.RunExclusivelyAsync(
+            () => SwapAsync(staged, ct),
+            whenBusy: why => LauncherUpdateResult.Of(LauncherUpdateDecision.HeldBecauseAnotherSwapIsRunning,
+                $"{staged.Version} is staged, but {why}"),
+            who: "launcher-update",
+            name: SwapLockName);
+    }
+
+    /// <summary>
+    /// The swap itself, run while <see cref="BinarySwapLock"/> is held: stop, replace, start, witness,
+    /// and then check that this Director survived it.
+    /// </summary>
+    private async Task<LauncherUpdateResult> SwapAsync(StagedLauncherUpdate staged, CancellationToken ct)
+    {
         var result = await _apply.ApplyAsync(
             staged.InstallTarget,
             staged.StagedBuild,
@@ -269,8 +358,13 @@ public sealed class LauncherUpdateOwner
         foreach (var step in steps)
             FileLog.Write($"[LauncherUpdateOwner]   step: {step}");
 
+        // THE NO-ORPHAN CHECK IS AN INVARIANT, NOT A NOTE. A failed check used to return Applied with a
+        // longer message, so every caller that switched on the decision - which is what a caller does -
+        // read "the launcher swap orphaned this Director" as a successful update, and the warning rode
+        // along in a string nothing inspects. It gets its own answer, which cannot be mistaken for one.
         var decision = result.Outcome switch
         {
+            SelfUpdateOutcome.Updated when !stillOurs => LauncherUpdateDecision.AppliedButThisDirectorLostItsInstance,
             SelfUpdateOutcome.Updated => LauncherUpdateDecision.Applied,
             SelfUpdateOutcome.RolledBack => LauncherUpdateDecision.RolledBack,
             _ => LauncherUpdateDecision.Failed,
@@ -435,67 +529,58 @@ public sealed class LauncherUpdateOwner
     // ---- production implementations ----
 
     /// <summary>
-    /// Ask, then insist - on ONE process, never its tree. See <see cref="StopInstalledLauncher"/> for
-    /// why the tree is forbidden here.
+    /// How the installed launcher is started: in managed mode, and NAMING the storage root it is to
+    /// serve. Separated from the start itself so the environment it is given can be asserted - the
+    /// value here is the whole difference between a swap that comes up and one that silently does not.
+    ///
+    /// <c>CC_DIRECTOR_ROOT</c> IS SET, NOT REMOVED, AND THAT IS THE POINT. A Director sets that
+    /// variable to its own INSTANCE HOME, and a child inherits it - so a launcher started from inside a
+    /// Director without any handling takes the instance home for the machine root and goes on to
+    /// supervise, register and signal in a tree no installer has ever written. This first fixed that by
+    /// REMOVING the variable, which is the right intent and the wrong mechanism: removing it does not
+    /// name the correct root, it merely stops naming the wrong one and leaves the child to fall back on
+    /// the process default. That default is the same thing as this install's root only when the install
+    /// happens to sit at the default location.
+    ///
+    /// Where it does not, the failure is silent and expensive, and it was OBSERVED rather than
+    /// reasoned about: on 2026-09-06 the end-to-end rig (scripts/launcher-swap-proof.ps1) swapped a
+    /// launcher on an isolated root, started the new build with the variable removed, and the new
+    /// process resolved to the MACHINE'S root instead - where it found the real launcher already
+    /// running and logged "CC Launcher already running in this session; exiting second instance". It
+    /// therefore never registered where the witness was looking, the witness correctly refused, the
+    /// swap rolled back, and a perfectly good build was PINNED. Four starts across two runs, all four
+    /// identical. An install that is not at the default path would have been left permanently refusing
+    /// its own launcher update, and the log would have said the build was bad.
+    ///
+    /// So the root is stated positively. It also still does the original job: an explicit value cannot
+    /// be an inherited instance home.
     /// </summary>
-    private static bool DefaultStopProcess(int pid)
+    public static ProcessStartInfo BuildLauncherStartInfo(InstallLayout layout)
     {
-        try
-        {
-            using var p = Process.GetProcessById(pid);
-            try
-            {
-                p.CloseMainWindow();
-                if (p.WaitForExit(3000)) return true;
-            }
-            catch (Exception ex)
-            {
-                FileLog.Write($"[LauncherUpdateOwner] polite stop of pid={pid} failed: {ex.Message}");
-            }
+        ArgumentNullException.ThrowIfNull(layout);
 
-            p.Kill(entireProcessTree: false);
-            return p.WaitForExit(5000);
-        }
-        catch (ArgumentException)
+        var psi = new ProcessStartInfo
         {
-            return true;   // already gone
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[LauncherUpdateOwner] stopping pid={pid} failed: {ex.Message}");
-            return false;
-        }
+            FileName = layout.PathFor(ComponentRegistry.Launcher),
+            WorkingDirectory = layout.LauncherDir,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add(LauncherTrayInstaller.InstalledArguments);
+        psi.Environment["CC_DIRECTOR_ROOT"] = layout.LocalRoot;
+        return psi;
     }
 
-    /// <summary>
-    /// Start the installed launcher in managed mode, with a CLEAN storage root.
-    ///
-    /// <c>CC_DIRECTOR_ROOT</c> is removed from the child's environment, and that line is load-bearing.
-    /// A Director sets that variable to its own instance home and a child inherits it, so a launcher
-    /// started from inside a Director without this would take the instance home for the machine root
-    /// and go on to supervise, register and signal in a tree no installer has ever written. The
-    /// installer starts the launcher with ShellExecute and needs none of this, because the installer's
-    /// own environment is clean - which is why this cannot simply reuse its launch.
-    /// </summary>
+    /// <summary>Start the installed launcher. See <see cref="BuildLauncherStartInfo"/> for the environment.</summary>
     private static int DefaultStartLauncher(InstallLayout layout)
     {
         try
         {
-            var exe = layout.PathFor(ComponentRegistry.Launcher);
-            var psi = new ProcessStartInfo
-            {
-                FileName = exe,
-                WorkingDirectory = layout.LauncherDir,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-            psi.ArgumentList.Add(LauncherTrayInstaller.InstalledArguments);
-            psi.Environment.Remove("CC_DIRECTOR_ROOT");
-
+            var psi = BuildLauncherStartInfo(layout);
             using var started = Process.Start(psi)
-                ?? throw new InvalidOperationException($"Process.Start returned null for {exe}");
-            FileLog.Write($"[LauncherUpdateOwner] started the launcher: pid={started.Id}, exe={exe} "
-                          + LauncherTrayInstaller.InstalledArguments);
+                ?? throw new InvalidOperationException($"Process.Start returned null for {psi.FileName}");
+            FileLog.Write($"[LauncherUpdateOwner] started the launcher: pid={started.Id}, exe={psi.FileName} "
+                          + $"{LauncherTrayInstaller.InstalledArguments}, CC_DIRECTOR_ROOT={layout.LocalRoot}");
             return started.Id;
         }
         catch (Exception ex)

--- a/tools/cc-director-setup-engine/LauncherUpdateOwner.cs
+++ b/tools/cc-director-setup-engine/LauncherUpdateOwner.cs
@@ -1,0 +1,507 @@
+using System.Diagnostics;
+using CcDirector.Core.Lifecycle;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>A staged launcher build the Director found, and what it must become.</summary>
+/// <param name="Version">The version the staged build declares about itself.</param>
+/// <param name="StagedBuild">The downloaded build waiting to be installed.</param>
+/// <param name="InstallTarget">The path the staged build must become.</param>
+public sealed record StagedLauncherUpdate(string Version, string StagedBuild, string InstallTarget);
+
+/// <summary>Why a staged launcher update was not applied on this pass, or that one was.</summary>
+public enum LauncherUpdateDecision
+{
+    /// <summary>Nothing is staged, or what is staged is not newer than the launcher that is installed.</summary>
+    NothingStaged,
+
+    /// <summary>A newer build is staged but no launcher is running, and it is not this loop's business to start one.</summary>
+    HeldBecauseLauncherNotRunning,
+
+    /// <summary>A newer build is staged but which process the launcher IS could not be established, so nothing was touched.</summary>
+    HeldBecauseUndecidable,
+
+    /// <summary>The staged build is one that already failed to come up and was pinned away from.</summary>
+    SkippedPinnedBadVersion,
+
+    /// <summary>The update was applied and the new launcher was witnessed alive and commandable.</summary>
+    Applied,
+
+    /// <summary>The update was applied, the new launcher was never witnessed, and the previous build was put back.</summary>
+    RolledBack,
+
+    /// <summary>The attempt failed before or during the swap; the message says what was left where.</summary>
+    Failed,
+}
+
+/// <summary>What one pass decided, and the sentence a person reads.</summary>
+public sealed record LauncherUpdateResult(LauncherUpdateDecision Decision, string Message, IReadOnlyList<string> Steps)
+{
+    public static LauncherUpdateResult Of(LauncherUpdateDecision decision, string message)
+        => new(decision, message, Array.Empty<string>());
+}
+
+/// <summary>
+/// THE DIRECTOR'S OWNERSHIP OF THE LAUNCHER'S UPDATE - the mirror image of
+/// <c>DirectorUpdateOwner</c>, which is the launcher owning the Director's update (issue #1033).
+///
+/// WHY IT HAS TO BE THE DIRECTOR. Whatever replaces a binary must outlive the process being replaced.
+/// The launcher cannot honestly swap itself: the only thing that could confirm the new build came up
+/// is the process that just exited. That argument is why the Director's update moved to the launcher,
+/// and it is the same argument in the other direction - so the launcher's update belongs to the
+/// Director, which is running beside it and is still there afterwards.
+///
+/// WHY THIS IS THE BOOTSTRAP, AND WHY IT IS URGENT. Nothing owned the launcher's update, so a launcher
+/// that fell behind stayed behind. On 2026-09-06 this account's main machine was running launcher
+/// 1.9.8, two days older than the code that lets a launcher be told anything at all, with a 2.0.4
+/// build staged since 1 September that nothing ever installed. That machine could not be commanded and
+/// could not be fixed remotely, because the thing that would receive the fix WAS the broken thing. A
+/// Director update still reaches such a machine, so this rides in with one.
+///
+/// TWO THINGS HERE ARE EASY TO GET WRONG AND BOTH WOULD FAIL SILENTLY:
+///
+/// First, THE WITNESS IS INVERTED. The Director's update is proved by the new Director answering with
+/// the new version. A launcher that starts and holds no command surface looks perfectly healthy from
+/// outside and is exactly today's failure, so "a process started" proves nothing here. The proof is
+/// <see cref="LauncherWitness"/>: a live registration declaring the new version AND a listener on the
+/// signal that tells the launcher to restart the Director.
+///
+/// Second, THE SWAP MUST NEVER TAKE THE DIRECTOR WITH IT. On Windows the launcher is the Director's
+/// parent process, so stopping it with a process-TREE kill would kill the very process performing the
+/// swap. Nothing here ever kills a tree; it asks politely first, and insists on one process id at a
+/// time. The Director keeps running across the whole swap and the new launcher re-adopts it - the
+/// launcher never starts a Director that already holds its instance.
+///
+/// AND THE ROOT IS THE SHARED ONE. A Director redirects its data tree to its instance home, so a
+/// layout resolved by <see cref="InstallLayout.Default"/> inside a Director points at
+/// <c>instances/&lt;slug&gt;/launcher</c> and <c>instances/&lt;slug&gt;/state</c> - directories no
+/// installer has ever written. Read that way, this would report "nothing staged" for ever, on every
+/// machine, while wired and logged and apparently working. The shared root is passed in.
+/// </summary>
+public sealed class LauncherUpdateOwner
+{
+    private readonly string _sharedRoot;
+    private readonly InstallLayout _layout;
+    private readonly LauncherWitness _witness;
+    private readonly LauncherSelfUpdate _apply;
+    private readonly TimeSpan _witnessTimeout;
+    private readonly SemaphoreSlim _oneAtATime = new(1, 1);
+
+    /// <param name="sharedRoot">
+    /// The machine-wide cc-director root - <c>InstanceContext.SharedRoot</c> inside a Director. NOT the
+    /// calling process's storage home; see the class comment.
+    /// </param>
+    /// <param name="directorStillHoldsItsInstance">
+    /// Asked after the swap: is this Director still the live owner of its instance? It is the check
+    /// that the launcher swap did not orphan or duplicate it. Required rather than defaulted, because a
+    /// default that always answered yes would be a check that cannot fail.
+    /// </param>
+    public LauncherUpdateOwner(
+        string sharedRoot,
+        Func<bool> directorStillHoldsItsInstance,
+        LauncherWitness? witness = null,
+        LauncherSelfUpdate? apply = null,
+        TimeSpan? witnessTimeout = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedRoot);
+        ArgumentNullException.ThrowIfNull(directorStillHoldsItsInstance);
+
+        _sharedRoot = sharedRoot;
+        _layout = new InstallLayout(sharedRoot);
+        _witness = witness ?? new LauncherWitness(sharedRoot);
+        _apply = apply ?? new LauncherSelfUpdate(_layout);
+        // A cold launcher start unpacks a ~134 MB single-file binary before it registers anything, and
+        // on the machine where somebody is watching for the first time that is slow exactly once.
+        _witnessTimeout = witnessTimeout ?? TimeSpan.FromMinutes(3);
+        DirectorStillHoldsItsInstance = directorStillHoldsItsInstance;
+    }
+
+    /// <summary>See the constructor.</summary>
+    public Func<bool> DirectorStillHoldsItsInstance { get; }
+
+    /// <summary>Every cc-launcher process on the machine (unfiltered - this class does the scoping).</summary>
+    public Func<IReadOnlyList<LauncherProcess>> ListLauncherProcesses { get; init; } = InstalledLauncherProcesses.List;
+
+    /// <summary>Ask the launcher serving a storage root to quit. True when the request was delivered.</summary>
+    public Func<string, bool> RequestQuit { get; init; } =
+        root => LifecycleSignal.Raise(LifecycleSignalNames.LauncherShutdown(root));
+
+    /// <summary>Stop ONE process id, escalating from polite to insistent. NEVER a process tree.</summary>
+    public Func<int, bool> StopProcess { get; init; } = DefaultStopProcess;
+
+    /// <summary>Start the installed launcher in managed mode. Returns the process id, or 0 when it could not be started.</summary>
+    public Func<InstallLayout, int> StartLauncher { get; init; } = DefaultStartLauncher;
+
+    /// <summary>
+    /// What version does a build on disk declare about itself? Production reads the file's own stamp;
+    /// a test supplies one, because a fake build has no version resource to read.
+    /// </summary>
+    public Func<string, string?> ReadVersionOnDisk { get; init; } = InstalledStateReader.ReadVersionFromDisk;
+
+    /// <summary>How long to wait for the stopped launcher's processes to go before insisting.</summary>
+    public TimeSpan GracefulStopTimeout { get; init; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>How long a process that was insisted upon is given to actually go before it is judged.</summary>
+    public TimeSpan StopSettleTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Where a staged launcher build waits - one definition, shared with the launcher's own updater.</summary>
+    public string StagedBuildPath => new LauncherUpdater(_layout).StagedExePath;
+
+    /// <summary>
+    /// One pass: look for a staged launcher build newer than the one installed, and install it. Never
+    /// throws - this runs on a background loop, so every failure comes back as a decision and a log line.
+    /// </summary>
+    public async Task<LauncherUpdateResult> RunOnceAsync(CancellationToken ct = default)
+    {
+        if (!await _oneAtATime.WaitAsync(TimeSpan.Zero, ct))
+        {
+            FileLog.Write("[LauncherUpdateOwner] a previous pass is still running; skipping this one.");
+            return LauncherUpdateResult.Of(LauncherUpdateDecision.HeldBecauseUndecidable,
+                "A previous launcher update pass is still running.");
+        }
+
+        try
+        {
+            return await RunOnceCoreAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LauncherUpdateOwner] RunOnceAsync FAILED: {ex}");
+            return LauncherUpdateResult.Of(LauncherUpdateDecision.Failed, $"The launcher update pass failed: {ex.Message}");
+        }
+        finally
+        {
+            _oneAtATime.Release();
+        }
+    }
+
+    private async Task<LauncherUpdateResult> RunOnceCoreAsync(CancellationToken ct)
+    {
+        var staged = FindStagedUpdate(out var why);
+        if (staged is null)
+        {
+            FileLog.Write($"[LauncherUpdateOwner] nothing to do: {why}");
+            return LauncherUpdateResult.Of(
+                why.StartsWith("pinned", StringComparison.Ordinal)
+                    ? LauncherUpdateDecision.SkippedPinnedBadVersion
+                    : LauncherUpdateDecision.NothingStaged,
+                why);
+        }
+
+        // WHICH process is the launcher, and is it ours? Both questions are asked before anything is
+        // stopped. A machine where more than one installed launcher is running does not know whose
+        // command surface it would be replacing, and a machine where none is running is not one this
+        // loop reopens - the same rule the launcher applies to a closed Director, for the same reason:
+        // starting an application somebody deliberately closed is not an update.
+        var reading = _witness.Read();
+        if (reading.ProcessAlive && VersionsMatch(staged.Version, reading.Version))
+        {
+            FileLog.Write($"[LauncherUpdateOwner] the running launcher already reports {reading.Version}; nothing to install.");
+            RecordInstalledVersion(staged.Version);
+            return LauncherUpdateResult.Of(LauncherUpdateDecision.NothingStaged,
+                $"The running launcher already reports {reading.Version}.");
+        }
+
+        List<LauncherProcess> ours;
+        try
+        {
+            ours = InstalledLauncherProcesses.Ours(_layout.LauncherDir, ListLauncherProcesses());
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LauncherUpdateOwner] the process list is unreadable: {ex.Message}");
+            return LauncherUpdateResult.Of(LauncherUpdateDecision.HeldBecauseUndecidable,
+                $"The process list could not be read, so which process the launcher is could not be established: {ex.Message}");
+        }
+
+        if (ours.Count == 0)
+        {
+            FileLog.Write($"[LauncherUpdateOwner] {staged.Version} is staged but no launcher is running from "
+                          + $"{_layout.LauncherDir}. Leaving both alone: it is installed the next time a launcher starts, "
+                          + "and nothing here reopens a launcher somebody closed.");
+            return LauncherUpdateResult.Of(LauncherUpdateDecision.HeldBecauseLauncherNotRunning,
+                $"{staged.Version} is staged, but no launcher is running from {_layout.LauncherDir}.");
+        }
+
+        if (ours.Count > 1)
+        {
+            var pids = string.Join(", ", ours.Select(p => p.Pid));
+            FileLog.Write($"[LauncherUpdateOwner] REFUSING to install {staged.Version}: {ours.Count} installed launcher "
+                          + $"processes are running ({pids}), so which one holds the command surface is unknown.");
+            return LauncherUpdateResult.Of(LauncherUpdateDecision.HeldBecauseUndecidable,
+                $"{ours.Count} installed launcher processes are running ({pids}); nothing was touched.");
+        }
+
+        FileLog.Write($"[LauncherUpdateOwner] installing launcher {staged.Version}: staged={staged.StagedBuild}, "
+                      + $"target={staged.InstallTarget}, running={reading.Detail}");
+
+        var result = await _apply.ApplyAsync(
+            staged.InstallTarget,
+            staged.StagedBuild,
+            staged.Version,
+            stopLauncher: StopInstalledLauncher,
+            startLauncher: () => StartLauncher(_layout) > 0,
+            // THE WITNESS, and the whole reason this is not the Director's update owner with the nouns
+            // changed: the new build is proved by a launcher that is running AND can be commanded,
+            // reporting the version just installed. A launcher that starts and opens nothing fails this.
+            isHealthy: _ => Task.FromResult(VersionsMatch(staged.Version, _witness.WitnessedVersion())),
+            healthTimeout: _witnessTimeout,
+            ct: ct);
+
+        var steps = new List<string>(result.Steps);
+
+        // THE NO-ORPHAN CHECK. The swap stops a process that on Windows is the Director's parent, so the
+        // one thing that must be true afterwards is that this Director is still the live owner of its
+        // instance - not killed with the launcher, and not duplicated by the new one.
+        bool stillOurs;
+        try { stillOurs = DirectorStillHoldsItsInstance(); }
+        catch (Exception ex)
+        {
+            stillOurs = false;
+            FileLog.Write($"[LauncherUpdateOwner] the no-orphan check itself failed: {ex.Message}");
+        }
+        steps.Add(stillOurs
+            ? "this Director still holds its instance after the swap"
+            : "THIS DIRECTOR NO LONGER HOLDS ITS INSTANCE after the launcher swap");
+        steps.Add($"after the swap: {_witness.Read().Detail}");
+
+        foreach (var step in steps)
+            FileLog.Write($"[LauncherUpdateOwner]   step: {step}");
+
+        var decision = result.Outcome switch
+        {
+            SelfUpdateOutcome.Updated => LauncherUpdateDecision.Applied,
+            SelfUpdateOutcome.RolledBack => LauncherUpdateDecision.RolledBack,
+            _ => LauncherUpdateDecision.Failed,
+        };
+
+        var message = stillOurs
+            ? result.Message
+            : result.Message + " THE DIRECTOR NO LONGER HOLDS ITS INSTANCE - the launcher swap took it with it.";
+
+        FileLog.Write($"[LauncherUpdateOwner] launcher {staged.Version}: {decision} - {message}");
+        return new LauncherUpdateResult(decision, message, steps);
+    }
+
+    /// <summary>
+    /// The staged launcher build waiting for THIS install, or null with the reason in
+    /// <paramref name="why"/>.
+    /// </summary>
+    public StagedLauncherUpdate? FindStagedUpdate(out string why)
+    {
+        var stagedPath = StagedBuildPath;
+        if (!File.Exists(stagedPath))
+        {
+            why = $"no launcher build is staged at {stagedPath}";
+            return null;
+        }
+
+        var stagedVersion = ReadVersionOnDisk(stagedPath);
+        if (string.IsNullOrWhiteSpace(stagedVersion))
+        {
+            // A build that will not say what it is cannot be compared with what is installed, and
+            // installing it anyway would mean not knowing afterwards whether it was the right one.
+            why = $"the build staged at {stagedPath} does not declare a version, so it cannot be installed";
+            FileLog.Write($"[LauncherUpdateOwner] {why}");
+            return null;
+        }
+
+        var installed = new InstalledStateReader(_layout).Read(ComponentRegistry.Launcher);
+        if (!installed.Present)
+        {
+            // Refresh-only, exactly like the launcher's own updater: this installs a NEWER launcher over
+            // an existing one. Placing a launcher on a machine that has none is an install, and installs
+            // are the installer's job.
+            why = $"no launcher is installed at {_layout.PathFor(ComponentRegistry.Launcher)}, so there is nothing to update";
+            return null;
+        }
+
+        if (!VersionUtil.IsNewer(stagedVersion, installed.Version))
+        {
+            why = $"the staged launcher {stagedVersion} is not newer than the installed {installed.Version ?? "unknown"}";
+            return null;
+        }
+
+        if (PinStore.Load(_layout).IsPinned(ComponentRegistry.Launcher.Id, stagedVersion))
+        {
+            why = $"pinned: launcher {stagedVersion} already failed to come up and is pinned away from";
+            FileLog.Write($"[LauncherUpdateOwner] {why}");
+            return null;
+        }
+
+        why = "";
+        return new StagedLauncherUpdate(stagedVersion, stagedPath, _layout.PathFor(ComponentRegistry.Launcher));
+    }
+
+    /// <summary>
+    /// Stop the installed launcher: ask it to quit, wait, and insist on whatever is left - ONE PROCESS
+    /// AT A TIME AND NEVER A TREE. True when no installed launcher process remains.
+    ///
+    /// The tree is the trap. The uninstaller's stop kills entire process trees, which is defensible
+    /// when the whole install is going away; here the Director is the launcher's child on Windows, so a
+    /// tree kill would end the process running this code, mid-swap, with the launcher binary half
+    /// replaced.
+    ///
+    /// A launcher too old to listen for the quit signal is the NORMAL case for this class - the
+    /// launchers that most need replacing are the ones that cannot be asked - so the polite request
+    /// failing is logged as the expected fact it is, not as an error.
+    /// </summary>
+    public bool StopInstalledLauncher()
+    {
+        var asked = RequestQuit(_sharedRoot);
+        FileLog.Write(asked
+            ? "[LauncherUpdateOwner] the launcher was asked to quit"
+            : "[LauncherUpdateOwner] no launcher is listening for the quit request - expected of a build that "
+              + "predates the lifecycle signals, which is exactly the build this replaces");
+
+        if (asked) WaitFor(() => OursNow().Count == 0, GracefulStopTimeout);
+
+        foreach (var p in OursNow())
+        {
+            if (p.Pid == Environment.ProcessId)
+            {
+                // Cannot happen with a correctly scoped list, and is asserted anyway: this process is a
+                // Director, and a Director that stopped itself here would leave the swap unfinished.
+                FileLog.Write("[LauncherUpdateOwner] REFUSING to stop this very process.");
+                continue;
+            }
+
+            var exited = StopProcess(p.Pid);
+            FileLog.Write(exited
+                ? $"[LauncherUpdateOwner] stopped installed launcher process {p.Pid}"
+                : $"[LauncherUpdateOwner] could NOT stop installed launcher process {p.Pid}");
+        }
+
+        WaitFor(() => OursNow().Count == 0, StopSettleTimeout);
+        var remaining = OursNow();
+        if (remaining.Count > 0)
+            FileLog.Write("[LauncherUpdateOwner] installed launcher process(es) STILL RUNNING: "
+                          + string.Join(", ", remaining.Select(p => p.Pid)));
+        return remaining.Count == 0;
+    }
+
+    private List<LauncherProcess> OursNow()
+    {
+        try
+        {
+            return InstalledLauncherProcesses.Ours(_layout.LauncherDir, ListLauncherProcesses());
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LauncherUpdateOwner] listing launcher processes failed: {ex.Message}");
+            // Unreadable is NOT empty. Answering "none left" here would report a stop nobody observed,
+            // so an unreadable list yields a process id nothing can stop and the caller waits its
+            // timeout out instead of believing a clean result.
+            return [new LauncherProcess(0, "the process list is unreadable")];
+        }
+    }
+
+    /// <summary>Record the version now installed, so the manifest and the binary do not drift apart.</summary>
+    private void RecordInstalledVersion(string version)
+    {
+        try
+        {
+            var manifest = InstalledManifest.Load(_layout);
+            if (string.Equals(manifest.Get(ComponentRegistry.Launcher.Id), version, StringComparison.Ordinal)) return;
+            manifest.Set(ComponentRegistry.Launcher.Id, version);
+            manifest.Save(_layout);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LauncherUpdateOwner] recording launcher {version} failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>Do these two versions describe the same build, ignoring any build metadata?</summary>
+    private static bool VersionsMatch(string expected, string? reported)
+    {
+        var left = VersionUtil.TryParse(expected);
+        var right = VersionUtil.TryParse(reported);
+        return left is not null && right is not null && left == right;
+    }
+
+    private static bool WaitFor(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            Thread.Sleep(250);
+        }
+        return condition();
+    }
+
+    // ---- production implementations ----
+
+    /// <summary>
+    /// Ask, then insist - on ONE process, never its tree. See <see cref="StopInstalledLauncher"/> for
+    /// why the tree is forbidden here.
+    /// </summary>
+    private static bool DefaultStopProcess(int pid)
+    {
+        try
+        {
+            using var p = Process.GetProcessById(pid);
+            try
+            {
+                p.CloseMainWindow();
+                if (p.WaitForExit(3000)) return true;
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[LauncherUpdateOwner] polite stop of pid={pid} failed: {ex.Message}");
+            }
+
+            p.Kill(entireProcessTree: false);
+            return p.WaitForExit(5000);
+        }
+        catch (ArgumentException)
+        {
+            return true;   // already gone
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LauncherUpdateOwner] stopping pid={pid} failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Start the installed launcher in managed mode, with a CLEAN storage root.
+    ///
+    /// <c>CC_DIRECTOR_ROOT</c> is removed from the child's environment, and that line is load-bearing.
+    /// A Director sets that variable to its own instance home and a child inherits it, so a launcher
+    /// started from inside a Director without this would take the instance home for the machine root
+    /// and go on to supervise, register and signal in a tree no installer has ever written. The
+    /// installer starts the launcher with ShellExecute and needs none of this, because the installer's
+    /// own environment is clean - which is why this cannot simply reuse its launch.
+    /// </summary>
+    private static int DefaultStartLauncher(InstallLayout layout)
+    {
+        try
+        {
+            var exe = layout.PathFor(ComponentRegistry.Launcher);
+            var psi = new ProcessStartInfo
+            {
+                FileName = exe,
+                WorkingDirectory = layout.LauncherDir,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            psi.ArgumentList.Add(LauncherTrayInstaller.InstalledArguments);
+            psi.Environment.Remove("CC_DIRECTOR_ROOT");
+
+            using var started = Process.Start(psi)
+                ?? throw new InvalidOperationException($"Process.Start returned null for {exe}");
+            FileLog.Write($"[LauncherUpdateOwner] started the launcher: pid={started.Id}, exe={exe} "
+                          + LauncherTrayInstaller.InstalledArguments);
+            return started.Id;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LauncherUpdateOwner] starting the launcher FAILED: {ex.Message}");
+            return 0;
+        }
+    }
+}

--- a/tools/cc-director-setup-engine/LauncherWitness.cs
+++ b/tools/cc-director-setup-engine/LauncherWitness.cs
@@ -1,0 +1,175 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Lifecycle;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>Whether the launcher's local command surface - the named lifecycle signal it listens on -
+/// is there, is absent, or cannot be observed at all on this platform.</summary>
+public enum LauncherCommandSurface
+{
+    /// <summary>A listener answers for the launcher's restart-the-Director signal. This launcher can be told things.</summary>
+    Present,
+
+    /// <summary>Nothing is listening. A launcher build that predates the command surface reads as this, and so does one whose signals failed to start.</summary>
+    Absent,
+
+    /// <summary>This platform cannot be asked. See <see cref="LifecycleSignal.HasListener"/> - a Unix listener leaves nothing to consult.</summary>
+    NotObservable,
+}
+
+/// <summary>
+/// One reading of the launcher serving a storage root: what its registration says, whether that
+/// process is alive, and whether it holds a command surface.
+/// </summary>
+/// <param name="Detail">One plain sentence, for a log or a decision record.</param>
+public sealed record LauncherWitnessReading(
+    bool Registered, bool ProcessAlive, int Pid, string? Version,
+    LauncherCommandSurface CommandSurface, string Detail)
+{
+    /// <summary>
+    /// The whole point of this class: a launcher counts as WITNESSED only when a live process is
+    /// registered AND its command surface is not absent. A process that started is not evidence of
+    /// anything - the failure this exists to catch looks exactly like a healthy launcher from the
+    /// outside.
+    /// </summary>
+    public bool Witnessed => Registered && ProcessAlive && CommandSurface != LauncherCommandSurface.Absent;
+}
+
+/// <summary>
+/// Reads what can be known, on this machine and with no network, about the launcher serving a storage
+/// root: the registration file the running launcher writes about itself, and whether it is listening
+/// for the lifecycle signal that tells it to restart the Director.
+///
+/// WHY THE PROCESS EXISTING IS NOT THE ANSWER. On 2026-09-06 a Director on this account could not be
+/// restarted by any route, and it was found out only after seventeen sessions had been drained. The
+/// launcher was 1.9.8 - two days older than the code that lets a launcher be told anything at all. It
+/// was running, it was registered, it was heartbeating to the Gateway, and it could not receive a
+/// single command. Every check that asks "is a launcher up" says yes about that machine. So the
+/// question here is never "did something start", it is "is the thing that started able to be
+/// commanded", and the evidence is a listener that answers.
+///
+/// WHY THE GATEWAY IS NOT CONSULTED. The launcher's command stream runs to the Gateway, so it is
+/// tempting to make "stream connected" the witness. It must not be. A launcher on a machine with no
+/// Gateway configured, or with the network down, is still a perfectly healthy launcher - and a witness
+/// that failed there would roll a good build back for a reason that has nothing to do with the build.
+/// This reads the two facts that are true locally and are true offline. Whether the stream is
+/// CONNECTED is a different question with a different answer and a different fix, and it belongs to
+/// the capability query that reports NotConnected apart from NotStreamCapable.
+///
+/// THE ROOT IS THE SHARED ONE, NEVER THE CALLING PROCESS'S OWN. A Director redirects its whole data
+/// tree to its instance home, so <see cref="LauncherDiscovery.DefaultPath"/> read from inside a
+/// Director points at <c>instances/&lt;slug&gt;/config/launcher/launcher.json</c> - a file no launcher
+/// has ever written. It would report "no launcher installed" on a machine whose launcher is running
+/// perfectly, every single time. The shared root is passed in for exactly this reason and the signal
+/// name is derived from the same value.
+/// </summary>
+public sealed class LauncherWitness
+{
+    private readonly string _sharedRoot;
+
+    public LauncherWitness(string sharedRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedRoot);
+        _sharedRoot = sharedRoot;
+    }
+
+    /// <summary>The registration file the launcher serving this root writes about itself.</summary>
+    public static string RegistrationPathFor(string sharedRoot)
+        => Path.Combine(sharedRoot, "config", "launcher", "launcher.json");
+
+    /// <summary>Where this witness reads the registration from. Overridable for tests.</summary>
+    public string RegistrationPath { get; init; } = "";
+
+    /// <summary>Is this process id alive? Test seam; production asks the operating system.</summary>
+    public Func<int, bool>? ProcessIsAlive { get; init; }
+
+    /// <summary>Does this named signal have a listener? Test seam; production asks the operating system.</summary>
+    public Func<string, bool?> HasListener { get; init; } = LifecycleSignal.HasListener;
+
+    /// <summary>Every cc-launcher process on the machine, for telling "no launcher" from "a launcher
+    /// serving somebody else's root". Test seam; production asks the operating system.</summary>
+    public Func<IReadOnlyList<LauncherProcess>> ListLauncherProcesses { get; init; } = InstalledLauncherProcesses.List;
+
+    /// <summary>The signal whose listener proves this launcher can be commanded at all.</summary>
+    public string CommandSignalName => LifecycleSignalNames.LauncherRestartDirector(_sharedRoot);
+
+    /// <summary>Read the launcher fact now. Never throws and never caches - a launcher starts and stops
+    /// while a Director runs.</summary>
+    public LauncherWitnessReading Read()
+    {
+        var path = string.IsNullOrWhiteSpace(RegistrationPath) ? RegistrationPathFor(_sharedRoot) : RegistrationPath;
+        var health = LauncherHealthProbe.ReadRegistration(path, ProcessIsAlive);
+
+        var surface = HasListener(CommandSignalName) switch
+        {
+            true => LauncherCommandSurface.Present,
+            false => LauncherCommandSurface.Absent,
+            null => LauncherCommandSurface.NotObservable,
+        };
+
+        if (health is null)
+            return new LauncherWitnessReading(false, false, 0, null, surface,
+                $"no launcher has registered at {path}{ServingAnotherRoot()}");
+
+        var version = health.Version ?? "unknown";
+        var detail = health switch
+        {
+            { Ok: false } => $"the registration at {path} names process {health.Pid}, which is not running"
+                              + ServingAnotherRoot(),
+            _ when surface == LauncherCommandSurface.Absent =>
+                $"launcher {version} is running as process {health.Pid} but nothing is listening for "
+                + $"{CommandSignalName}, so it cannot be told anything",
+            _ when surface == LauncherCommandSurface.NotObservable =>
+                $"launcher {version} is running as process {health.Pid}; whether it is listening for "
+                + $"{CommandSignalName} cannot be observed on this platform",
+            _ => $"launcher {version} is running as process {health.Pid} and is listening for {CommandSignalName}",
+        };
+
+        return new LauncherWitnessReading(true, health.Ok, health.Pid, health.Version, surface, detail);
+    }
+
+    /// <summary>
+    /// The sentence that turns "no launcher here" into the reason, when a launcher IS running from this
+    /// install and has registered somewhere else.
+    ///
+    /// This is a real machine state and it was invisible: on 2026-09-06 a launcher was started by hand
+    /// from a shell that had inherited a Director's <c>CC_DIRECTOR_ROOT</c>, so it took that Director's
+    /// INSTANCE HOME for the machine root. It came up perfectly - registered, heartbeating, stream
+    /// connected, both lifecycle signals armed - and every one of those facts was filed under the wrong
+    /// root: its registration went to <c>instances/&lt;slug&gt;/config/launcher</c> and its signals were
+    /// named for that root, so nothing computing from the real root could see or reach it. Read without
+    /// this, the machine says "no launcher", which sends the next person looking for a process that is
+    /// plainly running.
+    /// </summary>
+    private string ServingAnotherRoot()
+    {
+        try
+        {
+            var running = InstalledLauncherProcesses.Ours(
+                Path.Combine(_sharedRoot, "launcher"), ListLauncherProcesses());
+            if (running.Count == 0) return "";
+
+            var pids = string.Join(", ", running.Select(p => p.Pid));
+            return $" - but launcher process(es) {pids} ARE running from this install, so they are serving a "
+                   + "different storage root: their registration and their signal names are keyed to that "
+                   + "root and nothing here can reach them";
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LauncherWitness] could not list launcher processes: {ex.Message}");
+            return "";
+        }
+    }
+
+    /// <summary>
+    /// The version of the launcher that is BOTH running and commandable, or null when there is no such
+    /// launcher. This is the shape an apply's health poll wants: null and "a version that is not the
+    /// one we installed" are both "not proved yet", and only a proved new version ends the wait.
+    /// </summary>
+    public string? WitnessedVersion()
+    {
+        var reading = Read();
+        return reading.Witnessed ? reading.Version : null;
+    }
+}

--- a/tools/cc-director-setup-engine/LauncherWitness.cs
+++ b/tools/cc-director-setup-engine/LauncherWitness.cs
@@ -29,11 +29,26 @@ public sealed record LauncherWitnessReading(
 {
     /// <summary>
     /// The whole point of this class: a launcher counts as WITNESSED only when a live process is
-    /// registered AND its command surface is not absent. A process that started is not evidence of
-    /// anything - the failure this exists to catch looks exactly like a healthy launcher from the
-    /// outside.
+    /// registered AND a listener actually answers for its command surface. A process that started is
+    /// not evidence of anything - the failure this exists to catch looks exactly like a healthy
+    /// launcher from the outside.
+    ///
+    /// NOT OBSERVABLE IS NOT WITNESSED, AND THAT IS THE DELIBERATE ANSWER. This first accepted
+    /// <see cref="LauncherCommandSurface.NotObservable"/> on the reasoning that a Unix listener cannot
+    /// be observed at all, so refusing there would refuse for ever. But accepting it means that on
+    /// Unix a live registration ALONE passes - which is precisely the liveness-only proof this class
+    /// exists to forbid, reintroduced on the one platform where nobody would notice. A witness that
+    /// cannot fail on a platform is not a witness on that platform.
+    ///
+    /// So the boolean stays honest and the CALLER carries the consequence:
+    /// <see cref="LauncherUpdateOwner"/> refuses to swap a launcher at all where the surface cannot be
+    /// observed, and says so, rather than installing a build it could never certify and rolling it
+    /// back three minutes later. Concretely: the Director's ownership of the launcher's update is
+    /// WINDOWS-ONLY until the launcher publishes its own capability - a fact the launcher could state
+    /// about itself in its registration, which would make this observable everywhere and is the right
+    /// fix when Phase 0 is extended beyond Windows.
     /// </summary>
-    public bool Witnessed => Registered && ProcessAlive && CommandSurface != LauncherCommandSurface.Absent;
+    public bool Witnessed => Registered && ProcessAlive && CommandSurface == LauncherCommandSurface.Present;
 }
 
 /// <summary>
@@ -57,6 +72,15 @@ public sealed record LauncherWitnessReading(
 /// CONNECTED is a different question with a different answer and a different fix, and it belongs to
 /// the capability query that reports NotConnected apart from NotStreamCapable.
 ///
+/// WHAT THE LISTENER PROVES, AND WHAT IT DOES NOT. A listener answering means the named signal's
+/// handle EXISTS in this logon session - the launcher got far enough to arm it. It does not prove the
+/// thread behind it is still pumping, so a launcher that armed its signals and then wedged reads as
+/// commandable here. That gap is not closed, and it cannot be closed by a stronger read: the only
+/// proof that a signal is being SERVICED is raising it, and raising this one restarts a Director as a
+/// side effect of the question. A capability check may not have consequences, so the limit is stated
+/// rather than traded for a destructive probe. It is also a much smaller gap than the one this
+/// replaces - the failure being fixed is a launcher that arms nothing at all.
+///
 /// THE ROOT IS THE SHARED ONE, NEVER THE CALLING PROCESS'S OWN. A Director redirects its whole data
 /// tree to its instance home, so <see cref="LauncherDiscovery.DefaultPath"/> read from inside a
 /// Director points at <c>instances/&lt;slug&gt;/config/launcher/launcher.json</c> - a file no launcher
@@ -74,9 +98,13 @@ public sealed class LauncherWitness
         _sharedRoot = sharedRoot;
     }
 
-    /// <summary>The registration file the launcher serving this root writes about itself.</summary>
+    /// <summary>
+    /// The registration file the launcher serving this root writes about itself. Composed by
+    /// <see cref="InstallLayout"/>, which owns every path inside an install - a second spelling of
+    /// this one here would be a copy free to drift from the one the launcher actually writes to.
+    /// </summary>
     public static string RegistrationPathFor(string sharedRoot)
-        => Path.Combine(sharedRoot, "config", "launcher", "launcher.json");
+        => new InstallLayout(sharedRoot).LauncherRegistrationPath;
 
     /// <summary>Where this witness reads the registration from. Overridable for tests.</summary>
     public string RegistrationPath { get; init; } = "";
@@ -147,7 +175,7 @@ public sealed class LauncherWitness
         try
         {
             var running = InstalledLauncherProcesses.Ours(
-                Path.Combine(_sharedRoot, "launcher"), ListLauncherProcesses());
+                new InstallLayout(_sharedRoot).LauncherDir, ListLauncherProcesses());
             if (running.Count == 0) return "";
 
             var pids = string.Join(", ", running.Select(p => p.Pid));

--- a/tools/cc-director-setup-engine/SingleProcessStop.cs
+++ b/tools/cc-director-setup-engine/SingleProcessStop.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// STOP ONE PROCESS. NEVER ITS TREE. This type exists so that the rule is a place rather than an
+/// argument.
+///
+/// The Director's ownership of the launcher's update stops the launcher and swaps its binary. On
+/// Windows the launcher is the Director's PARENT process, so a stop aimed at the launcher that killed
+/// its process tree would end the Director performing the swap - halfway through, with the launcher
+/// binary already renamed aside and nothing left running to put it back or to start what was
+/// installed. The uninstaller's stop (<see cref="LauncherStopper"/>) kills trees on purpose, because
+/// there the whole install is going away; the two stops otherwise look identical and the wrong one is
+/// one word away.
+///
+/// That one word used to be a boolean argument inside the swap's own file, guarded by a test that read
+/// the source text for it. A source-text guard is the weakest kind of proof and it could only ever see
+/// the spelling it was written for. Putting the kill HERE, in a type whose entire purpose is the
+/// single-process form, means the file that performs the swap contains no process kill at all - so
+/// there is no argument in it to flip, and the guard can assert an absence that is complete for that
+/// file rather than a string that happens to be the current spelling.
+/// </summary>
+public static class SingleProcessStop
+{
+    /// <summary>
+    /// Ask <paramref name="pid"/> to close, then insist - on that process alone. True when it is gone
+    /// (including when it had already exited before this was called).
+    ///
+    /// Politeness first is not decoration: a healthy launcher asked to close shuts its own state down
+    /// cleanly, and killing it first would deny it that. Insisting second is not optional either - the
+    /// launchers that most need replacing are old enough to ignore a polite request.
+    /// </summary>
+    public static bool Stop(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            try
+            {
+                process.CloseMainWindow();
+                if (process.WaitForExit(3000)) return true;
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[SingleProcessStop] polite stop of pid={pid} failed: {ex.Message}");
+            }
+
+            // The one kill, and the only place this argument is written for the swap path.
+            process.Kill(entireProcessTree: false);
+            return process.WaitForExit(5000);
+        }
+        catch (ArgumentException)
+        {
+            return true;   // already gone
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SingleProcessStop] stopping pid={pid} failed: {ex.Message}");
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## What this is

Phase 0 of issue thefrederiksen/devthrottle_internal#1923: **the Director installs the launcher's staged update.**

Nothing owned the launcher's own update, so a launcher that fell behind stayed behind. On
2026-09-06 this account's main machine was running launcher 1.9.8 — two days older than the code
that lets a launcher be told anything at all — with a 2.0.4 build staged since 1 September that
nothing ever installed. That machine could not be commanded and could not be fixed remotely,
because the thing that would receive the fix was the broken thing. A Director update still reaches
it, so the fix rides in with one.

This is the mirror of the launcher owning the Director's update: whatever replaces a binary has to
outlive the process being replaced, and the launcher cannot honestly swap itself.

It is Phase 0 only. Phases 1 to 6 are not in this branch.

## The two things that would have failed silently

**The witness is inverted.** A launcher that starts and holds no command surface looks perfectly
healthy from outside, and is exactly the failure being fixed — so "a process started" proves
nothing here. The proof is a live registration declaring the new version **and** a listener on the
signal that tells the launcher to restart the Director, asked without raising it (raising it would
restart a Director as a side effect of the question).

**The swap must never take the Director with it.** On Windows the launcher is the Director's parent
process, so a process-tree kill would end the process performing the swap. The kill now lives in a
type whose only purpose is the single-process form, so the file that performs the swap expresses no
kill at all.

## Proof, and its exact limits

**Read this section before quoting anything here as proved.**

### The witness, on this machine, against a known-bad and a known-good input

The same class, on the same machine, hours apart:

| | earlier today | after the launcher was updated |
|---|---|---|
| surface | `Absent` | `Present` |
| `WITNESSED` | **False** | **True** |

The earlier reading was taken while a launcher was running, registered, heartbeating and
stream-connected — everything a liveness check looks at — and the witness still said no, correctly,
because it could not be commanded from the true shared root. A check that has never returned no is
not a check; this one has returned both.

### The end-to-end swap: `scripts/launcher-swap-proof.ps1`

Committed on this branch. It builds two real launcher binaries at different versions, lays out an
isolated storage root, starts a real launcher against it, and drives the real pass — a real stop, a
real binary replacement, a real start, and a witness that must find the **new** version alive and
commandable. It also asserts that the machine's own launcher did not move.

It found a defect that no amount of reading had caught (below), returned **FAIL** against it, and
returns **PASS** after the fix. It is therefore a check that has been observed to fail.

### WHAT THE RIG COVERS, AND WHAT IT DOES NOT

**The rig proves the swap on an isolated root. It does not prove the swap on a launcher that is a
live Director's parent.** That difference is the whole point of the no-orphan rule and it is not
left for a reader to infer:

- **Covered:** an installed launcher running from an isolated root is stopped for real, its binary
  is replaced for real, a new process is started for real by the production start path, and the new
  build is witnessed — registered, alive, and holding a live command surface.
- **NOT covered:** the launcher in the rig **supervises no Director**. On a real machine the
  installed launcher is the parent of the Director performing the swap, and the invariant that the
  Director keeps running across the swap and is re-adopted by the new launcher — the reason the stop
  refuses to kill a process tree — **has never been exercised, on any machine.** It is asserted only
  through a fake, in `LauncherUpdateOwnerTests`.
- **Also not covered:** the original Phase 0 proof named in the issue (this machine going 1.9.8 to
  2.0.x with no human touching the launcher) was **not** performed. The machine's launcher was
  updated by hand by somebody else during the first session, which removed the before-state.
- **Also not covered:** nothing was run on macOS or Linux. Where a listener cannot be observed, this
  code now deliberately refuses to swap at all, so Phase 0 is **Windows-only** until the launcher
  publishes its own capability.

Why the rig rather than this machine: the running launcher here is the parent of the Director
carrying the live fleet, and the owner's standing instruction is to ask him before anything stops or
replaces it. That question is outstanding and unanswered, so it was not done.

## The defect the rig found

The start **removed** `CC_DIRECTOR_ROOT` from the new launcher's environment, so a launcher could
not inherit a Director's instance home. Right intent, wrong mechanism: removing a variable does not
name the correct root, it only stops naming a wrong one, and the child then falls back on the
process default — which equals this install's root only when the install sits at the default path.

Run against an isolated root, the swapped launcher resolved to the **machine's** root instead, found
the real launcher already running there, and logged `CC Launcher already running in this session;
exiting second instance`. It never registered where the witness was looking, so the witness
correctly refused, the swap rolled back, and a perfectly good build was **pinned**. Four starts
across two runs, all four identical.

An install anywhere but the default path would have been left permanently refusing its own launcher
update, with the log blaming the build. The root is now stated positively — which also still does
the original job, since an explicit value cannot be an inherited instance home.

## The review findings, fixed

An independent review of the first draft returned eleven findings. Seven were real:

1. **The "already the staged version" shortcut accepted an uncommandable launcher and then recorded
   it.** It tested "alive", not "witnessed", and wrote the version into the installed manifest — so
   the record agreed with the binary and the pass reported nothing to do for ever. The test that
   enshrined this now forbids it.
2. **The witness accepted a surface that could not be observed**, which let a live registration
   alone pass on Unix — liveness-only proof, reintroduced on the platform nobody watches. Refused;
   and where the surface cannot be observed, nothing is swapped at all and the reason is named.
3. **The no-orphan check was diagnostic, not an invariant.** A failed check still returned `Applied`
   with a longer message. It is its own decision now.
4. **The two update owners were uncoordinated** and each stops the other's process. They now take
   one machine-wide lock, never blocking, the same shape as the tool reconcile's. What it cannot
   cover — a launcher too old to take it — is stated where the lock is defined.
5. **An earlier failure in the same `try` skipped the launcher pass**, so a network timeout stranded
   a launcher build that was already downloaded and needed no network. It has its own `try`.
6. **The process list dropped a launcher it could not read**, which reads downstream as "not ours"
   and then as "nothing to stop". Unreadable is now undecidable, and that decision is separated so
   it can be driven with a known-bad input.
7. **The tree-kill guard was a source scan for one spelling in one file.** The kill moved into its
   own type, so the guard now asserts a complete absence for the swap's file.

The four weaker findings were also addressed: the limit of what a listener proves is stated rather
than traded for a destructive probe; the rollback now asserts what the machine actually is
afterwards rather than implying it returned to health; and the two paths the witness hard-coded come
from `InstallLayout`.

## The second review round

A fix round is new writing, so the fix round was reviewed as hard as the first draft. Eight more
findings came back and all eight are addressed. Three mattered:

- **The rig could delete a directory it did not own.** It decided what it could delete with a
  deny-list: an uncanonicalized string compare against one default path. A trailing-dot form of the
  real root passes that compare and resolves to the real root; so does an ancestor, a child, or any
  installation not at the default path. It is an allow-list now: a canonical path, inside the scratch
  parent, carrying the rig's marker, which either does not exist or carries the sentinel the rig
  wrote. Anything it cannot classify survives.
- **A third route swaps the same binary.** The launcher's detached self-update helper calls the same
  apply directly and did not take the lock, so two swaps could overlap on one target - the second
  deleting the first's real backup, and a failed health check then "rolling back" to the bad build.
  It takes the lock now, and waits rather than skipping, because it exists to perform exactly one
  swap and has no next cycle to return on.
- **Witnessed does not mean installed.** A witness says a launcher is registered, alive and
  commandable, not that the installed binary is that version - any launcher can write the
  registration. The process the witness saw must now be the one running from the install directory,
  or nothing is recorded.

Also: the unreadable-process rule was too broad in one direction (one other signed-in user's launcher
would have wedged this user's updates for ever) and too narrow in another (a null main module still
failed open); it is a pure function driven by tests now. The lock-name override is internal rather
than a public knob. The rig builds its driver from the current tree every run, keys its launcher
builds to the tree's identity, and names its output and verdict per run, so it cannot pass against
stale binaries or read a concurrent run's verdict.

## Testing

- The default local gate is green.
- The parked run: Core.Tests green (4388 passed). Gateway.Tests had ONE failure out of 2364 on a run
  that predates this second round; it is being re-run and judged against the parent, and the result
  will be posted on this pull request before it merges.
- **Every new assertion was checked by mutation, reconciled both ways:** each new test dies to the
  defect it names, and each defect kills the test that names it. No survivors.
