### PR TITLE
Refuse to save over a settings file that could not be parsed (#2735)

### DIFF
--- a/src/CcDirector.Avalonia.Tests/ClaudeSettingsFileTests.cs
+++ b/src/CcDirector.Avalonia.Tests/ClaudeSettingsFileTests.cs
@@ -187,6 +187,167 @@ public sealed class ClaudeSettingsFileTests : IDisposable
         Assert.True(File.Exists(nested));
     }
 
+    // ---- The merge contract, field by field --------------------------------
+
+    /// <summary>
+    /// Every field the dialog owns, all set at once, each asserted by name and value - and every
+    /// field it does NOT own asserted to survive. Without this the suite stayed green if the $schema
+    /// URL, any of the four environment variable names, the deny list, the plugin map or the
+    /// empty-env removal were wrong, because the shared edits helper left them all empty.
+    /// </summary>
+    [Fact]
+    public void Save_EveryEditedFieldIsWritten_AndEveryUnknownFieldSurvives()
+    {
+        File.WriteAllText(_path, """
+        {
+          "hooks": { "SessionStart": [ { "hooks": [ { "command": "cc-director-preamble" } ] } ] },
+          "mcpServers": { "vault": { "command": "cc-vault" } },
+          "statusLine": { "type": "command", "command": "my-status" },
+          "permissions": { "additionalDirectories": ["/srv"] },
+          "env": { "SOMETHING_ELSE": "keep me" }
+        }
+        """);
+
+        var result = ClaudeSettingsFile.Save(_path, new ClaudeSettingsEdits(
+            PermissionMode: "bypassPermissions",
+            Allow: new List<string> { "Bash(git status)", "Read(*)" },
+            Deny: new List<string> { "Bash(rm -rf *)" },
+            Model: "  claude-opus-5  ",
+            EffortLevel: "high",
+            MaxOutputTokens: "8192",
+            BashTimeoutMs: "600000",
+            EnabledPlugins: new Dictionary<string, bool> { ["a@repo"] = true, ["b@repo"] = false }));
+
+        Assert.Equal(SettingsSaveKind.Merged, result.Kind);
+        var root = JsonNode.Parse(File.ReadAllText(_path))!.AsObject();
+
+        Assert.Equal("https://json.schemastore.org/claude-code-settings.json", root["$schema"]!.GetValue<string>());
+
+        var perms = root["permissions"]!.AsObject();
+        Assert.Equal("bypassPermissions", perms["defaultMode"]!.GetValue<string>());
+        Assert.Equal(new[] { "Bash(git status)", "Read(*)" },
+            perms["allow"]!.AsArray().Select(n => n!.GetValue<string>()).ToArray());
+        Assert.Equal(new[] { "Bash(rm -rf *)" },
+            perms["deny"]!.AsArray().Select(n => n!.GetValue<string>()).ToArray());
+        Assert.Equal("/srv", perms["additionalDirectories"]![0]!.GetValue<string>());
+
+        var env = root["env"]!.AsObject();
+        Assert.Equal("claude-opus-5", env["ANTHROPIC_MODEL"]!.GetValue<string>());   // trimmed
+        Assert.Equal("high", env["CLAUDE_CODE_EFFORT_LEVEL"]!.GetValue<string>());
+        Assert.Equal("8192", env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"]!.GetValue<string>());
+        Assert.Equal("600000", env["BASH_DEFAULT_TIMEOUT_MS"]!.GetValue<string>());
+        Assert.Equal("keep me", env["SOMETHING_ELSE"]!.GetValue<string>());
+
+        var plugins = root["enabledPlugins"]!.AsObject();
+        Assert.True(plugins["a@repo"]!.GetValue<bool>());
+        Assert.False(plugins["b@repo"]!.GetValue<bool>());
+
+        Assert.Equal("cc-director-preamble",
+            root["hooks"]!["SessionStart"]![0]!["hooks"]![0]!["command"]!.GetValue<string>());
+        Assert.Equal("cc-vault", root["mcpServers"]!["vault"]!["command"]!.GetValue<string>());
+        Assert.Equal("my-status", root["statusLine"]!["command"]!.GetValue<string>());
+    }
+
+    /// <summary>Blank edits REMOVE their environment variables, and an env left empty is removed entirely.</summary>
+    [Fact]
+    public void Save_BlankEnvEdits_RemoveTheVariablesAndThenTheEnvObject()
+    {
+        File.WriteAllText(_path, """
+        { "env": { "ANTHROPIC_MODEL": "old", "CLAUDE_CODE_EFFORT_LEVEL": "low",
+                   "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "1", "BASH_DEFAULT_TIMEOUT_MS": "2" } }
+        """);
+
+        ClaudeSettingsFile.Save(_path, Edits());
+
+        var root = JsonNode.Parse(File.ReadAllText(_path))!.AsObject();
+        Assert.False(root.ContainsKey("env"));
+    }
+
+    /// <summary>A variable this dialog does not own keeps the env object alive when ours are cleared.</summary>
+    [Fact]
+    public void Save_BlankEnvEdits_KeepEnvWhenSomebodyElsesVariableIsThere()
+    {
+        File.WriteAllText(_path, """
+        { "env": { "ANTHROPIC_MODEL": "old", "SOMETHING_ELSE": "keep me" } }
+        """);
+
+        ClaudeSettingsFile.Save(_path, Edits());
+
+        var env = JsonNode.Parse(File.ReadAllText(_path))!.AsObject()["env"]!.AsObject();
+        Assert.False(env.ContainsKey("ANTHROPIC_MODEL"));
+        Assert.Equal("keep me", env["SOMETHING_ELSE"]!.GetValue<string>());
+    }
+
+    // ---- States found by re-reading this diff for the same defect it fixes ----
+
+    /// <summary>
+    /// A DIRECTORY at the settings path. File.Exists answers false for one, which folded it into
+    /// Absent - the permissive branch, the one that says "go ahead and create" - and the create then
+    /// threw out of a button click that has nowhere to put an exception. Something is at that path,
+    /// so the answer is Unreadable, not Absent.
+    /// </summary>
+    [Fact]
+    public void Read_PathIsADirectory_IsUnreadableNotAbsent()
+    {
+        var asDirectory = Path.Combine(_dir, "settings-as-a-directory.json");
+        Directory.CreateDirectory(asDirectory);
+
+        var read = ClaudeSettingsFile.Read(asDirectory);
+
+        Assert.Equal(ConfigReadKind.Unreadable, read.Kind);
+        Assert.Contains("is a directory", read.Problem);
+    }
+
+    /// <summary>And a save against it refuses rather than throwing.</summary>
+    [Fact]
+    public void Save_PathIsADirectory_RefusesInsteadOfThrowing()
+    {
+        var asDirectory = Path.Combine(_dir, "settings-as-a-directory.json");
+        Directory.CreateDirectory(asDirectory);
+
+        var result = ClaudeSettingsFile.Save(asDirectory, Edits());
+
+        Assert.Equal(SettingsSaveKind.RefusedUnreadable, result.Kind);
+        Assert.False(result.Saved);
+    }
+
+    /// <summary>
+    /// The write goes through a sibling temp file and a move, so a crash part-way cannot leave a
+    /// half-written settings file - which would be this fix manufacturing the exact state it refuses
+    /// to write over.
+    ///
+    /// WHAT THIS TEST ACTUALLY PROVES, which is less: that the temp file is cleaned up and the result
+    /// parses. It does NOT prove atomicity. Reverting the move to an in-place WriteAllText was tried
+    /// and all tests still passed, so this test does not distinguish the two implementations. The
+    /// atomicity is correct by construction and matches how config.json and the key store in this
+    /// repository already write; it is not covered by a test, and saying so here is cheaper than a
+    /// name that implies otherwise.
+    /// </summary>
+    [Fact]
+    public void Save_LeavesNoTempFileBehind_AndTheResultParses()
+    {
+        File.WriteAllText(_path, WithAHook);
+
+        ClaudeSettingsFile.Save(_path, Edits());
+
+        Assert.Equal(new[] { "settings.json" },
+            Directory.GetFiles(_dir).Select(Path.GetFileName).OrderBy(n => n).ToArray());
+        Assert.NotNull(JsonNode.Parse(File.ReadAllText(_path)));
+    }
+
+    /// <summary>
+    /// Saved is a POSITIVE test of the kinds that actually wrote. A refusal and a failed write are
+    /// both "not saved", and neither may drift onto the success path if another kind is added.
+    /// </summary>
+    [Fact]
+    public void Saved_IsTrueOnlyForTheTwoKindsThatWrote()
+    {
+        Assert.True(new SettingsSaveResult(SettingsSaveKind.Created, null).Saved);
+        Assert.True(new SettingsSaveResult(SettingsSaveKind.Merged, null).Saved);
+        Assert.False(new SettingsSaveResult(SettingsSaveKind.RefusedUnreadable, "x").Saved);
+        Assert.False(new SettingsSaveResult(SettingsSaveKind.WriteFailed, "x").Saved);
+    }
+
     // ---- The read itself: three answers, never two -------------------------
 
     [Fact]

--- a/src/CcDirector.Avalonia.Tests/ClaudeSettingsFileTests.cs
+++ b/src/CcDirector.Avalonia.Tests/ClaudeSettingsFileTests.cs
@@ -281,6 +281,35 @@ public sealed class ClaudeSettingsFileTests : IDisposable
     // ---- States found by re-reading this diff for the same defect it fixes ----
 
     /// <summary>
+    /// ABSENT IS REACHED ONLY BY PROVEN ABSENCE. The reader used to ask File.Exists first and treat
+    /// false as "no file", but .NET returns false from that probe when the path cannot be PROBED -
+    /// permissions among them - so an existing file the user could not open answered Absent and was
+    /// replaced. The refusal was bypassed by the most likely reason a file is unreadable.
+    ///
+    /// WHAT THIS TEST DOES NOT PROVE, checked by mutation rather than assumed: reverting the reader
+    /// to the File.Exists-first form leaves this test PASSING, because a locked file still answers
+    /// File.Exists true and both versions then fail on the open. The mutation is caught instead by
+    /// the two directory tests below, which is the discriminating case reachable without touching
+    /// access-control lists. The permission-denied half - where File.Exists itself answers false for
+    /// a file that exists - rests on the .NET documentation and on attempting the read FIRST, and is
+    /// not covered by any test here; arranging it means denying directory traversal, which leaves
+    /// undeletable fixtures behind. This test is kept because it pins the locked-file answer, not
+    /// because it proves the probe change.
+    /// </summary>
+    [Fact]
+    public void Read_FileExistsButCannotBeOpened_IsNeverAbsent()
+    {
+        File.WriteAllText(_path, WithAHook);
+
+        using var _ = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var read = ClaudeSettingsFile.Read(_path);
+
+        Assert.NotEqual(ConfigReadKind.Absent, read.Kind);
+        Assert.Equal(ConfigReadKind.Unreadable, read.Kind);
+    }
+
+    /// <summary>
     /// A DIRECTORY at the settings path. File.Exists answers false for one, which folded it into
     /// Absent - the permissive branch, the one that says "go ahead and create" - and the create then
     /// threw out of a button click that has nowhere to put an exception. Something is at that path,
@@ -328,11 +357,17 @@ public sealed class ClaudeSettingsFileTests : IDisposable
     {
         File.WriteAllText(_path, WithAHook);
 
-        ClaudeSettingsFile.Save(_path, Edits());
+        var result = ClaudeSettingsFile.Save(_path, Edits(mode: "acceptEdits"));
+
+        // Assert the save ACTUALLY HAPPENED first. Without this the whole test passed on a Save that
+        // did nothing at all: the fixture already held one valid settings.json, which satisfied both
+        // assertions below on its own. A test that a no-op passes is not a test.
+        Assert.Equal(SettingsSaveKind.Merged, result.Kind);
+        var root = JsonNode.Parse(File.ReadAllText(_path))!.AsObject();
+        Assert.Equal("acceptEdits", root["permissions"]!["defaultMode"]!.GetValue<string>());
 
         Assert.Equal(new[] { "settings.json" },
             Directory.GetFiles(_dir).Select(Path.GetFileName).OrderBy(n => n).ToArray());
-        Assert.NotNull(JsonNode.Parse(File.ReadAllText(_path)));
     }
 
     /// <summary>

--- a/src/CcDirector.Avalonia.Tests/ClaudeSettingsFileTests.cs
+++ b/src/CcDirector.Avalonia.Tests/ClaudeSettingsFileTests.cs
@@ -19,6 +19,13 @@ namespace CcDirector.Avalonia.Tests;
 ///
 /// Every test below writes a real file to a real temporary path, because the thing being asserted is
 /// what is left ON DISK afterwards.
+///
+/// WHAT IS ASSERTED, narrowly: a settings file that was FOUND and could not be PARSED is never
+/// written over. Two states defeat the broader "could not be READ" and neither is covered here -
+/// invalid UTF-8, which the decoder silently replaces so the file parses and is rewritten mangled
+/// (issue 2752), and a dangling symbolic link, which reports not-found and is replaced (issue 2751).
+/// Both are pre-existing behaviours of the code this replaced. They are named rather than implied,
+/// because a test file that reads as covering them is worse than one that says it does not.
 /// </summary>
 public sealed class ClaudeSettingsFileTests : IDisposable
 {
@@ -362,6 +369,9 @@ public sealed class ClaudeSettingsFileTests : IDisposable
         // Assert the save ACTUALLY HAPPENED first. Without this the whole test passed on a Save that
         // did nothing at all: the fixture already held one valid settings.json, which satisfied both
         // assertions below on its own. A test that a no-op passes is not a test.
+        //
+        // It still only exercises a SUCCESSFUL move, which consumes the temp file by itself, so it
+        // does not prove the failure-path cleanup - deleting that cleanup leaves this green.
         Assert.Equal(SettingsSaveKind.Merged, result.Kind);
         var root = JsonNode.Parse(File.ReadAllText(_path))!.AsObject();
         Assert.Equal("acceptEdits", root["permissions"]!["defaultMode"]!.GetValue<string>());
@@ -425,7 +435,11 @@ public sealed class ClaudeSettingsFileTests : IDisposable
         Assert.NotNull(unreadable.Problem);
     }
 
-    /// <summary>A read never throws - the failure is the return value, so no caller can skip handling it.</summary>
+    /// <summary>
+    /// An unreadable file comes back as a VALUE, so no caller can skip handling it. Covers invalid
+    /// JSON only - it is not evidence for a general "never throws", and the comment on Read no
+    /// longer makes that claim.
+    /// </summary>
     [Fact]
     public void Read_UnreadableFile_DoesNotThrow()
     {

--- a/src/CcDirector.Avalonia.Tests/ClaudeSettingsFileTests.cs
+++ b/src/CcDirector.Avalonia.Tests/ClaudeSettingsFileTests.cs
@@ -1,0 +1,242 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Nodes;
+using CcDirector.Avalonia;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The settings dialog edits a few fields inside a file it does not own. Saving is a MERGE into
+/// whatever else is in there - hooks above all, because on this fleet the hooks are what inject the
+/// preamble that tells every session the rules it runs under.
+///
+/// The defect these tests exist for: the read returned null for "no file" AND for "there is a file
+/// and I could not read it", and the save turned that null into a fresh empty object and wrote it.
+/// A settings file locked for an instant by another process, or hand-edited into invalid JSON, was
+/// replaced by only the handful of fields the dialog knows about. Everything else - hooks included -
+/// was gone, and the window said "Saved".
+///
+/// Every test below writes a real file to a real temporary path, because the thing being asserted is
+/// what is left ON DISK afterwards.
+/// </summary>
+public sealed class ClaudeSettingsFileTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _path;
+
+    public ClaudeSettingsFileTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-settings-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _path = Path.Combine(_dir, "settings.json");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* the temp sweeper gets it */ }
+    }
+
+    private static ClaudeSettingsEdits Edits(string? mode = "plan") => new(
+        PermissionMode: mode,
+        Allow: new List<string> { "Bash(git status)" },
+        Deny: new List<string>(),
+        Model: null,
+        EffortLevel: null,
+        MaxOutputTokens: null,
+        BashTimeoutMs: null,
+        EnabledPlugins: new Dictionary<string, bool>());
+
+    /// <summary>A settings file carrying a hook, exactly as Claude Code writes one.</summary>
+    private const string WithAHook = """
+    {
+      "$schema": "https://json.schemastore.org/claude-code-settings.json",
+      "hooks": {
+        "SessionStart": [
+          {
+            "hooks": [
+              { "type": "command", "command": "cc-director-preamble" }
+            ]
+          }
+        ]
+      },
+      "mcpServers": { "vault": { "command": "cc-vault" } }
+    }
+    """;
+
+    // ---- The defect itself -------------------------------------------------
+
+    /// <summary>
+    /// THE REGRESSION TEST. A settings file that is present but not parseable must not be written
+    /// over. Before the fix this failed on the first assertion: the save merged into a fresh empty
+    /// object and the hook was gone from disk.
+    /// </summary>
+    [Fact]
+    public void Save_FileExistsButIsNotValidJson_RefusesAndLeavesTheHooksOnDisk()
+    {
+        // A half-written file - the shape a crash or a concurrent writer leaves behind.
+        var truncated = WithAHook.Substring(0, WithAHook.Length / 2);
+        File.WriteAllText(_path, truncated);
+
+        var result = ClaudeSettingsFile.Save(_path, Edits());
+
+        Assert.Equal(SettingsSaveKind.RefusedUnreadable, result.Kind);
+        Assert.True(result.Refused);
+        Assert.Contains("not valid JSON", result.Problem);
+
+        // The file is byte-for-byte as it was found. Nothing was salvaged, nothing was destroyed.
+        Assert.Equal(truncated, File.ReadAllText(_path));
+    }
+
+    /// <summary>
+    /// The same refusal when the file cannot be OPENED rather than parsed - the transient case, and
+    /// the one most likely to happen to a real person: another process holds it for an instant.
+    /// </summary>
+    [Fact]
+    public void Save_FileIsLockedByAnotherProcess_RefusesAndLeavesTheHooksOnDisk()
+    {
+        File.WriteAllText(_path, WithAHook);
+
+        using (var _ = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            var result = ClaudeSettingsFile.Save(_path, Edits());
+
+            Assert.Equal(SettingsSaveKind.RefusedUnreadable, result.Kind);
+            Assert.Contains("could not be opened", result.Problem);
+        }
+
+        // Once the lock is gone the hook is still there, because the save never touched the file.
+        var root = JsonNode.Parse(File.ReadAllText(_path))!.AsObject();
+        Assert.Equal(
+            "cc-director-preamble",
+            root["hooks"]!["SessionStart"]![0]!["hooks"]![0]!["command"]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// A file holding valid JSON that is not an object - "null", an array, a number. There is content
+    /// there, it cannot be merged into, and it must not be written over either. Deliberately NOT
+    /// folded into Absent.
+    /// </summary>
+    [Theory]
+    [InlineData("null")]
+    [InlineData("[1, 2, 3]")]
+    [InlineData("\"a string\"")]
+    public void Save_FileHoldsJsonThatIsNotAnObject_Refuses(string content)
+    {
+        File.WriteAllText(_path, content);
+
+        var result = ClaudeSettingsFile.Save(_path, Edits());
+
+        Assert.Equal(SettingsSaveKind.RefusedUnreadable, result.Kind);
+        Assert.Equal(content, File.ReadAllText(_path));
+    }
+
+    // ---- The two answers that were always right, kept so the fix cannot over-correct ----
+
+    /// <summary>
+    /// A readable file is still merged into, and every field the dialog does not edit survives. This
+    /// is the behaviour the refusal must not cost us: refusing to write ALWAYS would be just as wrong
+    /// in the other direction.
+    /// </summary>
+    [Fact]
+    public void Save_FileIsReadable_MergesAndPreservesEverythingItDoesNotEdit()
+    {
+        File.WriteAllText(_path, WithAHook);
+
+        var result = ClaudeSettingsFile.Save(_path, Edits(mode: "acceptEdits"));
+
+        Assert.Equal(SettingsSaveKind.Merged, result.Kind);
+
+        var root = JsonNode.Parse(File.ReadAllText(_path))!.AsObject();
+
+        // What it does not own, carried through untouched.
+        Assert.Equal(
+            "cc-director-preamble",
+            root["hooks"]!["SessionStart"]![0]!["hooks"]![0]!["command"]!.GetValue<string>());
+        Assert.Equal("cc-vault", root["mcpServers"]!["vault"]!["command"]!.GetValue<string>());
+
+        // What it does own, written.
+        Assert.Equal("acceptEdits", root["permissions"]!["defaultMode"]!.GetValue<string>());
+        Assert.Equal("Bash(git status)", root["permissions"]!["allow"]![0]!.GetValue<string>());
+    }
+
+    /// <summary>An absent file is genuinely absent and may be created - the third state has not eaten this one.</summary>
+    [Fact]
+    public void Save_NoFileAtAll_CreatesIt()
+    {
+        Assert.False(File.Exists(_path));
+
+        var result = ClaudeSettingsFile.Save(_path, Edits());
+
+        Assert.Equal(SettingsSaveKind.Created, result.Kind);
+        Assert.Null(result.Problem);
+
+        var root = JsonNode.Parse(File.ReadAllText(_path))!.AsObject();
+        Assert.Equal("plan", root["permissions"]!["defaultMode"]!.GetValue<string>());
+    }
+
+    /// <summary>The parent directory is created when the file is genuinely new.</summary>
+    [Fact]
+    public void Save_NoFileAndNoDirectory_CreatesBoth()
+    {
+        var nested = Path.Combine(_dir, "deeper", "settings.json");
+
+        var result = ClaudeSettingsFile.Save(nested, Edits());
+
+        Assert.Equal(SettingsSaveKind.Created, result.Kind);
+        Assert.True(File.Exists(nested));
+    }
+
+    // ---- The read itself: three answers, never two -------------------------
+
+    [Fact]
+    public void Read_NoFile_IsAbsent()
+    {
+        var read = ClaudeSettingsFile.Read(_path);
+
+        Assert.Equal(ConfigReadKind.Absent, read.Kind);
+        Assert.Null(read.Root);
+        Assert.Null(read.Problem);
+    }
+
+    [Fact]
+    public void Read_GoodFile_IsLoadedAndCarriesTheContent()
+    {
+        File.WriteAllText(_path, WithAHook);
+
+        var read = ClaudeSettingsFile.Read(_path);
+
+        Assert.Equal(ConfigReadKind.Loaded, read.Kind);
+        Assert.NotNull(read.Root);
+        Assert.True(read.Root!.ContainsKey("hooks"));
+    }
+
+    /// <summary>
+    /// The distinction the whole fix rests on: absent and unreadable are DIFFERENT answers. Before the
+    /// fix both were a null and no caller could tell them apart.
+    /// </summary>
+    [Fact]
+    public void Read_AbsentAndUnreadableAreDifferentAnswers()
+    {
+        var absent = ClaudeSettingsFile.Read(_path);
+
+        File.WriteAllText(_path, "{ this is not json");
+        var unreadable = ClaudeSettingsFile.Read(_path);
+
+        Assert.NotEqual(absent.Kind, unreadable.Kind);
+        Assert.Equal(ConfigReadKind.Absent, absent.Kind);
+        Assert.Equal(ConfigReadKind.Unreadable, unreadable.Kind);
+        Assert.NotNull(unreadable.Problem);
+    }
+
+    /// <summary>A read never throws - the failure is the return value, so no caller can skip handling it.</summary>
+    [Fact]
+    public void Read_UnreadableFile_DoesNotThrow()
+    {
+        File.WriteAllText(_path, "{ this is not json");
+
+        var read = ClaudeSettingsFile.Read(_path);
+
+        Assert.Equal(ConfigReadKind.Unreadable, read.Kind);
+    }
+}

--- a/src/CcDirector.Avalonia/ClaudeConfigDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/ClaudeConfigDialog.axaml.cs
@@ -103,7 +103,13 @@ public partial class ClaudeConfigDialog : Window
         FileLog.Write("[ClaudeConfigDialog] LoadConfig: reading configuration files");
 
         var claudeJson = ReadJsonFile(_claudeJsonPath);
-        var settingsJson = ReadJsonFile(_settingsJsonPath);
+
+        // The settings file is read through the three-answer reader, because a file that is THERE and
+        // unreadable must not be presented as an empty one. Loading it blank showed a plausible screen -
+        // permission mode "plan", no rules, no plugins, "No hooks configured" - that described nothing
+        // on disk, and pressing Save on that screen is what destroyed the file.
+        var settingsRead = ClaudeSettingsFile.Read(_settingsJsonPath);
+        var settingsJson = settingsRead.Root;
 
         LoadGeneralTab(claudeJson, settingsJson);
         LoadPermissionsTab(settingsJson);
@@ -111,7 +117,19 @@ public partial class ClaudeConfigDialog : Window
         LoadHooksTab(settingsJson);
         LoadFilesTab();
 
-        SaveStatusText.Text = "";
+        if (settingsRead.Kind == ConfigReadKind.Unreadable)
+        {
+            SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#EF4444"));
+            SaveStatusText.Text = $"{Path.GetFileName(_settingsJsonPath)} {settingsRead.Problem}. "
+                                  + "The fields below are EMPTY because it could not be read, not because "
+                                  + "it is empty. Saving is refused until that file is fixed or moved.";
+            FileLog.Write($"[ClaudeConfigDialog] LoadConfig: settings file unreadable - {settingsRead.Problem}");
+        }
+        else
+        {
+            SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#22C55E"));
+            SaveStatusText.Text = "";
+        }
     }
 
     private void LoadGeneralTab(JsonNode? claudeJson, JsonNode? settingsJson)
@@ -247,57 +265,44 @@ public partial class ClaudeConfigDialog : Window
     {
         FileLog.Write("[ClaudeConfigDialog] SaveConfig: writing configuration files");
 
-        SaveSettingsJson();
+        var settings = SaveSettingsJson();
+        if (settings.Refused)
+        {
+            // Say so, and say it in the place the word "Saved" would otherwise have appeared. Reporting
+            // success over a write that did not happen is how the old behaviour hid: the file was left
+            // alone only by accident of the caller, and the person was told it had been saved either way.
+            SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#EF4444"));
+            SaveStatusText.Text = $"NOT saved - {Path.GetFileName(_settingsJsonPath)} {settings.Problem}. "
+                                  + "Fix or move that file, then reopen this window.";
+            FileLog.Write("[ClaudeConfigDialog] SaveConfig: ABORTED, settings file unreadable");
+            return;
+        }
+
         SaveClaudeJson();
 
+        SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#22C55E"));
         SaveStatusText.Text = "Saved";
         FileLog.Write("[ClaudeConfigDialog] SaveConfig: complete");
     }
 
-    private void SaveSettingsJson()
+    /// <summary>
+    /// Merge this dialog's fields into the user's settings file. The merge, and the refusal to merge
+    /// into a file that cannot be read, live in <see cref="ClaudeSettingsFile"/>; this only gathers
+    /// what the controls hold.
+    /// </summary>
+    private SettingsSaveResult SaveSettingsJson()
     {
-        // Read existing file to preserve fields we don't edit (hooks, schema, etc.)
-        JsonNode? root = ReadJsonFile(_settingsJsonPath);
-        var obj = root as JsonObject ?? new JsonObject();
+        var edits = new ClaudeSettingsEdits(
+            PermissionMode: PermissionModeCombo.SelectedItem as string,
+            Allow: _allowedRules.ToList(),
+            Deny: _deniedRules.ToList(),
+            Model: ModelOverrideInput.Text,
+            EffortLevel: EffortLevelCombo.SelectedItem as string,
+            MaxOutputTokens: MaxTokensInput.Text,
+            BashTimeoutMs: BashTimeoutInput.Text,
+            EnabledPlugins: _plugins.ToDictionary(p => p.FullKey, p => p.IsEnabled));
 
-        // Ensure $schema is present
-        if (obj["$schema"] == null)
-            obj["$schema"] = "https://json.schemastore.org/claude-code-settings.json";
-
-        // Permissions
-        var perms = obj["permissions"] as JsonObject ?? new JsonObject();
-        obj["permissions"] = perms;
-
-        var selectedMode = PermissionModeCombo.SelectedItem as string;
-        if (!string.IsNullOrEmpty(selectedMode))
-            perms["defaultMode"] = selectedMode;
-        else
-            perms.Remove("defaultMode");
-
-        perms["allow"] = new JsonArray(_allowedRules.Select(r => JsonValue.Create(r)).ToArray());
-        perms["deny"] = new JsonArray(_deniedRules.Select(r => JsonValue.Create(r)).ToArray());
-
-        // Environment variables
-        var env = obj["env"] as JsonObject ?? new JsonObject();
-        obj["env"] = env;
-
-        SetOrRemoveEnv(env, "ANTHROPIC_MODEL", ModelOverrideInput.Text);
-        SetOrRemoveEnv(env, "CLAUDE_CODE_EFFORT_LEVEL", EffortLevelCombo.SelectedItem as string);
-        SetOrRemoveEnv(env, "CLAUDE_CODE_MAX_OUTPUT_TOKENS", MaxTokensInput.Text);
-        SetOrRemoveEnv(env, "BASH_DEFAULT_TIMEOUT_MS", BashTimeoutInput.Text);
-
-        // Remove env object entirely if empty
-        if (env.Count == 0)
-            obj.Remove("env");
-
-        // Plugins
-        var pluginsObj = new JsonObject();
-        foreach (var p in _plugins)
-            pluginsObj[p.FullKey] = p.IsEnabled;
-        obj["enabledPlugins"] = pluginsObj;
-
-        // Write
-        WriteJsonFile(_settingsJsonPath, obj);
+        return ClaudeSettingsFile.Save(_settingsJsonPath, edits);
     }
 
     private void SaveClaudeJson()
@@ -308,14 +313,6 @@ public partial class ClaudeConfigDialog : Window
         obj["autoUpdates"] = AutoUpdatesCheck.IsChecked == true;
 
         WriteJsonFile(_claudeJsonPath, obj);
-    }
-
-    private static void SetOrRemoveEnv(JsonObject env, string key, string? value)
-    {
-        if (!string.IsNullOrWhiteSpace(value))
-            env[key] = value.Trim();
-        else
-            env.Remove(key);
     }
 
     // -- Permission Rules -----------------------------------------------------

--- a/src/CcDirector.Avalonia/ClaudeConfigDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/ClaudeConfigDialog.axaml.cs
@@ -23,6 +23,14 @@ public partial class ClaudeConfigDialog : Window
     private readonly string? _projectSettingsPath;
     private readonly string? _projectLocalSettingsPath;
 
+    /// <summary>
+    /// Whether the controls on screen were populated from a settings file that was actually READ.
+    /// False after a load that could not read it, and only a successful reload clears it. Saving is
+    /// refused while it is false, because blank controls that never described the file must never be
+    /// written over it - not even once the file itself has been repaired.
+    /// </summary>
+    private bool _controlsReflectTheFile = true;
+
     private readonly ObservableCollection<string> _allowedRules = new();
     private readonly ObservableCollection<string> _deniedRules = new();
     private readonly ObservableCollection<PluginEntry> _plugins = new();
@@ -117,12 +125,21 @@ public partial class ClaudeConfigDialog : Window
         LoadHooksTab(settingsJson);
         LoadFilesTab();
 
-        if (settingsRead.Kind == ConfigReadKind.Unreadable)
+        // LATCHED on the load, not re-derived at save time. The controls now on screen either came
+        // from a successful read or they did not, and only the load knows which. Re-asking the file at
+        // save time answers a different question: if the person repairs the file externally and
+        // presses Save without Reload, the fresh read succeeds and these BLANK controls - "plan", no
+        // rules, no env, no plugins - are written over the repaired file. That would have moved the
+        // defect rather than fixed it, which is the failure this whole change exists to stop.
+        _controlsReflectTheFile = settingsRead.Kind != ConfigReadKind.Unreadable;
+
+        if (!_controlsReflectTheFile)
         {
             SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#EF4444"));
             SaveStatusText.Text = $"{Path.GetFileName(_settingsJsonPath)} {settingsRead.Problem}. "
                                   + "The fields below are EMPTY because it could not be read, not because "
-                                  + "it is empty. Saving is refused until that file is fixed or moved.";
+                                  + "it is empty. Fix or move that file and press Reload - saving is "
+                                  + "refused until a reload succeeds, so these blanks cannot overwrite it.";
             FileLog.Write($"[ClaudeConfigDialog] LoadConfig: settings file unreadable - {settingsRead.Problem}");
         }
         else
@@ -265,20 +282,45 @@ public partial class ClaudeConfigDialog : Window
     {
         FileLog.Write("[ClaudeConfigDialog] SaveConfig: writing configuration files");
 
+        if (!_controlsReflectTheFile)
+        {
+            // The file may well be readable again by now - that is exactly the case this guards. The
+            // question is not "can the file be read?" but "do these controls describe it?", and the
+            // answer was settled at load time and has not changed since.
+            SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#EF4444"));
+            SaveStatusText.Text = $"NOT saved - {Path.GetFileName(_settingsJsonPath)} could not be read when "
+                                  + "this window opened, so the fields shown never described it. Press Reload "
+                                  + "first; saving now would overwrite the file with blanks.";
+            FileLog.Write("[ClaudeConfigDialog] SaveConfig: REFUSED, controls never reflected the settings file");
+            return;
+        }
+
         var settings = SaveSettingsJson();
-        if (settings.Refused)
+        if (!settings.Saved)
         {
             // Say so, and say it in the place the word "Saved" would otherwise have appeared. Reporting
             // success over a write that did not happen is how the old behaviour hid: the file was left
             // alone only by accident of the caller, and the person was told it had been saved either way.
+            // Tested POSITIVELY on Saved rather than on Refused, so a new outcome added to that enum
+            // cannot quietly join the success path.
+            var advice = settings.Refused
+                ? "Fix or move that file, then reopen this window."
+                : "Your settings were not changed.";
             SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#EF4444"));
-            SaveStatusText.Text = $"NOT saved - {Path.GetFileName(_settingsJsonPath)} {settings.Problem}. "
-                                  + "Fix or move that file, then reopen this window.";
-            FileLog.Write("[ClaudeConfigDialog] SaveConfig: ABORTED, settings file unreadable");
+            SaveStatusText.Text = $"NOT saved - {Path.GetFileName(_settingsJsonPath)} {settings.Problem}. {advice}";
+            FileLog.Write($"[ClaudeConfigDialog] SaveConfig: ABORTED, outcome={settings.Kind}");
             return;
         }
 
-        SaveClaudeJson();
+        var prefs = SaveClaudeJson();
+        if (!prefs.Saved)
+        {
+            SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#EF4444"));
+            SaveStatusText.Text = $"Settings saved, but {Path.GetFileName(_claudeJsonPath)} {prefs.Problem} - "
+                                  + "the automatic-updates setting was NOT changed.";
+            FileLog.Write($"[ClaudeConfigDialog] SaveConfig: partial, .claude.json outcome={prefs.Kind}");
+            return;
+        }
 
         SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#22C55E"));
         SaveStatusText.Text = "Saved";
@@ -300,19 +342,64 @@ public partial class ClaudeConfigDialog : Window
             EffortLevel: EffortLevelCombo.SelectedItem as string,
             MaxOutputTokens: MaxTokensInput.Text,
             BashTimeoutMs: BashTimeoutInput.Text,
-            EnabledPlugins: _plugins.ToDictionary(p => p.FullKey, p => p.IsEnabled));
+            EnabledPlugins: PluginMap());
 
         return ClaudeSettingsFile.Save(_settingsJsonPath, edits);
     }
 
-    private void SaveClaudeJson()
+    /// <summary>
+    /// The plugin enablement map, LAST ONE WINS on a repeated key.
+    ///
+    /// Deliberately not <c>ToDictionary</c>: that throws on a duplicate key, and the code this
+    /// replaced assigned through a JsonObject indexer, which silently overwrote. Today the keys come
+    /// from JSON object property names and cannot repeat, so the two agree - but the difference is
+    /// between "overwrites" and "throws out of a button click", and this dialog's click handler is
+    /// exactly where an exception used to disappear.
+    /// </summary>
+    private Dictionary<string, bool> PluginMap()
     {
-        JsonNode? root = ReadJsonFile(_claudeJsonPath);
-        if (root is not JsonObject obj) return; // Don't create .claude.json if it doesn't exist
+        var map = new Dictionary<string, bool>(StringComparer.Ordinal);
+        foreach (var p in _plugins)
+            map[p.FullKey] = p.IsEnabled;
+        return map;
+    }
 
+    /// <summary>
+    /// Save the one field this dialog owns in <c>.claude.json</c>, and say which of the three things
+    /// happened. It reads through the same three-answer reader as the settings file: the old reader
+    /// returned null for absent and unreadable alike, and while this method declined to write on
+    /// either - so it never clobbered anything - the caller then displayed a green "Saved" over an
+    /// edit that was silently dropped.
+    /// </summary>
+    private SettingsSaveResult SaveClaudeJson()
+    {
+        var read = ClaudeSettingsFile.Read(_claudeJsonPath);
+
+        // Absent is deliberately NOT an error and NOT a create: this dialog does not own the file's
+        // existence, and minting one Claude Code never wrote is not this button's business.
+        if (read.Kind == ConfigReadKind.Absent)
+            return new SettingsSaveResult(SettingsSaveKind.Merged, null);
+
+        if (read.Kind == ConfigReadKind.Unreadable)
+        {
+            FileLog.Write($"[ClaudeConfigDialog] SaveClaudeJson REFUSED: {_claudeJsonPath} {read.Problem}");
+            return new SettingsSaveResult(SettingsSaveKind.RefusedUnreadable, read.Problem);
+        }
+
+        var obj = read.Root!;
         obj["autoUpdates"] = AutoUpdatesCheck.IsChecked == true;
 
-        WriteJsonFile(_claudeJsonPath, obj);
+        try
+        {
+            WriteJsonFile(_claudeJsonPath, obj);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ClaudeConfigDialog] SaveClaudeJson FAILED writing {_claudeJsonPath}: {ex.Message}");
+            return new SettingsSaveResult(SettingsSaveKind.WriteFailed, $"could not be written ({ex.Message})");
+        }
+
+        return new SettingsSaveResult(SettingsSaveKind.Merged, null);
     }
 
     // -- Permission Rules -----------------------------------------------------
@@ -377,7 +464,23 @@ public partial class ClaudeConfigDialog : Window
     // -- Button Handlers ------------------------------------------------------
 
     private void BtnReload_Click(object? sender, RoutedEventArgs e) => LoadConfig();
-    private void BtnSave_Click(object? sender, RoutedEventArgs e) => SaveConfig();
+    private void BtnSave_Click(object? sender, RoutedEventArgs e)
+    {
+        // An event handler is an entry point and carries the catch. Without one, anything thrown here
+        // reaches the application's unhandled-UI-exception handler, which marks it Handled - so the
+        // press produces no file, no message and no trace on screen. That silence is the same defect
+        // this dialog was fixed for, one layer up.
+        try
+        {
+            SaveConfig();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ClaudeConfigDialog] BtnSave_Click FAILED: {ex}");
+            SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#EF4444"));
+            SaveStatusText.Text = $"NOT saved - {ex.Message}";
+        }
+    }
     private void BtnClose_Click(object? sender, RoutedEventArgs e) => Close();
 
     // -- JSON Helpers ---------------------------------------------------------

--- a/src/CcDirector.Avalonia/ClaudeConfigDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/ClaudeConfigDialog.axaml.cs
@@ -25,11 +25,15 @@ public partial class ClaudeConfigDialog : Window
 
     /// <summary>
     /// Whether the controls on screen were populated from a settings file that was actually READ.
-    /// False after a load that could not read it, and only a successful reload clears it. Saving is
-    /// refused while it is false, because blank controls that never described the file must never be
-    /// written over it - not even once the file itself has been repaired.
+    /// Saving is refused while this is false, because blank controls that never described the file
+    /// must never be written over it - not even once the file itself has been repaired.
+    ///
+    /// DEFAULTS TO FALSE, and that is the point of it. Defaulted true it was a binary sitting on its
+    /// own permissive branch: the parameterless constructor never loads anything, yet the markup
+    /// still wires the Save button, so an instance built that way authorised blank controls to
+    /// overwrite a real file. Nothing may earn the right to save except a load that succeeded.
     /// </summary>
-    private bool _controlsReflectTheFile = true;
+    private bool _controlsReflectTheFile;
 
     private readonly ObservableCollection<string> _allowedRules = new();
     private readonly ObservableCollection<string> _deniedRules = new();
@@ -109,6 +113,12 @@ public partial class ClaudeConfigDialog : Window
     private void LoadConfig()
     {
         FileLog.Write("[ClaudeConfigDialog] LoadConfig: reading configuration files");
+
+        // DROPPED FIRST, raised only by a load that runs all the way through. The loaders below clear
+        // their collections before refilling them, so one throwing part-way leaves the controls in a
+        // partial state that describes nothing; if this were only assigned at the end, that partial
+        // state would keep whatever the last successful load had granted, and Save would write it.
+        _controlsReflectTheFile = false;
 
         var claudeJson = ReadJsonFile(_claudeJsonPath);
 
@@ -312,15 +322,7 @@ public partial class ClaudeConfigDialog : Window
             return;
         }
 
-        var prefs = SaveClaudeJson();
-        if (!prefs.Saved)
-        {
-            SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#EF4444"));
-            SaveStatusText.Text = $"Settings saved, but {Path.GetFileName(_claudeJsonPath)} {prefs.Problem} - "
-                                  + "the automatic-updates setting was NOT changed.";
-            FileLog.Write($"[ClaudeConfigDialog] SaveConfig: partial, .claude.json outcome={prefs.Kind}");
-            return;
-        }
+        SaveClaudeJson();
 
         SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#22C55E"));
         SaveStatusText.Text = "Saved";
@@ -371,35 +373,20 @@ public partial class ClaudeConfigDialog : Window
     /// either - so it never clobbered anything - the caller then displayed a green "Saved" over an
     /// edit that was silently dropped.
     /// </summary>
-    private SettingsSaveResult SaveClaudeJson()
+    // NOT TOUCHED BY THIS CHANGE, deliberately. This method reads .claude.json through the old
+    // two-answer reader and has the same unreadable-versus-absent fold as its settings.json twin,
+    // plus an in-place write and a silent no-op the caller still reports as saved. All of that is a
+    // DIFFERENT defect in a DIFFERENT file: this change's claim - that a settings file which could
+    // not be read is never written over - stays true without it. It is filed separately with the
+    // review that found it, rather than fixed here, because every extra fix is new writing.
+    private void SaveClaudeJson()
     {
-        var read = ClaudeSettingsFile.Read(_claudeJsonPath);
+        JsonNode? root = ReadJsonFile(_claudeJsonPath);
+        if (root is not JsonObject obj) return; // Don't create .claude.json if it doesn't exist
 
-        // Absent is deliberately NOT an error and NOT a create: this dialog does not own the file's
-        // existence, and minting one Claude Code never wrote is not this button's business.
-        if (read.Kind == ConfigReadKind.Absent)
-            return new SettingsSaveResult(SettingsSaveKind.Merged, null);
-
-        if (read.Kind == ConfigReadKind.Unreadable)
-        {
-            FileLog.Write($"[ClaudeConfigDialog] SaveClaudeJson REFUSED: {_claudeJsonPath} {read.Problem}");
-            return new SettingsSaveResult(SettingsSaveKind.RefusedUnreadable, read.Problem);
-        }
-
-        var obj = read.Root!;
         obj["autoUpdates"] = AutoUpdatesCheck.IsChecked == true;
 
-        try
-        {
-            WriteJsonFile(_claudeJsonPath, obj);
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[ClaudeConfigDialog] SaveClaudeJson FAILED writing {_claudeJsonPath}: {ex.Message}");
-            return new SettingsSaveResult(SettingsSaveKind.WriteFailed, $"could not be written ({ex.Message})");
-        }
-
-        return new SettingsSaveResult(SettingsSaveKind.Merged, null);
+        WriteJsonFile(_claudeJsonPath, obj);
     }
 
     // -- Permission Rules -----------------------------------------------------
@@ -463,7 +450,24 @@ public partial class ClaudeConfigDialog : Window
 
     // -- Button Handlers ------------------------------------------------------
 
-    private void BtnReload_Click(object? sender, RoutedEventArgs e) => LoadConfig();
+    private void BtnReload_Click(object? sender, RoutedEventArgs e)
+    {
+        // An entry point, so it carries the catch. Without one, a load that throws part-way left the
+        // PREVIOUS status standing - including a green "Saved" from an earlier press - over controls
+        // that had already been half cleared. The latch is dropped at the top of LoadConfig, so a
+        // throw here leaves saving refused, which is the safe half; this makes it visible too.
+        try
+        {
+            LoadConfig();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ClaudeConfigDialog] BtnReload_Click FAILED: {ex}");
+            SaveStatusText.Foreground = new SolidColorBrush(Color.Parse("#EF4444"));
+            SaveStatusText.Text = $"Reload FAILED - {ex.Message}. The fields shown may be incomplete, "
+                                  + "so saving is refused until a reload succeeds.";
+        }
+    }
     private void BtnSave_Click(object? sender, RoutedEventArgs e)
     {
         // An event handler is an entry point and carries the catch. Without one, anything thrown here

--- a/src/CcDirector.Avalonia/ClaudeSettingsFile.cs
+++ b/src/CcDirector.Avalonia/ClaudeSettingsFile.cs
@@ -120,23 +120,37 @@ public static class ClaudeSettingsFile
     /// </summary>
     public static ConfigRead Read(string path)
     {
-        // Something is at that path and it is NOT a file. File.Exists answers false for a directory,
-        // which would fold this into Absent - the permissive branch, the one that says "go ahead and
-        // create". Creating is then an unhandled write failure rather than an answer. A directory in
-        // the way is a state of the world, so it gets its own answer like every other one.
-        if (Directory.Exists(path))
-        {
-            FileLog.Write($"[ClaudeSettingsFile] Read: {path} is a directory, not a settings file");
-            return new ConfigRead(ConfigReadKind.Unreadable, null, "is a directory, not a file");
-        }
-
-        if (!File.Exists(path))
-            return new ConfigRead(ConfigReadKind.Absent, null, null);
-
+        // ABSENCE IS PROVEN, NEVER ASSUMED. This used to ask File.Exists and Directory.Exists first
+        // and treat false as "no file". Both are absence-shaped probes: .NET documents them as
+        // returning false when the path cannot be PROBED - a permissions failure among them - so an
+        // existing file the user was not allowed to open answered "absent", landed in the permissive
+        // branch, and was replaced. Permissions are the single most likely reason a settings file
+        // cannot be read, so the refusal was bypassed by the exact condition it exists for.
+        //
+        // Now the read is attempted first and the ANSWER decides. Only the file system positively
+        // reporting "there is nothing here" yields Absent; every other failure - permissions, a
+        // sharing lock, a directory in the way, a path too long - is Unreadable, which writes nothing.
         string text;
         try
         {
             text = File.ReadAllText(path);
+        }
+        catch (FileNotFoundException)
+        {
+            return new ConfigRead(ConfigReadKind.Absent, null, null);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return new ConfigRead(ConfigReadKind.Absent, null, null);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            // Covers both "you may not read this file" and, on Windows, "this path is a directory".
+            // Distinguished only for the message, never for the verdict - the verdict is the same
+            // either way, so a wrong guess about which it is cannot make this permissive.
+            var what = Directory.Exists(path) ? "is a directory, not a file" : $"could not be opened ({ex.Message})";
+            FileLog.Write($"[ClaudeSettingsFile] Read: {path} {what}");
+            return new ConfigRead(ConfigReadKind.Unreadable, null, what);
         }
         catch (Exception ex)
         {
@@ -194,6 +208,7 @@ public static class ClaudeSettingsFile
 
         Apply(obj, edits);
 
+        string? temp = null;
         try
         {
             var dir = Path.GetDirectoryName(path);
@@ -207,7 +222,7 @@ public static class ClaudeSettingsFile
             // a crash or a full disk part-way through leaves the settings file destroyed or
             // unparsable - this fix would then have MANUFACTURED the very state it refuses to write
             // over. The move is the commit point: readers see the old file or the new one.
-            var temp = Path.Combine(dir ?? ".", $".settings.{Guid.NewGuid():N}.tmp");
+            temp = Path.Combine(dir ?? ".", $".settings.{Guid.NewGuid():N}.tmp");
             File.WriteAllText(temp, json);
             File.Move(temp, path, overwrite: true);
 
@@ -217,10 +232,22 @@ public static class ClaudeSettingsFile
         catch (Exception ex)
         {
             // NOT swallowed and NOT a fallback: turned into an answer the caller must render. Letting
-            // it throw sends it to the dialog's click handler, which has no catch, and from there to
-            // the application's unhandled-exception handler, which marks it Handled - so the person
-            // presses Save, nothing happens, and nothing is said.
+            // it throw sends it to the dialog's click handler, and from there to the application's
+            // unhandled-exception handler, which marks it Handled - so the person presses Save,
+            // nothing happens, and nothing is said.
             FileLog.Write($"[ClaudeSettingsFile] Save FAILED writing {path}: {ex.Message}");
+
+            // Do not leave the half-written temp file behind. Its own try: failing to clean up is not
+            // a reason to lose the real error, and the real error is what the person needs.
+            if (temp is not null)
+            {
+                try { File.Delete(temp); }
+                catch (Exception cleanup)
+                {
+                    FileLog.Write($"[ClaudeSettingsFile] Save: could not remove the temp file {temp}: {cleanup.Message}");
+                }
+            }
+
             return new SettingsSaveResult(SettingsSaveKind.WriteFailed, $"could not be written ({ex.Message})");
         }
 

--- a/src/CcDirector.Avalonia/ClaudeSettingsFile.cs
+++ b/src/CcDirector.Avalonia/ClaudeSettingsFile.cs
@@ -54,6 +54,14 @@ public enum SettingsSaveKind
     /// to have no name.
     /// </summary>
     RefusedUnreadable,
+
+    /// <summary>
+    /// The read said it was safe to write and the WRITE itself failed - the disk, the permissions,
+    /// the path. Distinct from a refusal: a refusal means we chose not to write, this means we tried
+    /// and could not, and the file may be in either state. Named because the alternative is an
+    /// exception out of a button click, and this dialog's click handler is where those disappear.
+    /// </summary>
+    WriteFailed,
 }
 
 /// <summary>The outcome of a save, and why when it refused.</summary>
@@ -61,6 +69,13 @@ public sealed record SettingsSaveResult(SettingsSaveKind Kind, string? Problem)
 {
     /// <summary>True when the file on disk was left exactly as it was found.</summary>
     public bool Refused => Kind == SettingsSaveKind.RefusedUnreadable;
+
+    /// <summary>
+    /// True only when the settings are on disk. Written as a POSITIVE test of the two kinds that
+    /// actually wrote, not as "not refused" - a later kind added to this enum must not silently
+    /// become a success, which is how the defect this class fixes came about in the first place.
+    /// </summary>
+    public bool Saved => Kind is SettingsSaveKind.Created or SettingsSaveKind.Merged;
 }
 
 /// <summary>
@@ -105,6 +120,16 @@ public static class ClaudeSettingsFile
     /// </summary>
     public static ConfigRead Read(string path)
     {
+        // Something is at that path and it is NOT a file. File.Exists answers false for a directory,
+        // which would fold this into Absent - the permissive branch, the one that says "go ahead and
+        // create". Creating is then an unhandled write failure rather than an answer. A directory in
+        // the way is a state of the world, so it gets its own answer like every other one.
+        if (Directory.Exists(path))
+        {
+            FileLog.Write($"[ClaudeSettingsFile] Read: {path} is a directory, not a settings file");
+            return new ConfigRead(ConfigReadKind.Unreadable, null, "is a directory, not a file");
+        }
+
         if (!File.Exists(path))
             return new ConfigRead(ConfigReadKind.Absent, null, null);
 
@@ -169,14 +194,35 @@ public static class ClaudeSettingsFile
 
         Apply(obj, edits);
 
-        var dir = Path.GetDirectoryName(path);
-        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-            Directory.CreateDirectory(dir);
+        try
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
 
-        var json = obj.ToJsonString(WriteOptions);
-        File.WriteAllText(path, json);
-        FileLog.Write($"[ClaudeSettingsFile] Save: {path} ({json.Length} bytes, "
-                      + $"{(creating ? "created" : "merged into existing")})");
+            var json = obj.ToJsonString(WriteOptions);
+
+            // Write a sibling temp file and MOVE it over the target, the same way config.json and the
+            // key store in this repository already do it. An in-place WriteAllText truncates first, so
+            // a crash or a full disk part-way through leaves the settings file destroyed or
+            // unparsable - this fix would then have MANUFACTURED the very state it refuses to write
+            // over. The move is the commit point: readers see the old file or the new one.
+            var temp = Path.Combine(dir ?? ".", $".settings.{Guid.NewGuid():N}.tmp");
+            File.WriteAllText(temp, json);
+            File.Move(temp, path, overwrite: true);
+
+            FileLog.Write($"[ClaudeSettingsFile] Save: {path} ({json.Length} bytes, "
+                          + $"{(creating ? "created" : "merged into existing")})");
+        }
+        catch (Exception ex)
+        {
+            // NOT swallowed and NOT a fallback: turned into an answer the caller must render. Letting
+            // it throw sends it to the dialog's click handler, which has no catch, and from there to
+            // the application's unhandled-exception handler, which marks it Handled - so the person
+            // presses Save, nothing happens, and nothing is said.
+            FileLog.Write($"[ClaudeSettingsFile] Save FAILED writing {path}: {ex.Message}");
+            return new SettingsSaveResult(SettingsSaveKind.WriteFailed, $"could not be written ({ex.Message})");
+        }
 
         return new SettingsSaveResult(
             creating ? SettingsSaveKind.Created : SettingsSaveKind.Merged, null);

--- a/src/CcDirector.Avalonia/ClaudeSettingsFile.cs
+++ b/src/CcDirector.Avalonia/ClaudeSettingsFile.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia;
+
+/// <summary>
+/// How a read of a Claude configuration file ended. THREE answers, not two.
+///
+/// The settings dialog edits a handful of fields inside a file it does not own: the same file also
+/// carries <c>hooks</c>, <c>mcpServers</c>, <c>statusLine</c> and anything else Claude Code puts
+/// there. Saving is therefore a MERGE, and a merge is only safe when the existing content was
+/// actually seen. "The file is not there" and "the file is there and I could not read it" are
+/// opposite facts about the world that happen to produce the same empty object, and folding them
+/// together is what let a save destroy the file it was merging into.
+/// </summary>
+public enum ConfigReadKind
+{
+    /// <summary>No file at that path. There is nothing to preserve, so a save may create one.</summary>
+    Absent,
+
+    /// <summary>The file was read and parsed. Its untouched fields must survive the save.</summary>
+    Loaded,
+
+    /// <summary>
+    /// A file IS at that path and its content could not be obtained - locked by another process,
+    /// a permissions failure, a half-written file, or invalid JSON from a hand edit. NOTHING may be
+    /// written over it, because what would be lost cannot even be enumerated.
+    /// </summary>
+    Unreadable,
+}
+
+/// <summary>The outcome of reading a configuration file, and what was in it when there was something.</summary>
+/// <param name="Kind">Which of the three answers this is.</param>
+/// <param name="Root">The parsed object - only ever set when <paramref name="Kind"/> is Loaded.</param>
+/// <param name="Problem">Why it could not be read, in words fit to show a person. Only set when Unreadable.</param>
+public sealed record ConfigRead(ConfigReadKind Kind, JsonObject? Root, string? Problem);
+
+/// <summary>How a save of the settings file ended.</summary>
+public enum SettingsSaveKind
+{
+    /// <summary>The file did not exist and was created.</summary>
+    Created,
+
+    /// <summary>The file existed, was read, and the edits were merged into it.</summary>
+    Merged,
+
+    /// <summary>
+    /// The file existed and could not be read, so NOTHING was written. This is the state that used
+    /// to have no name.
+    /// </summary>
+    RefusedUnreadable,
+}
+
+/// <summary>The outcome of a save, and why when it refused.</summary>
+public sealed record SettingsSaveResult(SettingsSaveKind Kind, string? Problem)
+{
+    /// <summary>True when the file on disk was left exactly as it was found.</summary>
+    public bool Refused => Kind == SettingsSaveKind.RefusedUnreadable;
+}
+
+/// <summary>
+/// The edits the settings dialog is able to make. Everything else in the file belongs to somebody
+/// else and is carried through untouched.
+/// </summary>
+/// <param name="PermissionMode">The default permission mode, or null to remove it.</param>
+/// <param name="Allow">The allow rules, replacing whatever is there.</param>
+/// <param name="Deny">The deny rules, replacing whatever is there.</param>
+/// <param name="Model">ANTHROPIC_MODEL, or null/blank to remove it.</param>
+/// <param name="EffortLevel">CLAUDE_CODE_EFFORT_LEVEL, or null/blank to remove it.</param>
+/// <param name="MaxOutputTokens">CLAUDE_CODE_MAX_OUTPUT_TOKENS, or null/blank to remove it.</param>
+/// <param name="BashTimeoutMs">BASH_DEFAULT_TIMEOUT_MS, or null/blank to remove it.</param>
+/// <param name="EnabledPlugins">The plugin enablement map, replacing whatever is there.</param>
+public sealed record ClaudeSettingsEdits(
+    string? PermissionMode,
+    IReadOnlyList<string> Allow,
+    IReadOnlyList<string> Deny,
+    string? Model,
+    string? EffortLevel,
+    string? MaxOutputTokens,
+    string? BashTimeoutMs,
+    IReadOnlyDictionary<string, bool> EnabledPlugins);
+
+/// <summary>
+/// Reading and writing the user's Claude <c>settings.json</c> without destroying the parts of it
+/// this application does not understand.
+///
+/// Split out of <see cref="ClaudeConfigDialog"/> so the merge decision can be exercised against a
+/// real file on a real path. The dialog resolves its paths from the user profile, so testing the
+/// save through the dialog would mean pointing a test at the developer's own settings - which is
+/// precisely the file this class exists to stop being overwritten.
+/// </summary>
+public static class ClaudeSettingsFile
+{
+    private static readonly JsonSerializerOptions WriteOptions = new() { WriteIndented = true };
+
+    /// <summary>
+    /// Read a configuration file and say which of the three things happened. Never throws: the
+    /// failure is the RETURN VALUE, because a caller that cannot see the difference between absent
+    /// and unreadable is the whole defect this replaces.
+    /// </summary>
+    public static ConfigRead Read(string path)
+    {
+        if (!File.Exists(path))
+            return new ConfigRead(ConfigReadKind.Absent, null, null);
+
+        string text;
+        try
+        {
+            text = File.ReadAllText(path);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ClaudeSettingsFile] Read: {path} exists but could not be opened: {ex.Message}");
+            return new ConfigRead(ConfigReadKind.Unreadable, null, $"could not be opened ({ex.Message})");
+        }
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(text);
+        }
+        catch (JsonException ex)
+        {
+            FileLog.Write($"[ClaudeSettingsFile] Read: {path} is not valid JSON: {ex.Message}");
+            return new ConfigRead(ConfigReadKind.Unreadable, null, $"is not valid JSON ({ex.Message})");
+        }
+
+        // Parsed, but not into an object - a file holding "null", a bare array or a number. There is
+        // content there and it is not something edits can be merged into, so it is not safe to write
+        // over either. Deliberately NOT folded into Absent.
+        if (node is not JsonObject obj)
+        {
+            FileLog.Write($"[ClaudeSettingsFile] Read: {path} parsed but does not hold a JSON object");
+            return new ConfigRead(ConfigReadKind.Unreadable, null, "does not hold a JSON object");
+        }
+
+        return new ConfigRead(ConfigReadKind.Loaded, obj, null);
+    }
+
+    /// <summary>
+    /// Merge <paramref name="edits"/> into the settings file at <paramref name="path"/> and write it
+    /// back, preserving every field the dialog does not edit.
+    ///
+    /// REFUSES, writing nothing, when the file is there and cannot be read. That refusal is the fix:
+    /// the previous behaviour treated an unreadable file as an empty one and wrote a fresh object
+    /// over it, which silently discarded the user's hooks - the very fields the read exists to carry
+    /// through, and, for this fleet, the ones that inject the preamble every session runs under.
+    /// </summary>
+    public static SettingsSaveResult Save(string path, ClaudeSettingsEdits edits)
+    {
+        ArgumentNullException.ThrowIfNull(edits);
+
+        var read = Read(path);
+        if (read.Kind == ConfigReadKind.Unreadable)
+        {
+            FileLog.Write($"[ClaudeSettingsFile] Save REFUSED for {path}: the file {read.Problem}. "
+                          + "Nothing was written - merging into a file that cannot be read would discard "
+                          + "every field this dialog does not edit, hooks included.");
+            return new SettingsSaveResult(SettingsSaveKind.RefusedUnreadable, read.Problem);
+        }
+
+        var creating = read.Kind == ConfigReadKind.Absent;
+        var obj = read.Root ?? new JsonObject();
+
+        Apply(obj, edits);
+
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var json = obj.ToJsonString(WriteOptions);
+        File.WriteAllText(path, json);
+        FileLog.Write($"[ClaudeSettingsFile] Save: {path} ({json.Length} bytes, "
+                      + $"{(creating ? "created" : "merged into existing")})");
+
+        return new SettingsSaveResult(
+            creating ? SettingsSaveKind.Created : SettingsSaveKind.Merged, null);
+    }
+
+    /// <summary>Apply the dialog's edits to an object, touching only the fields it owns.</summary>
+    private static void Apply(JsonObject obj, ClaudeSettingsEdits edits)
+    {
+        if (obj["$schema"] is null)
+            obj["$schema"] = "https://json.schemastore.org/claude-code-settings.json";
+
+        var perms = obj["permissions"] as JsonObject ?? new JsonObject();
+        obj["permissions"] = perms;
+
+        if (!string.IsNullOrEmpty(edits.PermissionMode))
+            perms["defaultMode"] = edits.PermissionMode;
+        else
+            perms.Remove("defaultMode");
+
+        perms["allow"] = new JsonArray(edits.Allow.Select(r => (JsonNode?)JsonValue.Create(r)).ToArray());
+        perms["deny"] = new JsonArray(edits.Deny.Select(r => (JsonNode?)JsonValue.Create(r)).ToArray());
+
+        var env = obj["env"] as JsonObject ?? new JsonObject();
+        obj["env"] = env;
+
+        SetOrRemove(env, "ANTHROPIC_MODEL", edits.Model);
+        SetOrRemove(env, "CLAUDE_CODE_EFFORT_LEVEL", edits.EffortLevel);
+        SetOrRemove(env, "CLAUDE_CODE_MAX_OUTPUT_TOKENS", edits.MaxOutputTokens);
+        SetOrRemove(env, "BASH_DEFAULT_TIMEOUT_MS", edits.BashTimeoutMs);
+
+        if (env.Count == 0)
+            obj.Remove("env");
+
+        var pluginsObj = new JsonObject();
+        foreach (var (key, enabled) in edits.EnabledPlugins)
+            pluginsObj[key] = enabled;
+        obj["enabledPlugins"] = pluginsObj;
+    }
+
+    private static void SetOrRemove(JsonObject env, string key, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            env[key] = value.Trim();
+        else
+            env.Remove(key);
+    }
+}

--- a/src/CcDirector.Avalonia/ClaudeSettingsFile.cs
+++ b/src/CcDirector.Avalonia/ClaudeSettingsFile.cs
@@ -17,10 +17,31 @@ namespace CcDirector.Avalonia;
 /// actually seen. "The file is not there" and "the file is there and I could not read it" are
 /// opposite facts about the world that happen to produce the same empty object, and folding them
 /// together is what let a save destroy the file it was merging into.
+///
+/// WHAT THIS GUARANTEES, STATED NARROWLY ON PURPOSE: a settings file that was FOUND and could not
+/// be PARSED is never written over. It deliberately does NOT say "could not be read", because two
+/// states defeat that stronger sentence and both are pre-existing behaviours of the code this
+/// replaced rather than regressions introduced with it:
+///
+///   - A file whose bytes are not valid UTF-8 is decoded with REPLACEMENT rather than rejected, so
+///     it parses, counts as read, and is written back corrupted (issue 2752). The fold there is one
+///     level in from this one: readable versus readable WITHOUT LOSS, and only the first has a name.
+///   - A dangling symbolic link answers "not found" from its missing target, so it is classified
+///     Absent and the LINK ITSELF is replaced by a regular file (issue 2751).
+///
+/// A guarantee that is falsified by two known states is a FALSE GUARANTEE, and shipping one is the
+/// defect this whole change exists to remove. So the sentence says only what the code keeps, and
+/// names what it does not.
 /// </summary>
 public enum ConfigReadKind
 {
-    /// <summary>No file at that path. There is nothing to preserve, so a save may create one.</summary>
+    /// <summary>
+    /// The file system reported nothing at that path, so a save may create one.
+    ///
+    /// This is as strong as an exception can make it and no stronger: a dangling symbolic link
+    /// reports "not found" from its missing TARGET while an entry does exist at the path, and lands
+    /// here (issue 2751). Absence is reported, not proven.
+    /// </summary>
     Absent,
 
     /// <summary>The file was read and parsed. Its untouched fields must survive the save.</summary>
@@ -114,22 +135,32 @@ public static class ClaudeSettingsFile
     private static readonly JsonSerializerOptions WriteOptions = new() { WriteIndented = true };
 
     /// <summary>
-    /// Read a configuration file and say which of the three things happened. Never throws: the
-    /// failure is the RETURN VALUE, because a caller that cannot see the difference between absent
-    /// and unreadable is the whole defect this replaces.
+    /// Read a configuration file and say which of the three things happened. Every failure reached
+    /// by the paths below is the RETURN VALUE rather than an exception, because a caller that cannot
+    /// see the difference between absent and unreadable is the whole defect this replaces.
+    ///
+    /// Deliberately not written as "never throws": only invalid JSON and an unopenable file are
+    /// covered by tests, so a blanket promise would be a claim the evidence does not carry.
     /// </summary>
     public static ConfigRead Read(string path)
     {
-        // ABSENCE IS PROVEN, NEVER ASSUMED. This used to ask File.Exists and Directory.Exists first
+        // ABSENCE IS REPORTED BY THE FILE SYSTEM, NOT INFERRED FROM A PROBE. This used to ask
+        // File.Exists and Directory.Exists first
         // and treat false as "no file". Both are absence-shaped probes: .NET documents them as
         // returning false when the path cannot be PROBED - a permissions failure among them - so an
         // existing file the user was not allowed to open answered "absent", landed in the permissive
         // branch, and was replaced. Permissions are the single most likely reason a settings file
         // cannot be read, so the refusal was bypassed by the exact condition it exists for.
         //
-        // Now the read is attempted first and the ANSWER decides. Only the file system positively
-        // reporting "there is nothing here" yields Absent; every other failure - permissions, a
-        // sharing lock, a directory in the way, a path too long - is Unreadable, which writes nothing.
+        // Now the read is attempted first and the ANSWER decides. Only the file system reporting
+        // "there is nothing here" yields Absent; every other failure - permissions, a sharing lock,
+        // a directory in the way, a path too long - is Unreadable, which writes nothing.
+        //
+        // This is stronger than a probe and it is still not PROOF of absence. A dangling symbolic
+        // link reports not-found from its missing target while an entry does exist at the path, and
+        // a trailing separator or an unavailable share can raise DirectoryNotFoundException over
+        // something that is there. Proving absence needs a link-aware check, not an exception type;
+        // issue 2751 carries that. Said here rather than left as a comfortable word.
         string text;
         try
         {
@@ -185,7 +216,7 @@ public static class ClaudeSettingsFile
     /// Merge <paramref name="edits"/> into the settings file at <paramref name="path"/> and write it
     /// back, preserving every field the dialog does not edit.
     ///
-    /// REFUSES, writing nothing, when the file is there and cannot be read. That refusal is the fix:
+    /// REFUSES, writing nothing, when the file is there and cannot be PARSED. That refusal is the fix:
     /// the previous behaviour treated an unreadable file as an empty one and wrote a fresh object
     /// over it, which silently discarded the user's hooks - the very fields the read exists to carry
     /// through, and, for this fleet, the ones that inject the preamble every session runs under.


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle_internal#1933.

## One claim, stated narrowly on purpose

**A settings file that was FOUND and could not be PARSED is never written over.**

It deliberately does not say *could not be read*. Two file states defeat that stronger sentence, and both are **pre-existing behaviours of the code this replaces**, not regressions introduced here - the old reader did `File.Exists`, then `File.ReadAllText`, then `Parse`, and reached the same two outcomes:

- **Invalid UTF-8** is decoded with *replacement* rather than rejected, so the file parses, counts as read, and is written back corrupted - thefrederiksen/devthrottle_internal#1947. That is this same defect one level in: readable versus readable *without loss*, and only the first has a name.
- **A dangling symbolic link** reports not-found from its missing target, so it is classified `Absent` and the **link itself** is replaced by a regular file - thefrederiksen/devthrottle_internal#1946. The population that symlinks `.claude` is the dotfiles population, for whom a dangling link is ordinary.

A guarantee falsified by two known states is a **false guarantee**, and shipping one is the thing this work exists to remove. So the sentence says only what the code keeps, and names what it does not - in the class, with issue numbers, where the next reader will hit them.

## The defect

`ClaudeConfigDialog.ReadJsonFile` returned `null` for two opposite facts - "there is no settings file" and "there is one and I could not read it" - and `SaveSettingsJson` turned that `null` into `new JsonObject()` and wrote it unconditionally.

A `settings.json` locked for an instant, or hand-edited into invalid JSON, was **replaced by only the fields this dialog knows about**. Everything else went - `hooks` included, which on this fleet inject the preamble every session runs under. The comment on the method's first line says the read exists to preserve exactly those fields.

The sibling fourteen lines below, `SaveClaudeJson`, declines to write - but its guard was written for the ABSENT case, so it covers unreadable only by accident. The unreadable case was reasoned about in neither.

## The fix

| Answer | Meaning | What a save does |
|---|---|---|
| `Absent` | the file system reported nothing there | creates one |
| `Loaded` | read and parsed | merges into it |
| `Unreadable` | something is there and its content could not be obtained | **writes nothing, and says why** |

The read is attempted **first** and the answer decides. The previous version asked `File.Exists`/`Directory.Exists` and treated false as "no file" - absence-shaped probes that .NET returns false from when a path cannot be *probed*, permissions among them - so an existing file the user could not open answered `Absent` and was replaced, bypassing the refusal by the most likely reason a file is unreadable.

Also: an unreadable file is no longer presented as an empty one; whether the controls describe the file is **latched**, defaulting to false, dropped before loading, raised only by a load that ran through; both button handlers carry a catch; the write goes through a temp file and a move, cleaned up on failure.

## Evidence

Twenty tests against real files, because what is asserted is what survives **on disk**. Two mutations were run and watched: reverting the reader to `File.Exists`-first kills the two directory tests; changing an environment variable name, the `deny` key, or the empty-`env` removal kills the merge-contract tests.

**Stated gaps, recorded in the tests themselves:** the permission-denied half of the probe change is not covered (a locked file answers `File.Exists` true in both versions); atomicity is not covered (reverting the move leaves every test passing); the temp-file test exercises only a *successful* move, so it does not prove the failure-path cleanup.

Three independent adversarial rounds. Serious findings went 2, 4, 2. Round 2's newly-introduced column dominating is why this branch was **reset rather than iterated**: both reviews were then applied in one considered pass and the change narrowed to its claim. Remaining findings are filed, not fixed - thefrederiksen/devthrottle_internal#1945, thefrederiksen/devthrottle_internal#1946, thefrederiksen/devthrottle_internal#1947.

One correction on the record: round 1's opening finding had two halves, an in-place write and a read-to-write race. The write was made atomic, the race was not, and the finding was reported as addressed. **A finding is not an atom.** The race is filed in thefrederiksen/devthrottle_internal#1942.

## The local gate is RED, and the red was accepted deliberately

`.\scripts\test-local.ps1` fails on this branch. **This is not an over-budget event and it is not caused by this change.**

- **Failing test:** `CcDirector.Setup.Engine.Tests.LauncherUpdateOwnerTests.WhileAnotherBinarySwapHoldsTheMachineWideLock_NothingIsTouched` - one failure against 540 passes, `System.ApplicationException: Object synchronization method was called from an unsynchronized block of code` (a mutex released off the thread that took it).
- **Judged against the parent, which is the deciding evidence:** `origin/main` was checked out **detached, with this branch's three files absent**, and that single test **fails there too**. It fails on main today, with or without this change.
- Corroborating, not proving: `cc-director-setup-engine.Tests` has no project reference to `CcDirector.Avalonia`, and this diff is three Avalonia files.
- **A guess, flagged as one:** the likely cause is this machine rather than main. The test's subject is a *machine-wide* lock, and twelve-plus `dotnet` processes and two `cc-director` processes were live on the host during the run, so another seat's suite may hold the thing this test asserts nobody holds. That is a hypothesis about the cause; what is not a hypothesis is that main fails it without this code.
- The test is filed as thefrederiksen/devthrottle_internal#1948 so it stops condemning innocent branches.

Everything else: nine suites `Completed`, `CcDirector.Avalonia.Tests` 389 to 397.

Recorded here because an unexplained accepted red teaches the next person to accept reds.
