### PR TITLE
Version 2.0.7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>2.0.6</Version>
+    <Version>2.0.7</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.


### PR DESCRIPTION
Bumps the version so the release workflow stamps 2.0.7. The release is cut by pushing the v2.0.7 tag, which this enables; no other change.