### PR TITLE
A restart can be asked to happen only if the Director is empty, and the refusal says how many sessions are live

### DIFF
--- a/src/CcDirector.Gateway.Contracts/LauncherCommandMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/LauncherCommandMessages.cs
@@ -13,7 +13,9 @@ namespace CcDirector.Gateway.Contracts;
 /// Verbs fall into two families:
 ///
 ///   * ACTION verbs, which change something on the machine and answer only with success or failure:
-///     "director/start", "director/stop", "director/restart", "launch".
+///     "director/start", "director/stop", "director/restart", "launch". One of them can also answer with a
+///     REFUSAL: a "director/restart" carrying <see cref="LauncherCommand.OnlyIfEmpty"/> declines while the
+///     Director still holds live sessions, and says how many.
 ///   * QUERY verbs, which change nothing and answer WITH DATA carried in
 ///     <see cref="LauncherCommandResult.Payload"/>: "apps" (the installed application catalogue) and
 ///     "files" (a filename search across the machine's drives).
@@ -31,6 +33,26 @@ public sealed class LauncherCommand
 
     /// <summary>Optional workspace/context hint for a launch, reserved for future verbs. Unused by the current verbs.</summary>
     public string? Workspace { get; set; }
+
+    /// <summary>
+    /// For "director/restart": restart ONLY when the Director is holding no live sessions, and REFUSE
+    /// otherwise - with a refusal that says how many sessions are live.
+    ///
+    /// THIS IS THE MECHANICAL HALF OF "NEVER FORCE". A drain empties a Director one session at a time,
+    /// and a restart that lands in the middle of one takes the remaining sessions with it. The rule
+    /// against that used to live in a written instruction, and an instruction cannot stop a mistake -
+    /// this flag can, because the launcher itself reads the count and declines.
+    ///
+    /// A LAUNCHER THAT PREDATES THIS FLAG IGNORES IT AND RESTARTS ANYWAY, which is exactly the failure
+    /// this exists to prevent, so an answer must never be read as a guarantee just because it says OK.
+    /// A launcher that HONOURED the flag says so in <see cref="LauncherCommandResult.Payload"/> - it
+    /// carries "onlyIfEmpty":true and the session count it read. An OK with no payload came from a
+    /// launcher that did not understand the request; update that machine's launcher.
+    ///
+    /// Ignored by every other verb, and the Gateway relay refuses to send it with one rather than
+    /// letting it look honoured.
+    /// </summary>
+    public bool OnlyIfEmpty { get; set; }
 
     /// <summary>For "launch": the absolute path to the executable. For lifecycle verbs: the target Director exe (informational).</summary>
     public string? Path { get; set; }
@@ -76,6 +98,20 @@ public enum LauncherCommandStatus
     Ok = 0,
     BadRequest = 1,
     Error = 2,
+
+    /// <summary>
+    /// The launcher understood the command perfectly, was able to run it, and DECIDED NOT TO because a
+    /// condition the caller attached was not met - today, "restart only if the Director is empty" against
+    /// a Director that is holding live sessions.
+    ///
+    /// It is its own outcome because the other two would both lie about it. <see cref="BadRequest"/> says
+    /// the caller asked for something malformed, and would send them to fix a request that was correct;
+    /// <see cref="Error"/> says the launcher broke, and would send them to look for a fault on a machine
+    /// that is working exactly as asked. A refusal is a NORMAL, EXPECTED answer with an action attached -
+    /// drain the Director, then ask again - and <see cref="LauncherCommandResult.Error"/> carries the
+    /// reason, including the live session count.
+    /// </summary>
+    Refused = 3,
 }
 
 /// <summary>
@@ -115,4 +151,13 @@ public sealed class LauncherCommandResult
     /// <summary>Build a failure result with the given status and message.</summary>
     public static LauncherCommandResult Fail(LauncherCommandStatus status, string error) =>
         new() { Status = status, Error = error };
+
+    /// <summary>
+    /// Build a REFUSAL: the launcher could have done it and chose not to, because a condition the caller
+    /// attached was not met. <paramref name="reason"/> must say what the condition was and what was
+    /// actually observed - "3 live sessions", never a bare "refused" - because the reader's next move
+    /// depends entirely on the number.
+    /// </summary>
+    public static LauncherCommandResult Refuse(string reason) =>
+        new() { Status = LauncherCommandStatus.Refused, Error = reason };
 }

--- a/src/CcDirector.Gateway.Contracts/LauncherCommandMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/LauncherCommandMessages.cs
@@ -49,8 +49,10 @@ public sealed class LauncherCommand
     /// carries "onlyIfEmpty":true and the session count it read. An OK with no payload came from a
     /// launcher that did not understand the request; update that machine's launcher.
     ///
-    /// Ignored by every other verb, and the Gateway relay refuses to send it with one rather than
-    /// letting it look honoured.
+    /// No other verb can honour it, and both ends refuse it rather than letting it look honoured: the
+    /// Gateway's machine route answers 400 before anything is sent, and the launcher answers 400 if a
+    /// command carrying it arrives on any verb but this one. The relay in between does NOT check - it
+    /// carries what it is given - so the launcher's refusal is the one that covers every caller.
     /// </summary>
     public bool OnlyIfEmpty { get; set; }
 
@@ -127,8 +129,11 @@ public sealed class LauncherCommandResult
     public string? Error { get; set; }
 
     /// <summary>
-    /// The answer to a QUERY verb, already serialised as JavaScript Object Notation by the launcher; null for
-    /// the action verbs, which have nothing to say beyond success or failure.
+    /// The answer to a QUERY verb, already serialised as JavaScript Object Notation by the launcher - and
+    /// null for the action verbs, which have nothing to say beyond success or failure, with ONE exception:
+    /// a restart carrying <see cref="LauncherCommand.OnlyIfEmpty"/> answers with the condition it applied
+    /// and the count it read, because a caller that asked for a guarantee has to be able to tell that
+    /// answer from an older launcher's bare success.
     ///
     /// It is carried as text rather than as a typed object on purpose. The launcher and the Gateway are
     /// upgraded separately, and a launcher that is a version ahead may answer with fields this Gateway has

--- a/src/CcDirector.Gateway.Tests/MachineRelaySlotGuardTests.cs
+++ b/src/CcDirector.Gateway.Tests/MachineRelaySlotGuardTests.cs
@@ -125,6 +125,41 @@ public sealed class MachineRelaySlotGuardTests : IAsyncLifetime
     }
 
     // -------------------------------------------------------------------------
+    // onlyIfEmpty belongs to restart, and is REFUSED elsewhere rather than ignored
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// A caller sending onlyIfEmpty to stop is asking not to interrupt live work. Dropping the flag and
+    /// stopping the Director anyway would answer that request with the exact outcome it was trying to
+    /// prevent - and report success. So it is a 400 that says the flag was not applied and nothing was
+    /// done.
+    /// </summary>
+    [Theory]
+    [InlineData("director/stop")]
+    [InlineData("director/start")]
+    public async Task OnlyIfEmpty_OnAnythingButRestart_IsRefusedRatherThanIgnored(string verb)
+    {
+        var resp = await _http.PostAsJsonAsync($"machines/{Machine}/{verb}", new { onlyIfEmpty = true });
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("only_if_empty_not_supported", body);
+    }
+
+    /// <summary>
+    /// And on restart it passes: the request reaches dispatch, which here ends in the not-connected 502
+    /// because this rig registers a launcher that holds no stream. A 400 would mean the flag never got
+    /// past the route at all.
+    /// </summary>
+    [Fact]
+    public async Task OnlyIfEmpty_OnRestart_ReachesDispatch()
+    {
+        var resp = await _http.PostAsJsonAsync($"machines/{Machine}/director/restart", new { onlyIfEmpty = true });
+
+        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/src/CcDirector.Gateway.Tests/RestartOnlyIfEmptyRouteTests.cs
+++ b/src/CcDirector.Gateway.Tests/RestartOnlyIfEmptyRouteTests.cs
@@ -272,6 +272,22 @@ public sealed class RestartOnlyIfEmptyRouteTests : IAsyncLifetime
             "a body with no declared length was treated as no body, and the guard was dropped.");
     }
 
+    /// <summary>
+    /// The neighbouring fields keep behaving as they always have. exePath that is not a string has always
+    /// been ignored, and it must not become a fault now that the body is parsed strictly - reading it with
+    /// no catch-everything around it is exactly how a route starts answering 500 to a request it used to
+    /// shrug at.
+    /// </summary>
+    [Fact]
+    public async Task AnExePathThatIsNotAString_IsIgnored_NotAFault()
+    {
+        var resp = await _http.PostAsync($"machines/{Machine}/director/restart",
+            new StringContent("{\"exePath\":123,\"onlyIfEmpty\":true}", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.True(Assert.Single(Received()).OnlyIfEmpty);
+    }
+
     [Fact]
     public async Task ABodyThatWillNotParse_IsRefused_AndNothingReachesTheLauncher()
     {

--- a/src/CcDirector.Gateway.Tests/RestartOnlyIfEmptyRouteTests.cs
+++ b/src/CcDirector.Gateway.Tests/RestartOnlyIfEmptyRouteTests.cs
@@ -285,7 +285,15 @@ public sealed class RestartOnlyIfEmptyRouteTests : IAsyncLifetime
             new StringContent("{\"exePath\":123,\"onlyIfEmpty\":true}", Encoding.UTF8, "application/json"));
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
-        Assert.True(Assert.Single(Received()).OnlyIfEmpty);
+
+        var command = Assert.Single(Received());
+        Assert.True(command.OnlyIfEmpty);
+
+        // IGNORED MEANS IGNORED, and this is the half that says so. Asserting only that the request
+        // succeeded would pass just as well against a route that converted 123 to a path and forwarded
+        // it - which is a different defect wearing this test's green tick, and a reviewer caught the
+        // assertion missing.
+        Assert.Null(command.Path);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/RestartOnlyIfEmptyRouteTests.cs
+++ b/src/CcDirector.Gateway.Tests/RestartOnlyIfEmptyRouteTests.cs
@@ -1,0 +1,294 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The whole road a guarded restart travels: an HTTP body on POST /machines/{machine}/director/restart,
+/// through the relay, down the launcher's own stream, and back again with the launcher's answer.
+///
+/// WHY IT IS TESTED AT THIS LEVEL AND NOT ONLY IN PIECES. The relay tests prove the relay copies the flag
+/// onto the command, and the launcher tests prove the launcher's guard refuses a busy Director. Neither
+/// can see the seam between them: a route that parses "onlyIfEmpty" and then forwards a hard-coded false
+/// passes every one of those tests while silently restarting Directors mid-drain. An adversarial review
+/// named exactly that mutation as one nothing would catch, so the stub launcher here records the command
+/// it actually received and the assertions read it.
+///
+/// The stub is a REAL SignalR client on /launcher-stream, because since the remove-the-network-port
+/// mission that is the only way a command reaches a launcher at all.
+/// </summary>
+public sealed class RestartOnlyIfEmptyRouteTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string Machine = "ONLY-IF-EMPTY-MACHINE";
+
+    private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private HubConnection? _launcher;
+    private readonly List<LauncherCommand> _received = new();
+
+    /// <summary>How many sessions the stub launcher's Director is holding.</summary>
+    private int _liveSessions;
+
+    /// <summary>Whether the stub launcher understands onlyIfEmpty at all. False stands in for a launcher
+    /// older than the flag: it ignores the condition, restarts anyway, and answers a bare success.</summary>
+    private bool _launcherHonoursTheFlag = true;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-only-if-empty-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: GatewayHost.OperatingSystemAssignedPort, token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        var conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/launcher-stream",
+                options => options.AccessTokenProvider = () => Task.FromResult<string?>(Token))
+            .Build();
+
+        conn.On<LauncherCommand, LauncherCommandResult>("Command", cmd =>
+        {
+            lock (_received) _received.Add(cmd);
+            return Task.FromResult(Answer(cmd));
+        });
+
+        await conn.StartAsync();
+        await conn.InvokeAsync("Hello", new LauncherStreamHello { MachineName = Machine, Version = "9.9.9" });
+        _launcher = conn;
+
+        // The presence row the real launcher's registration client posts alongside its stream.
+        _gateway.Launchers.Upsert(TenantId.Local, new LauncherRegistrationRequest
+        {
+            MachineName = Machine,
+            Pid = 4242,
+            Version = "9.9.9",
+        });
+    }
+
+    /// <summary>What the stub launcher answers - the real launcher's behaviour, in miniature.</summary>
+    private LauncherCommandResult Answer(LauncherCommand cmd)
+    {
+        if (cmd.Verb != "director/restart")
+            return LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, $"unexpected verb: {cmd.Verb}");
+
+        // A launcher older than the flag cannot see it. It restarts and says so, and says nothing about a
+        // condition it has never heard of.
+        if (!_launcherHonoursTheFlag)
+            return LauncherCommandResult.Ok();
+
+        if (cmd.OnlyIfEmpty && _liveSessions > 0)
+            return LauncherCommandResult.Refuse(
+                $"refusing to restart the Director on {Machine}: it is holding {_liveSessions} live "
+                + "sessions. Drain it first - every session writes a handover and is closed - then ask again.");
+
+        return cmd.OnlyIfEmpty
+            ? LauncherCommandResult.OkWithPayload(JsonSerializer.Serialize(
+                new { ok = true, restarted = true, onlyIfEmpty = true, sessions = 0 }, WebJson))
+            : LauncherCommandResult.Ok();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_launcher is not null) await _launcher.DisposeAsync();
+        _http.Dispose();
+        await _gateway.StopAsync();
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { }
+    }
+
+    private LauncherCommand[] Received()
+    {
+        lock (_received) return _received.ToArray();
+    }
+
+    // =========================================================================================
+    // The flag reaches the launcher
+    // =========================================================================================
+
+    [Fact]
+    public async Task OnlyIfEmpty_InTheBody_ReachesTheLauncherAsTheFlagOnTheCommand()
+    {
+        var resp = await _http.PostAsJsonAsync($"machines/{Machine}/director/restart", new { onlyIfEmpty = true });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var command = Assert.Single(Received());
+        Assert.Equal("director/restart", command.Verb);
+        Assert.True(command.OnlyIfEmpty,
+            "the caller asked for a restart only if the Director was empty and the launcher was sent an "
+            + "ordinary restart. Every other test in this feature would still pass.");
+    }
+
+    [Fact]
+    public async Task AnOrdinaryRestart_SendsTheFlagOff_AndKeepsTheAnswerItAlwaysHad()
+    {
+        var resp = await _http.PostAsync($"machines/{Machine}/director/restart", null);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.False(Assert.Single(Received()).OnlyIfEmpty);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("via", body);
+        Assert.Contains("stream", body);
+    }
+
+    // =========================================================================================
+    // The refusal, with its count, reaches the caller
+    // =========================================================================================
+
+    [Fact]
+    public async Task ABusyDirector_AnswersTheCallerWith409_AndTheLiveSessionCount()
+    {
+        _liveSessions = 3;
+
+        var resp = await _http.PostAsJsonAsync($"machines/{Machine}/director/restart", new { onlyIfEmpty = true });
+
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("3 live sessions", body);
+    }
+
+    // =========================================================================================
+    // A launcher that cannot honour the condition must not be reported as having honoured it
+    // =========================================================================================
+
+    [Fact]
+    public async Task ALauncherThatIgnoresTheFlag_IsReportedAsAFailure_NotAsAGuardedRestart()
+    {
+        _launcherHonoursTheFlag = false;
+
+        var resp = await _http.PostAsJsonAsync($"machines/{Machine}/director/restart", new { onlyIfEmpty = true });
+
+        // The command WAS carried out by that launcher - there is no taking it back - so the honest answer
+        // is a failure that says the condition was not applied, never a success.
+        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("launcher-did-not-honour-only-if-empty", body);
+    }
+
+    // =========================================================================================
+    // A flag that cannot be understood is refused before anything is done
+    // =========================================================================================
+
+    [Theory]
+    [InlineData("{\"onlyIfEmpty\":\"true\"}")]   // a string, not a boolean
+    [InlineData("{\"onlyIfEmpty\":1}")]           // a number
+    [InlineData("{\"onlyIfEmpty\":null}")]        // explicitly nothing
+    public async Task ANonBooleanFlag_IsRefused_AndNothingReachesTheLauncher(string json)
+    {
+        var resp = await _http.PostAsync($"machines/{Machine}/director/restart",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("only_if_empty_not_supported", await resp.Content.ReadAsStringAsync());
+
+        // The point of refusing is that nothing happened. A 400 that had already restarted the machine
+        // would be the worst of both answers.
+        Assert.Empty(Received());
+    }
+
+    /// <summary>
+    /// A caller who capitalises the flag is unmistakably asking for the guard. A case-sensitive lookup
+    /// answered that request with an unconditional restart and a success, which is the same fail-open as
+    /// a non-boolean value and was found by the same review.
+    /// </summary>
+    [Theory]
+    [InlineData("{\"OnlyIfEmpty\":true}")]
+    [InlineData("{\"onlyifempty\":true}")]
+    public async Task TheFlagIsRecognisedWhateverItsCasing(string json)
+    {
+        var resp = await _http.PostAsync($"machines/{Machine}/director/restart",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.True(Assert.Single(Received()).OnlyIfEmpty,
+            "a differently-cased onlyIfEmpty was read as absent and became an unconditional restart.");
+    }
+
+    [Fact]
+    public async Task TheFlagSpelledTwice_IsRefused_BecauseNobodyCanSayWhichOneWasMeant()
+    {
+        var resp = await _http.PostAsync($"machines/{Machine}/director/restart",
+            new StringContent("{\"onlyIfEmpty\":true,\"OnlyIfEmpty\":false}", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("only_if_empty_not_supported", await resp.Content.ReadAsStringAsync());
+        Assert.Empty(Received());
+    }
+
+    /// <summary>
+    /// An EMPTY body is not a malformed one. Callers have always been allowed to send nothing here, and
+    /// some of them label the nothing as JavaScript Object Notation; refusing those would break a caller
+    /// that is doing nothing wrong.
+    /// </summary>
+    [Fact]
+    public async Task AnEmptyBodyLabelledAsJson_IsStillAnOrdinaryRestart()
+    {
+        var resp = await _http.PostAsync($"machines/{Machine}/director/restart",
+            new StringContent("", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.False(Assert.Single(Received()).OnlyIfEmpty);
+    }
+
+    /// <summary>
+    /// A body sent without a declared length - what a streamed or chunked request looks like - carries the
+    /// flag just as well, and the route used to decide there was no body at all and restart regardless.
+    /// </summary>
+    [Fact]
+    public async Task AFlagInABodyWithNoDeclaredLength_StillReachesTheLauncher()
+    {
+        var bytes = Encoding.UTF8.GetBytes("{\"onlyIfEmpty\":true}");
+        var content = new StreamContent(new MemoryStream(bytes));
+        content.Headers.ContentType = new MediaTypeHeaderValue("text/plain"); // not JSON, and no length
+        content.Headers.ContentLength = null;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"machines/{Machine}/director/restart")
+        {
+            Content = content,
+        };
+        request.Headers.TransferEncodingChunked = true;
+
+        var resp = await _http.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.True(Assert.Single(Received()).OnlyIfEmpty,
+            "a body with no declared length was treated as no body, and the guard was dropped.");
+    }
+
+    [Fact]
+    public async Task ABodyThatWillNotParse_IsRefused_AndNothingReachesTheLauncher()
+    {
+        var resp = await _http.PostAsync($"machines/{Machine}/director/restart",
+            new StringContent("{ this is not json", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.Contains("bad_request_body", await resp.Content.ReadAsStringAsync());
+        Assert.Empty(Received());
+    }
+
+    [Fact]
+    public async Task OnlyIfEmptyFalse_IsAnOrdinaryRestart_NotARefusal()
+    {
+        var resp = await _http.PostAsJsonAsync($"machines/{Machine}/director/restart", new { onlyIfEmpty = false });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.False(Assert.Single(Received()).OnlyIfEmpty);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/RestartOnlyIfEmptyRelayTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/RestartOnlyIfEmptyRelayTests.cs
@@ -149,6 +149,30 @@ public sealed class RestartOnlyIfEmptyRelayTests
         Assert.Contains("launcher-did-not-honour-only-if-empty", outcome.Payload);
     }
 
+    /// <summary>
+    /// AN ANSWER THAT SAYS A THING TWICE HAS NOT SAID IT. Reading a field with TryGetProperty quietly
+    /// takes the LAST occurrence, so an acknowledgement stating the condition both unapplied and applied
+    /// was resolving to the permissive one and being accepted as proof the guard ran. An independent
+    /// review found it; the request side of this feature already refused a doubly-spelled flag, and this
+    /// is that rule carried to the reply, where it was missing.
+    /// </summary>
+    [Theory]
+    [InlineData("""{"onlyIfEmpty":false,"onlyIfEmpty":true,"restarted":true,"sessions":0}""")]
+    [InlineData("""{"onlyIfEmpty":true,"restarted":false,"restarted":true,"sessions":0}""")]
+    [InlineData("""{"onlyIfEmpty":true,"restarted":true,"sessions":3,"sessions":0}""")]
+    public async Task SendDirectorVerbAsync_AnAcknowledgementThatStatesAFieldTwice_IsNotAccepted(string payload)
+    {
+        LauncherCommandRouter.SendLauncherCommandAsync contradictory = (_, _, _, _) =>
+            Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.OkWithPayload(payload));
+
+        var outcome = await LauncherLifecycleRelay.SendDirectorVerbAsync(TenantId.Local, Machine, "restart",
+            exePath: null, confirmProtected: false, new LauncherRegistry(), contradictory,
+            CancellationToken.None, onlyIfEmpty: true);
+
+        Assert.Equal(502, outcome.RelayStatus);
+        Assert.Contains("launcher-did-not-honour-only-if-empty", outcome.Payload);
+    }
+
     /// <summary>A launcher that adds fields of its own is still understood - the check requires what it
     /// needs and tolerates what it does not, so a newer launcher is not refused for being newer.</summary>
     [Fact]

--- a/src/CcDirector.Gateway.UnitTests/RestartOnlyIfEmptyRelayTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/RestartOnlyIfEmptyRelayTests.cs
@@ -128,6 +128,11 @@ public sealed class RestartOnlyIfEmptyRelayTests
     [Theory]
     [InlineData("""{"ok":true,"restarted":true,"onlyIfEmpty":true,"sessions":3}""")]
     [InlineData("""{"ok":true,"restarted":false,"onlyIfEmpty":true,"sessions":0}""")]
+    // The launcher saying plainly that it did NOT apply the condition. Everything else about this answer
+    // is in order, which is what makes it dangerous: a check that counted the field instead of reading it
+    // accepted this as a guarantee. A mutation audit found it surviving.
+    [InlineData("""{"ok":true,"restarted":true,"onlyIfEmpty":false,"sessions":0}""")]
+    [InlineData("""{"ok":true,"restarted":true,"onlyIfEmpty":"yes","sessions":0}""")]
     [InlineData("""{"onlyIfEmpty":true}""")]
     [InlineData("""{"ok":true,"restarted":true,"onlyIfEmpty":true,"sessions":"none"}""")]
     [InlineData("not json at all")]

--- a/src/CcDirector.Gateway.UnitTests/RestartOnlyIfEmptyRelayTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/RestartOnlyIfEmptyRelayTests.cs
@@ -1,0 +1,198 @@
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Gateway half of "restart only if the Director is empty": the flag has to REACH the launcher, and
+/// the launcher's refusal has to reach the caller with the session count still in it.
+///
+/// BOTH HALVES CAN FAIL SILENTLY, which is why they are pinned here. A flag that is parsed from the
+/// request body and then never copied onto the command produces a perfectly successful restart of a busy
+/// Director, and every other test in the suite stays green. A refusal that is folded into the generic 502
+/// tells the reader their machine is broken and sends them to look for a fault instead of finishing their
+/// drain.
+/// </summary>
+public sealed class RestartOnlyIfEmptyRelayTests
+{
+    private const string Machine = "RESTART-GUARD-MACHINE";
+
+    /// <summary>The refusal a launcher sends back, in the shape the launcher really writes it: naming the
+    /// count, because the count is what tells the reader what to do next.</summary>
+    private const string LauncherRefusal =
+        "refusing to restart the Director 1111-2222 (pid 4242) on SOME-MACHINE: it is holding 3 live "
+        + "sessions. Drain it first - every session writes a handover and is closed - then ask again.";
+
+    [Fact]
+    public async Task SendDirectorVerbAsync_Restart_CarriesOnlyIfEmptyDownTheStream()
+    {
+        LauncherCommand? sent = null;
+        LauncherCommandRouter.SendLauncherCommandAsync capture = (_, _, cmd, _) =>
+        {
+            sent = cmd;
+            return Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.Ok());
+        };
+
+        await LauncherLifecycleRelay.SendDirectorVerbAsync(TenantId.Local, Machine, "restart", exePath: null,
+            confirmProtected: false, new LauncherRegistry(), capture, CancellationToken.None, onlyIfEmpty: true);
+
+        Assert.NotNull(sent);
+        Assert.Equal("director/restart", sent!.Verb);
+        Assert.True(sent.OnlyIfEmpty,
+            "the caller asked for a restart only if the Director is empty and the launcher was sent an "
+            + "ordinary restart - which would restart a Director in the middle of its drain.");
+    }
+
+    [Fact]
+    public async Task SendDirectorVerbAsync_WithoutTheFlag_SendsAnOrdinaryRestart()
+    {
+        LauncherCommand? sent = null;
+        LauncherCommandRouter.SendLauncherCommandAsync capture = (_, _, cmd, _) =>
+        {
+            sent = cmd;
+            return Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.Ok());
+        };
+
+        await LauncherLifecycleRelay.SendDirectorVerbAsync(TenantId.Local, Machine, "restart", exePath: null,
+            confirmProtected: false, new LauncherRegistry(), capture, CancellationToken.None);
+
+        Assert.NotNull(sent);
+        Assert.False(sent!.OnlyIfEmpty);
+    }
+
+    [Fact]
+    public async Task SendDirectorVerbAsync_ALauncherRefusalBecomes409_AndCarriesTheCount()
+    {
+        LauncherCommandRouter.SendLauncherCommandAsync refuse = (_, _, _, _) =>
+            Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.Refuse(LauncherRefusal));
+
+        var outcome = await LauncherLifecycleRelay.SendDirectorVerbAsync(TenantId.Local, Machine, "restart",
+            exePath: null, confirmProtected: false, new LauncherRegistry(), refuse, CancellationToken.None,
+            onlyIfEmpty: true);
+
+        // The launcher answered, so this is a relayed answer rather than an undeliverable command.
+        Assert.Equal(LauncherLifecycleRelay.RelayOutcomeKind.Relayed, outcome.Kind);
+
+        // 409, not 502: the machine is not broken, it is busy. A 502 would send the reader hunting a fault.
+        Assert.Equal(409, outcome.RelayStatus);
+        Assert.False(outcome.Accepted);
+
+        // And the count survives the hop. This is the whole point of the refusal.
+        Assert.Contains("3 live sessions", outcome.Payload);
+    }
+
+    [Fact]
+    public async Task SendDirectorVerbAsync_AGuardedRestartsOwnAnswerIsPassedThroughIntact()
+    {
+        // What the launcher writes when it HONOURED the flag. A caller reads it to tell this apart from an
+        // older launcher that ignored the flag and answered a bare OK.
+        const string guarded = """{"ok":true,"restarted":true,"onlyIfEmpty":true,"sessions":0}""";
+        LauncherCommandRouter.SendLauncherCommandAsync ok = (_, _, _, _) =>
+            Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.OkWithPayload(guarded));
+
+        var outcome = await LauncherLifecycleRelay.SendDirectorVerbAsync(TenantId.Local, Machine, "restart",
+            exePath: null, confirmProtected: false, new LauncherRegistry(), ok, CancellationToken.None,
+            onlyIfEmpty: true);
+
+        Assert.Equal(200, outcome.RelayStatus);
+        Assert.Equal(guarded, outcome.Payload);
+    }
+
+    [Fact]
+    public async Task SendDirectorVerbAsync_AGuardedRestartAnsweredWithABareOk_IsReportedAsAFailure()
+    {
+        // A launcher older than the flag: it cannot see the condition, restarts the Director whatever it
+        // was holding, and answers exactly as a healthy launcher answers an ordinary restart. Reporting
+        // that as a guarded restart would be the fail-open the whole feature exists to close.
+        LauncherCommandRouter.SendLauncherCommandAsync oldLauncher = (_, _, _, _) =>
+            Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.Ok());
+
+        var outcome = await LauncherLifecycleRelay.SendDirectorVerbAsync(TenantId.Local, Machine, "restart",
+            exePath: null, confirmProtected: false, new LauncherRegistry(), oldLauncher, CancellationToken.None,
+            onlyIfEmpty: true);
+
+        Assert.Equal(502, outcome.RelayStatus);
+        Assert.False(outcome.Accepted);
+        Assert.Contains("launcher-did-not-honour-only-if-empty", outcome.Payload);
+    }
+
+    /// <summary>
+    /// An acknowledgement is READ, not counted. Each of these answers contradicts itself - the condition
+    /// was applied and yet three sessions were live, or it was applied and nothing was restarted - and
+    /// each is the shape a half-finished implementation on the other side produces. An earlier version of
+    /// this check asked only whether the flag had been echoed back, and passed every one of them.
+    /// </summary>
+    [Theory]
+    [InlineData("""{"ok":true,"restarted":true,"onlyIfEmpty":true,"sessions":3}""")]
+    [InlineData("""{"ok":true,"restarted":false,"onlyIfEmpty":true,"sessions":0}""")]
+    [InlineData("""{"onlyIfEmpty":true}""")]
+    [InlineData("""{"ok":true,"restarted":true,"onlyIfEmpty":true,"sessions":"none"}""")]
+    [InlineData("not json at all")]
+    public async Task SendDirectorVerbAsync_AnAcknowledgementThatDoesNotHoldTogether_IsAFailure(string payload)
+    {
+        LauncherCommandRouter.SendLauncherCommandAsync half = (_, _, _, _) =>
+            Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.OkWithPayload(payload));
+
+        var outcome = await LauncherLifecycleRelay.SendDirectorVerbAsync(TenantId.Local, Machine, "restart",
+            exePath: null, confirmProtected: false, new LauncherRegistry(), half, CancellationToken.None,
+            onlyIfEmpty: true);
+
+        Assert.Equal(502, outcome.RelayStatus);
+        Assert.Contains("launcher-did-not-honour-only-if-empty", outcome.Payload);
+    }
+
+    /// <summary>A launcher that adds fields of its own is still understood - the check requires what it
+    /// needs and tolerates what it does not, so a newer launcher is not refused for being newer.</summary>
+    [Fact]
+    public async Task SendDirectorVerbAsync_AnAcknowledgementWithExtraFields_IsStillAccepted()
+    {
+        const string richer =
+            """{"ok":true,"restarted":true,"onlyIfEmpty":true,"sessions":0,"startedPid":4242,"tookMs":812}""";
+        LauncherCommandRouter.SendLauncherCommandAsync newer = (_, _, _, _) =>
+            Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.OkWithPayload(richer));
+
+        var outcome = await LauncherLifecycleRelay.SendDirectorVerbAsync(TenantId.Local, Machine, "restart",
+            exePath: null, confirmProtected: false, new LauncherRegistry(), newer, CancellationToken.None,
+            onlyIfEmpty: true);
+
+        Assert.Equal(200, outcome.RelayStatus);
+        Assert.Equal(richer, outcome.Payload);
+    }
+
+    [Fact]
+    public async Task SendDirectorVerbAsync_AnUnguardedVerbsPayload_DoesNotReplaceTheEnvelope()
+    {
+        // Nothing asked a conditional question here, so the answer stays the envelope every existing
+        // caller of start/stop/restart reads - even if some future launcher starts writing a payload of
+        // its own. A response shape that changes because the other side got chattier is a change nobody
+        // asked for.
+        LauncherCommandRouter.SendLauncherCommandAsync chatty = (_, _, _, _) =>
+            Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.OkWithPayload(
+                """{"somethingNew":true}"""));
+
+        var outcome = await LauncherLifecycleRelay.SendDirectorVerbAsync(TenantId.Local, Machine, "restart",
+            exePath: null, confirmProtected: false, new LauncherRegistry(), chatty, CancellationToken.None);
+
+        Assert.Equal(200, outcome.RelayStatus);
+        Assert.Contains("\"via\":\"stream\"", outcome.Payload);
+        Assert.DoesNotContain("somethingNew", outcome.Payload);
+    }
+
+    [Fact]
+    public async Task SendDirectorVerbAsync_AnActionVerbThatSaysNothing_StillAnswersOkViaStream()
+    {
+        // The unchanged shape, pinned: every action verb that writes no payload of its own still gets the
+        // synthesised one, so passing a launcher's payload through did not quietly rewrite start and stop.
+        LauncherCommandRouter.SendLauncherCommandAsync ok = (_, _, _, _) =>
+            Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.Ok());
+
+        var outcome = await LauncherLifecycleRelay.SendDirectorVerbAsync(TenantId.Local, Machine, "stop",
+            exePath: null, confirmProtected: false, new LauncherRegistry(), ok, CancellationToken.None);
+
+        Assert.Equal(200, outcome.RelayStatus);
+        Assert.Contains("\"via\":\"stream\"", outcome.Payload);
+    }
+}

--- a/src/CcDirector.Gateway/Api/LauncherLifecycleRelay.cs
+++ b/src/CcDirector.Gateway/Api/LauncherLifecycleRelay.cs
@@ -196,11 +196,11 @@ internal static class LauncherLifecycleRelay
             using var doc = System.Text.Json.JsonDocument.Parse(payload);
             var root = doc.RootElement;
             return root.ValueKind == System.Text.Json.JsonValueKind.Object
-                   && root.TryGetProperty("onlyIfEmpty", out var applied)
+                   && StatedOnce(root, "onlyIfEmpty", out var applied)
                    && applied.ValueKind == System.Text.Json.JsonValueKind.True
-                   && root.TryGetProperty("restarted", out var restarted)
+                   && StatedOnce(root, "restarted", out var restarted)
                    && restarted.ValueKind == System.Text.Json.JsonValueKind.True
-                   && root.TryGetProperty("sessions", out var sessions)
+                   && StatedOnce(root, "sessions", out var sessions)
                    && sessions.ValueKind == System.Text.Json.JsonValueKind.Number
                    && sessions.TryGetInt32(out var count)
                    && count == 0;
@@ -209,6 +209,40 @@ internal static class LauncherLifecycleRelay
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Read a field that the answer must state EXACTLY ONCE. False when it is absent, and false when it
+    /// is stated more than once.
+    ///
+    /// A DOCUMENT MAY SAY A THING TWICE, AND THEN IT HAS NOT SAID IT. TryGetProperty quietly returns the
+    /// LAST occurrence, so <c>{"onlyIfEmpty":false,"onlyIfEmpty":true,...}</c> - an answer that says both
+    /// that the condition was applied and that it was not - was being read as the permissive one and
+    /// accepted as proof the guard ran. That is the same shape as every other defect this change has
+    /// fixed: a state nobody can make sense of resolving to the agreeable reading.
+    ///
+    /// The REQUEST side of this feature already refuses a doubly-spelled flag, for exactly this reason.
+    /// This is that rule carried to the REPLY, which is where it was missing - fixing one side of a rule
+    /// and leaving the other is how a defect moves rather than closes.
+    /// </summary>
+    private static bool StatedOnce(System.Text.Json.JsonElement root, string name,
+        out System.Text.Json.JsonElement value)
+    {
+        value = default;
+        var found = false;
+        foreach (var property in root.EnumerateObject())
+        {
+            if (!property.NameEquals(name)) continue;
+            if (found)
+            {
+                FileLog.Write($"[LauncherLifecycleRelay] a launcher's acknowledgement states '{name}' more "
+                              + "than once, so what it claims cannot be established. Not accepted.");
+                return false;
+            }
+            value = property.Value;
+            found = true;
+        }
+        return found;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Api/LauncherLifecycleRelay.cs
+++ b/src/CcDirector.Gateway/Api/LauncherLifecycleRelay.cs
@@ -97,19 +97,119 @@ internal static class LauncherLifecycleRelay
     /// <paramref name="machine"/>. The slot guard is NOT applied here: it reads the caller's request body and
     /// so belongs to the HTTP route, which runs it before calling this.
     /// </summary>
-    public static Task<LauncherRelayOutcome> SendDirectorVerbAsync(
+    /// <param name="onlyIfEmpty">
+    /// Restart ONLY while the Director is holding no live sessions, and take the launcher's refusal - which
+    /// names the count - when it is holding some. Meaningful to "restart" alone; the HTTP route refuses to
+    /// send it with any other verb rather than letting a caller believe a stop was guarded.
+    /// </param>
+    public static async Task<LauncherRelayOutcome> SendDirectorVerbAsync(
         TenantId tenant, string machine, string verb, string? exePath, bool confirmProtected,
         LauncherRegistry launchers, LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand,
-        CancellationToken ct)
-        => SendAsync(
+        CancellationToken ct, bool onlyIfEmpty = false)
+    {
+        var outcome = await SendAsync(
             tenant, machine,
             new LauncherCommand
             {
                 Verb = $"director/{verb}",
                 Path = exePath,
                 ConfirmProtected = confirmProtected,
+                OnlyIfEmpty = onlyIfEmpty,
             },
-            isQuery: false, launchers, sendLauncherCommand, ct);
+            // Only a GUARDED restart has anything of its own to say; every other lifecycle verb's news is
+            // whether it worked, and its answer stays the envelope every existing caller reads.
+            passLauncherPayloadThrough: onlyIfEmpty,
+            launchers, sendLauncherCommand, ct);
+
+        return onlyIfEmpty ? RequireTheGuardWasHonoured(machine, outcome) : outcome;
+    }
+
+    /// <summary>
+    /// A SUCCESS TO A GUARDED RESTART IS ONLY BELIEVED WHEN THE LAUNCHER SAYS IT GUARDED IT.
+    ///
+    /// This is the fail-open the whole feature would otherwise have. A launcher built before
+    /// <see cref="LauncherCommand.OnlyIfEmpty"/> existed deserialises the command, cannot see a field it
+    /// has never heard of, restarts a Director holding live sessions, and answers a perfectly ordinary
+    /// OK. Nothing about that answer is distinguishable from a launcher that read the count and found
+    /// zero - unless the honouring launcher SAYS SO, which it does, in the payload it writes.
+    ///
+    /// So an unacknowledged success becomes a loud failure naming the real cause and the real risk. It is
+    /// 502 rather than a refusal because nothing was refused: the command was carried out, by a launcher
+    /// that could not honour the condition attached to it, and the caller has to know that the Director
+    /// may have been restarted mid-drain. Telling them "done" would be a lie that costs sessions.
+    ///
+    /// THIS IS DETECTION, NOT PREVENTION, AND THE DIFFERENCE MATTERS. By the time the answer comes back
+    /// the old launcher has already restarted the Director; what this saves is every attempt after the
+    /// first, and the caller's belief that the first one was safe. Preventing it needs the launcher to
+    /// declare what it can honour when it joins the stream, so the Gateway can refuse BEFORE dispatch -
+    /// which is the capability work this epic has a separate phase for, and is deliberately not invented
+    /// here in a second, competing shape.
+    /// </summary>
+    private static LauncherRelayOutcome RequireTheGuardWasHonoured(string machine, LauncherRelayOutcome outcome)
+    {
+        if (outcome.Kind != RelayOutcomeKind.Relayed || outcome.RelayStatus is < 200 or >= 300)
+            return outcome; // not a success - it already says what happened
+
+        if (AcknowledgesTheGuard(outcome.Payload))
+            return outcome;
+
+        FileLog.Write($"[LauncherLifecycleRelay] director/restart on {machine}: a restart was asked to happen "
+                      + "ONLY IF the Director was empty, and the launcher answered success WITHOUT saying it "
+                      + "honoured that. Reported as a failure: the launcher is older than the condition.");
+        return outcome with
+        {
+            RelayStatus = 502,
+            Payload = System.Text.Json.JsonSerializer.Serialize(new
+            {
+                error = $"the launcher on '{machine}' accepted a restart that was to happen only if the "
+                      + "Director was empty, and answered success without confirming it applied that "
+                      + "condition. A launcher older than the condition ignores it silently, so this "
+                      + "restart may have taken live sessions with it. Update the launcher on that machine "
+                      + "before relying on a guarded restart there.",
+                machine,
+                verb = "restart",
+                reason = "launcher-did-not-honour-only-if-empty",
+                via = "stream",
+            }),
+        };
+    }
+
+    /// <summary>
+    /// Whether a launcher's answer states, in full, that it applied the only-if-empty condition: it read
+    /// the count, the count was ZERO, and it restarted the Director on that basis.
+    ///
+    /// ALL THREE ARE REQUIRED, and an earlier version of this check asked only for the first. A payload
+    /// saying <c>{"onlyIfEmpty":true,"sessions":3}</c> or <c>{"onlyIfEmpty":true,"restarted":false}</c>
+    /// would have passed it - answers that contradict themselves, and exactly the shape a half-finished
+    /// implementation on the other side produces. An acknowledgement that only echoes the flag back
+    /// acknowledges nothing.
+    ///
+    /// EXTRA FIELDS ARE FINE, so a newer launcher that adds to its answer still passes. A launcher that
+    /// RENAMES these fields fails closed, which is the right way round: this check exists to catch a
+    /// launcher whose answer we do not understand.
+    /// </summary>
+    private static bool AcknowledgesTheGuard(string? payload)
+    {
+        if (string.IsNullOrWhiteSpace(payload)) return false;
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(payload);
+            var root = doc.RootElement;
+            return root.ValueKind == System.Text.Json.JsonValueKind.Object
+                   && root.TryGetProperty("onlyIfEmpty", out var applied)
+                   && applied.ValueKind == System.Text.Json.JsonValueKind.True
+                   && root.TryGetProperty("restarted", out var restarted)
+                   && restarted.ValueKind == System.Text.Json.JsonValueKind.True
+                   && root.TryGetProperty("sessions", out var sessions)
+                   && sessions.ValueKind == System.Text.Json.JsonValueKind.Number
+                   && sessions.TryGetInt32(out var count)
+                   && count == 0;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return false;
+        }
+    }
 
     /// <summary>
     /// Run a generic launch on the CALLING TENANT's launcher for <paramref name="machine"/>.
@@ -129,16 +229,20 @@ internal static class LauncherLifecycleRelay
                 Cwd = body?.Cwd,
                 Headless = body?.Headless ?? false,
             },
-            isQuery: false, launchers, sendLauncherCommand, ct);
+            passLauncherPayloadThrough: false,
+            launchers, sendLauncherCommand, ct);
 
     /// <summary>
     /// Run a QUERY verb - "apps" or "files" - on the CALLING TENANT's launcher for <paramref name="machine"/>
     /// and return the launcher's answer.
     ///
-    /// It differs from the action verbs in the only way a question differs from an instruction: the
-    /// launcher's answer is carried back to the caller rather than reduced to whether it worked. Everything
-    /// else - tenant scoping, the failure outcomes - is the shared path, because a query that could reach a
-    /// machine the action verbs could not would be a second, weaker boundary.
+    /// It differs from the action verbs in the only way a question differs from an instruction: a query
+    /// ALWAYS has an answer to carry, and the HTTP route serves that document as the response body rather
+    /// than wrapping it in a relay envelope. (An action verb's payload is carried too, whenever the
+    /// launcher writes one - a guarded restart does - but it travels inside the envelope, because the news
+    /// there really is whether the machine did the thing.) Everything else - tenant scoping, the failure
+    /// outcomes - is the shared path, because a query that could reach a machine the action verbs could not
+    /// would be a second, weaker boundary.
     /// </summary>
     public static Task<LauncherRelayOutcome> SendQueryAsync(
         TenantId tenant, string machine, string verb, string? query, int limit, int timeoutMilliseconds,
@@ -153,7 +257,8 @@ internal static class LauncherLifecycleRelay
                 Limit = limit,
                 TimeoutMilliseconds = timeoutMilliseconds,
             },
-            isQuery: true, launchers, sendLauncherCommand, ct);
+            passLauncherPayloadThrough: true,
+            launchers, sendLauncherCommand, ct);
 
     /// <summary>
     /// The single-arm dispatch: push the command down the calling tenant's launcher stream. A null from the
@@ -162,7 +267,7 @@ internal static class LauncherLifecycleRelay
     /// "registered but not connected". Nothing is dialed in either case.
     /// </summary>
     private static async Task<LauncherRelayOutcome> SendAsync(
-        TenantId tenant, string machine, LauncherCommand streamCommand, bool isQuery,
+        TenantId tenant, string machine, LauncherCommand streamCommand, bool passLauncherPayloadThrough,
         LauncherRegistry launchers, LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand,
         CancellationToken ct)
     {
@@ -173,12 +278,24 @@ internal static class LauncherLifecycleRelay
             {
                 LauncherCommandStatus.Ok => 200,
                 LauncherCommandStatus.BadRequest => 400,
+                // A REFUSAL IS 409, NOT 502. The launcher understood the command, could have run it, and
+                // declined because a condition the caller attached was not met - "restart only if empty"
+                // against a Director holding live sessions. 502 would say the machine is broken and send
+                // the reader to look for a fault that is not there; 409 says the machine is in a state
+                // that conflicts with the request, which is exactly what happened, and the launcher's own
+                // sentence (carrying the session count) rides back in the body.
+                LauncherCommandStatus.Refused => 409,
                 _ => 502,
             };
-            // A QUERY answers with data, so its payload is passed through exactly as the launcher wrote it.
-            // Synthesising {ok:true} here - which is right for an action verb, whose only news is that it
-            // worked - would throw away the entire answer and hand the caller a success with no result in it.
-            var streamPayload = isQuery && streamResult.IsOk && streamResult.Payload is not null
+            // WHOSE ANSWER THE CALLER GETS IS DECIDED BY THE CALLER'S QUESTION, NOT BY WHAT CAME BACK.
+            // A query asked for data, so the launcher's own document is passed through - synthesising
+            // {ok:true} over it would hand back a success with the whole result thrown away. A guarded
+            // restart asked a CONDITIONAL question, so its answer travels too: it carries the condition
+            // the launcher honoured and the count it read, which is the only way to tell it from an older
+            // launcher that ignored the flag. Every other verb keeps the envelope it has always had,
+            // byte for byte, even if some future launcher starts writing a payload for it - a response
+            // shape that changes because the other side got chattier is a change nobody asked for.
+            var streamPayload = passLauncherPayloadThrough && streamResult.IsOk && streamResult.Payload is not null
                 ? streamResult.Payload
                 : streamResult.IsOk
                 ? System.Text.Json.JsonSerializer.Serialize(new { ok = true, via = "stream" })

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -639,7 +639,11 @@ internal static class MachineEndpoints
                         verb,
                     }, statusCode: 400);
 
-                if (doc.RootElement.TryGetProperty("exePath", out var ep))
+                // ONLY A STRING IS READ AS A PATH. GetString throws on a number or an object, and this
+                // block no longer sits under a catch-everything - narrowing that catch to a parse failure
+                // is what made this reachable, so a body of {"exePath": 123} would have left the route as
+                // an unhandled fault instead of the ignored field it has always been.
+                if (doc.RootElement.TryGetProperty("exePath", out var ep) && ep.ValueKind == JsonValueKind.String)
                     exePathFromBody = ep.GetString();
                 if (doc.RootElement.TryGetProperty("confirmProtected", out var cp) && cp.ValueKind == JsonValueKind.True)
                     confirmProtectedFromBody = true;
@@ -654,7 +658,7 @@ internal static class MachineEndpoints
         // stopping the Director anyway would answer that request with the exact outcome it was trying to
         // prevent, and report success. A stop that must not interrupt anything has no implementation here
         // yet - so the honest answer is to say so.
-        if (onlyIfEmptyFromBody && verb != "restart")
+        if (false && onlyIfEmptyFromBody && verb != "restart")
             return OnlyIfEmptyNotUnderstood(machine, verb,
                 $"onlyIfEmpty is understood by 'restart' alone, and this is '{verb}'");
 

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -27,6 +27,8 @@ namespace CcDirector.Gateway.Api;
 ///   GET  /launchers                                 list registered launchers
 ///
 ///   POST /machines/{machine}/director/restart       push -> launcher verb director/restart
+///        body {"onlyIfEmpty": true} restarts ONLY while that Director holds no live sessions, and
+///        answers 409 with the launcher's own sentence - naming how many are live - when it holds some
 ///   POST /machines/{machine}/director/start         push -> launcher verb director/start
 ///   POST /machines/{machine}/director/stop          push -> launcher verb director/stop
 ///   POST /machines/{machine}/launch                 push -> launcher verb launch
@@ -589,20 +591,72 @@ internal static class MachineEndpoints
         // Do NOT gate on ContentLength - transfer-encoded bodies may have no explicit length.
         string? exePathFromBody = null;
         bool? confirmProtectedFromBody = null;
-        try
+        var onlyIfEmptyFromBody = false;
+
+        // THE BODY IS READ, NOT GUESSED AT. This used to decide whether a body existed from the content
+        // type or a declared length, and that heuristic was wrong in both directions: an empty body
+        // labelled as JavaScript Object Notation was parsed and failed, while a chunked body - which
+        // declares no length - carrying "onlyIfEmpty" was treated as no body at all and quietly became an
+        // unconditional restart. Reading the bytes answers both: nothing sent is absent, anything sent
+        // must parse.
+        ctx.Request.EnableBuffering();
+        using var bodyReader = new StreamReader(ctx.Request.Body, leaveOpen: true);
+        var bodyText = await bodyReader.ReadToEndAsync(ct);
+        if (!string.IsNullOrWhiteSpace(bodyText))
         {
-            ctx.Request.EnableBuffering();
-            if (ctx.Request.ContentType?.Contains("json", StringComparison.OrdinalIgnoreCase) == true
-                || ctx.Request.ContentLength is > 0)
+            JsonDocument doc;
+            try
             {
-                using var doc = await JsonDocument.ParseAsync(ctx.Request.Body, cancellationToken: ct);
+                doc = JsonDocument.Parse(bodyText);
+            }
+            catch (JsonException ex)
+            {
+                // A BODY THAT WAS SENT AND WILL NOT PARSE IS A 400, NOT AN EMPTY BODY. No body at all is
+                // fine - every field here is optional - but silently discarding a body the caller did
+                // send discards whatever safety flag was in it, and this route's flags decide whether
+                // somebody's live sessions survive.
+                FileLog.Write($"[MachineEndpoints] RELAY_REFUSED machine={machine} verb={verb} reason=unparseable body: {ex.Message}");
+                return Results.Json(new
+                {
+                    error = "bad_request_body",
+                    detail = "the request body was sent but could not be read as JavaScript Object Notation, "
+                           + "so nothing was done. It is not treated as an empty body: a flag that was meant "
+                           + "to be in it would have been dropped in silence.",
+                    machine,
+                    verb,
+                }, statusCode: 400);
+            }
+
+            using (doc)
+            {
+                if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                    return Results.Json(new
+                    {
+                        error = "bad_request_body",
+                        detail = $"the request body must be a JavaScript Object Notation object; this one is "
+                               + $"{doc.RootElement.ValueKind}. Nothing was done.",
+                        machine,
+                        verb,
+                    }, statusCode: 400);
+
                 if (doc.RootElement.TryGetProperty("exePath", out var ep))
                     exePathFromBody = ep.GetString();
                 if (doc.RootElement.TryGetProperty("confirmProtected", out var cp) && cp.ValueKind == JsonValueKind.True)
                     confirmProtectedFromBody = true;
+
+                if (ReadOnlyIfEmpty(doc.RootElement, machine, verb, out onlyIfEmptyFromBody) is { } flagRefusal)
+                    return flagRefusal;
             }
         }
-        catch { /* body is optional */ }
+
+        // ONLY-IF-EMPTY BELONGS TO RESTART, AND ASKING FOR IT ANYWHERE ELSE IS REFUSED RATHER THAN IGNORED.
+        // A caller sending it to stop is asking not to interrupt live work; quietly dropping the flag and
+        // stopping the Director anyway would answer that request with the exact outcome it was trying to
+        // prevent, and report success. A stop that must not interrupt anything has no implementation here
+        // yet - so the honest answer is to say so.
+        if (onlyIfEmptyFromBody && verb != "restart")
+            return OnlyIfEmptyNotUnderstood(machine, verb,
+                $"onlyIfEmpty is understood by 'restart' alone, and this is '{verb}'");
 
         // Slot guard: refuse restart/stop targeting the main build or slots 1-4 without confirm.
         if ((verb == "restart" || verb == "stop") && exePathFromBody is { } exePath)
@@ -629,8 +683,80 @@ internal static class MachineEndpoints
         // guard above has already run before anything is delivered.
         var outcome = await LauncherLifecycleRelay.SendDirectorVerbAsync(
             tenant, machine, verb, exePathFromBody, confirmProtectedFromBody == true,
-            launchers, sendLauncherCommand, ct);
+            launchers, sendLauncherCommand, ct, onlyIfEmptyFromBody);
         return ToResult(machine, verb, outcome);
+    }
+
+    /// <summary>
+    /// Read the onlyIfEmpty flag out of a lifecycle request body. Returns null when the body is fine (and
+    /// <paramref name="onlyIfEmpty"/> holds the answer), or the refusal to return when it is not.
+    ///
+    /// IT IS THE ONE FIELD ON THIS ROUTE WHOSE ABSENCE IS THE DANGEROUS READING, and every rule here comes
+    /// from that. exePath and confirmProtected may safely be read as absent when they are malformed,
+    /// because absent is their careful side - a missing confirmProtected REFUSES. Absent here means
+    /// "restart regardless of what the Director is holding", so anything the caller might have MEANT as
+    /// the flag and this route cannot be sure of has to be refused instead of ignored:
+    ///
+    ///   * a value that is not a boolean - "true", 1, null - is refused rather than read as false;
+    ///   * the NAME is matched without regard to case, because {"OnlyIfEmpty": true} is unmistakably a
+    ///     caller asking for the guard, and a case-sensitive lookup answered it with an unconditional
+    ///     restart and a success;
+    ///   * two spellings of the name in one object are refused, because which one wins is a detail of the
+    ///     parser and not something the caller can have intended.
+    ///
+    /// WHAT IT STILL CANNOT CATCH, stated rather than implied: a plain misspelling ("onlyIfEmtpy") is
+    /// indistinguishable from a field this route has never heard of, and is ignored. Closing that needs
+    /// the guard to be something other than an optional field - a separate route, or a required mode on
+    /// every lifecycle call - which is a bigger change than this one and is not smuggled in here.
+    /// </summary>
+    private static IResult? ReadOnlyIfEmpty(JsonElement body, string machine, string verb, out bool onlyIfEmpty)
+    {
+        onlyIfEmpty = false;
+
+        JsonElement? found = null;
+        foreach (var property in body.EnumerateObject())
+        {
+            if (!property.NameEquals("onlyIfEmpty")
+                && !string.Equals(property.Name, "onlyIfEmpty", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (found is not null)
+                return OnlyIfEmptyNotUnderstood(machine, verb,
+                    "the request body names onlyIfEmpty more than once, and which spelling would win is a "
+                    + "detail of the parser rather than anything you asked for");
+
+            found = property.Value;
+        }
+
+        if (found is not { } value)
+            return null; // absent: an ordinary, unconditional lifecycle call
+
+        if (value.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+            return OnlyIfEmptyNotUnderstood(machine, verb,
+                $"onlyIfEmpty must be true or false; this request sent {value.ValueKind}");
+
+        onlyIfEmpty = value.ValueKind == JsonValueKind.True;
+        return null;
+    }
+
+    /// <summary>
+    /// The one refusal for every way a caller can ask for onlyIfEmpty and not get it: on a verb that
+    /// cannot honour it, or written as something that is not a boolean. Both mean the same thing to the
+    /// reader - the condition you attached was NOT applied and nothing was done - and they are refused
+    /// rather than ignored because the whole point of the flag is that live work is not interrupted.
+    /// </summary>
+    private static IResult OnlyIfEmptyNotUnderstood(string machine, string verb, string reason)
+    {
+        FileLog.Write($"[MachineEndpoints] RELAY_REFUSED machine={machine} verb={verb} reason={reason}");
+        return Results.Json(new
+        {
+            error = "only_if_empty_not_supported",
+            detail = reason + ". It was NOT applied and nothing was done: a flag that asks not to "
+                   + "interrupt live work must never be dropped in silence.",
+            machine,
+            verb,
+            hint = "Send \"onlyIfEmpty\": true (a boolean) on POST /machines/{machine}/director/restart.",
+        }, statusCode: 400);
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -692,10 +692,12 @@ internal static class MachineEndpoints
     /// <paramref name="onlyIfEmpty"/> holds the answer), or the refusal to return when it is not.
     ///
     /// IT IS THE ONE FIELD ON THIS ROUTE WHOSE ABSENCE IS THE DANGEROUS READING, and every rule here comes
-    /// from that. exePath and confirmProtected may safely be read as absent when they are malformed,
-    /// because absent is their careful side - a missing confirmProtected REFUSES. Absent here means
-    /// "restart regardless of what the Director is holding", so anything the caller might have MEANT as
-    /// the flag and this route cannot be sure of has to be refused instead of ignored:
+    /// from that. A malformed confirmProtected is safely read as absent, because absent is its careful
+    /// side - a missing confirmProtected REFUSES a protected slot. (A missing exePath is NOT the careful
+    /// side: it skips the slot guard entirely. That is this route's long-standing behaviour, pinned by its
+    /// own test, and it is neither changed nor endorsed here.) Absent HERE means "restart regardless of
+    /// what the Director is holding", so anything the caller might have MEANT as the flag and this route
+    /// cannot be sure of has to be refused instead of ignored:
     ///
     ///   * a value that is not a boolean - "true", 1, null - is refused rather than read as false;
     ///   * the NAME is matched without regard to case, because {"OnlyIfEmpty": true} is unmistakably a

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -658,7 +658,7 @@ internal static class MachineEndpoints
         // stopping the Director anyway would answer that request with the exact outcome it was trying to
         // prevent, and report success. A stop that must not interrupt anything has no implementation here
         // yet - so the honest answer is to say so.
-        if (false && onlyIfEmptyFromBody && verb != "restart")
+        if (onlyIfEmptyFromBody && verb != "restart")
             return OnlyIfEmptyNotUnderstood(machine, verb,
                 $"onlyIfEmpty is understood by 'restart' alone, and this is '{verb}'");
 

--- a/src/CcDirector.Launcher.Tests/RestartOnlyIfEmptyTests.cs
+++ b/src/CcDirector.Launcher.Tests/RestartOnlyIfEmptyTests.cs
@@ -78,7 +78,7 @@ public sealed class RestartOnlyIfEmptyTests
 
         // The guard's own verdict first: an empty Director is not refused, and it says the count it
         // reached that on rather than leaving the caller to read the machine a second time.
-        Assert.Null(rig.Supervisor.RefuseRestartUnlessEmpty(out var counted));
+        Assert.Null(rig.Supervisor.RefuseRestartUnlessEmpty(out var counted, out _));
         Assert.Equal(0, counted);
 
         // Then the whole restart. It stops the Director it found and goes on to start the installed one,
@@ -248,7 +248,7 @@ public sealed class RestartOnlyIfEmptyTests
             var supervisor = new DirectorSupervisor(new InstallLayout(root),
                 new DirectorInstanceLocator(instanceHome));
 
-            Assert.Null(supervisor.RefuseRestartUnlessEmpty(out var counted));
+            Assert.Null(supervisor.RefuseRestartUnlessEmpty(out var counted, out _));
             Assert.Equal(0, counted);
 
             var launch = await Assert.ThrowsAsync<FileNotFoundException>(
@@ -257,6 +257,129 @@ public sealed class RestartOnlyIfEmptyTests
         }
         finally
         {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// A RESOLVED CONFLICT IS REFUSED, not counted. The locator has a state the first version of this
+    /// guard did not model: several live processes claim one instance home AND the tie-break can name
+    /// the installed one, so there IS a Director and its roster reads perfectly. An independent review
+    /// found the guard permitting there - it asked whether a Director had been resolved and never
+    /// whether resolving it had been a conflict.
+    ///
+    /// The rig gives the locator an installed image to break the tie with, which is what separates this
+    /// from the undecidable case above: there the answer is "none of them", here it is "this one, and
+    /// something else is also claiming the home".
+    /// </summary>
+    [Fact]
+    public async Task RestartAsync_OnlyIfEmpty_RefusesWhenTheMachineHoldsAResolvedConflict()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var root = Path.Combine(Path.GetTempPath(), "cc-restart-conflict-" + Guid.NewGuid().ToString("N"));
+        var instanceHome = Path.Combine(root, "instances", "default");
+        var registrations = Path.Combine(instanceHome, "config", "director", "instances");
+        var journalDir = Path.Combine(instanceHome, "config", "director", "crash-journal");
+        Directory.CreateDirectory(registrations);
+
+        // The installed Director, as a real file, so one claimant can be certified against it as the
+        // installed image and the tie-break has something to decide with.
+        var layout = new InstallLayout(root);
+        var installed = layout.PathFor(ComponentRegistry.Director);
+        Directory.CreateDirectory(Path.GetDirectoryName(installed)!);
+        File.Copy(Path.Combine(Environment.SystemDirectory, "cmd.exe"), installed);
+
+        using var theInstalledOne = StartIdleHelper(installed);
+        using var theOtherClaimant = StartIdleHelper();
+        try
+        {
+            var installedId = Guid.NewGuid().ToString();
+            WriteRegistration(registrations, installedId, theInstalledOne.Id);
+            WriteRegistration(registrations, Guid.NewGuid().ToString(), theOtherClaimant.Id);
+
+            var locator = new DirectorInstanceLocator(instanceHome, null, installed);
+            var lookup = locator.Resolve();
+
+            // The rig is only the rig if the locator really produced the resolved-conflict state.
+            Assert.Equal(DirectorResolution.Running, lookup.Outcome);
+            Assert.NotNull(lookup.Director);
+            Assert.NotNull(lookup.Conflict);
+
+            // And an empty roster for the chosen Director, so nothing but the conflict can be the reason.
+            new DirectorCrashJournal(lookup.Director!.DirectorId, theInstalledOne.Id, Environment.MachineName,
+                Environment.UserName, DateTimeOffset.UtcNow, journalDir).Update(Array.Empty<DirectorCrashJournalSession>());
+            Assert.Equal(0, locator.ReadSessionCount(lookup.Director!));
+
+            var supervisor = new DirectorSupervisor(layout, locator);
+            var outcome = await supervisor.RestartAsync(onlyIfEmpty: true);
+
+            Assert.Equal(DirectorRestartVerdict.Refused, outcome.Verdict);
+            Assert.Contains("more than one live process claims", outcome.Reason);
+
+            theInstalledOne.Refresh();
+            theOtherClaimant.Refresh();
+            Assert.False(theInstalledOne.HasExited || theOtherClaimant.HasExited,
+                "a machine with two claimants on one instance home was acted on anyway.");
+        }
+        finally
+        {
+            try { if (!theInstalledOne.HasExited) theInstalledOne.Kill(entireProcessTree: true); } catch { }
+            try { if (!theOtherClaimant.HasExited) theOtherClaimant.Kill(entireProcessTree: true); } catch { }
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// THE GUARD'S READING IS THE ONE THAT ACTS. When the guard finds nothing running it permits the
+    /// restart as a start - and the stop that follows must not go looking again, because a second
+    /// reading can see a Director the decision never covered. A review demonstrated exactly that: a
+    /// registration unreadable at guard time and readable a moment later, whose Director was holding
+    /// three sessions.
+    ///
+    /// WHAT THIS TEST OBSERVES: that a guarded restart which decided on "nothing is running" asks
+    /// NOBODY to shut down - there is no shutdown signal raised at all. The stand-in Director here is
+    /// registered and alive and would answer one; it is invisible to the guard only because its
+    /// registration will not parse, which is the same condition the review used.
+    /// </summary>
+    [Fact]
+    public async Task RestartAsync_OnlyIfEmpty_DecidingNothingIsRunning_AsksNobodyToStop()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var root = Path.Combine(Path.GetTempPath(), "cc-restart-toctou-" + Guid.NewGuid().ToString("N"));
+        var instanceHome = Path.Combine(root, "instances", "default");
+        var registrations = Path.Combine(instanceHome, "config", "director", "instances");
+        Directory.CreateDirectory(registrations);
+
+        var directorId = Guid.NewGuid().ToString();
+        using var director = Rig.StartShutdownListeningHelper(directorId);
+        try
+        {
+            // A registration that will not parse: the locator skips it, so the machine reads as nothing
+            // running even though this process is alive and listening for its own shutdown signal.
+            File.WriteAllText(Path.Combine(registrations, directorId + ".json"), "{ this will not parse");
+
+            var locator = new DirectorInstanceLocator(instanceHome);
+            Assert.Equal(DirectorResolution.NotRunning, locator.Resolve().Outcome);
+
+            var supervisor = new DirectorSupervisor(new InstallLayout(root), locator);
+
+            // The guard permits (it saw nothing), and the restart then goes to start the installed
+            // Director, which this rig does not install.
+            await Assert.ThrowsAsync<FileNotFoundException>(() => supervisor.RestartAsync(onlyIfEmpty: true));
+
+            // THE ASSERTION: nothing was asked to stop. The stand-in is still alive, and it exits the
+            // moment its shutdown signal is raised - so its being alive is the evidence that no signal
+            // was sent to it.
+            director.Refresh();
+            Assert.False(director.HasExited,
+                "a guarded restart that decided nothing was running went on to stop a Director anyway - "
+                + "which is the decision and the action using two different readings of the machine.");
+        }
+        finally
+        {
+            try { if (!director.HasExited) director.Kill(entireProcessTree: true); } catch { }
             try { Directory.Delete(root, recursive: true); } catch { }
         }
     }
@@ -346,10 +469,17 @@ public sealed class RestartOnlyIfEmptyTests
             """);
 
     /// <summary>A harmless long-running process to stand in for a claimant that is never asked anything.</summary>
-    private static Process StartIdleHelper()
+    private static Process StartIdleHelper() =>
+        StartIdleHelper(Path.Combine(Environment.SystemDirectory, "cmd.exe"));
+
+    /// <summary>
+    /// The same stand-in, running a NAMED image - a copy of the command interpreter placed where the
+    /// installed Director would be. It is what lets the locator certify one claimant as the installed
+    /// image and break a tie, which is the only way to reach the resolved-conflict state from outside.
+    /// </summary>
+    private static Process StartIdleHelper(string exePath)
     {
-        var psi = new ProcessStartInfo(Path.Combine(Environment.SystemDirectory, "cmd.exe"),
-            "/c ping -n 60 127.0.0.1")
+        var psi = new ProcessStartInfo(exePath, "/c ping -n 60 127.0.0.1")
         {
             UseShellExecute = false,
             CreateNoWindow = true,
@@ -455,7 +585,7 @@ public sealed class RestartOnlyIfEmptyTests
         /// a helper that only slept would look identical whether the launcher asked it to stop or not.
         /// </summary>
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-        private static Process StartShutdownListeningHelper(string directorId)
+        internal static Process StartShutdownListeningHelper(string directorId)
         {
             var signal = LifecycleSignalNames.DirectorShutdown(directorId);
             var script = "$e = New-Object System.Threading.EventWaitHandle "

--- a/src/CcDirector.Launcher.Tests/RestartOnlyIfEmptyTests.cs
+++ b/src/CcDirector.Launcher.Tests/RestartOnlyIfEmptyTests.cs
@@ -1,0 +1,498 @@
+using System.Diagnostics;
+using CcDirector.Core.Instances;
+using CcDirector.Core.Lifecycle;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Launcher;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Launcher.Tests;
+
+/// <summary>
+/// RESTART ONLY IF THE DIRECTOR IS EMPTY - the mechanical guarantee behind "never force".
+///
+/// A drain empties a Director one session at a time, and a restart that arrives in the middle of one
+/// takes every session that is left with it. The rule against that used to be a sentence in a written
+/// instruction; these tests are the rule being enforced by the launcher instead.
+///
+/// THE REFUSAL IS THE FEATURE, so it is tested first and hardest. A suite that only proved the happy
+/// path would prove nothing here: an implementation that ignored the flag entirely and restarted every
+/// time would pass it.
+///
+/// HOW THE RIG WORKS, because the fidelity is the point. Nothing is mocked. A real helper process stands
+/// in for the Director, a real instance registration names it (so the real
+/// <see cref="DirectorInstanceLocator"/> resolves it exactly as it resolves a live Director), and a real
+/// <see cref="DirectorCrashJournal"/> writes the live session roster the launcher reads to get its count.
+/// The helper LISTENS FOR THE SAME SHUTDOWN SIGNAL a Director listens for and exits when it is raised, so
+/// "the Director was stopped" is an observed process exit rather than an assumption.
+///
+/// WHAT THE PERMITTED CASE OBSERVES, AND WHAT IT DOES NOT. When the guard permits, the launcher stops the
+/// Director and then starts the INSTALLED one - and this rig deliberately installs no Director under its
+/// temporary root, so that last step throws <see cref="FileNotFoundException"/> naming the exact path it
+/// went to. That throw IS the observation that the restart proceeded; what it does not prove is that a
+/// real Director comes up afterwards, which is the shipped, unchanged half of
+/// <see cref="DirectorSupervisor.RestartAsync(CancellationToken)"/> and is not what this change touches.
+/// </summary>
+public sealed class RestartOnlyIfEmptyTests
+{
+    // -------------------------------------------------------------------------
+    // ASSERTION ONE: sessions live -> it refuses, AND the refusal names the count.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RestartAsync_OnlyIfEmpty_RefusesAndNamesTheLiveSessionCount()
+    {
+        if (!OperatingSystem.IsWindows()) return; // the rig's stand-in Director is a Windows helper process
+
+        using var rig = Rig.Start(liveSessions: 3);
+
+        var outcome = await rig.Supervisor.RestartAsync(onlyIfEmpty: true);
+
+        Assert.Equal(DirectorRestartVerdict.Refused, outcome.Verdict);
+        Assert.Equal(3, outcome.Sessions);
+
+        // NAMING THE COUNT IS THE REQUIREMENT. "Refused, 3 sessions still live" is actionable - the drain
+        // is not finished - and a bare "refused" is not. The number and the noun are asserted TOGETHER on
+        // purpose: a bare Contains("3") would also pass on a refusal that named no count at all, because
+        // the Director's identifier is a globally unique identifier and usually contains a 3.
+        Assert.Contains("3 live sessions", outcome.Reason);
+
+        // AND NOTHING WAS DONE. A refusal that had already stopped the Director would be the exact damage
+        // this guard exists to prevent, wearing an apology.
+        rig.Helper.Refresh();
+        Assert.False(rig.Helper.HasExited,
+            "the restart was refused and yet the Director was stopped anyway - the guard ran too late.");
+    }
+
+    // -------------------------------------------------------------------------
+    // ASSERTION TWO: no sessions -> it restarts.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RestartAsync_OnlyIfEmpty_StopsThenStartsTheDirector_WhenItHoldsNoSessions()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var rig = Rig.Start(liveSessions: 0);
+
+        // The guard's own verdict first: an empty Director is not refused, and it says the count it
+        // reached that on rather than leaving the caller to read the machine a second time.
+        Assert.Null(rig.Supervisor.RefuseRestartUnlessEmpty(out var counted));
+        Assert.Equal(0, counted);
+
+        // Then the whole restart. It stops the Director it found and goes on to start the installed one,
+        // which this rig does not install - so the launch throws, naming the path it went to.
+        var launch = await Assert.ThrowsAsync<FileNotFoundException>(
+            () => rig.Supervisor.RestartAsync(onlyIfEmpty: true));
+        Assert.Contains(rig.Supervisor.DirectorExePath, launch.Message, StringComparison.OrdinalIgnoreCase);
+
+        // The stop is observed, not assumed: the stand-in Director received the shutdown signal and exited.
+        Assert.True(WaitForExit(rig.Helper),
+            "the restart was permitted and yet the Director was never stopped.");
+    }
+
+    // -------------------------------------------------------------------------
+    // The A/B that shows the flag is what makes the difference: the SAME busy Director,
+    // restarted without it, is restarted.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RestartAsync_WithoutOnlyIfEmpty_StillRestartsABusyDirector()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var rig = Rig.Start(liveSessions: 3);
+
+        var launch = await Assert.ThrowsAsync<FileNotFoundException>(
+            () => rig.Supervisor.RestartAsync(onlyIfEmpty: false));
+        Assert.Contains(rig.Supervisor.DirectorExePath, launch.Message, StringComparison.OrdinalIgnoreCase);
+
+        Assert.True(WaitForExit(rig.Helper),
+            "an unconditional restart must still restart a busy Director - the tray menu and the "
+            + "staged-update signal both depend on it.");
+    }
+
+    // -------------------------------------------------------------------------
+    // The fail-open case: a count that could not be read is a REFUSAL, never an empty Director.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RestartAsync_OnlyIfEmpty_RefusesWhenTheLiveSessionCountCannotBeRead()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        // A running Director with no readable roster - which is what a Director that has not yet opened
+        // its crash journal looks like from outside. It is indistinguishable from an idle one, and that is
+        // exactly why it must not be treated as idle.
+        using var rig = Rig.Start(liveSessions: null);
+
+        var outcome = await rig.Supervisor.RestartAsync(onlyIfEmpty: true);
+
+        Assert.Equal(DirectorRestartVerdict.Refused, outcome.Verdict);
+        Assert.Null(outcome.Sessions);
+        Assert.Contains("unknown", outcome.Reason, StringComparison.OrdinalIgnoreCase);
+
+        rig.Helper.Refresh();
+        Assert.False(rig.Helper.HasExited,
+            "an unreadable session count was treated as an empty Director and the restart went ahead.");
+    }
+
+    /// <summary>
+    /// The OTHER unknown: two live processes claim the instance, so which one is the Director cannot be
+    /// decided and neither can its session count. Refused, for the same reason an unreadable roster is.
+    /// </summary>
+    [Fact]
+    public async Task RestartAsync_OnlyIfEmpty_RefusesWhenWhichProcessIsTheDirectorIsUndecidable()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var root = Path.Combine(Path.GetTempPath(), "cc-restart-ambiguous-" + Guid.NewGuid().ToString("N"));
+        var instanceHome = Path.Combine(root, "instances", "default");
+        var registrations = Path.Combine(instanceHome, "config", "director", "instances");
+        Directory.CreateDirectory(registrations);
+
+        using var first = StartIdleHelper();
+        using var second = StartIdleHelper();
+        try
+        {
+            WriteRegistration(registrations, Guid.NewGuid().ToString(), first.Id);
+            WriteRegistration(registrations, Guid.NewGuid().ToString(), second.Id);
+
+            var locator = new DirectorInstanceLocator(instanceHome);
+            Assert.Equal(DirectorResolution.Ambiguous, locator.Resolve().Outcome);
+
+            var supervisor = new DirectorSupervisor(new InstallLayout(root), locator);
+            var outcome = await supervisor.RestartAsync(onlyIfEmpty: true);
+
+            Assert.Equal(DirectorRestartVerdict.Refused, outcome.Verdict);
+            Assert.Null(outcome.Sessions);
+            Assert.Contains("undecidable", outcome.Reason, StringComparison.OrdinalIgnoreCase);
+
+            first.Refresh();
+            second.Refresh();
+            Assert.False(first.HasExited || second.HasExited,
+                "a machine nobody can make sense of was restarted anyway.");
+        }
+        finally
+        {
+            try { if (!first.HasExited) first.Kill(entireProcessTree: true); } catch { }
+            try { if (!second.HasExited) second.Kill(entireProcessTree: true); } catch { }
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// A RESTART THAT STOPS AND STARTS NOTHING IS NOT A REFUSAL. The distinction was missed in the first
+    /// draft of this feature and found by review: a refusal promises the machine is exactly as the caller
+    /// left it, and this outcome promises the opposite - the stop ran and nothing came back. Reporting it
+    /// as a refusal would tell somebody their Director is untouched at the moment it has gone.
+    /// </summary>
+    [Fact]
+    public async Task ARestartThatStartsNothing_IsReportedAsNotStarted_AndOnTheWireAsAFault()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var root = Path.Combine(Path.GetTempPath(), "cc-restart-nostart-" + Guid.NewGuid().ToString("N"));
+        var instanceHome = Path.Combine(root, "instances", "default");
+        var registrations = Path.Combine(instanceHome, "config", "director", "instances");
+        Directory.CreateDirectory(registrations);
+
+        // An installed Director must EXIST for the launch to get as far as being skipped - Start checks
+        // the file before it checks the machine. It is never executed here: two live processes already
+        // claim the instance, so the launch is declined before anything is started.
+        var layout = new InstallLayout(root);
+        Directory.CreateDirectory(Path.GetDirectoryName(layout.PathFor(ComponentRegistry.Director))!);
+        File.WriteAllText(layout.PathFor(ComponentRegistry.Director), "not a real Director");
+
+        using var first = StartIdleHelper();
+        using var second = StartIdleHelper();
+        try
+        {
+            WriteRegistration(registrations, Guid.NewGuid().ToString(), first.Id);
+            WriteRegistration(registrations, Guid.NewGuid().ToString(), second.Id);
+
+            var supervisor = new DirectorSupervisor(layout, new DirectorInstanceLocator(instanceHome));
+            var outcome = await supervisor.RestartAsync(onlyIfEmpty: false);
+
+            Assert.Equal(DirectorRestartVerdict.NotStarted, outcome.Verdict);
+            Assert.Null(outcome.StartedPid);
+            Assert.Contains("no new Director was started", outcome.Reason);
+
+            // And on the wire it is a fault, not the 409 a refusal becomes.
+            await using var launcher = DispatchOnly(supervisor);
+            var result = await launcher.DispatchAsync(new LauncherCommand { Verb = "director/restart" });
+            Assert.Equal(LauncherCommandStatus.Error, result.Status);
+        }
+        finally
+        {
+            try { if (!first.HasExited) first.Kill(entireProcessTree: true); } catch { }
+            try { if (!second.HasExited) second.Kill(entireProcessTree: true); } catch { }
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// A Director that is not running is EMPTY, and that is a real answer rather than a missing one -
+    /// nothing is holding a session because nothing is holding anything. The restart then does what a
+    /// restart of a stopped Director has always done, which is go and start one.
+    /// </summary>
+    [Fact]
+    public async Task RestartAsync_OnlyIfEmpty_StartsTheDirector_WhenNoneIsRunning()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cc-restart-stopped-" + Guid.NewGuid().ToString("N"));
+        var instanceHome = Path.Combine(root, "instances", "default");
+        Directory.CreateDirectory(instanceHome);
+        try
+        {
+            var supervisor = new DirectorSupervisor(new InstallLayout(root),
+                new DirectorInstanceLocator(instanceHome));
+
+            Assert.Null(supervisor.RefuseRestartUnlessEmpty(out var counted));
+            Assert.Equal(0, counted);
+
+            var launch = await Assert.ThrowsAsync<FileNotFoundException>(
+                () => supervisor.RestartAsync(onlyIfEmpty: true));
+            Assert.Contains(supervisor.DirectorExePath, launch.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // The command boundary: a "director/restart" arriving on the launcher's stream
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// The seam between the command and the guard, which nothing else crosses. An adversarial review
+    /// pointed out that a launcher passing a hard-coded false to the supervisor would pass every other
+    /// test in this feature: the supervisor tests call the supervisor directly, and the Gateway tests
+    /// answer with a stub launcher. This drives a real command through the real dispatch into a real
+    /// supervisor, and the refusal it produces is the one the Gateway would receive on the wire.
+    /// </summary>
+    [Fact]
+    public async Task ARestartCommandCarryingTheFlag_IsRefusedOnTheWire_NamingTheLiveSessionCount()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var rig = Rig.Start(liveSessions: 3);
+        await using var launcher = DispatchOnly(rig.Supervisor);
+
+        var result = await launcher.DispatchAsync(new LauncherCommand
+        {
+            Verb = "director/restart",
+            OnlyIfEmpty = true,
+        });
+
+        Assert.Equal(LauncherCommandStatus.Refused, result.Status);
+        Assert.Contains("3 live sessions", result.Error);
+
+        rig.Helper.Refresh();
+        Assert.False(rig.Helper.HasExited, "the command was refused and the Director was stopped anyway.");
+    }
+
+    /// <summary>
+    /// The flag is refused on any verb that cannot honour it, at the boundary, rather than ignored. A verb
+    /// that quietly drops it would answer a request to spare live work with a success that spared nothing.
+    /// </summary>
+    [Theory]
+    [InlineData("director/stop")]
+    [InlineData("director/start")]
+    [InlineData("apps")]
+    public async Task TheFlagOnAVerbThatCannotHonourIt_IsRefused_AndNothingIsDone(string verb)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var rig = Rig.Start(liveSessions: 3);
+        await using var launcher = DispatchOnly(rig.Supervisor);
+
+        var result = await launcher.DispatchAsync(new LauncherCommand { Verb = verb, OnlyIfEmpty = true });
+
+        Assert.Equal(LauncherCommandStatus.BadRequest, result.Status);
+        Assert.Contains("onlyIfEmpty", result.Error);
+
+        rig.Helper.Refresh();
+        Assert.False(rig.Helper.HasExited, $"'{verb}' carrying onlyIfEmpty acted on the Director anyway.");
+    }
+
+    /// <summary>
+    /// A launcher stream client wired to a real supervisor and to nothing else. No Gateway is configured,
+    /// so it dials nowhere and never starts a connection; <c>DispatchAsync</c> is the command path itself,
+    /// which is the only part under test here.
+    /// </summary>
+    private static LauncherStreamClient DispatchOnly(DirectorSupervisor supervisor) =>
+        new(new CcDirector.Core.Configuration.GatewayConfig(), version: "test", supervisor, new LaunchService());
+
+    // -------------------------------------------------------------------------
+    // The rig
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// The instance registration a Director writes when it starts - the file the locator reads to learn
+    /// which process it is supervising.
+    /// </summary>
+    private static void WriteRegistration(string registrationsDirectory, string directorId, int pid) =>
+        File.WriteAllText(Path.Combine(registrationsDirectory, directorId + ".json"),
+            $$"""
+            {
+              "DirectorId": "{{directorId}}",
+              "Pid": {{pid}},
+              "StartedAt": "{{DateTime.UtcNow:o}}",
+              "ControlEndpoint": "",
+              "Version": "9.9.9"
+            }
+            """);
+
+    /// <summary>A harmless long-running process to stand in for a claimant that is never asked anything.</summary>
+    private static Process StartIdleHelper()
+    {
+        var psi = new ProcessStartInfo(Path.Combine(Environment.SystemDirectory, "cmd.exe"),
+            "/c ping -n 60 127.0.0.1")
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+        };
+        return Process.Start(psi) ?? throw new InvalidOperationException("could not start a helper process");
+    }
+
+    /// <summary>
+    /// A temporary storage root holding one stand-in Director: a real live process, a real instance
+    /// registration naming it, and (unless the count is meant to be unreadable) a real crash-journal
+    /// roster carrying the live sessions.
+    /// </summary>
+    private sealed class Rig : IDisposable
+    {
+        private readonly string _root;
+
+        private Rig(string root, Process helper, DirectorSupervisor supervisor)
+        {
+            _root = root;
+            Helper = helper;
+            Supervisor = supervisor;
+        }
+
+        /// <summary>The stand-in Director process.</summary>
+        public Process Helper { get; }
+
+        public DirectorSupervisor Supervisor { get; }
+
+        /// <param name="liveSessions">How many sessions the stand-in Director is holding, or null to write
+        /// no roster at all - the "count cannot be read" case.</param>
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public static Rig Start(int? liveSessions)
+        {
+            var root = Path.Combine(Path.GetTempPath(), "cc-restart-empty-" + Guid.NewGuid().ToString("N"));
+            var instanceHome = Path.Combine(root, "instances", "default");
+            var registrations = Path.Combine(instanceHome, "config", "director", "instances");
+            var journalDir = Path.Combine(instanceHome, "config", "director", "crash-journal");
+            Directory.CreateDirectory(registrations);
+
+            var directorId = Guid.NewGuid().ToString();
+            var helper = StartShutdownListeningHelper(directorId);
+            try
+            {
+                // The registration must be written AFTER the process starts: the locator rejects a
+                // registration whose process started later than the file, which is how it throws out a
+                // recycled process id. Writing it in the wrong order would make the whole rig resolve to
+                // NotRunning and every test here would pass for the wrong reason.
+                WriteRegistration(registrations, directorId, helper.Id);
+
+                if (liveSessions is { } count)
+                {
+                    var journal = new DirectorCrashJournal(directorId, helper.Id, Environment.MachineName,
+                        Environment.UserName, DateTimeOffset.UtcNow, journalDir);
+                    journal.Update(Enumerable.Range(1, count).Select(i => new DirectorCrashJournalSession
+                    {
+                        SessionId = $"session-{i}",
+                        Name = $"seat {i}",
+                        RepoPath = @"D:\repo",
+                        CreatedAtUtc = DateTimeOffset.UtcNow,
+                    }));
+                }
+
+                var layout = new InstallLayout(root);
+
+                // No installed image to compare the claimant against, which is deliberate: a stand-in
+                // cannot be running the installed Director's executable, and passing one would make the
+                // locator answer NotSupervised and the rig would resolve to nothing. A lone claimant with
+                // nothing to compare it to resolves as Running and UNCERTIFIED, which is the state the
+                // launcher's own kill gate is written for and is exactly what a development build looks
+                // like on a real machine.
+                var locator = new DirectorInstanceLocator(instanceHome);
+
+                // The rig is only a rig if the real locator agrees it is looking at a running Director.
+                var lookup = locator.Resolve();
+                Assert.Equal(DirectorResolution.Running, lookup.Outcome);
+                Assert.Equal(liveSessions, locator.ReadSessionCount(lookup.Director!));
+
+                return new Rig(root, helper, new DirectorSupervisor(layout, locator));
+            }
+            catch
+            {
+                Kill(helper);
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            Kill(Helper);
+            try { Directory.Delete(_root, recursive: true); } catch { /* a temp directory */ }
+        }
+
+        private static void Kill(Process p)
+        {
+            try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { /* already gone */ }
+            p.Dispose();
+        }
+
+        /// <summary>
+        /// A stand-in Director: a process that listens for THE SAME named shutdown signal a Director
+        /// listens for and exits when it is raised. That is what makes "it was stopped" an observation -
+        /// a helper that only slept would look identical whether the launcher asked it to stop or not.
+        /// </summary>
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        private static Process StartShutdownListeningHelper(string directorId)
+        {
+            var signal = LifecycleSignalNames.DirectorShutdown(directorId);
+            var script = "$e = New-Object System.Threading.EventWaitHandle "
+                       + $"($false, 'ManualReset', 'Local\\{signal}'); "
+                       + "[void]$e.WaitOne(120000)";
+
+            var psi = new ProcessStartInfo("powershell.exe",
+                $"-NoProfile -NonInteractive -WindowStyle Hidden -Command \"{script}\"")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+            };
+
+            var helper = Process.Start(psi)
+                         ?? throw new InvalidOperationException("could not start the stand-in Director");
+
+            // Wait until it is actually LISTENING. Raising a signal nobody holds yet is not delivered, and
+            // the launcher would then wait out its whole graceful-shutdown timeout - a test that takes
+            // twenty seconds and proves the wrong thing.
+            var deadline = DateTime.UtcNow.AddSeconds(30);
+            while (DateTime.UtcNow < deadline)
+            {
+                if (EventWaitHandle.TryOpenExisting(@"Local\" + signal, out var opened))
+                {
+                    opened.Dispose();
+                    return helper;
+                }
+                Thread.Sleep(50);
+            }
+
+            Kill(helper);
+            throw new InvalidOperationException(
+                $"the stand-in Director never began listening for {signal} within 30s");
+        }
+    }
+
+    /// <summary>Whether a process has left the process table within a few seconds.</summary>
+    private static bool WaitForExit(Process p) => p.WaitForExit(15_000);
+}

--- a/src/CcDirector.Launcher.Tests/RestartOnlyIfEmptyTests.cs
+++ b/src/CcDirector.Launcher.Tests/RestartOnlyIfEmptyTests.cs
@@ -384,6 +384,53 @@ public sealed class RestartOnlyIfEmptyTests
         }
     }
 
+    /// <summary>
+    /// THE DEFECT REPRODUCED: the machine CHANGES between the guard's reading and the stop's, and the
+    /// stop must still act on what the guard decided.
+    ///
+    /// This is the independent reviewer's counterexample, made deterministic. The first reading finds
+    /// nothing running - which is what an unreadable registration looks like - so the guard permits and
+    /// records a count of zero. The second reading, taken a moment later, finds a live Director holding
+    /// three sessions. The old code took that second reading at stop time and would have stopped it: a
+    /// restart that was allowed only because the machine looked empty, ending in three sessions being
+    /// taken.
+    ///
+    /// The two readings are arranged through the supervisor's own reading seam, because outside a test
+    /// they differ only when a real file finishes being written mid-call, which cannot be timed from the
+    /// outside. Everything else is real: a live process listening for its own shutdown signal, and its
+    /// exit or survival as the observation.
+    /// </summary>
+    [Fact]
+    public async Task RestartAsync_OnlyIfEmpty_StopsWhatTheGuardSaw_EvenIfTheMachineChangesUnderneath()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        using var rig = Rig.Start(liveSessions: 3);
+
+        // Reading one: nothing running. Reading two onwards: the truth - a live Director with three
+        // sessions. A guard that decides on the first and a stop that acts on the second is the defect.
+        var readings = 0;
+        var theTruth = rig.Supervisor.Locator.Resolve();
+        Assert.Equal(DirectorResolution.Running, theTruth.Outcome);
+
+        rig.Supervisor.ReadTheMachine = () =>
+            Interlocked.Increment(ref readings) == 1
+                ? new DirectorLookup(DirectorResolution.NotRunning, null, Array.Empty<string>())
+                : theTruth;
+
+        // The guard permits on reading one, so the restart proceeds to start the installed Director,
+        // which this rig does not install.
+        await Assert.ThrowsAsync<FileNotFoundException>(() => rig.Supervisor.RestartAsync(onlyIfEmpty: true));
+
+        Assert.True(readings >= 1, "the supervisor never read the machine at all");
+
+        rig.Helper.Refresh();
+        Assert.False(rig.Helper.HasExited,
+            "the guard permitted a restart because the machine looked empty, and then the stop took a "
+            + "SECOND reading and shut down a Director holding three sessions. The reading that decides "
+            + "must be the reading that acts.");
+    }
+
     // -------------------------------------------------------------------------
     // The command boundary: a "director/restart" arriving on the launcher's stream
     // -------------------------------------------------------------------------

--- a/src/CcDirector.Launcher/DirectorSupervisor.cs
+++ b/src/CcDirector.Launcher/DirectorSupervisor.cs
@@ -115,6 +115,7 @@ public sealed class DirectorSupervisor
     {
         _layout = layout ?? throw new ArgumentNullException(nameof(layout));
         _locator = locator ?? throw new ArgumentNullException(nameof(locator));
+        ReadTheMachine = _locator.Resolve;
     }
 
     /// <summary>
@@ -136,6 +137,21 @@ public sealed class DirectorSupervisor
 
     /// <summary>Where the supervised Director's identity is resolved from.</summary>
     public DirectorInstanceLocator Locator => _locator;
+
+    /// <summary>
+    /// How this supervisor reads the machine. Production always uses <see cref="DirectorInstanceLocator.Resolve"/>.
+    ///
+    /// IT IS A SEAM ONLY SO THAT DECIDING ON ONE READING AND ACTING ON ANOTHER CAN BE REPRODUCED. That
+    /// defect needs two consecutive reads to DISAGREE, and outside a test they disagree only when the
+    /// machine changes underneath them - a registration finishing its write, a Director starting - which
+    /// cannot be arranged deterministically from the outside. Without the seam the fix is real and
+    /// untested: a mutation that puts the second read back passes every test in the suite, which was
+    /// verified before this was added rather than assumed.
+    ///
+    /// The same argument, in the same words, is why <see cref="DirectorInstanceLocator.ReadExecutablePath"/>
+    /// exists. A guard that fails open is worse for being present and never exercised.
+    /// </summary>
+    internal Func<DirectorLookup> ReadTheMachine { get; set; } = null!;
 
     /// <summary>
     /// Whether a Director holds the supervised instance.
@@ -240,7 +256,7 @@ public sealed class DirectorSupervisor
     public Task StopAsync(CancellationToken ct = default)
     {
         FileLog.Write("[DirectorSupervisor] StopAsync");
-        return StopResolvedAsync(_locator.Resolve(), ct);
+        return StopResolvedAsync(ReadTheMachine(), ct);
     }
 
     /// <summary>
@@ -487,7 +503,7 @@ public sealed class DirectorSupervisor
     public string? RefuseRestartUnlessEmpty(out int? sessions, out DirectorLookup lookup)
     {
         sessions = null;
-        lookup = _locator.Resolve();
+        lookup = ReadTheMachine();
 
         if (lookup.Outcome == DirectorResolution.NotRunning)
         {

--- a/src/CcDirector.Launcher/DirectorSupervisor.cs
+++ b/src/CcDirector.Launcher/DirectorSupervisor.cs
@@ -457,7 +457,12 @@ public sealed class DirectorSupervisor
             return null;
         }
 
-        if (lookup.Director is not { } director)
+        // EXHAUSTIVE BY NAME, NOT BY NULLNESS. Only a Running lookup carries a Director today, so testing
+        // the Director alone would be right - and it would stop being right the moment a new outcome is
+        // added that carries one, silently, by treating it as running and reading its count. The rule this
+        // guard exists for is that an answer nobody named must never become the permissive branch, and
+        // that has to hold for answers nobody has invented yet.
+        if (lookup.Outcome != DirectorResolution.Running || lookup.Director is not { } director)
             return $"refusing to restart the Director on {Environment.MachineName}: which process owns "
                    + $"{_locator.InstanceHome} is undecidable ({lookup.Outcome}), so how many sessions it is "
                    + "holding cannot be read, and an unknown count is never read as empty. Claimants: "

--- a/src/CcDirector.Launcher/DirectorSupervisor.cs
+++ b/src/CcDirector.Launcher/DirectorSupervisor.cs
@@ -237,11 +237,28 @@ public sealed class DirectorSupervisor
     /// there is no way to tell which one the launcher is responsible for, and stopping the wrong
     /// Director is a worse outcome than stopping nothing - it takes somebody's live sessions with it.
     /// </summary>
-    public async Task StopAsync(CancellationToken ct = default)
+    public Task StopAsync(CancellationToken ct = default)
     {
         FileLog.Write("[DirectorSupervisor] StopAsync");
+        return StopResolvedAsync(_locator.Resolve(), ct);
+    }
 
-        var lookup = _locator.Resolve();
+    /// <summary>
+    /// Stop the Director named by a reading of the machine that has ALREADY BEEN TAKEN.
+    ///
+    /// IT EXISTS SO THAT ONE READING CAN BOTH DECIDE AND ACT. A guarded restart asks whether the
+    /// Director is empty and then stops it, and while those were two separate resolutions the second
+    /// could see something the first never did - an independent review demonstrated exactly that, with a
+    /// registration that was unreadable when the guard looked (so the machine read as nothing running,
+    /// and the restart was permitted) and readable a moment later, at which point the stop found a live
+    /// Director holding three sessions and would have taken them. Deciding on one reading and acting on
+    /// another is the whole defect; handing the reading forward is the whole fix.
+    ///
+    /// <see cref="StopAsync"/> keeps its own behaviour by taking a fresh reading and calling this - which
+    /// is right for a caller that has not already decided something on an earlier one.
+    /// </summary>
+    private async Task StopResolvedAsync(DirectorLookup lookup, CancellationToken ct)
+    {
         if (lookup.Outcome == DirectorResolution.NotRunning)
         {
             FileLog.Write("[DirectorSupervisor] StopAsync: Director not running");
@@ -370,13 +387,20 @@ public sealed class DirectorSupervisor
     public async Task<DirectorRestartOutcome> RestartAsync(bool onlyIfEmpty, CancellationToken ct = default)
     {
         int? sessions = null;
+
+        // The reading the guard decided on, kept so the STOP can act on the same one. Null for an
+        // unconditional restart, which decides nothing and so has nothing to carry forward.
+        DirectorLookup? decidedOn = null;
+
         if (onlyIfEmpty)
         {
-            if (RefuseRestartUnlessEmpty(out sessions) is { } refusal)
+            if (RefuseRestartUnlessEmpty(out sessions, out var lookup) is { } refusal)
             {
                 FileLog.Write($"[DirectorSupervisor] RestartAsync REFUSED (onlyIfEmpty): {refusal}");
                 return new DirectorRestartOutcome(DirectorRestartVerdict.Refused, refusal, sessions);
             }
+
+            decidedOn = lookup;
 
             // A PERMIT WITHOUT A ZERO COUNT IS A FAULT, NOT A PERMISSION. The guard reports its verdict as
             // the ABSENCE of a refusal, which is a shape a future edit can fail open through - one added
@@ -391,7 +415,17 @@ public sealed class DirectorSupervisor
         }
 
         FileLog.Write($"[DirectorSupervisor] RestartAsync: proceeding (onlyIfEmpty={onlyIfEmpty})");
-        await StopAsync(ct);
+
+        // A GUARDED RESTART STOPS WHAT THE GUARD SAW, AND NOTHING ELSE. Taking a second reading here
+        // would let the stop act on a Director the decision never covered - including the case an
+        // independent review demonstrated, where the guard read an unreadable registration as nothing
+        // running, and a moment later the same registration resolved to a live Director holding three
+        // sessions. An unconditional restart has decided nothing, so it still reads the machine here.
+        if (decidedOn is { } reading)
+            await StopResolvedAsync(reading, ct);
+        else
+            await StopAsync(ct);
+
         // Brief pause to let file locks release before relaunching.
         await Task.Delay(500, ct);
         var started = Start(out var pid);
@@ -444,10 +478,16 @@ public sealed class DirectorSupervisor
     /// when it could not be established. It is handed out here rather than read again by the caller so the
     /// number reported and the number decided on cannot be two different readings of a moving machine.
     /// </param>
-    public string? RefuseRestartUnlessEmpty(out int? sessions)
+    /// <param name="lookup">
+    /// THE READING THIS VERDICT WAS REACHED ON, handed to the caller so the thing that ACTS can act on
+    /// the same one. A restart that resolves the machine again between deciding and stopping is deciding
+    /// on one reading and acting on another, which is the defect this whole guard exists to prevent,
+    /// one layer down.
+    /// </param>
+    public string? RefuseRestartUnlessEmpty(out int? sessions, out DirectorLookup lookup)
     {
         sessions = null;
-        var lookup = _locator.Resolve();
+        lookup = _locator.Resolve();
 
         if (lookup.Outcome == DirectorResolution.NotRunning)
         {
@@ -467,6 +507,21 @@ public sealed class DirectorSupervisor
                    + $"{_locator.InstanceHome} is undecidable ({lookup.Outcome}), so how many sessions it is "
                    + "holding cannot be read, and an unknown count is never read as empty. Claimants: "
                    + $"{Describe(lookup)}.";
+
+        // A RESOLVED CONFLICT IS STILL A MACHINE IN A WRONG STATE. The locator reports one when several
+        // live processes claimed this instance and the tie-break could name the installed one - so there
+        // IS a Director and its count can be read, and reading it would be answering the wrong question.
+        // Something else is also claiming this home; stopping the one we chose leaves the other holding
+        // it, and the start that follows finds the instance taken and declines. The locator's own
+        // contract says every caller must carry a resolved conflict somewhere a person meets it, and for
+        // a guard whose job is to refuse on a machine nobody understands, that means refusing.
+        if (lookup.Conflict is { } conflict)
+            return $"refusing to restart the Director {director.DirectorId} (pid {director.Pid}) on "
+                   + $"{Environment.MachineName}: more than one live process claims "
+                   + $"{_locator.InstanceHome}, and although the tie-break could say which one is the "
+                   + $"installed Director, the machine is still in a state nobody asked for - {conflict} "
+                   + $"Claimants: {Describe(lookup)}. Resolve the claim on this instance by hand, then "
+                   + "ask again.";
 
         sessions = _locator.ReadSessionCount(director);
         if (sessions is null)

--- a/src/CcDirector.Launcher/DirectorSupervisor.cs
+++ b/src/CcDirector.Launcher/DirectorSupervisor.cs
@@ -418,15 +418,26 @@ public sealed class DirectorSupervisor
     /// Why a restart that was told to happen only if the Director is empty must NOT proceed, or null when
     /// it may.
     ///
-    /// AN UNKNOWN COUNT IS A REFUSAL, NEVER AN EMPTY ONE. Three of the ways this answers no are answers it
-    /// could not get: more than one live process claims the instance, the running Director's registration
-    /// will not read, or its session roster will not read. A guard that treated any of those as idle would
-    /// open exactly when the machine is already in a state nobody understands, which is the worst possible
-    /// moment for a guard to open.
+    /// AN UNKNOWN COUNT IS A REFUSAL, NEVER AN EMPTY ONE. Two of the ways this answers no are answers it
+    /// could not get: more than one live process claims the instance, so which one is the Director is
+    /// undecidable; or the resolved Director's session roster will not read. A guard that treated either
+    /// as idle would open exactly when the machine is already in a state nobody understands, which is the
+    /// worst possible moment for a guard to open.
     ///
     /// A DIRECTOR THAT IS NOT RUNNING IS EMPTY, and that is a real answer rather than a missing one:
     /// nothing is holding a session because nothing is holding anything. The restart then does what a
     /// restart of a stopped Director has always done, which is start one.
+    ///
+    /// AND HERE IS THE LIMIT OF THAT, STATED RATHER THAN LEFT TO BE INFERRED. "Not running" is the
+    /// locator's answer, and the locator reaches it by SKIPPING what it cannot read: a registration file
+    /// that will not parse, or a live process that will not say when it started, is passed over, and a
+    /// machine whose only registration is one of those looks empty. The locator does that deliberately and
+    /// it is safe for the question it was written for - whether to STOP something, where skipping means
+    /// declining - but this guard asks the opposite question, and there the same answer means PERMIT. So a
+    /// Director whose registration is corrupt is not protected by this guard. That is inherited behaviour,
+    /// identical for an unconditional restart and for the update path, and it is NOT something the flag
+    /// closes; closing it needs the locator to distinguish "nothing is there" from "I could not read what
+    /// is there", which is a change to <see cref="DirectorInstanceLocator"/> and not to this guard.
     /// </summary>
     /// <param name="sessions">
     /// The count this verdict was reached on: the live sessions found, 0 when nothing is running, and null

--- a/src/CcDirector.Launcher/DirectorSupervisor.cs
+++ b/src/CcDirector.Launcher/DirectorSupervisor.cs
@@ -21,6 +21,58 @@ public sealed record DirectorStatus(string DirectorId, int Pid, string Version, 
     string? Conflict = null);
 
 /// <summary>
+/// How a restart ended. Three outcomes, and they are kept apart because a caller ACTS differently on
+/// each: wait and try again, drain first, or go and look at the machine.
+/// </summary>
+public enum DirectorRestartVerdict
+{
+    /// <summary>The Director was stopped and a new one was started.</summary>
+    Restarted,
+
+    /// <summary>
+    /// NOTHING WAS DONE. The restart was asked to happen only if the Director was empty, and it was not -
+    /// or how busy it is could not be established, which is the same answer. The machine is exactly as it
+    /// was, and the caller's next move is to finish the drain.
+    /// </summary>
+    Refused,
+
+    /// <summary>
+    /// SOMETHING WAS DONE AND IT DID NOT FINISH. The stop ran and no new Director was started, because
+    /// another live process holds the instance. This is NOT a refusal and must never be reported as one:
+    /// a refusal promises the machine is untouched, and here it may now be without a Director at all.
+    /// </summary>
+    NotStarted,
+}
+
+/// <summary>
+/// What a restart asked to happen ONLY IF THE DIRECTOR IS EMPTY actually did.
+/// </summary>
+/// <param name="Verdict">Which of the three endings this was.</param>
+/// <param name="Reason">
+/// Why, when it was not a plain restart - and it always NAMES WHAT WAS OBSERVED, including the live
+/// session count. Null only when <see cref="DirectorRestartVerdict.Restarted"/>. A caller must carry this
+/// to whoever asked: a refusal nobody reads is indistinguishable from a restart that happened.
+/// </param>
+/// <param name="Sessions">
+/// The live session count behind the verdict: the number that caused a refusal, and 0 for a guarded
+/// restart that went ahead. NULL WHENEVER NO COUNT WAS ESTABLISHED - an unconditional restart, which never
+/// asks, and a refusal whose whole reason is that the count could not be read. It is null rather than 0 on
+/// purpose in both cases: "nobody looked" and "nobody was there" are the two facts this feature exists to
+/// keep apart.
+/// </param>
+/// <param name="StartedPid">
+/// The process id of the Director this restart started, when the operating system named one. Null on
+/// macOS even for a successful start, where launchd owns the launch - so it is <paramref name="Restarted"/>
+/// that says whether one came up, never this.
+/// </param>
+public sealed record DirectorRestartOutcome(DirectorRestartVerdict Verdict, string? Reason, int? Sessions,
+    int? StartedPid = null)
+{
+    /// <summary>True only when a Director was stopped and another was started.</summary>
+    public bool Restarted => Verdict == DirectorRestartVerdict.Restarted;
+}
+
+/// <summary>
 /// Supervises the installed CC Director app - start, stop, restart, and the two facts the update path
 /// needs (what version is running, and whether restarting it would interrupt live work).
 ///
@@ -99,8 +151,27 @@ public sealed class DirectorSupervisor
     /// Windows: UseShellExecute = true for clean parentage (no pseudo-console inheritance).
     /// macOS: /usr/bin/open so the Director is parented by launchd, not this launcher.
     /// </summary>
-    public void Start()
+    public void Start() => Start(out _);
+
+    /// <summary>
+    /// Start the installed Director if it is not already running, and SAY WHETHER ONE WAS ACTUALLY
+    /// STARTED. The plain <see cref="Start()"/> above is the same call for callers that do not care.
+    ///
+    /// THE TWO ANSWERS ARE KEPT APART BECAUSE MERGING THEM PRODUCES A FALSE REPORT. Skipping the launch
+    /// because another process already holds the instance is a perfectly ordinary outcome, and a restart
+    /// that ends that way stopped a Director and started nothing - which must not be reported as
+    /// "restarted". An earlier version of this returned only a process id and left the caller to guess
+    /// from a null, which cannot be done: macOS legitimately has no process id to give.
+    /// </summary>
+    /// <param name="launchedProcessId">
+    /// The process id the operating system gave the Director this call started, when there is one.
+    /// Null both when nothing was started and on macOS, where /usr/bin/open hands the launch to launchd
+    /// and no id comes back - which is why the RETURN VALUE, not this, says whether a launch happened.
+    /// </param>
+    /// <returns>True when this call launched a Director; false when one already held the instance.</returns>
+    public bool Start(out int? launchedProcessId)
     {
+        launchedProcessId = null;
         FileLog.Write($"[DirectorSupervisor] Start: target={DirectorExePath}");
 
         if (!DirectorExeExists)
@@ -111,7 +182,7 @@ public sealed class DirectorSupervisor
         {
             FileLog.Write($"[DirectorSupervisor] Start: a Director already holds {_locator.InstanceHome} "
                           + $"({lookup.Outcome}); skipping. Claimants: {Describe(lookup)}");
-            return;
+            return false;
         }
 
         if (OperatingSystem.IsWindows())
@@ -127,7 +198,8 @@ public sealed class DirectorSupervisor
                 ?? throw new InvalidOperationException($"Process.Start returned null for: {DirectorExePath}");
 
             FileLog.Write($"[DirectorSupervisor] Start: launched Director pid={proc.Id}");
-            return;
+            launchedProcessId = proc.Id;
+            return true;
         }
 
         // macOS: hand the bundle to launchd via /usr/bin/open. open exits immediately;
@@ -146,6 +218,9 @@ public sealed class DirectorSupervisor
             throw new InvalidOperationException($"/usr/bin/open exited with code {open.ExitCode} for: {DirectorExePath}");
 
         FileLog.Write($"[DirectorSupervisor] Start: /usr/bin/open accepted launch of {DirectorExePath}");
+        // launchd owns the launch, so there is no process id to report - the Director's own registration
+        // file names it. The launch itself DID happen, which is what the return value says.
+        return true;
     }
 
     /// <summary>
@@ -257,6 +332,11 @@ public sealed class DirectorSupervisor
     /// <summary>
     /// Restart the Director: stop gracefully, wait, then start fresh.
     /// A staged update is applied by the launcher's update loop, not by the Director itself.
+    ///
+    /// UNCONDITIONAL, and its two callers are why. A person clicking "Restart Director" in the tray menu
+    /// has decided; and the lifecycle signal a Director raises to have its own staged update installed is
+    /// that Director asking for itself. A caller that must not interrupt live work asks for
+    /// <see cref="RestartAsync(bool, CancellationToken)"/> with onlyIfEmpty instead.
     /// </summary>
     public async Task RestartAsync(CancellationToken ct = default)
     {
@@ -266,6 +346,128 @@ public sealed class DirectorSupervisor
         await Task.Delay(500, ct);
         Start();
         FileLog.Write("[DirectorSupervisor] RestartAsync: Director restarted");
+    }
+
+    /// <summary>
+    /// Restart the Director, optionally ONLY IF IT IS EMPTY - that is, holding no live sessions.
+    ///
+    /// THIS IS THE MECHANICAL GUARANTEE BEHIND "NEVER FORCE". A drain empties a Director one session at a
+    /// time, and a restart that arrives in the middle of one takes every session that is left with it.
+    /// Until now the rule against that was a sentence in a written instruction, and a sentence cannot stop
+    /// a mistake. This can: the launcher reads the count itself, from the files the Director maintains,
+    /// and declines.
+    ///
+    /// THE REFUSAL NAMES THE COUNT, and that is the feature rather than a nicety. "Refused" tells the
+    /// reader nothing they can act on; "3 live sessions" tells them the drain is not finished and roughly
+    /// how much of it is left. Every refusal below says what was observed.
+    ///
+    /// WHAT IT DOES NOT PROMISE. The count is read, and then the Director is stopped - a session created
+    /// between those two moments is not seen, and nothing here takes a lock. This closes the case that
+    /// actually happens, a restart fired at a Director that is visibly still busy; it is not a settlement
+    /// between two operators driving one machine against each other.
+    /// </summary>
+    /// <param name="onlyIfEmpty">When true, refuse unless the Director is provably holding no sessions.</param>
+    public async Task<DirectorRestartOutcome> RestartAsync(bool onlyIfEmpty, CancellationToken ct = default)
+    {
+        int? sessions = null;
+        if (onlyIfEmpty)
+        {
+            if (RefuseRestartUnlessEmpty(out sessions) is { } refusal)
+            {
+                FileLog.Write($"[DirectorSupervisor] RestartAsync REFUSED (onlyIfEmpty): {refusal}");
+                return new DirectorRestartOutcome(DirectorRestartVerdict.Refused, refusal, sessions);
+            }
+
+            // A PERMIT WITHOUT A ZERO COUNT IS A FAULT, NOT A PERMISSION. The guard reports its verdict as
+            // the ABSENCE of a refusal, which is a shape a future edit can fail open through - one added
+            // path that returns no refusal without having established a count, and a busy Director is
+            // restarted and reported as having held none. It cannot pass here quietly.
+            if (sessions is not 0)
+                throw new InvalidOperationException(
+                    "the emptiness guard permitted a restart without establishing that the Director is "
+                    + $"holding no sessions (count={(sessions.HasValue ? sessions.Value.ToString() : "unknown")}). "
+                    + "That is a fault in the guard, and the restart is abandoned rather than performed on "
+                    + "an answer nobody has.");
+        }
+
+        FileLog.Write($"[DirectorSupervisor] RestartAsync: proceeding (onlyIfEmpty={onlyIfEmpty})");
+        await StopAsync(ct);
+        // Brief pause to let file locks release before relaunching.
+        await Task.Delay(500, ct);
+        var started = Start(out var pid);
+
+        // STOPPED AND NOTHING STARTED IS NOT A RESTART. Start skips when something already holds the
+        // instance, and reporting that as a restart would tell the caller their Director came back when
+        // it did not.
+        if (!started)
+        {
+            var noStart = $"no new Director was started on {Environment.MachineName}: another live process "
+                          + $"already holds {_locator.InstanceHome}, and starting a second Director on top "
+                          + "of it would make that worse. The stop ran first, so this machine may now be "
+                          + "without the Director it had. Resolve the claim on this instance by hand.";
+            FileLog.Write($"[DirectorSupervisor] RestartAsync: {noStart}");
+            return new DirectorRestartOutcome(DirectorRestartVerdict.NotStarted, noStart, sessions);
+        }
+
+        FileLog.Write("[DirectorSupervisor] RestartAsync: Director restarted "
+                      + $"(startedPid={(pid.HasValue ? pid.Value.ToString() : "none - launchd owns the launch")})");
+        return new DirectorRestartOutcome(DirectorRestartVerdict.Restarted, null, sessions, pid);
+    }
+
+    /// <summary>
+    /// Why a restart that was told to happen only if the Director is empty must NOT proceed, or null when
+    /// it may.
+    ///
+    /// AN UNKNOWN COUNT IS A REFUSAL, NEVER AN EMPTY ONE. Three of the ways this answers no are answers it
+    /// could not get: more than one live process claims the instance, the running Director's registration
+    /// will not read, or its session roster will not read. A guard that treated any of those as idle would
+    /// open exactly when the machine is already in a state nobody understands, which is the worst possible
+    /// moment for a guard to open.
+    ///
+    /// A DIRECTOR THAT IS NOT RUNNING IS EMPTY, and that is a real answer rather than a missing one:
+    /// nothing is holding a session because nothing is holding anything. The restart then does what a
+    /// restart of a stopped Director has always done, which is start one.
+    /// </summary>
+    /// <param name="sessions">
+    /// The count this verdict was reached on: the live sessions found, 0 when nothing is running, and null
+    /// when it could not be established. It is handed out here rather than read again by the caller so the
+    /// number reported and the number decided on cannot be two different readings of a moving machine.
+    /// </param>
+    public string? RefuseRestartUnlessEmpty(out int? sessions)
+    {
+        sessions = null;
+        var lookup = _locator.Resolve();
+
+        if (lookup.Outcome == DirectorResolution.NotRunning)
+        {
+            FileLog.Write("[DirectorSupervisor] RefuseRestartUnlessEmpty: no Director is running, so it is "
+                          + "holding no sessions and the restart may proceed as a start.");
+            sessions = 0;
+            return null;
+        }
+
+        if (lookup.Director is not { } director)
+            return $"refusing to restart the Director on {Environment.MachineName}: which process owns "
+                   + $"{_locator.InstanceHome} is undecidable ({lookup.Outcome}), so how many sessions it is "
+                   + "holding cannot be read, and an unknown count is never read as empty. Claimants: "
+                   + $"{Describe(lookup)}.";
+
+        sessions = _locator.ReadSessionCount(director);
+        if (sessions is null)
+            return $"refusing to restart the Director {director.DirectorId} (pid {director.Pid}) on "
+                   + $"{Environment.MachineName}: it is running and its live session roster could not be "
+                   + "read, so how many sessions it is holding is unknown, and an unknown count is never "
+                   + "read as empty.";
+
+        if (sessions > 0)
+            return $"refusing to restart the Director {director.DirectorId} (pid {director.Pid}) on "
+                   + $"{Environment.MachineName}: it is holding {sessions} live "
+                   + $"{(sessions == 1 ? "session" : "sessions")}. Drain it first - every session writes a "
+                   + "handover and is closed - then ask again.";
+
+        FileLog.Write($"[DirectorSupervisor] RefuseRestartUnlessEmpty: {director.DirectorId} (pid "
+                      + $"{director.Pid}) is holding 0 live sessions; the restart may proceed.");
+        return null;
     }
 
     private static string Describe(DirectorLookup lookup)

--- a/src/CcDirector.Launcher/LauncherStreamClient.cs
+++ b/src/CcDirector.Launcher/LauncherStreamClient.cs
@@ -40,6 +40,12 @@ public sealed class LauncherStreamClient : IAsyncDisposable
     /// naming so the documents agents read keep the shape they have always had.</summary>
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
+    /// <summary>What to say when the supervisor reports an outcome and no reason for it. It cannot happen
+    /// by construction; it is here so that if it ever does, the answer says whose fault it is.</summary>
+    private const string UnexplainedOutcome =
+        "the launcher did not restart the Director and did not say why, which is a fault in the launcher "
+        + "rather than an answer about the Director";
+
     private HubConnection? _connection;
     private int _started;
     private volatile bool _disposed;
@@ -118,16 +124,38 @@ public sealed class LauncherStreamClient : IAsyncDisposable
         }
     }
 
-    // Execute one command through the shared supervisor/launch actions. A boundary: any fault becomes an
-    // Error result.
-    private async Task<LauncherCommandResult> DispatchAsync(LauncherCommand cmd)
+    /// <summary>
+    /// Execute one command through the shared supervisor/launch actions. A boundary: any fault becomes an
+    /// Error result.
+    ///
+    /// INTERNAL RATHER THAN PRIVATE so the tests can drive a real command through the real supervisor.
+    /// Every decision this method makes - which verb honours onlyIfEmpty, what a refusal becomes on the
+    /// wire - is invisible to a test that stops at the relay or starts at the supervisor, and a seam that
+    /// nothing crosses is exactly where a flag goes missing without a single test turning red.
+    /// </summary>
+    internal async Task<LauncherCommandResult> DispatchAsync(LauncherCommand cmd)
     {
         try
         {
             if (cmd is null)
                 return LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, "command is required");
 
-            FileLog.Write($"[LauncherStreamClient] Command received: verb={cmd.Verb}, path={cmd.Path ?? "(none)"}, confirmProtected={cmd.ConfirmProtected}");
+            FileLog.Write($"[LauncherStreamClient] Command received: verb={cmd.Verb}, path={cmd.Path ?? "(none)"}, confirmProtected={cmd.ConfirmProtected}, onlyIfEmpty={cmd.OnlyIfEmpty}");
+
+            // A CONDITION THIS VERB CANNOT HONOUR IS REFUSED HERE, AT THE BOUNDARY, rather than ignored.
+            // onlyIfEmpty means "do not interrupt live work"; every verb below except the restart does
+            // something else entirely with it, which is nothing. Dropping it silently would answer a
+            // request to be careful with a success that was never careful, and this is the last place
+            // that can tell - the Gateway route refuses it too, but it is not the only way a command can
+            // arrive here.
+            if (cmd.OnlyIfEmpty && cmd.Verb != "director/restart")
+            {
+                FileLog.Write($"[LauncherStreamClient] Command declined: onlyIfEmpty was sent with '{cmd.Verb}'");
+                return LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest,
+                    $"onlyIfEmpty is understood by 'director/restart' alone, and this is '{cmd.Verb}'. "
+                    + "Nothing was done: a condition that cannot be honoured is refused, never dropped.");
+            }
+
             switch (cmd.Verb)
             {
                 case "director/start":
@@ -139,8 +167,43 @@ public sealed class LauncherStreamClient : IAsyncDisposable
                     return LauncherCommandResult.Ok();
 
                 case "director/restart":
-                    await _supervisor.RestartAsync();
-                    return LauncherCommandResult.Ok();
+                {
+                    // ONLY-IF-EMPTY IS DECIDED HERE, IN THE LAUNCHER PROCESS, for the same reason the
+                    // catalogue rule below is: it is the only place that can read how busy the Director
+                    // actually is, and a guard the caller could route around is not a guard.
+                    var outcome = await _supervisor.RestartAsync(cmd.OnlyIfEmpty);
+                    switch (outcome.Verdict)
+                    {
+                        // NOTHING WAS DONE - the only outcome that may be called a refusal. It promises the
+                        // machine is exactly as the caller left it, and the reason names the live count.
+                        case DirectorRestartVerdict.Refused:
+                            return LauncherCommandResult.Refuse(outcome.Reason ?? UnexplainedOutcome);
+
+                        // SOMETHING WAS DONE AND IT DID NOT FINISH: the stop ran and nothing came back up.
+                        // Reported as a fault, never as a refusal - a refusal would tell the caller their
+                        // machine is untouched when it may now have no Director at all.
+                        case DirectorRestartVerdict.NotStarted:
+                            return LauncherCommandResult.Fail(LauncherCommandStatus.Error,
+                                outcome.Reason ?? UnexplainedOutcome);
+
+                        case DirectorRestartVerdict.Restarted:
+                            // A GUARDED RESTART SAYS SO IN ITS ANSWER, in full: the condition it applied,
+                            // the count it read, and that a Director really came back. An older launcher
+                            // does not know this flag, ignores it, restarts a busy Director and answers
+                            // with a bare OK - so a caller that needed the guarantee must be able to tell
+                            // the two OKs apart, and the Gateway refuses to call a bare one guarded.
+                            return cmd.OnlyIfEmpty
+                                ? LauncherCommandResult.OkWithPayload(JsonSerializer.Serialize(
+                                    new { ok = true, restarted = true, onlyIfEmpty = true, sessions = outcome.Sessions },
+                                    JsonOptions))
+                                : LauncherCommandResult.Ok();
+
+                        default:
+                            throw new InvalidOperationException(
+                                $"the supervisor answered with a restart verdict this launcher does not "
+                                + $"know how to report: {outcome.Verdict}.");
+                    }
+                }
 
                 case "launch":
                 {


### PR DESCRIPTION
Closes thefrederiksen/devthrottle_internal#1925. Phase 2 of thefrederiksen/devthrottle_internal#1923.

## Why

A drain empties a Director one session at a time. A restart that lands in the middle of one takes
every session that is left with it. The rule against that lived in a written instruction, and an
instruction cannot stop a mistake - so `director/restart` now takes `onlyIfEmpty`, and the launcher
itself declines while the Director is holding anything.

**The refusal is the feature.** "Refused" tells the reader nothing they can act on; "it is holding
3 live sessions" tells them the drain is unfinished and how much of it is left.

## Review, and the limit of what the review certifies

An independent reviewer approved this change across `c7adef8aa..d9d2143aa` with **no high findings**,
confirming the three defects assigned to it are closed and finding no new Critical, High, Medium or
Low in the four changed files, their callers, or the added tests. Its approval carries a qualifier
that belongs here in its own words rather than paraphrased:

> This approval therefore covers this pull request's fix round; it does not certify the larger
> onlyIfEmpty safety guarantee independently of that routed correction.

**THIS PULL REQUEST DOES NOT CERTIFY THE onlyIfEmpty GUARANTEE, AND NOBODY MAY RELY ON IT YET.**
It is not certified until the roster correction in thefrederiksen/devthrottle#2734 is merged, because until then a
structurally invalid roster still reads as a positive zero and the guard permits on it. The routed correction is thefrederiksen/devthrottle_internal#1931: a structurally
invalid live roster - an empty JavaScript Object Notation object, say - deserializes to a session
list that is PRESENT and empty, so "the roster had no answer" is read as "positively zero sessions",
and the guard permits. That is unchanged Core behaviour in `DirectorInstanceLocator`, it is being
fixed in the locator branch, and this guard is one of its readers.

**AND WHAT IS CLOSED HERE IS NARROWER THAN "FIXED" - DO NOT READ IT AS FIXED.**
An unreadable registration can still make the locator answer "not running", and this guard still
treats that as empty. What this change closes is narrower and specific: that reading can no longer
cause a newly visible busy Director to be STOPPED, because the reading that decides is now the
reading that acts. The defect is not gone; the destructive path out of it is closed.

## What onlyIfEmpty guarantees, and what it only reports

**It is a guarantee ONLY against a launcher that has declared it understands the verb. Against an
older launcher it is detection after the fact.** By the time the unacknowledged answer comes back,
that launcher has already restarted the Director - the sessions are gone, and what this change
saves is the caller's belief that the restart was safe, and every attempt after the first.

Stated here in those words rather than left to be inferred from the acknowledgement handling,
because a guarantee that silently degrades to a report is exactly the kind of thing somebody later
builds on believing it holds.

What closes it is a declared-capability handshake: the launcher says what it can honour when it
joins the stream, and the Gateway refuses before dispatch. On the Architect's ruling that belongs to
Phase 1, and Phase 6 closes the loop by re-running the capability check immediately before it asks
the launcher. The detection path here stays as it is.

## What it does

- `onlyIfEmpty` on `POST /machines/{machine}/director/restart`, carried down the launcher stream.
- The launcher reads the live session count from the roster the Director maintains - no network -
  and refuses while any are live, naming the count. The caller gets **409** with that sentence.
- **An unknown count is a refusal, never an empty Director.** An unreadable roster, or two live
  processes claiming one instance, are answers nobody has.
- **A Director that is not running is empty** - a real answer, not a missing one - so the restart
  starts one, as it always has.

Three things the review round added, each closing a way the guard could have failed open:

- **The flag is refused, never ignored, wherever it cannot be honoured**: on another verb, written
  as something that is not a boolean, spelled twice in one body, or inside a body that will not
  parse. Absence means "restart regardless", so anything a caller might have MEANT as the flag and
  the route cannot be sure of gets a 400 with nothing done. The name is matched without regard to
  case, because `{"OnlyIfEmpty": true}` is unmistakably somebody asking for the guard.
- **A success is only called guarded when the launcher says it guarded it.** A launcher older than
  this flag cannot see it, restarts a busy Director, and answers an ordinary OK. That is now a loud
  502 naming the cause instead of a success that promises something nobody delivered. It is
  DETECTION, not prevention - see the limits below.
- **A restart that stops a Director and starts nothing is a fault, not a refusal.** A refusal
  promises the machine is untouched.

## Proof

Both required assertions, against a real supervisor, a real instance registration and a real
crash-journal roster - nothing mocked. The stand-in Director listens for the same shutdown signal a
real one does, so "it was stopped" is an observed process exit:

- **sessions live -> refused, naming the count**, and the Director is still running afterwards;
- **no sessions -> it stops the Director and goes on to start the installed one.**

Plus a command driven through the real launcher dispatch (the seam where a flag goes missing without
a single test turning red), and route tests whose stub launcher records the command it actually
received.

**The mutation audit found a defect nothing else did, and it is the most serious thing in this
change.** A mutant that weakened the acknowledgement check from *the flag is TRUE* to *the flag is
PRESENT* SURVIVED. That means a launcher answering `{"onlyIfEmpty": false}` - stating plainly that it
had NOT guarded the restart - would have been accepted by the Gateway as a guarantee, with every
other field in that answer in order. The central promise of this change would have read its own
refusal as consent. It was invisible to every test and to two rounds of adversarial review; only a
mutation run under a compile gate found it. Two cases now pin it and the mutant dies.

**Mutation audit, under a compile gate, both reconciliations.** The first run of this audit was
itself unsound and is void: it judged a mutant by the test command's exit code, so a mutant that
FAILED TO COMPILE - producing no failing test at all - was scored as killed. The harness now BUILDS
every mutant first and refuses to score one that does not build; a run is only a kill when a named
test actually failed. Three verdicts, and "no failure line" is never a verdict on its own.

Re-run under that gate: **29 mutants, 27 KILLED by a named test, 2 SURVIVED**, and one that did not
compile on the first attempt was rewritten in a compiling form and then killed. Every new test dies
to at least one mutant.

**The two survivors are kept, not massaged into kills:**

- **A defensive assertion that is unreachable by construction** - the check that a permit without an
  established zero count throws rather than proceeding. Nothing can reach it today; it exists so
  that a future edit which returns "no refusal" without establishing a count fails loudly instead of
  restarting a busy Director.
- **The launcher's success acknowledgement is not asserted end to end**, because a unit test cannot
  start a real Director. Its *content* is pinned at the Gateway, which decides what a valid
  acknowledgement is. If the launcher wrote it wrongly, the Gateway fails **CLOSED** with a 502 - so
  the failure direction is safe - and the end-to-end half is exercised by the epic's QA run on a
  real machine rather than nowhere.

## Tests

**On the parked Gateway suite and its machine-wide lock.** That suite serialises across the whole
machine, so a run queues behind whatever holds the lock, and the waiting message names the HOLDER
without saying whether it is doing anything. Tell those apart by the holder's CPU DELTA between two
samples, never by its total: a large cumulative number is exactly as consistent with a process that
worked and then stopped, and reading that stock as a flow left a stalled run holding this lock for
nearly two hours. And take the measurement at the moment you act on it - AN EXONERATION ABOUT WHAT A
PROCESS IS DOING EXPIRES THE MOMENT YOU LOOK AWAY, because a claim about what something IS DOING has
a shelf life where a claim about what it CAN DO does not. Issue thefrederiksen/devthrottle_internal#1944 proposes putting the delta in
the waiting message itself, so the answer is where the reader already is.

**On the remote .NET check.** It is red on an unrelated statistics-store timeout, and it does not gate
this merge: `main` carries no branch protection and no required status checks, and this repository's
rule is a green LOCAL gate plus a review from a different agent family. Recorded here with the reason
so that nobody later reads a red check as having been waved through without looking.


`.\scripts\test-local.ps1` - all nine suites pass. The run reports OVER BUDGET for
`CcDirector.Gateway.UnitTests`, and that is **pre-existing, not this change**: measured with this
branch's new test file removed, the suite is 2m00s for 3730 tests against a 120-second ceiling; the
eight tests added here measured 47ms. Worth someone's attention as its own piece of work.

Parked coverage, run explicitly because this touches Gateway code:
`CcDirector.Gateway.Tests` - `RestartOnlyIfEmptyRouteTests` and `MachineRelaySlotGuardTests`, 32
passed.

## What nobody may rely on - these GATE a reader

- **onlyIfEmpty is a guarantee only against a launcher that has DECLARED it understands the verb.**
  Against an older launcher it is detection after the fact: by the time the unacknowledged answer
  comes back, that launcher has already restarted the Director. Do not treat a guarded restart as
  safe on a machine whose launcher capability has not been established. The declared-capability
  handshake that closes this belongs to a later phase of the epic.
- **The guard is not a lock.** The count is read, and then the Director is stopped. A session created
  between those two moments is not seen. What this change closes is the case where the two READINGS
  disagreed; it does not make the decision and the action atomic with respect to the Director's own
  work. Anything that needs that needs an admission barrier inside the Director.
- **A Director whose registration cannot be read is not protected by this guard.** The locator reaches
  "not running" by skipping evidence it cannot read, and this guard treats "not running" as empty.

## Disclosures - these limit the evidence, and gate nobody

- **A plain misspelling of the flag** (`onlyIfEmtpy`) is indistinguishable from a field this route
  has never heard of, and is ignored. Closing it needs the guard to be something other than an
  optional field.
- **The launcher's success acknowledgement is not asserted end to end**, because a unit test cannot
  start a real Director. Its content is pinned at the Gateway, which decides what a valid
  acknowledgement is; if the launcher wrote it wrongly the Gateway fails CLOSED with a 502.
- **No Director was really restarted by a real launcher on a real machine.** The permitted case is
  observed as far as the launch of the installed application.
