### PR TITLE
Refuse to re-open a dictation upload whose delivery record cannot be read (#2745)

### DIFF
--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -2046,6 +2046,23 @@ export interface DictationSubmitResult {
   transcript: string;
   error?: string;
   outOfCredits?: boolean;
+  /** Set when the Gateway refused to touch this upload's on-disk delivery record (issue #2745): the record is
+   *  there but cannot be read. "needs-operator" (a 409): it was read and is not a delivery record, or is
+   *  another account's - no retry changes that, someone has to look at the file. "retry-later" (a 423): it
+   *  could not be read just now and a retry may read it. Never terminal, never acknowledged; the driver keeps
+   *  the reason on screen past the throttle hour and slows the operator-needed case right down. */
+  recordRefusal?: RecordRefusalKind;
+}
+
+export type RecordRefusalKind = "needs-operator" | "retry-later";
+
+// The refusal kind carried by a Gateway error body, or undefined when the body is not a record refusal. A
+// refusal body always names the record kind in `record` (see the Gateway's RecordRefusal); the status says
+// whether a retry can help.
+function recordRefusalKind(body: unknown, status: number): RecordRefusalKind | undefined {
+  const record = body && typeof body === "object" ? (body as { record?: unknown }).record : undefined;
+  if (typeof record !== "string") return undefined;
+  return status === 423 ? "retry-later" : "needs-operator";
 }
 
 export interface DictationUploadArgs {
@@ -2117,8 +2134,8 @@ export async function uploadDictationToSession(
   // result (terminal:false) with the honest reason, so the driver keeps the audio and retries.
   const sid = args.sessionId;
   const uploadId = args.uploadId;
-  const held = (error: string, outOfCredits = false): DictationSubmitResult =>
-    ({ terminal: false, submitted: false, movedOn: false, transcript: "", error, outOfCredits });
+  const held = (error: string, outOfCredits = false, recordRefusal?: RecordRefusalKind): DictationSubmitResult =>
+    ({ terminal: false, submitted: false, movedOn: false, transcript: "", error, outOfCredits, recordRefusal });
   const permanent = (reason: PermanentDictationReason): DictationSubmitResult =>
     ({ terminal: false, submitted: false, movedOn: false, transcript: "", permanent: true, permanentReason: reason });
 
@@ -2136,7 +2153,15 @@ export async function uploadDictationToSession(
   } catch {
     return held(DICTATION_HELD_NO_CONNECTION_MESSAGE);
   }
-  if (!reg.ok) return held(transcriptionFailureMessage(await readGatewayErrorBody(reg), reg.status, true));
+  if (!reg.ok) {
+    // Read once, parse once: the message mapper wants the error sentence, and the record-refusal flag (issue
+    // #2745) wants the `record` field of the same body.
+    const text = await reg.text().catch(() => "");
+    let parsed: unknown;
+    try { parsed = JSON.parse(text); } catch { parsed = undefined; }
+    const serverError = stringFromErrorBody(parsed) ?? (text.trim() ? text : undefined);
+    return held(transcriptionFailureMessage(serverError, reg.status, true), false, recordRefusalKind(parsed, reg.status));
+  }
   const regBody = (await reg.json().catch(() => ({}))) as {
     upload_id?: string;
     terminal?: boolean;
@@ -2242,7 +2267,8 @@ export async function uploadDictationToSession(
       // there but is not readable as a delivery record, or belongs to another account. That is not a
       // missing-chunk answer, and re-sending chunks cannot change it - an operator has to look at the file
       // the server named. Held with that message; no ack, because an ack retires the server's evidence.
-      if (typeof body.record === "string") return held(transcriptionFailureMessage(body.error, comp.status, true));
+      if (typeof body.record === "string")
+        return held(transcriptionFailureMessage(body.error, comp.status, true), false, recordRefusalKind(body, comp.status));
       // Missing chunks: send exactly those, pausing (held) if the connection drops mid-chunk.
       const missing = (body.missing ?? []).filter((i) => ranges[i]);
       if (missing.length === 0) return held(transcriptionFailureMessage(undefined, 502, true));
@@ -2290,7 +2316,7 @@ export async function uploadDictationToSession(
 
     const body = (await comp.json().catch(() => ({}))) as {
       submitted?: boolean; movedOn?: boolean; dropped?: boolean; transcript?: string; error?: string;
-      permanent?: boolean; reason?: string;
+      permanent?: boolean; reason?: string; record?: string;
     };
 
     // Genuinely permanent, non-retryable failure (issue #1184). The server (a later, coordinated step)
@@ -2304,8 +2330,9 @@ export async function uploadDictationToSession(
 
     if (!comp.ok) {
       // A reachable Gateway that answered with a server-side transcription fault (timeout / outage / no
-      // key / session gone). Held, not lost - the honest "saved and will keep trying" copy.
-      return held(transcriptionFailureMessage(body.error, comp.status, true));
+      // key / session gone) - or, at 423, a delivery record it could not read just now (issue #2745). Held,
+      // not lost - the honest "saved and will keep trying" copy.
+      return held(transcriptionFailureMessage(body.error, comp.status, true), false, recordRefusalKind(body, comp.status));
     }
 
     // 200: the server made a final decision. submitted -> the turn was injected; movedOn -> the server

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -2237,8 +2237,13 @@ export async function uploadDictationToSession(
     }
 
     if (comp.status === 409) {
+      const body = (await comp.json().catch(() => ({}))) as { missing?: number[]; record?: string; error?: string };
+      // The Gateway refused to touch this upload's DELIVERY RECORD (issue #2745): the record on the server is
+      // there but is not readable as a delivery record, or belongs to another account. That is not a
+      // missing-chunk answer, and re-sending chunks cannot change it - an operator has to look at the file
+      // the server named. Held with that message; no ack, because an ack retires the server's evidence.
+      if (typeof body.record === "string") return held(transcriptionFailureMessage(body.error, comp.status, true));
       // Missing chunks: send exactly those, pausing (held) if the connection drops mid-chunk.
-      const body = (await comp.json().catch(() => ({}))) as { missing?: number[] };
       const missing = (body.missing ?? []).filter((i) => ranges[i]);
       if (missing.length === 0) return held(transcriptionFailureMessage(undefined, 502, true));
       let uploaded = total - missing.length;
@@ -2389,6 +2394,18 @@ export function transcriptionFailureMessage(serverError: string | undefined, sta
 
   if (status === 403)
     return "This device is not allowed to use transcription on this Gateway.";
+
+  // The Gateway refused to re-open, deliver, or write over this upload because its on-disk DELIVERY RECORD
+  // is there but cannot be read (issue #2745). "Unreadable" (a 423) means it could not be read just now
+  // (locked, a disk fault) and a retry may read it; anything else (a 409) means it was read and is not a
+  // delivery record, or is another account's, and no retry will change that - an operator has to look at
+  // the file the server named in its log. Neither is a transcription outage, and the saved copy must never
+  // be sent again on the strength of either, so this is ahead of every "transcription service" line below.
+  // Keyed on the sentence, not the status, so the wording follows what the server SAID was wrong.
+  if (raw.includes("delivery record for upload"))
+    return raw.includes(" is unreadable")
+      ? "The server could not read this recording's delivery record just now. Your recording is saved and will try again."
+      : "The server's delivery record for this recording is damaged and needs an operator to look at it. Your recording is saved and cannot go through until that is fixed.";
 
   // The session the dictation was headed for is gone (exited / not found).
   if (status === 404 || status === 410 || raw.includes("session not found") || raw.includes("session has exited"))

--- a/packages/client-core/src/api/dictationUnreadableRecord.test.ts
+++ b/packages/client-core/src/api/dictationUnreadableRecord.test.ts
@@ -75,6 +75,7 @@ describe("a dictation whose server-side delivery record cannot be read (issue #2
     expect(result.submitted).toBe(false);
     expect(result.error).toContain("delivery record");
     expect(result.error).toContain("operator");
+    expect(result.recordRefusal).toBe("needs-operator");
     expect(ackFired(calls)).toBe(false);
     expect(chunkPuts(calls)).toBe(0);
     expect(calls.some((c) => c.url.includes("/complete"))).toBe(false);
@@ -92,6 +93,7 @@ describe("a dictation whose server-side delivery record cannot be read (issue #2
     expect(result.terminal).toBe(false);
     expect(result.error).toContain("could not read");
     expect(result.error).not.toContain("transcription service");
+    expect(result.recordRefusal).toBe("retry-later");
   });
 
   it("a 409 record refusal at COMPLETE is not read as a missing-chunk answer: held, no re-upload, no ack", async () => {
@@ -108,6 +110,7 @@ describe("a dictation whose server-side delivery record cannot be read (issue #2
     expect(result.terminal).toBe(false);
     expect(result.submitted).toBe(false);
     expect(result.error).toContain("delivery record");
+    expect(result.recordRefusal).toBe("needs-operator");
     // A resumed clip completes FIRST and sends only what the server reports missing (see the control below).
     // The refusal carries no missing list, so no chunk may have been sent on the strength of it.
     expect(chunkPuts(calls)).toBe(0);
@@ -128,6 +131,7 @@ describe("a dictation whose server-side delivery record cannot be read (issue #2
 
     expect(result.terminal).toBe(false);
     expect(result.error).toContain("could not read");
+    expect(result.recordRefusal).toBe("retry-later");
     expect(ackFired(calls)).toBe(false);
   });
 
@@ -150,6 +154,7 @@ describe("a dictation whose server-side delivery record cannot be read (issue #2
 
     expect(result.terminal).toBe(true);
     expect(result.submitted).toBe(true);
+    expect(result.recordRefusal).toBeUndefined();
     expect(chunkPuts(calls)).toBe(1); // exactly the chunk the server reported missing
     expect(ackFired(calls)).toBe(true);
   });

--- a/packages/client-core/src/api/dictationUnreadableRecord.test.ts
+++ b/packages/client-core/src/api/dictationUnreadableRecord.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { transcriptionFailureMessage, uploadDictationToSession, type DictationUploadArgs } from "./client";
+
+// Client half of issue #2745: the Gateway now REFUSES to re-open, deliver, or write over an upload whose
+// on-disk delivery record is there but cannot be read. It answers 409 (the record was read and is not a
+// delivery record, or is another account's - an operator has to look at the file) or 423 Locked (the record could
+// not be read just now - a retry may read it), with a body that carries `record` (the kind) and an `error`
+// sentence naming the file. Neither is a terminal outcome, so the client must keep its on-device copy, must
+// NOT acknowledge (an ack retires the server's evidence), must not read the 409 as a missing-chunk answer,
+// and must tell the user what is actually wrong rather than "the transcription service had a problem".
+
+const UPLOAD_ID = "33333333-3333-3333-3333-333333333333";
+const MALFORMED_ERROR =
+  `the delivery record for upload ${UPLOAD_ID} is Malformed: the record has no State property (file: C:\\x\\record.json); refusing to re-open, deliver, or overwrite it`;
+const UNREADABLE_ERROR =
+  `the delivery record for upload ${UPLOAD_ID} is Unreadable: being used by another process (file: C:\\x\\record.json); refusing to re-open, deliver, or overwrite it`;
+
+function fakeResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function baseArgs(): DictationUploadArgs {
+  return {
+    sessionId: "11111111-1111-1111-1111-111111111111",
+    uploadId: UPLOAD_ID,
+    audio: new Blob(["hello"], { type: "audio/webm" }),
+    before: "",
+    after: "",
+    prefix: "",
+    baselineBufferBytes: 0,
+    resumed: true,
+  };
+}
+
+interface Call {
+  url: string;
+  method: string;
+}
+
+function mockFetch(route: (url: string, method: string) => Response): Call[] {
+  const calls: Call[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown, init?: { method?: string }) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      calls.push({ url, method });
+      return route(url, method);
+    }),
+  );
+  return calls;
+}
+
+const ackFired = (calls: Call[]) => calls.some((c) => c.url.includes(`/dictation/${UPLOAD_ID}/ack`) && c.method === "POST");
+const chunkPuts = (calls: Call[]) => calls.filter((c) => c.url.includes("/chunk/") && c.method === "PUT").length;
+
+describe("a dictation whose server-side delivery record cannot be read (issue #2745)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("a 409 record refusal at REGISTER is held with the damaged-record message, no ack, no upload", async () => {
+    const calls = mockFetch((url) => {
+      if (url.includes("/dictation/upload"))
+        return fakeResponse(409, { error: MALFORMED_ERROR, upload_id: UPLOAD_ID, record: "Malformed", file: "C:\\x\\record.json" });
+      throw new Error("unexpected fetch: " + url);
+    });
+
+    const result = await uploadDictationToSession(baseArgs());
+
+    expect(result.terminal).toBe(false);
+    expect(result.submitted).toBe(false);
+    expect(result.error).toContain("delivery record");
+    expect(result.error).toContain("operator");
+    expect(ackFired(calls)).toBe(false);
+    expect(chunkPuts(calls)).toBe(0);
+    expect(calls.some((c) => c.url.includes("/complete"))).toBe(false);
+  });
+
+  it("a 423 record refusal at REGISTER is held with the could-not-read message, not as a transcription outage", async () => {
+    mockFetch((url) => {
+      if (url.includes("/dictation/upload"))
+        return fakeResponse(423, { error: UNREADABLE_ERROR, upload_id: UPLOAD_ID, record: "Unreadable", file: "C:\\x\\record.json" });
+      throw new Error("unexpected fetch: " + url);
+    });
+
+    const result = await uploadDictationToSession(baseArgs());
+
+    expect(result.terminal).toBe(false);
+    expect(result.error).toContain("could not read");
+    expect(result.error).not.toContain("transcription service");
+  });
+
+  it("a 409 record refusal at COMPLETE is not read as a missing-chunk answer: held, no re-upload, no ack", async () => {
+    const calls = mockFetch((url, method) => {
+      if (url.includes("/dictation/upload")) return fakeResponse(200, { upload_id: UPLOAD_ID });
+      if (url.includes("/chunk/") && method === "PUT") return fakeResponse(200, { ok: true, index: 0 });
+      if (url.includes("/complete"))
+        return fakeResponse(409, { error: MALFORMED_ERROR, upload_id: UPLOAD_ID, record: "Malformed", file: "C:\\x\\record.json" });
+      throw new Error("unexpected fetch: " + url);
+    });
+
+    const result = await uploadDictationToSession(baseArgs());
+
+    expect(result.terminal).toBe(false);
+    expect(result.submitted).toBe(false);
+    expect(result.error).toContain("delivery record");
+    // A resumed clip completes FIRST and sends only what the server reports missing (see the control below).
+    // The refusal carries no missing list, so no chunk may have been sent on the strength of it.
+    expect(chunkPuts(calls)).toBe(0);
+    expect(calls.filter((c) => c.url.includes("/complete")).length).toBe(1);
+    expect(ackFired(calls)).toBe(false);
+  });
+
+  it("a 423 record refusal at COMPLETE is held with the could-not-read message", async () => {
+    const calls = mockFetch((url, method) => {
+      if (url.includes("/dictation/upload")) return fakeResponse(200, { upload_id: UPLOAD_ID });
+      if (url.includes("/chunk/") && method === "PUT") return fakeResponse(200, { ok: true, index: 0 });
+      if (url.includes("/complete"))
+        return fakeResponse(423, { error: UNREADABLE_ERROR, upload_id: UPLOAD_ID, record: "Unreadable", file: "C:\\x\\record.json" });
+      throw new Error("unexpected fetch: " + url);
+    });
+
+    const result = await uploadDictationToSession(baseArgs());
+
+    expect(result.terminal).toBe(false);
+    expect(result.error).toContain("could not read");
+    expect(ackFired(calls)).toBe(false);
+  });
+
+  it("a plain 409 missing-chunk answer still drives the missing chunks (control)", async () => {
+    let completes = 0;
+    const calls = mockFetch((url, method) => {
+      if (url.includes("/dictation/upload")) return fakeResponse(200, { upload_id: UPLOAD_ID });
+      if (url.includes("/chunk/") && method === "PUT") return fakeResponse(200, { ok: true, index: 0 });
+      if (url.includes("/complete")) {
+        completes += 1;
+        return completes === 1
+          ? fakeResponse(409, { missing: [0] })
+          : fakeResponse(200, { submitted: true, movedOn: false, transcript: "hello" });
+      }
+      if (url.includes("/ack")) return fakeResponse(200, { ok: true, retired: true });
+      throw new Error("unexpected fetch: " + url);
+    });
+
+    const result = await uploadDictationToSession(baseArgs());
+
+    expect(result.terminal).toBe(true);
+    expect(result.submitted).toBe(true);
+    expect(chunkPuts(calls)).toBe(1); // exactly the chunk the server reported missing
+    expect(ackFired(calls)).toBe(true);
+  });
+
+  it("the message mapper names the record problem for both statuses and never the transcription service", () => {
+    expect(transcriptionFailureMessage(MALFORMED_ERROR, 409, true)).toContain("operator");
+    expect(transcriptionFailureMessage(UNREADABLE_ERROR, 423, true)).toContain("could not read");
+    expect(transcriptionFailureMessage(UNREADABLE_ERROR, 423, true)).not.toContain("transcription service");
+  });
+});

--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -902,3 +902,62 @@ describe("abandonPendingDictation", () => {
     expect(deletePending).not.toHaveBeenCalled();
   });
 });
+
+describe("a record refusal from the Gateway (issue #2745): the driver keeps the reason and slows the loop", () => {
+  const OPERATOR_MESSAGE =
+    "The server's delivery record for this recording is damaged and needs an operator to look at it. Your recording is saved and cannot go through until that is fixed.";
+  const RETRY_LATER_MESSAGE =
+    "The server could not read this recording's delivery record just now. Your recording is saved and will try again.";
+  const NEEDS_OPERATOR: DictationSubmitResult = {
+    terminal: false, submitted: false, movedOn: false, transcript: "", error: OPERATOR_MESSAGE, recordRefusal: "needs-operator",
+  };
+  const RETRY_LATER: DictationSubmitResult = {
+    terminal: false, submitted: false, movedOn: false, transcript: "", error: RETRY_LATER_MESSAGE, recordRefusal: "retry-later",
+  };
+
+  it("keeps the operator-needed reason on screen for a clip older than the throttle hour", async () => {
+    // Without the refusal kind, heldMessage replaces every reason with the generic "still trying in the
+    // background" line once the clip is an hour old - the wrong answer to a user whose recording cannot go
+    // through until someone looks at a file on the server.
+    const old = { ...makeRecord("id-old-refused"), createdAt: Date.now() - 2 * 60 * 60 * 1000 };
+    vi.mocked(listPending).mockResolvedValue([old]);
+    vi.mocked(uploadDictationToSession).mockResolvedValue(NEEDS_OPERATOR);
+
+    await resumePendingDictations();
+
+    const status = statusFor("id-old-refused");
+    expect(status?.phase).toBe("held");
+    expect(status?.error).toBe(OPERATOR_MESSAGE);
+    expect(deletePending).not.toHaveBeenCalled();
+  });
+
+  it("retries an operator-needed refusal on the slow cadence from the first attempt, not the fast loop", async () => {
+    const rec = makeRecord("id-refused-slow");
+    vi.mocked(getPending).mockResolvedValue(rec);
+    vi.mocked(uploadDictationToSession).mockResolvedValue(NEEDS_OPERATOR);
+
+    await retryPendingDictation("id-refused-slow");
+    expect(uploadDictationToSession).toHaveBeenCalledTimes(1);
+
+    // The fast loop would have fired again within two seconds and several more times inside a minute.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(uploadDictationToSession).toHaveBeenCalledTimes(1);
+
+    // It is still retried - the operator fixing the file is exactly what a later attempt would find.
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    expect(uploadDictationToSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a could-not-read-just-now refusal on the ordinary fast cadence (control)", async () => {
+    const rec = makeRecord("id-refused-fast");
+    vi.mocked(getPending).mockResolvedValue(rec);
+    vi.mocked(uploadDictationToSession).mockResolvedValue(RETRY_LATER);
+
+    await retryPendingDictation("id-refused-fast");
+    expect(uploadDictationToSession).toHaveBeenCalledTimes(1);
+    expect(statusFor("id-refused-fast")?.error).toBe(RETRY_LATER_MESSAGE);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(vi.mocked(uploadDictationToSession).mock.calls.length).toBeGreaterThan(2);
+  });
+});

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -1,4 +1,4 @@
-import { abandonDictation, sendPrompt, uploadDictationToSession } from "../api/client";
+import { abandonDictation, sendPrompt, uploadDictationToSession, type RecordRefusalKind } from "../api/client";
 import { captureLossWarning, logCaptureHealth } from "./captureHealth";
 import { deletePending, getPending, listPending, savePending, type PendingDictation } from "./pendingStore";
 import { clearDictationStatus, publishDictationStatus } from "./status";
@@ -711,8 +711,8 @@ async function driveRecord(rec: PendingDictation, opts: DriveOptions): Promise<v
     }
 
     // Held: keep the audio and keep trying. Publish the honest held reason and schedule the next attempt.
-    publishHeld(rec, heldMessage(rec, outcome.error));
-    scheduleNext(rec, opts.attempt, Boolean(outcome.outOfCredits));
+    publishHeld(rec, heldMessage(rec, outcome.error, outcome.recordRefusal));
+    scheduleNext(rec, opts.attempt, Boolean(outcome.outOfCredits), outcome.recordRefusal);
   } catch {
     // uploadDictationToSession returns a held result rather than throwing, so this is a defensive net for
     // an unexpected fault: keep the audio and keep trying - never drop it.
@@ -775,16 +775,21 @@ async function kickAll(): Promise<void> {
 // Schedule the next automatic attempt for a held clip. The delay is hard (exponential from two seconds,
 // capped at fifteen) for the first hour since the clip was recorded, then throttled to five minutes - and
 // out of credits is always throttled (a fast retry cannot conjure credits). Never stops.
-function scheduleNext(rec: PendingDictation, attempt: number, outOfCredits: boolean): void {
+function scheduleNext(rec: PendingDictation, attempt: number, outOfCredits: boolean, recordRefusal?: RecordRefusalKind): void {
   clearScheduled(rec.id);
-  const delay = nextDelayMs(rec, attempt, outOfCredits);
+  const delay = nextDelayMs(rec, attempt, outOfCredits, recordRefusal);
   const t = setTimeout(() => void driveById(rec.id, { resumed: true, attempt: attempt + 1 }), delay);
   _timers.set(rec.id, t);
 }
 
-function nextDelayMs(rec: PendingDictation, attempt: number, outOfCredits: boolean): number {
+// A "needs-operator" record refusal (issue #2745) is throttled from the first attempt: the Gateway has said
+// its delivery record for this upload is damaged and no retry changes that until someone looks at the file,
+// so a fast loop is pure churn in both logs. It is still retried - the operator fixing the file is exactly
+// what a later attempt would find - just at the slow cadence. A "retry-later" refusal (the record could not
+// be read just now) stays on the ordinary cadence, because that one really may clear on the next try.
+function nextDelayMs(rec: PendingDictation, attempt: number, outOfCredits: boolean, recordRefusal?: RecordRefusalKind): number {
   const age = Date.now() - rec.createdAt;
-  if (outOfCredits || age >= HARD_WINDOW_MS) return THROTTLED_DELAY_MS;
+  if (outOfCredits || recordRefusal === "needs-operator" || age >= HARD_WINDOW_MS) return THROTTLED_DELAY_MS;
   return Math.min(HARD_MIN_DELAY_MS * 2 ** attempt, HARD_MAX_DELAY_MS);
 }
 
@@ -798,8 +803,13 @@ function clearScheduled(id: string): void {
 
 // The held status line to show: waiting-for-connection when offline, the throttled line once past the hard
 // hour, otherwise the specific reason the last attempt returned (or a generic retrying line).
-function heldMessage(rec: PendingDictation, reason: string | undefined): string {
+//
+// A record refusal (issue #2745) keeps its reason on screen whatever the clip's age: "still trying in the
+// background" is the wrong answer to a user whose recording cannot go through until an operator looks at a
+// file on the server, and the age throttle exists for outages, not for that.
+function heldMessage(rec: PendingDictation, reason: string | undefined, recordRefusal?: RecordRefusalKind): string {
   if (isOffline()) return WAITING_FOR_CONNECTION_MESSAGE;
+  if (recordRefusal !== undefined && reason !== undefined) return reason;
   if (Date.now() - rec.createdAt >= HARD_WINDOW_MS) return THROTTLED_MESSAGE;
   return reason ?? RETRYING_MESSAGE;
 }

--- a/src/CcDirector.Gateway.Tests/UnreadableDictationTombstoneTests.cs
+++ b/src/CcDirector.Gateway.Tests/UnreadableDictationTombstoneTests.cs
@@ -1,0 +1,230 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #2745, the front-door half: a dictation upload whose terminal tombstone is on disk but CANNOT BE
+/// READ is not re-opened, not injected, and not written over.
+///
+/// The de-dupe guard in front of register and complete tests positively for a DELIVERED or ABANDONED record,
+/// which is the right direction - but the reader beneath it used to answer null for "no record" and for "a
+/// record I could not read" alike, and null fails that positive test. So a corrupt, half-written or locked
+/// tombstone fell through to Register plus MarkPending, the upload was re-opened as a fresh PENDING, and the
+/// operator's speech was injected a second time. The comment above that guard promised it could not happen.
+///
+/// These tests drive a real GatewayHost over HTTP with no Director present, exactly as
+/// <see cref="DurableDictationDedupeTests"/> does: a prior delivery is a tombstone written to the same
+/// staging root the Gateway reads, and the corruption is done to that file. Each refusal is asserted as a
+/// PRESENCE - the specific status, the named kind in the body, the tombstone's bytes unchanged, no PENDING
+/// marker - next to a control showing a genuinely absent id still opens normally, so the fix cannot have
+/// worked by refusing everything.
+///
+/// REVERT-PROVABLE: make <c>VoiceUploadStore.ReadRecordFile</c> answer Absent for a file it cannot parse
+/// (the old fold) and the register test goes red on "the tombstone was overwritten with a PENDING marker" -
+/// the reported symptom - while the control stays green.
+/// </summary>
+public sealed class UnreadableDictationTombstoneTests : IAsyncLifetime
+{
+    private const string GatewayToken = "test-token";
+    private const string NotARecord = "{ this is not a delivery record";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private string? _originalRoot;
+
+    private readonly string _storageRoot =
+        Path.Combine(Path.GetTempPath(), "cc-unreadable-storage-" + Guid.NewGuid().ToString("N"));
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-unreadable-instances-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _originalRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _storageRoot);
+
+        _gateway = NewGateway();
+        await _gateway.StartAsync();
+        _http = NewClient(_gateway.Port);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _originalRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* cleanup */ }
+        try { if (Directory.Exists(_storageRoot)) Directory.Delete(_storageRoot, true); } catch { /* cleanup */ }
+    }
+
+    // ===== register: the leg from the issue ========================================================
+
+    [Fact]
+    public async Task ReRegister_OfACorruptTombstone_IsRefused_AndTheUploadIsNotReopened()
+    {
+        // A delivered upload whose tombstone can no longer be parsed.
+        var uploadId = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(uploadId);
+        var before = File.ReadAllBytes(path);
+
+        var resp = await RegisterAsync(uploadId);
+
+        // Refused, by name, with the file named for whoever has to fix it.
+        Assert.Equal(HttpStatusCode.Conflict, resp.status);
+        Assert.Equal("Malformed", resp.body.GetProperty("record").GetString());
+        Assert.Equal(path, resp.body.GetProperty("file").GetString());
+        Assert.Contains(uploadId, resp.body.GetProperty("error").GetString());
+        // Not a terminal outcome either: the client must not drop its copy on the strength of this.
+        Assert.False(resp.body.TryGetProperty("terminal", out var terminal) && terminal.GetBoolean());
+
+        // The reported symptom, asserted as its absence-of-harm PRESENCE: the tombstone's bytes are exactly
+        // what they were, no PENDING marker exists, and the store still reads the marker as Malformed.
+        Assert.Equal(before, File.ReadAllBytes(path));
+        Assert.False(Store().IsPending(uploadId), "the upload was re-opened as PENDING - the #2745 re-injection door");
+        Assert.Equal(DictationRecordReadKind.Malformed, Store().Read(uploadId).Kind);
+
+        // CONTROL: a genuinely absent id on the same Gateway still opens as a fresh PENDING upload, so the
+        // refusal above is a decision about THIS marker and not a Gateway that refuses everything.
+        var fresh = Guid.NewGuid().ToString();
+        var control = await RegisterAsync(fresh);
+        Assert.Equal(HttpStatusCode.OK, control.status);
+        Assert.Equal(fresh, control.body.GetProperty("upload_id").GetString());
+        Assert.True(Store().IsPending(fresh));
+    }
+
+    [Fact]
+    public async Task ReRegister_WhileTheTombstoneIsLocked_IsRefusedAsUnreadable_AndReadsNormallyOnceReleased()
+    {
+        // The locked-file case from the issue. Only Windows enforces a share lock against a reader.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var uploadId = Guid.NewGuid().ToString();
+        var store = Store();
+        store.MarkDelivered(uploadId, submitted: true, movedOn: false, transcript: "said once");
+        var path = RecordPath(uploadId);
+        var before = File.ReadAllBytes(path);
+
+        using (new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            var locked = await RegisterAsync(uploadId);
+
+            // Could not look is a 503 - "try again" - and never "open it".
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, locked.status);
+            Assert.Equal("Unreadable", locked.body.GetProperty("record").GetString());
+        }
+
+        // Released: the same register now gets the cached terminal outcome the tombstone always held. The
+        // bytes never moved, which is why it can.
+        Assert.Equal(before, File.ReadAllBytes(path));
+        var released = await RegisterAsync(uploadId);
+        Assert.Equal(HttpStatusCode.OK, released.status);
+        Assert.True(released.body.GetProperty("terminal").GetBoolean());
+        Assert.Equal("said once", released.body.GetProperty("transcript").GetString());
+    }
+
+    // ===== complete: the injection point =============================================================
+
+    [Fact]
+    public async Task ReComplete_OfACorruptTombstone_IsRefused_WithNothingInjectedAndNothingWritten()
+    {
+        var uploadId = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(uploadId);
+        var before = File.ReadAllBytes(path);
+
+        var resp = await _http.PostAsJsonAsync($"/dictation/{uploadId}/complete",
+            new { sessionId = Guid.NewGuid().ToString(), totalChunks = 1 });
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+        Assert.Equal("Malformed", body.GetProperty("record").GetString());
+        // Neither a cached submitted turn nor a dropped one: no outcome at all was fabricated.
+        Assert.False(body.TryGetProperty("submitted", out var s) && s.GetBoolean());
+        Assert.False(body.TryGetProperty("dropped", out var d) && d.GetBoolean());
+
+        Assert.Equal(before, File.ReadAllBytes(path));
+        Assert.False(Store().IsPending(uploadId));
+    }
+
+    // ===== abandon: the write from the phone ===========================================================
+
+    [Fact]
+    public async Task Abandon_OfACorruptTombstone_IsRefused_AndTheMarkerIsLeftAsItIs()
+    {
+        var uploadId = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(uploadId);
+        var before = File.ReadAllBytes(path);
+
+        var resp = await _http.PostAsync($"/dictation/{uploadId}/abandon", content: null);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+        Assert.Equal("Malformed", body.GetProperty("record").GetString());
+        Assert.False(body.TryGetProperty("ok", out var ok) && ok.GetBoolean());
+
+        // Not turned into an ABANDONED tombstone: had it been DELIVERED, a later re-complete would have told
+        // the user "dropped" about speech that was acted on.
+        Assert.Equal(before, File.ReadAllBytes(path));
+        Assert.Equal(DictationRecordReadKind.Malformed, Store().Read(uploadId).Kind);
+
+        // CONTROL: an abandon of a readable PENDING upload still lands as ABANDONED.
+        var pending = Guid.NewGuid().ToString();
+        Store().Register(pending);
+        Store().MarkPending(pending, Guid.NewGuid().ToString());
+        var control = await _http.PostAsync($"/dictation/{pending}/abandon", content: null);
+        Assert.Equal(HttpStatusCode.OK, control.StatusCode);
+        Assert.Equal(DictationDeliveryState.Abandoned, Store().ReadRecord(pending)!.State);
+    }
+
+    // ===== helpers =================================================================================
+
+    private static VoiceUploadStore Store() => new(CcStorage.DictationUploads(), TenantId.Local);
+
+    private static string RecordPath(string uploadId)
+        => Path.Combine(CcStorage.DictationUploads(), Guid.Parse(uploadId).ToString("N"), "record.json");
+
+    // A real DELIVERED tombstone written by the store the Gateway reads, then its bytes replaced with
+    // something that is not a delivery record. The id genuinely WAS delivered; only the marker is unreadable.
+    private static string CorruptDeliveredTombstone(string uploadId)
+    {
+        Store().MarkDelivered(uploadId, submitted: true, movedOn: false, transcript: "said once");
+        var path = RecordPath(uploadId);
+        Assert.True(File.Exists(path));
+        File.WriteAllText(path, NotARecord, Encoding.UTF8);
+        return path;
+    }
+
+    private async Task<(HttpStatusCode status, JsonElement body)> RegisterAsync(string uploadId)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/dictation/upload")
+        {
+            Content = JsonContent.Create(new { sessionId = Guid.NewGuid().ToString(), baselineBufferBytes = 0 }),
+        };
+        req.Headers.Add("Idempotency-Key", uploadId);
+        var resp = await _http.SendAsync(req);
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        return (resp.StatusCode, body);
+    }
+
+    private GatewayHost NewGateway() => new(
+        port: GatewayHost.OperatingSystemAssignedPort, token: GatewayToken, authEnabled: false,
+        instancesDirectory: _instancesDir,
+        workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+
+    private static HttpClient NewClient(int port)
+    {
+        var http = new HttpClient
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{port}/"),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GatewayToken);
+        return http;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/UnreadableDictationTombstoneTests.cs
+++ b/src/CcDirector.Gateway.Tests/UnreadableDictationTombstoneTests.cs
@@ -66,12 +66,15 @@ public sealed class UnreadableDictationTombstoneTests : IAsyncLifetime
 
     // ===== register: the leg from the issue ========================================================
 
-    [Fact]
-    public async Task ReRegister_OfACorruptTombstone_IsRefused_AndTheUploadIsNotReopened()
+    [Theory]
+    [InlineData(NotARecord)]         // not JSON at all
+    [InlineData("{}")]               // valid JSON, no properties: State would default to PENDING and re-open
+    [InlineData("{\"garbage\":1}")]  // valid JSON, an unrelated object: the same default
+    public async Task ReRegister_OfACorruptTombstone_IsRefused_AndTheUploadIsNotReopened(string bytes)
     {
-        // A delivered upload whose tombstone can no longer be parsed.
+        // A delivered upload whose tombstone can no longer be read as a delivery record.
         var uploadId = Guid.NewGuid().ToString();
-        var path = CorruptDeliveredTombstone(uploadId);
+        var path = CorruptDeliveredTombstone(uploadId, bytes);
         var before = File.ReadAllBytes(path);
 
         var resp = await RegisterAsync(uploadId);
@@ -115,8 +118,9 @@ public sealed class UnreadableDictationTombstoneTests : IAsyncLifetime
         {
             var locked = await RegisterAsync(uploadId);
 
-            // Could not look is a 503 - "try again" - and never "open it".
-            Assert.Equal(HttpStatusCode.ServiceUnavailable, locked.status);
+            // Could not look is a 423 Locked - "try again" - and never "open it". Not a 503: the phone reads
+            // 502/503/504 as "the Gateway is unreachable", and this Gateway answered.
+            Assert.Equal(HttpStatusCode.Locked, locked.status);
             Assert.Equal("Unreadable", locked.body.GetProperty("record").GetString());
         }
 
@@ -191,12 +195,12 @@ public sealed class UnreadableDictationTombstoneTests : IAsyncLifetime
 
     // A real DELIVERED tombstone written by the store the Gateway reads, then its bytes replaced with
     // something that is not a delivery record. The id genuinely WAS delivered; only the marker is unreadable.
-    private static string CorruptDeliveredTombstone(string uploadId)
+    private static string CorruptDeliveredTombstone(string uploadId, string bytes = NotARecord)
     {
         Store().MarkDelivered(uploadId, submitted: true, movedOn: false, transcript: "said once");
         var path = RecordPath(uploadId);
         Assert.True(File.Exists(path));
-        File.WriteAllText(path, NotARecord, Encoding.UTF8);
+        File.WriteAllText(path, bytes, Encoding.UTF8);
         return path;
     }
 

--- a/src/CcDirector.Gateway.Tests/UnreadableDictationTombstoneTests.cs
+++ b/src/CcDirector.Gateway.Tests/UnreadableDictationTombstoneTests.cs
@@ -98,7 +98,8 @@ public sealed class UnreadableDictationTombstoneTests : IAsyncLifetime
         var fresh = Guid.NewGuid().ToString();
         var control = await RegisterAsync(fresh);
         Assert.Equal(HttpStatusCode.OK, control.status);
-        Assert.Equal(fresh, control.body.GetProperty("upload_id").GetString());
+        // The store answers the normalized 32-character form of the id, as it always has.
+        Assert.Equal(Guid.Parse(fresh).ToString("N"), control.body.GetProperty("upload_id").GetString());
         Assert.True(Store().IsPending(fresh));
     }
 

--- a/src/CcDirector.Gateway.Tests/UnreadableDictationTombstoneTests.cs
+++ b/src/CcDirector.Gateway.Tests/UnreadableDictationTombstoneTests.cs
@@ -83,7 +83,7 @@ public sealed class UnreadableDictationTombstoneTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.Conflict, resp.status);
         Assert.Equal("Malformed", resp.body.GetProperty("record").GetString());
         Assert.Equal(path, resp.body.GetProperty("file").GetString());
-        Assert.Contains(uploadId, resp.body.GetProperty("error").GetString());
+        Assert.Contains(Guid.Parse(uploadId).ToString("N"), resp.body.GetProperty("error").GetString());
         // Not a terminal outcome either: the client must not drop its copy on the strength of this.
         Assert.False(resp.body.TryGetProperty("terminal", out var terminal) && terminal.GetBoolean());
 

--- a/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreRecordHookCollection.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreRecordHookCollection.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The tests that install <c>VoiceUploadStore.BetweenRecordReadAndWriteForTests</c> - a process-wide static
+/// seam - run in this collection, which xUnit runs with no other collection alongside it. Two classes that
+/// both set that hook and run in parallel can replace or clear each other's callback mid-test, and the
+/// interleaving proofs would then be proving nothing about the gate they are aimed at.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class VoiceUploadStoreRecordHookCollection
+{
+    public const string Name = "VoiceUploadStore record hook";
+}

--- a/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreTenantPartitionTests.cs
@@ -193,7 +193,14 @@ public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
         // not a missing file.
         Assert.Contains("alpha-secret-transcript", File.ReadAllText(bFile));
 
-        Assert.Null(b.ReadRecord(id));
+        // Refused under its OWN name (issue #2745), not reported as absent: "absent" is the one answer that
+        // lets a caller open the upload, and opening here would write B's PENDING marker over A's record.
+        var refused = b.Read(id);
+        Assert.Equal(DictationRecordReadKind.ForeignTenant, refused.Kind);
+        Assert.Null(refused.Record);
+        Assert.True(refused.Refuses);
+        // And the strict read will not quietly hand back null for it either.
+        Assert.Throws<UnreadableDictationRecordException>(() => b.ReadRecord(id));
 
         // The same check on the PENDING projection, which reads records by enumeration rather than by id: a
         // foreign pending record planted in this partition must not lock a session here either.

--- a/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreTenantPartitionTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreTenantPartitionTests.cs
@@ -220,6 +220,35 @@ public sealed class VoiceUploadStoreTenantPartitionTests : IDisposable
     }
 
     [Fact]
+    public void The_tombstone_sweep_never_retires_another_tenants_record_planted_in_this_partition()
+    {
+        // The same mis-computed-root scenario as the read and lock tests above, put to the RESOLVED-TOMBSTONE
+        // sweep (issue #2745 review): it retires aged DELIVERED / ABANDONED markers, and it must decline one
+        // stamped for another tenant rather than delete that account's de-dupe evidence.
+        var id = Guid.NewGuid().ToString();
+        var a = _base.ForTenant(_tenantA);
+        var b = _base.ForTenant(_tenantB);
+
+        a.MarkDelivered(id, submitted: true, movedOn: false, transcript: "alpha-secret-transcript");
+        b.Register(id);
+        var aFile = Path.Combine(a.Root, Guid.Parse(id).ToString("N"), "record.json");
+        var bFile = Path.Combine(b.Root, Guid.Parse(id).ToString("N"), "record.json");
+        Assert.NotEqual(aFile, bFile); // ahead of the copy, for the reason in the class comment
+        File.Copy(aFile, bFile, overwrite: true);
+        Assert.Equal(DictationRecordReadKind.ForeignTenant, b.Read(id).Kind); // the plant is really foreign here
+
+        // Positive control: B's OWN aged tombstone is retired by the very same sweep call, so the survival
+        // below is a refusal and not a sweep that did nothing. A future cutoff makes "aged" deterministic.
+        var own = Guid.NewGuid().ToString();
+        b.MarkDelivered(own, submitted: true, movedOn: false, transcript: "bravo");
+        Assert.Equal(1, b.SweepResolvedTombstones(TimeSpan.FromDays(-1)));
+        Assert.False(b.Exists(own));
+
+        Assert.True(File.Exists(bFile), "the sweep must not have retired another tenant's tombstone");
+        Assert.Contains("alpha-secret-transcript", File.ReadAllText(bFile));
+    }
+
+    [Fact]
     public void The_session_lock_projection_never_crosses_tenants()
     {
         var idA = Guid.NewGuid().ToString();

--- a/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreTests.cs
@@ -10,6 +10,7 @@ namespace CcDirector.Gateway.Tests;
 /// Unit tests for <see cref="VoiceUploadStore"/> - the Gateway-side resumable upload staging
 /// behind the guaranteed audio-turn front door. Each test stages under an isolated temp root.
 /// </summary>
+[Collection(VoiceUploadStoreRecordHookCollection.Name)]
 public sealed class VoiceUploadStoreTests : IDisposable
 {
     private readonly string _root = Path.Combine(Path.GetTempPath(), "cc-upload-" + Guid.NewGuid().ToString("N"));

--- a/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreUnreadableRecordTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreUnreadableRecordTests.cs
@@ -100,8 +100,13 @@ public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
     [Theory]
     [InlineData("")]                                              // an empty file - a write that never finished
     [InlineData("null")]                                          // JSON null: parses, and is nothing
-    [InlineData("{\"State\":\"Zombie\",\"Submitted\":true}")]     // a state name this build does not know
-    [InlineData("{\"State\":99,\"Submitted\":true}")]             // a state NUMBER the enum does not name: deserializes, matches nothing
+    [InlineData("[]")]                                            // valid JSON, not an object
+    [InlineData("{}")]                                            // valid, empty: every property defaults, and State's default is PENDING
+    [InlineData("{\"garbage\":1}")]                               // valid, unrelated: the same default PENDING
+    [InlineData("{\"State\":\"Pending\"}")]                       // names a state but nothing else a record carries
+    [InlineData("{\"state\":\"Delivered\",\"submitted\":true,\"movedOn\":false,\"transcript\":\"x\",\"reason\":null}")] // wrong case: the serializer would default all of it
+    [InlineData("{\"State\":\"Zombie\",\"Submitted\":true,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")] // a state name this build does not know
+    [InlineData("{\"State\":99,\"Submitted\":true,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")]         // a state NUMBER the enum does not name: deserializes, matches nothing
     public void Every_shape_that_is_not_a_delivery_record_is_Malformed(string bytes)
     {
         var id = Guid.NewGuid().ToString();
@@ -157,12 +162,14 @@ public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
 
     // ===== no writer puts a new marker on top of one it cannot read ===================================
 
-    [Fact]
-    public void MarkPending_over_a_corrupt_tombstone_refuses_and_leaves_the_file_byte_for_byte()
+    [Theory]
+    [InlineData("{ this is not json")]   // the syntax case
+    [InlineData("{}")]                   // the SHAPE case: valid JSON whose every property defaults, State to PENDING
+    public void MarkPending_over_a_corrupt_tombstone_refuses_and_leaves_the_file_byte_for_byte(string bytes)
     {
         // The write that re-opens an upload. This is what register used to reach after the fold.
         var id = Guid.NewGuid().ToString();
-        var path = CorruptDeliveredTombstone(id, "{ this is not json");
+        var path = CorruptDeliveredTombstone(id, bytes);
         var before = File.ReadAllBytes(path);
 
         Assert.Throws<UnreadableDictationRecordException>(() => _store.MarkPending(id, Guid.NewGuid().ToString()));
@@ -240,9 +247,11 @@ public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
     [Fact]
     public void A_corrupt_marker_does_not_lock_a_session()
     {
-        // The documented decision on IsPending: the lock fails open, because nothing a client can do would
-        // ever release a lock held by a marker every delivery path refuses. Pinned so a future reader sees it
-        // asserted, not assumed. The compensating fail-closed default is on the user-input send source.
+        // The documented decision on IsPending: the lock projection fails open, because nothing a client can
+        // do would ever clear a "receiving a dictation" state held by a marker every delivery path refuses.
+        // What that projection drives is display (the session's dictation badge); sends are never refused by
+        // source, so a missed lock costs a badge and cannot cost a delivery. Pinned so a future reader sees it
+        // asserted, not assumed.
         var id = Guid.NewGuid().ToString();
         var session = Guid.NewGuid().ToString();
         _store.Register(id);

--- a/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreUnreadableRecordTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreUnreadableRecordTests.cs
@@ -33,6 +33,7 @@ namespace CcDirector.Gateway.Tests;
 /// Malformed assertion here goes red on the claim, not on a crash; the writer tests go red on the file
 /// having been overwritten.
 /// </summary>
+[Collection(VoiceUploadStoreRecordHookCollection.Name)]
 public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
 {
     private readonly string _root =
@@ -111,6 +112,12 @@ public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
     [InlineData("{\"State\":1,\"Submitted\":true,\"MovedOn\":false,\"Transcript\":\"x\",\"Reason\":null}")]         // 1 is DELIVERED, and would fabricate an outcome the phone acks and drops its copy for
     [InlineData("{\"State\":2,\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":\"r\"}")]        // 2 is ABANDONED
     [InlineData("{\"State\":3,\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":\"r\"}")]        // 3 is FAILED
+    [InlineData("{\"State\":\"0\",\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")]     // the number as a STRING: the converter reads it as PENDING
+    [InlineData("{\"State\":\"1\",\"Submitted\":true,\"MovedOn\":false,\"Transcript\":\"x\",\"Reason\":null}")]     // "1" as DELIVERED - an outcome the phone would ack and drop its copy for
+    [InlineData("{\"State\":\"2\",\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":\"r\"}")]    // "2" as ABANDONED
+    [InlineData("{\"State\":\"3\",\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":\"r\"}")]    // "3" as FAILED
+    [InlineData("{\"State\":\"pending\",\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")] // a casing the store never writes: the converter would accept it
+    [InlineData("{\"State\":\"\",\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")]      // an empty name
     [InlineData("{\"State\":\"Delivered\",\"Submitted\":true,\"MovedOn\":false,\"Transcript\":null,\"Reason\":null}")] // a transcript that is not a string: the store never writes one
     [InlineData("{\"State\":\"Pending\",\"Submitted\":\"yes\",\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")] // a flag that is not a boolean
     public void Every_shape_that_is_not_a_delivery_record_is_Malformed(string bytes)
@@ -291,33 +298,13 @@ public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
         _store.Register(id);
         _store.MarkPending(id, session);
 
-        using var deliverStarted = new System.Threading.ManualResetEventSlim(false);
-        Exception? deliverFailure = null;
-        System.Threading.Thread? deliver = null;
-        var deliverFinishedWhileInsideTheGate = false;
-        VoiceUploadStore.BetweenRecordReadAndWriteForTests = uid =>
-        {
-            // Inside OpenPending's hold of the gate, after its read and before its write: a complete tries to
-            // land the DELIVERED tombstone from another thread.
-            deliver = new System.Threading.Thread(() =>
-            {
-                deliverStarted.Set();
-                try { _store.MarkDelivered(id, submitted: true, movedOn: false, transcript: "landed"); }
-                catch (Exception ex) { deliverFailure = ex; }
-            });
-            deliver.Start();
-            deliverStarted.Wait(TimeSpan.FromSeconds(5));
-            // The claim: it has NOT finished while we hold the gate. (Joined with a timeout: a join that
-            // succeeds here is the old race, made deterministic.)
-            deliverFinishedWhileInsideTheGate = deliver.Join(TimeSpan.FromMilliseconds(500));
-        };
+        var competing = new CompetingWriter(() => _store.MarkDelivered(id, submitted: true, movedOn: false, transcript: "landed"));
+        VoiceUploadStore.BetweenRecordReadAndWriteForTests = _ => competing.StartAndObserveBlocked();
         try
         {
             var opened = _store.OpenPending(id, session);
             Assert.True(opened.Opened);
-            Assert.False(deliverFinishedWhileInsideTheGate, "a DELIVERED write landed inside the register transition - the race is open");
-            Assert.True(deliver!.Join(TimeSpan.FromSeconds(10)), "the deferred delivery never completed");
-            Assert.Null(deliverFailure);
+            competing.AssertWasBlockedInsideTheGate("the register transition");
         }
         finally
         {
@@ -328,6 +315,110 @@ public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
         Assert.Equal(DictationDeliveryState.Delivered, _store.ReadRecord(id)!.State);
         Assert.Equal("landed", _store.ReadRecord(id)!.Transcript);
         Assert.False(_store.IsPending(id));
+    }
+
+    [Fact]
+    public void Abandon_names_every_answer_and_never_writes_over_a_delivery()
+    {
+        var reason = "user_abandoned";
+
+        // PENDING: abandoned, chunks discarded.
+        var pending = Guid.NewGuid().ToString();
+        _store.Register(pending);
+        _store.MarkPending(pending, Guid.NewGuid().ToString());
+        var a = _store.Abandon(pending, reason);
+        Assert.True(a.Abandoned);
+        Assert.Equal(DictationDeliveryState.Pending, a.Before.Record!.State);
+        Assert.Equal(DictationDeliveryState.Abandoned, _store.ReadRecord(pending)!.State);
+
+        // Absent: abandoned (a tombstone for an id that never staged, as the raw writer always allowed).
+        var absent = Guid.NewGuid().ToString();
+        Assert.True(_store.Abandon(absent, reason).Abandoned);
+
+        // DELIVERED: NOT abandoned; the delivery is the stronger fact and stands.
+        var delivered = Guid.NewGuid().ToString();
+        _store.MarkDelivered(delivered, submitted: true, movedOn: false, transcript: "said once");
+        var d = _store.Abandon(delivered, reason);
+        Assert.False(d.Abandoned);
+        Assert.Equal(DictationDeliveryState.Delivered, d.Before.Record!.State);
+        Assert.Equal("said once", _store.ReadRecord(delivered)!.Transcript);
+
+        // MALFORMED: refused by name, file untouched.
+        var corrupt = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(corrupt, "{}");
+        var before = File.ReadAllBytes(path);
+        var refused = _store.Abandon(corrupt, reason);
+        Assert.False(refused.Abandoned);
+        Assert.Equal(DictationRecordReadKind.Malformed, refused.Before.Kind);
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void A_delivery_cannot_land_between_Abandon_reading_and_writing()
+    {
+        // The round-three interleaving: abandon reads PENDING, a complete injects the speech and lands
+        // DELIVERED, abandon writes ABANDONED over it, and the next re-complete tells the user "dropped" about
+        // words that were acted on. Under one hold of the gate the delivery blocks until the abandon has
+        // finished and then lands after it - and delivery over abandoned is the truthful final state.
+        var id = Guid.NewGuid().ToString();
+        _store.Register(id);
+        _store.MarkPending(id, Guid.NewGuid().ToString());
+
+        var competing = new CompetingWriter(() => _store.MarkDelivered(id, submitted: true, movedOn: false, transcript: "landed"));
+        VoiceUploadStore.BetweenRecordReadAndWriteForTests = _ => competing.StartAndObserveBlocked();
+        try
+        {
+            var abandoned = _store.Abandon(id, "user_abandoned");
+            Assert.True(abandoned.Abandoned);
+            competing.AssertWasBlockedInsideTheGate("the abandon transition");
+        }
+        finally
+        {
+            VoiceUploadStore.BetweenRecordReadAndWriteForTests = null;
+        }
+
+        Assert.Equal(DictationDeliveryState.Delivered, _store.ReadRecord(id)!.State);
+    }
+
+    // A writer on another thread that is started while the test holds the record gate. The proof it gives is
+    // POSITIVE: the thread is observed in a wait (blocked on the gate) while still alive, or the test fails -
+    // both when the thread finished inside the gate (the gate did not hold it: the race is open) and when it
+    // never reached the gate at all (nothing was proven). A timeout that merely says "it did not finish yet"
+    // would pass with the gate removed whenever the competing write was slow.
+    private sealed class CompetingWriter
+    {
+        private readonly System.Threading.Thread _thread;
+        private Exception? _failure;
+        private bool _observedBlocked;
+        private bool _finishedInsideTheGate;
+
+        public CompetingWriter(Action write)
+        {
+            _thread = new System.Threading.Thread(() =>
+            {
+                try { write(); }
+                catch (Exception ex) { _failure = ex; }
+            });
+        }
+
+        public void StartAndObserveBlocked()
+        {
+            _thread.Start();
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+            while (DateTime.UtcNow < deadline && _thread.IsAlive
+                   && (_thread.ThreadState & System.Threading.ThreadState.WaitSleepJoin) == 0)
+                System.Threading.Thread.Sleep(5);
+            _finishedInsideTheGate = !_thread.IsAlive;
+            _observedBlocked = _thread.IsAlive && (_thread.ThreadState & System.Threading.ThreadState.WaitSleepJoin) != 0;
+        }
+
+        public void AssertWasBlockedInsideTheGate(string transition)
+        {
+            Assert.False(_finishedInsideTheGate, $"a DELIVERED write landed inside {transition} - the race is open");
+            Assert.True(_observedBlocked, $"the competing writer was never observed blocked on the gate during {transition}");
+            Assert.True(_thread.Join(TimeSpan.FromSeconds(10)), "the deferred delivery never completed");
+            Assert.Null(_failure);
+        }
     }
 
     // ===== the sweeps and the lock ==================================================================

--- a/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreUnreadableRecordTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreUnreadableRecordTests.cs
@@ -1,0 +1,276 @@
+using System;
+using System.IO;
+using System.Text;
+using CcDirector.Core.Tenancy;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #2745: a dictation delivery record that is there but cannot be read is NOT "no record".
+///
+/// The reader used to answer null for both, and the de-dupe guard in front of register read that null as
+/// "never delivered" and re-opened the upload - so the operator's own speech was injected into a live
+/// session a second time. The read now has five answers, each with a name, and this file pins the store
+/// half of the fix:
+///
+///   - <see cref="VoiceUploadStore.Read"/> names every answer: Absent, Present, Malformed, Unreadable,
+///     ForeignTenant (the last is pinned in <c>VoiceUploadStoreTenantPartitionTests</c>).
+///   - the strict <see cref="VoiceUploadStore.ReadRecord"/> returns null ONLY for Absent and throws for
+///     the rest, so no caller can fold them back into "absent".
+///   - every WRITER refuses to put a new marker on top of one it cannot read, and leaves the file exactly as
+///     it found it.
+///   - the sweeps leave such a marker standing.
+///   - the session LOCK does not project from it - a decision, documented on IsPending, that is pinned
+///     here so it stays a decision and cannot drift back into being an accident.
+///
+/// The endpoint half - a re-register, a re-complete and an abandon against such a marker are all refused
+/// with nothing injected and the file untouched - is host-bound and lives in the parked Gateway.Tests suite
+/// (<c>UnreadableDictationTombstoneTests</c>).
+///
+/// REVERT-PROVABLE: restore the old <c>ReadRecordFile</c> (catch everything, return null) and every
+/// Malformed assertion here goes red on the claim, not on a crash; the writer tests go red on the file
+/// having been overwritten.
+/// </summary>
+public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "cc-upload-unreadable-" + Guid.NewGuid().ToString("N"));
+
+    private readonly VoiceUploadStore _store;
+
+    public VoiceUploadStoreUnreadableRecordTests() => _store = new VoiceUploadStore(_root, TenantId.Local);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best-effort */ }
+    }
+
+    // ===== the answers, each by name ================================================================
+
+    [Fact]
+    public void An_unknown_id_is_Absent_and_the_strict_read_is_null()
+    {
+        // The control for every refusal below: a genuinely absent record is still the one answer that says
+        // "go ahead", and the strict read still hands back null for it.
+        var id = Guid.NewGuid().ToString();
+
+        var read = _store.Read(id);
+
+        Assert.Equal(DictationRecordReadKind.Absent, read.Kind);
+        Assert.False(read.Refuses);
+        Assert.Null(_store.ReadRecord(id));
+    }
+
+    [Fact]
+    public void A_delivered_tombstone_is_Present_with_its_record()
+    {
+        var id = Guid.NewGuid().ToString();
+        _store.MarkDelivered(id, submitted: true, movedOn: false, transcript: "said once");
+
+        var read = _store.Read(id);
+
+        Assert.Equal(DictationRecordReadKind.Present, read.Kind);
+        Assert.False(read.Refuses);
+        Assert.Equal(DictationDeliveryState.Delivered, read.Record!.State);
+        Assert.Equal("said once", _store.ReadRecord(id)!.Transcript);
+    }
+
+    [Fact]
+    public void A_corrupt_tombstone_is_Malformed_not_Absent_and_the_strict_read_throws()
+    {
+        // The defect itself, at the reader. A delivered tombstone whose bytes are no longer a delivery record.
+        var id = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(id, "{ this is not json");
+
+        var read = _store.Read(id);
+
+        Assert.Equal(DictationRecordReadKind.Malformed, read.Kind);
+        Assert.True(read.Refuses, "a marker that cannot be understood must refuse, never permit");
+        Assert.Null(read.Record);
+        Assert.Equal(path, read.Path);
+        Assert.False(string.IsNullOrWhiteSpace(read.Problem), "the refusal must say what was wrong");
+
+        var ex = Assert.Throws<UnreadableDictationRecordException>(() => _store.ReadRecord(id));
+        Assert.Equal(DictationRecordReadKind.Malformed, ex.Read.Kind);
+        Assert.Contains(path, ex.Message);
+    }
+
+    [Theory]
+    [InlineData("")]                                              // an empty file - a write that never finished
+    [InlineData("null")]                                          // JSON null: parses, and is nothing
+    [InlineData("{\"State\":\"Zombie\",\"Submitted\":true}")]     // a state name this build does not know
+    [InlineData("{\"State\":99,\"Submitted\":true}")]             // a state NUMBER the enum does not name: deserializes, matches nothing
+    public void Every_shape_that_is_not_a_delivery_record_is_Malformed(string bytes)
+    {
+        var id = Guid.NewGuid().ToString();
+        CorruptDeliveredTombstone(id, bytes);
+
+        var read = _store.Read(id);
+
+        Assert.Equal(DictationRecordReadKind.Malformed, read.Kind);
+        Assert.Throws<UnreadableDictationRecordException>(() => _store.ReadRecord(id));
+    }
+
+    [Fact]
+    public void A_directory_where_the_record_should_be_is_Unreadable_not_Absent()
+    {
+        // "Could not look", in a form every platform produces: the path exists and is not a file. The old
+        // reader's File.Exists pre-check answered false here, which folded this straight into "absent".
+        var id = Guid.NewGuid().ToString();
+        _store.MarkDelivered(id, submitted: true, movedOn: false, transcript: "said once");
+        var path = RecordPath(id);
+        File.Delete(path);
+        Directory.CreateDirectory(path);
+
+        var read = _store.Read(id);
+
+        Assert.Equal(DictationRecordReadKind.Unreadable, read.Kind);
+        Assert.True(read.Refuses);
+        Assert.Equal(path, read.Path);
+        Assert.Throws<UnreadableDictationRecordException>(() => _store.ReadRecord(id));
+    }
+
+    [Fact]
+    public void A_tombstone_held_open_by_another_writer_is_Unreadable_not_Absent()
+    {
+        // The locked-file case from the issue. Only Windows enforces a share lock against a reader, so the
+        // claim is only askable there; elsewhere the directory test above covers "could not look".
+        if (!OperatingSystem.IsWindows()) return;
+
+        var id = Guid.NewGuid().ToString();
+        _store.MarkDelivered(id, submitted: true, movedOn: false, transcript: "said once");
+        var path = RecordPath(id);
+        using (new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            var read = _store.Read(id);
+
+            Assert.Equal(DictationRecordReadKind.Unreadable, read.Kind);
+            Assert.True(read.Refuses);
+            Assert.Throws<UnreadableDictationRecordException>(() => _store.ReadRecord(id));
+        }
+
+        // Released: the same marker reads as what it always was. The refusal was about the moment, not the file.
+        Assert.Equal(DictationRecordReadKind.Present, _store.Read(id).Kind);
+    }
+
+    // ===== no writer puts a new marker on top of one it cannot read ===================================
+
+    [Fact]
+    public void MarkPending_over_a_corrupt_tombstone_refuses_and_leaves_the_file_byte_for_byte()
+    {
+        // The write that re-opens an upload. This is what register used to reach after the fold.
+        var id = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(id, "{ this is not json");
+        var before = File.ReadAllBytes(path);
+
+        Assert.Throws<UnreadableDictationRecordException>(() => _store.MarkPending(id, Guid.NewGuid().ToString()));
+
+        Assert.Equal(before, File.ReadAllBytes(path));
+        Assert.False(_store.IsPending(id), "a refused re-open must not have produced a PENDING marker");
+        Assert.Equal(DictationRecordReadKind.Malformed, _store.Read(id).Kind);
+    }
+
+    [Fact]
+    public void MarkDelivered_and_MarkAbandoned_over_a_corrupt_tombstone_refuse_and_leave_the_file()
+    {
+        // The two terminal writers share one path; both are asked, because the abandon leg reaches one of
+        // them directly from the phone.
+        var id = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(id, "{ this is not json");
+        var before = File.ReadAllBytes(path);
+
+        Assert.Throws<UnreadableDictationRecordException>(() => _store.MarkDelivered(id, true, false, "again"));
+        Assert.Throws<UnreadableDictationRecordException>(() => _store.MarkAbandoned(id, "user_abandoned"));
+
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void MarkFailed_ClearFailed_and_the_rebaseline_over_a_corrupt_tombstone_write_nothing()
+    {
+        var id = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(id, "{ this is not json");
+        var before = File.ReadAllBytes(path);
+
+        Assert.Throws<UnreadableDictationRecordException>(() => _store.MarkFailed(id, "audio_too_large"));
+        Assert.False(_store.ClearFailed(id));
+        Assert.False(_store.RecordFailedDeliveryBaseline(id, 4096));
+
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    // ===== the sweeps and the lock ==================================================================
+
+    [Fact]
+    public void The_tombstone_sweep_leaves_a_corrupt_tombstone_standing()
+    {
+        var id = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(id, "{ this is not json");
+
+        // Positive control: the sweep really runs and really retires an aged READABLE tombstone, so the
+        // survival below is a decision and not a sweep that did nothing.
+        var control = Guid.NewGuid().ToString();
+        _store.MarkDelivered(control, submitted: true, movedOn: false, transcript: "old");
+        var removed = _store.SweepResolvedTombstones(TimeSpan.FromDays(-1));
+        Assert.Equal(1, removed);
+        Assert.False(_store.Exists(control));
+
+        Assert.True(File.Exists(path), "the sweep must not destroy a marker it could not read");
+    }
+
+    [Fact]
+    public void The_stale_pending_sweep_leaves_a_corrupt_marker_standing()
+    {
+        var id = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(id, "{ this is not json");
+        var before = File.ReadAllBytes(path);
+
+        // Positive control: an aged readable PENDING really is abandoned by this sweep.
+        var control = Guid.NewGuid().ToString();
+        _store.Register(control);
+        _store.MarkPending(control, Guid.NewGuid().ToString());
+        Assert.Equal(1, _store.ExpireStalePending(TimeSpan.FromDays(-1)));
+        Assert.Equal(DictationDeliveryState.Abandoned, _store.ReadRecord(control)!.State);
+
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void A_corrupt_marker_does_not_lock_a_session()
+    {
+        // The documented decision on IsPending: the lock fails open, because nothing a client can do would
+        // ever release a lock held by a marker every delivery path refuses. Pinned so a future reader sees it
+        // asserted, not assumed. The compensating fail-closed default is on the user-input send source.
+        var id = Guid.NewGuid().ToString();
+        var session = Guid.NewGuid().ToString();
+        _store.Register(id);
+        _store.MarkPending(id, session);
+        Assert.True(_store.IsSessionLocked(session)); // positive control: a readable PENDING does lock
+
+        File.WriteAllText(RecordPath(id), "{ this is not json");
+
+        // The lock projection is cached per store instance and hydrated from disk once, so the question is
+        // put to a FRESH store over the same root - which is also exactly what a Gateway restart does.
+        var restarted = new VoiceUploadStore(_root, TenantId.Local);
+        Assert.False(restarted.IsPending(id));
+        Assert.False(restarted.IsSessionLocked(session));
+        Assert.DoesNotContain(session, restarted.LockedSessionIds());
+    }
+
+    // ===== helpers ================================================================================
+
+    // A real DELIVERED tombstone written by the store itself, then its bytes replaced: the directory, the
+    // file, and the fact that this id WAS delivered are all genuine. Returns the record path.
+    private string CorruptDeliveredTombstone(string id, string bytes)
+    {
+        _store.MarkDelivered(id, submitted: true, movedOn: false, transcript: "said once");
+        var path = RecordPath(id);
+        Assert.True(File.Exists(path));
+        File.WriteAllText(path, bytes, Encoding.UTF8);
+        return path;
+    }
+
+    private string RecordPath(string id) => Path.Combine(_root, Guid.Parse(id).ToString("N"), "record.json");
+}

--- a/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreUnreadableRecordTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/VoiceUploadStoreUnreadableRecordTests.cs
@@ -106,7 +106,13 @@ public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
     [InlineData("{\"State\":\"Pending\"}")]                       // names a state but nothing else a record carries
     [InlineData("{\"state\":\"Delivered\",\"submitted\":true,\"movedOn\":false,\"transcript\":\"x\",\"reason\":null}")] // wrong case: the serializer would default all of it
     [InlineData("{\"State\":\"Zombie\",\"Submitted\":true,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")] // a state name this build does not know
-    [InlineData("{\"State\":99,\"Submitted\":true,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")]         // a state NUMBER the enum does not name: deserializes, matches nothing
+    [InlineData("{\"State\":99,\"Submitted\":true,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")]         // a state NUMBER the enum does not name
+    [InlineData("{\"State\":0,\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")]         // a state number the enum DOES name: 0 is PENDING, and would re-open
+    [InlineData("{\"State\":1,\"Submitted\":true,\"MovedOn\":false,\"Transcript\":\"x\",\"Reason\":null}")]         // 1 is DELIVERED, and would fabricate an outcome the phone acks and drops its copy for
+    [InlineData("{\"State\":2,\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":\"r\"}")]        // 2 is ABANDONED
+    [InlineData("{\"State\":3,\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":\"r\"}")]        // 3 is FAILED
+    [InlineData("{\"State\":\"Delivered\",\"Submitted\":true,\"MovedOn\":false,\"Transcript\":null,\"Reason\":null}")] // a transcript that is not a string: the store never writes one
+    [InlineData("{\"State\":\"Pending\",\"Submitted\":\"yes\",\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null}")] // a flag that is not a boolean
     public void Every_shape_that_is_not_a_delivery_record_is_Malformed(string bytes)
     {
         var id = Guid.NewGuid().ToString();
@@ -116,6 +122,23 @@ public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
 
         Assert.Equal(DictationRecordReadKind.Malformed, read.Kind);
         Assert.Throws<UnreadableDictationRecordException>(() => _store.ReadRecord(id));
+    }
+
+    [Fact]
+    public void A_record_carrying_a_property_this_build_does_not_know_is_still_Present()
+    {
+        // The compatibility ruling, pinned: the five known properties, present and of the right kind, are the
+        // contract. A record written by a newer Gateway carries fields this build has never heard of, and a
+        // rollback that refused every one of them would hold every upload on the machine.
+        var id = Guid.NewGuid().ToString();
+        CorruptDeliveredTombstone(id,
+            "{\"State\":\"Delivered\",\"Submitted\":true,\"MovedOn\":false,\"Transcript\":\"said once\",\"Reason\":null," +
+            "\"SessionId\":\"\",\"Tenant\":\"\",\"AddedByALaterBuild\":{\"nested\":[1,2,3]}}");
+
+        var read = _store.Read(id);
+
+        Assert.Equal(DictationRecordReadKind.Present, read.Kind);
+        Assert.Equal("said once", read.Record!.Transcript);
     }
 
     [Fact]
@@ -208,6 +231,105 @@ public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
         Assert.Equal(before, File.ReadAllBytes(path));
     }
 
+    // ===== the register transition is ONE gated operation ============================================
+
+    [Fact]
+    public void OpenPending_names_every_answer_and_writes_only_when_it_may()
+    {
+        // Absent: opened, fresh PENDING for the session.
+        var fresh = Guid.NewGuid().ToString();
+        var session = Guid.NewGuid().ToString();
+        var opened = _store.OpenPending(fresh, session);
+        Assert.True(opened.Opened);
+        Assert.Equal(DictationRecordReadKind.Absent, opened.Before.Kind);
+        Assert.Equal(Guid.Parse(fresh).ToString("N"), opened.UploadId);
+        Assert.True(_store.IsPending(fresh));
+        Assert.Equal(session, _store.ReadRecord(fresh)!.SessionId);
+
+        // A blank id mints one, as Register does.
+        Assert.True(_store.OpenPending(null, session).Opened);
+
+        // FAILED: re-opened, carrying the re-baseline forward (issue #1593).
+        var failed = Guid.NewGuid().ToString();
+        _store.Register(failed);
+        _store.MarkPending(failed, session);
+        Assert.True(_store.RecordFailedDeliveryBaseline(failed, 4096));
+        _store.MarkFailed(failed, "audio_too_large");
+        var reopened = _store.OpenPending(failed, session);
+        Assert.True(reopened.Opened);
+        Assert.Equal(DictationDeliveryState.Failed, reopened.Before.Record!.State);
+        Assert.Equal(4096, _store.ReadRecord(failed)!.RebaselineBufferBytes);
+
+        // DELIVERED: NOT opened; the terminal record is handed back for the cached-outcome answer, and the
+        // tombstone is exactly what it was.
+        var delivered = Guid.NewGuid().ToString();
+        _store.MarkDelivered(delivered, submitted: true, movedOn: false, transcript: "said once");
+        var terminal = _store.OpenPending(delivered, session);
+        Assert.False(terminal.Opened);
+        Assert.Equal(DictationDeliveryState.Delivered, terminal.Before.Record!.State);
+        Assert.Equal("said once", _store.ReadRecord(delivered)!.Transcript);
+
+        // MALFORMED: NOT opened, refused by name, file untouched.
+        var corrupt = Guid.NewGuid().ToString();
+        var path = CorruptDeliveredTombstone(corrupt, "{}");
+        var before = File.ReadAllBytes(path);
+        var refused = _store.OpenPending(corrupt, session);
+        Assert.False(refused.Opened);
+        Assert.Equal(DictationRecordReadKind.Malformed, refused.Before.Kind);
+        Assert.Equal(before, File.ReadAllBytes(path));
+    }
+
+    [Fact]
+    public void A_tombstone_cannot_land_between_OpenPending_reading_and_writing()
+    {
+        // The interleaving from the review: register reads PENDING, a complete lands DELIVERED, register
+        // writes PENDING over it, and the delivered speech is injected again on the next complete. With the
+        // transition under one hold of the gate the complete's write cannot get in: it blocks until the open
+        // has finished, then lands AFTER it, and the tombstone is what remains.
+        var id = Guid.NewGuid().ToString();
+        var session = Guid.NewGuid().ToString();
+        _store.Register(id);
+        _store.MarkPending(id, session);
+
+        using var deliverStarted = new System.Threading.ManualResetEventSlim(false);
+        Exception? deliverFailure = null;
+        System.Threading.Thread? deliver = null;
+        var deliverFinishedWhileInsideTheGate = false;
+        VoiceUploadStore.BetweenRecordReadAndWriteForTests = uid =>
+        {
+            // Inside OpenPending's hold of the gate, after its read and before its write: a complete tries to
+            // land the DELIVERED tombstone from another thread.
+            deliver = new System.Threading.Thread(() =>
+            {
+                deliverStarted.Set();
+                try { _store.MarkDelivered(id, submitted: true, movedOn: false, transcript: "landed"); }
+                catch (Exception ex) { deliverFailure = ex; }
+            });
+            deliver.Start();
+            deliverStarted.Wait(TimeSpan.FromSeconds(5));
+            // The claim: it has NOT finished while we hold the gate. (Joined with a timeout: a join that
+            // succeeds here is the old race, made deterministic.)
+            deliverFinishedWhileInsideTheGate = deliver.Join(TimeSpan.FromMilliseconds(500));
+        };
+        try
+        {
+            var opened = _store.OpenPending(id, session);
+            Assert.True(opened.Opened);
+            Assert.False(deliverFinishedWhileInsideTheGate, "a DELIVERED write landed inside the register transition - the race is open");
+            Assert.True(deliver!.Join(TimeSpan.FromSeconds(10)), "the deferred delivery never completed");
+            Assert.Null(deliverFailure);
+        }
+        finally
+        {
+            VoiceUploadStore.BetweenRecordReadAndWriteForTests = null;
+        }
+
+        // The tombstone landed AFTER the open, and it is what stands: no PENDING buried it.
+        Assert.Equal(DictationDeliveryState.Delivered, _store.ReadRecord(id)!.State);
+        Assert.Equal("landed", _store.ReadRecord(id)!.Transcript);
+        Assert.False(_store.IsPending(id));
+    }
+
     // ===== the sweeps and the lock ==================================================================
 
     [Fact]
@@ -247,10 +369,11 @@ public sealed class VoiceUploadStoreUnreadableRecordTests : IDisposable
     [Fact]
     public void A_corrupt_marker_does_not_lock_a_session()
     {
-        // The documented decision on IsPending: the lock projection fails open, because nothing a client can
-        // do would ever clear a "receiving a dictation" state held by a marker every delivery path refuses.
-        // What that projection drives is display (the session's dictation badge); sends are never refused by
-        // source, so a missed lock costs a badge and cannot cost a delivery. Pinned so a future reader sees it
+        // The documented decision on IsPending: the lock projection fails open, because nothing on the delivery
+        // or abandon paths can clear a "receiving a dictation" state held by a marker every one of them refuses
+        // (only an explicit acknowledgement retires it, and that is the client saying its copy is gone). What
+        // the projection drives is display (the session's dictation badge); sends are never refused by source,
+        // so a missed lock costs a badge and cannot cost a delivery. Pinned so a future reader sees it
         // asserted, not assumed.
         var id = Guid.NewGuid().ToString();
         var session = Guid.NewGuid().ToString();

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -205,7 +205,19 @@ internal static class GatewayDictationEndpoint
             // (delivered or abandoned), do NOT re-open it as a fresh PENDING upload - return the cached
             // outcome so a re-registering client (whose earlier response was lost) drops its on-device copy
             // and acknowledges instead of re-uploading and re-injecting. Survives a restart (on disk).
-            var existing = string.IsNullOrWhiteSpace(key) ? null : store.ReadRecord(key);
+            //
+            // And if the record is there but cannot be READ - corrupt, locked, a shape this build does not
+            // know, stamped for another tenant - do not re-open it either (issue #2745). A marker we cannot
+            // read is still a marker: it says this upload id already became something, and re-opening it is
+            // how the operator's own speech was injected a second time. The client is told why and holds the
+            // recording; nothing is written over the marker, so the evidence is still there for an operator.
+            var read = string.IsNullOrWhiteSpace(key) ? DictationRecordRead.Absent : store.Read(key);
+            if (read.Refuses)
+            {
+                FileLog.Write($"[GatewayDictation] upload re-register REFUSED: {read.Describe(key)}; not re-opened");
+                return RecordRefusal(read, key);
+            }
+            var existing = read.Record;
             if (existing is { State: DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned })
             {
                 FileLog.Write($"[GatewayDictation] upload re-register of terminal uploadId={key} state={existing.State}");
@@ -287,7 +299,18 @@ internal static class GatewayDictationEndpoint
             // window and even after a Gateway restart (the record and this check both live on disk). This
             // handles the SEQUENTIAL/after-restart retry; the in-memory single-flight below handles two
             // CONCURRENT completes racing before the first tombstone is written (they share one run).
-            var settled = store.ReadRecord(uploadId);
+            //
+            // A tombstone that is there but cannot be read is refused outright (issue #2745): this is the
+            // injection point, and "I could not read the marker" is not "there is no marker". The orange mark
+            // is cleared because nothing is going to happen for this upload until an operator looks at the file.
+            var read = store.Read(uploadId);
+            if (read.Refuses)
+            {
+                EndTranscribing(transcribingSessions, tenant, req.SessionId!);
+                FileLog.Write($"[GatewayDictation] complete REFUSED: {read.Describe(uploadId)}; nothing injected");
+                return RecordRefusal(read, uploadId);
+            }
+            var settled = read.Record;
             if (settled is { State: DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned })
             {
                 EndTranscribing(transcribingSessions, tenant, req.SessionId!);
@@ -384,7 +407,18 @@ internal static class GatewayDictationEndpoint
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
             if (!gate.TryOpen(ctx, out var store, out var tenant, out var deny)) return deny;
 
-            var existing = store.ReadRecord(uploadId);
+            // An abandon WRITES an ABANDONED tombstone over whatever marker is there. Over a marker that cannot
+            // be read that would destroy the only evidence of what this upload id became - and if it was in
+            // fact DELIVERED, a later re-complete would then tell the user "dropped" about speech that was
+            // acted on. So an unreadable marker refuses the abandon too (issue #2745); the ack leg remains the
+            // client's way to retire it once its own copy is gone.
+            var read = store.Read(uploadId);
+            if (read.Refuses)
+            {
+                FileLog.Write($"[GatewayDictation] abandon REFUSED: {read.Describe(uploadId)}; marker left as it is");
+                return RecordRefusal(read, uploadId);
+            }
+            var existing = read.Record;
             if (existing is { State: DictationDeliveryState.Delivered })
             {
                 FileLog.Write($"[GatewayDictation] abandon uploadId={uploadId}: already DELIVERED, not abandoning");
@@ -483,6 +517,27 @@ internal static class GatewayDictationEndpoint
         => record.State == DictationDeliveryState.Abandoned
             ? DictationOutcome.Dropped(record.Reason ?? "")
             : DictationOutcome.Submitted(record.Submitted, record.MovedOn, record.Transcript);
+
+    // The response for an upload id whose delivery record is there but cannot be read (issue #2745): the
+    // register, complete and abandon legs all refuse rather than re-open, inject, or write over it. The
+    // status says whether a retry can help: a marker that could not be READ (locked, permission, a disk
+    // fault) may read fine in a moment, so 503 - the client keeps the recording and tries again later. A
+    // marker that was read and is not a delivery record, or is another tenant's, will not change by itself,
+    // so 409 - it needs an operator at the file the body names. Neither is a terminal outcome, so the client
+    // does not drop its copy; and neither is a 2xx, so nothing downstream treats it as opened.
+    private static IResult RecordRefusal(DictationRecordRead read, string uploadId)
+    {
+        var status = read.Kind == DictationRecordReadKind.Unreadable
+            ? StatusCodes.Status503ServiceUnavailable
+            : StatusCodes.Status409Conflict;
+        return Results.Json(new
+        {
+            error = read.Describe(uploadId) + "; refusing to re-open, deliver, or overwrite it",
+            upload_id = uploadId,
+            record = read.Kind.ToString(),
+            file = read.Path,
+        }, statusCode: status);
+    }
 
     // The register-time response for an upload id that is already terminal: echoes the id plus the cached
     // outcome so a re-registering client drops its copy and acknowledges instead of re-uploading.
@@ -594,6 +649,11 @@ internal static class GatewayDictationEndpoint
             // that no longer exists, and the retry gets dropped as "moved on" by OUR OWN noise. Taking the
             // larger of the two costs nothing when no attempt failed (the stored value is absent) and is what
             // stops the observed drop when one did.
+            //
+            // The STRICT read, deliberately (issue #2745): the complete leg has already refused a marker it
+            // cannot read before this core ever runs, so a throw here can only mean the marker went bad between
+            // that check and this one. It lands in the complete handler's catch as a 502 with the file named,
+            // and nothing is injected - which is the right answer for a marker nobody can read.
             var effectiveBaseline = Math.Max(
                 req.BaselineBufferBytes, store.ReadRecord(uploadId)?.RebaselineBufferBytes ?? 0);
             if (req.Resumed && session is not null && req.BaselineBufferBytes > 0 &&

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -416,22 +416,25 @@ internal static class GatewayDictationEndpoint
             // fact DELIVERED, a later re-complete would then tell the user "dropped" about speech that was
             // acted on. So an unreadable marker refuses the abandon too (issue #2745); the ack leg remains the
             // client's way to retire it once its own copy is gone.
-            var read = store.Read(uploadId);
-            if (read.Refuses)
+            //
+            // And the read, the already-delivered decision and the ABANDONED write are ONE operation under the
+            // upload's record gate (review round three): as two calls, a complete could inject the speech and
+            // land DELIVERED in between, and the abandon then wrote over it.
+            var abandon = store.Abandon(uploadId, "user_abandoned");
+            if (abandon.Before.Refuses)
             {
-                FileLog.Write($"[GatewayDictation] abandon REFUSED: {read.Describe(uploadId)}; marker left as it is");
-                return RecordRefusal(read, uploadId);
+                FileLog.Write($"[GatewayDictation] abandon REFUSED: {abandon.Before.Describe(uploadId)}; marker left as it is");
+                return RecordRefusal(abandon.Before, uploadId);
             }
-            var existing = read.Record;
-            if (existing is { State: DictationDeliveryState.Delivered })
+            var existing = abandon.Before.Record;
+            if (!abandon.Abandoned)
             {
                 FileLog.Write($"[GatewayDictation] abandon uploadId={uploadId}: already DELIVERED, not abandoning");
                 return Results.Json(new { ok = true, upload_id = uploadId, abandoned = false, already_delivered = true });
             }
 
-            store.MarkAbandoned(uploadId, "user_abandoned");
             // Clear the in-memory transcribing marks so the roster un-oranges at once (the durable PENDING
-            // marker - the "Uploading from phone" source - is already gone via MarkAbandoned). Keyed to the
+            // marker - the "Uploading from phone" source - is already gone via the abandon). Keyed to the
             // caller's own tenant (issue #1884, Gap B), so an abandon can never clear another account's mark.
             var sid = existing?.SessionId;
             if (!string.IsNullOrEmpty(sid))

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -521,14 +521,16 @@ internal static class GatewayDictationEndpoint
     // The response for an upload id whose delivery record is there but cannot be read (issue #2745): the
     // register, complete and abandon legs all refuse rather than re-open, inject, or write over it. The
     // status says whether a retry can help: a marker that could not be READ (locked, permission, a disk
-    // fault) may read fine in a moment, so 503 - the client keeps the recording and tries again later. A
-    // marker that was read and is not a delivery record, or is another tenant's, will not change by itself,
-    // so 409 - it needs an operator at the file the body names. Neither is a terminal outcome, so the client
-    // does not drop its copy; and neither is a 2xx, so nothing downstream treats it as opened.
+    // fault) may read fine in a moment, so 423 Locked - the client keeps the recording and tries again
+    // later. NOT 503: the phone client reads every 502/503/504 as "the Gateway is unreachable" and flips its
+    // connection banner, and this Gateway answered. A marker that was read and is not a delivery record, or
+    // is another tenant's, will not change by itself, so 409 - it needs an operator at the file the body
+    // names. Neither is a terminal outcome, so the client does not drop its copy; and neither is a 2xx, so
+    // nothing downstream treats it as opened.
     private static IResult RecordRefusal(DictationRecordRead read, string uploadId)
     {
         var status = read.Kind == DictationRecordReadKind.Unreadable
-            ? StatusCodes.Status503ServiceUnavailable
+            ? StatusCodes.Status423Locked
             : StatusCodes.Status409Conflict;
         return Results.Json(new
         {

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -211,27 +211,31 @@ internal static class GatewayDictationEndpoint
             // read is still a marker: it says this upload id already became something, and re-opening it is
             // how the operator's own speech was injected a second time. The client is told why and holds the
             // recording; nothing is written over the marker, so the evidence is still there for an operator.
-            var read = string.IsNullOrWhiteSpace(key) ? DictationRecordRead.Absent : store.Read(key);
-            if (read.Refuses)
+            //
+            // And it is ONE operation under the upload's record gate (review round two): the read, the decision,
+            // the staging refresh and the PENDING write happen together in OpenPending. As three separate calls
+            // a complete could land the DELIVERED tombstone between the read and the PENDING write, and the
+            // write buried it - the same re-injection, reached through a race instead of a fold.
+            var opened = store.OpenPending(string.IsNullOrWhiteSpace(key) ? null : key, sid);
+            var uploadId = opened.UploadId;
+            if (opened.Before.Refuses)
             {
-                FileLog.Write($"[GatewayDictation] upload re-register REFUSED: {read.Describe(key)}; not re-opened");
-                return RecordRefusal(read, key);
+                FileLog.Write($"[GatewayDictation] upload re-register REFUSED: {opened.Before.Describe(uploadId)}; not re-opened");
+                return RecordRefusal(opened.Before, uploadId);
             }
-            var existing = read.Record;
-            if (existing is { State: DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned })
+            if (!opened.Opened)
             {
-                FileLog.Write($"[GatewayDictation] upload re-register of terminal uploadId={key} state={existing.State}");
-                return TerminalRegisterResult(store.Register(key), existing);
+                var existing = opened.Before.Record!;
+                FileLog.Write($"[GatewayDictation] upload re-register of terminal uploadId={uploadId} state={existing.State}");
+                return TerminalRegisterResult(uploadId, existing);
             }
-            // A PENDING or FAILED record (or none) is (re-)opened as a fresh PENDING upload. Register
-            // (re-)opens the staging dir; MarkPending writes the explicit durable PENDING marker carrying the
-            // sessionId, which BOTH persists the owning session on disk for the enforced session lock (issue
-            // #1188, so the lock survives a Gateway restart) AND, for a FAILED id, IS the retry re-entry back
-            // to PENDING - overwriting the FAILED marker while keeping the staged chunks (issue #1185).
-            if (existing is { State: DictationDeliveryState.Failed })
-                FileLog.Write($"[GatewayDictation] upload re-register clears FAILED uploadId={key}, retrying");
-            var uploadId = store.Register(string.IsNullOrWhiteSpace(key) ? null : key);
-            store.MarkPending(uploadId, sid);
+            // A PENDING or FAILED record (or none) has been (re-)opened as a fresh PENDING upload: the staging
+            // dir exists and the explicit durable PENDING marker carries the sessionId, which BOTH persists the
+            // owning session on disk for the enforced session lock (issue #1188, so the lock survives a Gateway
+            // restart) AND, for a FAILED id, IS the retry re-entry back to PENDING - overwriting the FAILED
+            // marker while keeping the staged chunks (issue #1185).
+            if (opened.Before.Record is { State: DictationDeliveryState.Failed })
+                FileLog.Write($"[GatewayDictation] upload re-register clears FAILED uploadId={uploadId}, retrying");
             _uploadSids.Set(tenant, uploadId, sid);
             try { transcribingSessions.Begin(tenant, sid); } catch { /* the orange mark is a nicety */ }
             FileLog.Write($"[GatewayDictation] upload registered sid={sid} uploadId={uploadId}");

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -512,6 +512,10 @@ public sealed class VoiceUploadStore
                         // became, and the sweep has no business destroying evidence it cannot read (#2745).
                         if (read.Kind != DictationRecordReadKind.Present) return;
                         var record = read.Record!;
+                        // Another tenant's record is never ours to retire (issue #1884), exactly as ExpireStalePending
+                        // already refuses. Reachable only through a mis-computed partition root - the one case
+                        // where deleting another account's de-dupe evidence would be worst.
+                        if (!BelongsHere(record)) return;
                         if (!IsRetirableTombstone(record.State)) return; // PENDING / FAILED are never aged out
                         if (Directory.GetLastWriteTimeUtc(dir) >= cutoff) return;
 
@@ -924,29 +928,41 @@ public sealed class VoiceUploadStore
             return DictationRecordRead.CouldNotRead(path, ex.Message);
         }
 
-        DictationDeliveryRecord? record;
+        DictationDeliveryRecord record;
         try
         {
-            record = JsonSerializer.Deserialize<DictationDeliveryRecord>(text, RecordJson);
+            // SHAPE FIRST, then value. The serializer fills in a default for every property the JSON does not
+            // mention, and the default for State is the enum's zero - PENDING. So "{}" or an unrelated object
+            // would deserialize into a perfectly readable pending record, and pending is re-openable: the
+            // exact re-injection this reader exists to refuse, reached through valid JSON. A delivery record
+            // has carried these five properties since the day it existed (issue #1183); a file that lacks one
+            // was not written by this store and is not a record.
+            using var doc = JsonDocument.Parse(text);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return Malformed(path, "the file does not hold a JSON object");
+            foreach (var required in RequiredRecordProperties)
+                if (!doc.RootElement.TryGetProperty(required, out _))
+                    return Malformed(path, $"the record has no {required} property");
+            record = JsonSerializer.Deserialize<DictationDeliveryRecord>(text, RecordJson)!;
         }
         catch (JsonException ex)
         {
-            FileLog.Write($"[VoiceUploadStore] ReadRecord {path} is not a delivery record: {ex.Message}");
-            return DictationRecordRead.NotUnderstood(path, ex.Message);
-        }
-        if (record is null)
-        {
-            FileLog.Write($"[VoiceUploadStore] ReadRecord {path} is not a delivery record: the file holds JSON null");
-            return DictationRecordRead.NotUnderstood(path, "the file holds JSON null");
+            return Malformed(path, ex.Message);
         }
         // A number the enum does not name deserializes without complaint, and then matches no state anywhere.
         if (!Enum.IsDefined(record.State))
-        {
-            var problem = $"state {(int)record.State} is not a delivery state this build knows";
-            FileLog.Write($"[VoiceUploadStore] ReadRecord {path} is not a delivery record: {problem}");
-            return DictationRecordRead.NotUnderstood(path, problem);
-        }
+            return Malformed(path, $"state {(int)record.State} is not a delivery state this build knows");
         return DictationRecordRead.Found(record);
+    }
+
+    // The properties every delivery record has carried since issue #1183. Case-sensitive, exactly as the
+    // serializer matches them: a file spelling one differently is one the serializer would silently default.
+    private static readonly string[] RequiredRecordProperties = { "State", "Submitted", "MovedOn", "Transcript", "Reason" };
+
+    private static DictationRecordRead Malformed(string path, string problem)
+    {
+        FileLog.Write($"[VoiceUploadStore] ReadRecord {path} is not a delivery record: {problem}");
+        return DictationRecordRead.NotUnderstood(path, problem);
     }
 
     /// <summary>
@@ -954,12 +970,14 @@ public sealed class VoiceUploadStore
     /// abandoned, its chunks retained. The enforced per-session dictation lock is a projection of this.
     ///
     /// A marker that cannot be read is NOT pending here. That is a decision, not the #2745 fold, and it goes
-    /// the other way from delivery on purpose: the lock keeps the human's keyboard out of a session while a
-    /// dictation is in flight, and a marker nobody can read can never finish flying - every delivery path
-    /// refuses it (see <see cref="Read"/>) - so locking on it would wedge the session shut until an operator
-    /// found the file, with no client action able to release it. The Core-side lock reader documents the
-    /// same fail-open choice for the same reason, and the user-input source default compensates for a missed
-    /// lock; nothing compensates for a re-injected dictation, which is why delivery is the side that refuses.
+    /// the other way from delivery on purpose. What this projection drives today is DISPLAY: the session's
+    /// "receiving a dictation" state and its orange mark. Sends are no longer refused by source - the Director
+    /// removed that rejection deliberately (see <c>Session.SendTextAsync</c>) - so a missed lock costs a
+    /// missing badge, nothing more. A marker nobody can read can never finish arriving, because every
+    /// delivery path refuses it (see <see cref="Read"/>); projecting a lock from it would paint the session as
+    /// receiving a dictation until an operator found the file, with no client action able to clear it. The
+    /// Core-side lock reader documents the same fail-open choice for the same reason. Nothing compensates for
+    /// a re-injected dictation, which is why delivery is the side that refuses and this side is not.
     /// </summary>
     public bool IsPending(string uploadId)
         => Read(uploadId) is { Kind: DictationRecordReadKind.Present, Record.State: DictationDeliveryState.Pending };

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -947,19 +947,25 @@ public sealed class VoiceUploadStore
                 if (Array.IndexOf(allowed, value.ValueKind) < 0)
                     return Malformed(path, $"the record's {name} is a JSON {value.ValueKind}, not {string.Join(" or ", allowed)}");
             }
+            // The state must be EXACTLY one of the names this store writes - ordinal, case-sensitive. The enum
+            // converter is more generous than that: it accepts a number spelled as a string ("1" is DELIVERED)
+            // and any casing ("pending" is PENDING), so checking the JSON kind alone still let "State":"0"
+            // re-open an upload and "State":"1" fabricate a delivered outcome. Only the canonical name is a
+            // record; nothing else was ever written by this store.
+            var stateName = doc.RootElement.GetProperty("State").GetString() ?? "";
+            if (Array.IndexOf(KnownStateNames, stateName) < 0)
+                return Malformed(path, $"state \"{stateName}\" is not a delivery state this build writes");
             record = JsonSerializer.Deserialize<DictationDeliveryRecord>(text, RecordJson)!;
         }
         catch (JsonException ex)
         {
             return Malformed(path, ex.Message);
         }
-        // A state NAME the enum does not carry throws above; this is the remaining way a value could arrive
-        // that matches no state anywhere, and it is kept so the claim "Present means a known state" is checked
-        // where it is made rather than assumed from the converter.
-        if (!Enum.IsDefined(record.State))
-            return Malformed(path, $"state {(int)record.State} is not a delivery state this build knows");
         return DictationRecordRead.Found(record);
     }
+
+    // The exact spellings the store writes for State, and the only ones it reads back.
+    private static readonly string[] KnownStateNames = Enum.GetNames<DictationDeliveryState>();
 
     // The properties every delivery record has carried since issue #1183, each with the JSON kinds the store
     // itself writes. Case-sensitive, exactly as the serializer matches them: a file spelling one differently is
@@ -1078,6 +1084,39 @@ public sealed class VoiceUploadStore
             FileLog.Write($"[VoiceUploadStore] OpenPending: uploadId={uid} sessionId={sessionId} opened " +
                 $"(was {(before.Record is { } r ? r.State.ToString() : before.Kind.ToString())})");
             return new DictationOpenOutcome(uid, before, true);
+        });
+    }
+
+    /// <summary>
+    /// The ABANDON transition as ONE operation under the per-upload gate (issue #2745, review round three):
+    /// read, decide, write the ABANDONED tombstone - or not - without releasing the gate in between. The
+    /// endpoint used to read, decide "not delivered", and then call the raw <see cref="MarkAbandoned"/>; a
+    /// complete could inject the speech and land DELIVERED between those two calls, and the abandon then wrote
+    /// ABANDONED over it - so the next re-complete told the user "dropped" about words that were acted on.
+    ///
+    /// Not abandoned when the read refuses (Malformed, Unreadable, ForeignTenant - nothing is written) or when
+    /// the record is already DELIVERED (delivery is the stronger fact and is final). PENDING, FAILED, ABANDONED
+    /// and absent are abandoned as before, discarding the staged chunks.
+    /// </summary>
+    public DictationAbandonOutcome Abandon(string uploadId, string reason)
+    {
+        var uid = NormalizeId(uploadId) ?? throw new InvalidOperationException("invalid upload id");
+        return WithRecordLock(uid, () =>
+        {
+            var before = Read(uid);
+            if (before.Refuses)
+            {
+                FileLog.Write($"[VoiceUploadStore] Abandon: uploadId={uid} refused ({before.Kind}); nothing written");
+                return new DictationAbandonOutcome(before, false);
+            }
+            if (before.Record is { State: DictationDeliveryState.Delivered })
+            {
+                FileLog.Write($"[VoiceUploadStore] Abandon: uploadId={uid} is DELIVERED; not abandoned");
+                return new DictationAbandonOutcome(before, false);
+            }
+            BetweenRecordReadAndWriteForTests?.Invoke(uid);
+            MarkAbandoned(uid, reason); // the gate is reentrant on this thread, so this stays inside it
+            return new DictationAbandonOutcome(before, true);
         });
     }
 
@@ -1662,3 +1701,10 @@ public sealed class UnreadableDictationRecordException : InvalidOperationExcepti
 /// and whether the PENDING marker was written.
 /// </summary>
 public sealed record DictationOpenOutcome(string UploadId, DictationRecordRead Before, bool Opened);
+
+/// <summary>
+/// What <see cref="VoiceUploadStore.Abandon"/> did: the record as it was BEFORE (so the caller can answer a
+/// refusal or an already-delivered outcome from the same read the decision was made on) and whether the
+/// ABANDONED tombstone was written.
+/// </summary>
+public sealed record DictationAbandonOutcome(DictationRecordRead Before, bool Abandoned);

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -506,8 +506,12 @@ public sealed class VoiceUploadStore
 
                         // Re-read INSIDE the gate: an ack may have retired it, or a re-complete rewritten it,
                         // since the enumeration above.
-                        var record = ReadRecordFile(RecordPath(dir));
-                        if (record is null) return;                     // no marker, or unreadable: leave it
+                        var read = ReadRecordFile(RecordPath(dir));
+                        // Only a marker we can READ is a candidate. No marker: nothing to retire. Malformed or
+                        // unreadable: leave it standing - it is still the only evidence of what this upload id
+                        // became, and the sweep has no business destroying evidence it cannot read (#2745).
+                        if (read.Kind != DictationRecordReadKind.Present) return;
+                        var record = read.Record!;
                         if (!IsRetirableTombstone(record.State)) return; // PENDING / FAILED are never aged out
                         if (Directory.GetLastWriteTimeUtc(dir) >= cutoff) return;
 
@@ -590,12 +594,15 @@ public sealed class VoiceUploadStore
                     {
                         if (!Directory.Exists(dir)) return;
 
-                        var record = ReadRecordFile(RecordPath(dir));
-                        // No marker, unreadable, or any state but PENDING: not ours. FAILED is left alone on
-                        // purpose - it holds no session lock (IsPending is false while FAILED) and it is an
-                        // explicit user-retryable pause, so ageing it out would cancel a retry the user was
-                        // offered rather than release a lock nobody can clear.
-                        if (record is not { State: DictationDeliveryState.Pending }) return;
+                        var read = ReadRecordFile(RecordPath(dir));
+                        // No marker, a marker we cannot read, or any state but PENDING: not ours. A marker we
+                        // cannot read holds no lock (see IsPending), so there is no lock here to release, and
+                        // abandoning it would write over the only evidence of what it was (#2745). FAILED is
+                        // left alone on purpose - it holds no session lock (IsPending is false while FAILED)
+                        // and it is an explicit user-retryable pause, so ageing it out would cancel a retry the
+                        // user was offered rather than release a lock nobody can clear.
+                        if (read is not { Kind: DictationRecordReadKind.Present, Record.State: DictationDeliveryState.Pending }) return;
+                        var record = read.Record!;
                         if (!BelongsHere(record)) return;               // another tenant's record: never ours to resolve
                         if (Directory.GetLastWriteTimeUtc(dir) >= cutoff) return;
 
@@ -827,49 +834,135 @@ public sealed class VoiceUploadStore
     // terminal tombstones written as record.json AFTER the heavy chunk bytes are discarded. The tombstone
     // is the durable "already resolved" marker and is retired only by a client acknowledgment - so it is
     // exactly as long-lived as the audio it guards, and a delivered/abandoned upload id never re-injects.
+    //
+    // That last sentence holds ONLY because the read that guards it distinguishes every answer the file can
+    // give (issue #2745). A record.json that is there but cannot be read - corrupt, half-written, locked by
+    // another process, in a shape this build does not know - is evidence that this upload id was already
+    // resolved. It is NOT "no record". Before #2745 the reader answered null for both, the de-dupe check
+    // above register saw null, and the upload was re-opened as a fresh PENDING - the operator's own speech
+    // injected a second time. See ReadRecordFile for the answers and Read for the contract.
 
     /// <summary>
-    /// The durable delivery record for this upload id, or null when there is none (an unknown id, or a
-    /// staged upload that was never given a marker). Read from disk, so it survives a Gateway restart (a
-    /// fresh store instance over the same root finds it).
+    /// The honest read of this upload id's durable delivery record: every answer the file can give has its
+    /// own <see cref="DictationRecordReadKind"/>, and only <see cref="DictationRecordReadKind.Absent"/> means
+    /// "never resolved here". Read from disk, so it survives a Gateway restart (a fresh store instance over
+    /// the same root finds it).
+    ///
+    /// A caller deciding whether to (re-)open, deliver, or overwrite MUST switch on the kind and must treat
+    /// <see cref="DictationRecordReadKind.Malformed"/>, <see cref="DictationRecordReadKind.Unreadable"/> and
+    /// <see cref="DictationRecordReadKind.ForeignTenant"/> as a refusal: a marker it cannot read is still a
+    /// marker, and writing over it destroys the only evidence of what this upload id already became.
+    /// </summary>
+    public DictationRecordRead Read(string uploadId)
+    {
+        var uid = NormalizeId(uploadId);
+        // Not a GUID-shaped id: it cannot name a staging directory, so nothing was ever written for it.
+        if (uid is null) return DictationRecordRead.Absent;
+        var path = RecordPath(DirFor(uid));
+        var read = ReadRecordFile(path);
+        if (read.Kind != DictationRecordReadKind.Present) return read;
+        // Tenant-checked as well as partitioned (issue #1884). See BelongsHere: the directory is the boundary,
+        // this is the independent second opinion, and a record that fails it is refused rather than handed to
+        // a caller it does not belong to. Refused with its OWN name, not as absent (issue #2745): "absent"
+        // means "go ahead and open", and opening here would write this tenant's PENDING marker over another
+        // tenant's record - which can only happen if a partition root was mis-computed, the very fault this
+        // check exists to catch, and the one moment a silent overwrite is least acceptable.
+        if (!BelongsHere(read.Record!))
+        {
+            FileLog.Write($"[VoiceUploadStore] Read: uploadId={uid} record belongs to another tenant " +
+                $"(partition={_tenant.ToLogString()}); refused");
+            return DictationRecordRead.Foreign(path);
+        }
+        return read;
+    }
+
+    /// <summary>
+    /// The durable delivery record for this upload id when it is present and readable, or null ONLY when it
+    /// is genuinely absent (an unknown id, or a staged upload that was never given a marker).
+    ///
+    /// Every other answer THROWS <see cref="UnreadableDictationRecordException"/> rather than returning null.
+    /// This is deliberate (issue #2745): null used to stand for both "no record" and "a record I could not
+    /// read", and the de-dupe guard read the second as the first. A caller that wants to act on those
+    /// answers calls <see cref="Read"/> and switches on the kind; a caller that did not think about them
+    /// fails loudly here instead of quietly re-opening a resolved upload. The store's own writers read
+    /// through this on purpose, so none of them can compose a new marker on top of one it cannot read.
     /// </summary>
     public DictationDeliveryRecord? ReadRecord(string uploadId)
     {
-        var uid = NormalizeId(uploadId);
-        if (uid is null) return null;
-        var record = ReadRecordFile(RecordPath(DirFor(uid)));
-        if (record is null) return null;
-        // Tenant-checked as well as partitioned (issue #1884). See BelongsHere: the directory is the boundary,
-        // this is the independent second opinion, and a record that fails it is treated as absent rather than
-        // handed to a caller it does not belong to.
-        if (!BelongsHere(record))
+        var read = Read(uploadId);
+        return read.Kind switch
         {
-            FileLog.Write($"[VoiceUploadStore] ReadRecord: uploadId={uid} record belongs to another tenant " +
-                $"(partition={_tenant.ToLogString()}); refused");
-            return null;
-        }
-        return record;
+            DictationRecordReadKind.Present => read.Record,
+            DictationRecordReadKind.Absent => null,
+            _ => throw new UnreadableDictationRecordException(uploadId, read),
+        };
     }
 
-    private static DictationDeliveryRecord? ReadRecordFile(string path)
+    // The one place a record.json is turned into an answer. Four answers, each with a name, and NO
+    // pre-check with File.Exists: that call answers false for a file it was not allowed to look at, which
+    // would fold "could not look" into "absent" one line before the honest read even starts.
+    private static DictationRecordRead ReadRecordFile(string path)
     {
-        if (!File.Exists(path)) return null;
+        string text;
         try
         {
-            return JsonSerializer.Deserialize<DictationDeliveryRecord>(File.ReadAllText(path), RecordJson);
+            text = File.ReadAllText(path);
+        }
+        catch (FileNotFoundException)
+        {
+            return DictationRecordRead.Absent;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return DictationRecordRead.Absent;
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[VoiceUploadStore] ReadRecord {path} failed: {ex.Message}");
-            return null;
+            // Locked by another process, permission denied, a directory sitting where the file should be,
+            // a disk fault: the file may well be there and we could not look. Say so; never say "absent".
+            FileLog.Write($"[VoiceUploadStore] ReadRecord {path} could not be read: {ex.Message}");
+            return DictationRecordRead.CouldNotRead(path, ex.Message);
         }
+
+        DictationDeliveryRecord? record;
+        try
+        {
+            record = JsonSerializer.Deserialize<DictationDeliveryRecord>(text, RecordJson);
+        }
+        catch (JsonException ex)
+        {
+            FileLog.Write($"[VoiceUploadStore] ReadRecord {path} is not a delivery record: {ex.Message}");
+            return DictationRecordRead.NotUnderstood(path, ex.Message);
+        }
+        if (record is null)
+        {
+            FileLog.Write($"[VoiceUploadStore] ReadRecord {path} is not a delivery record: the file holds JSON null");
+            return DictationRecordRead.NotUnderstood(path, "the file holds JSON null");
+        }
+        // A number the enum does not name deserializes without complaint, and then matches no state anywhere.
+        if (!Enum.IsDefined(record.State))
+        {
+            var problem = $"state {(int)record.State} is not a delivery state this build knows";
+            FileLog.Write($"[VoiceUploadStore] ReadRecord {path} is not a delivery record: {problem}");
+            return DictationRecordRead.NotUnderstood(path, problem);
+        }
+        return DictationRecordRead.Found(record);
     }
 
     /// <summary>
-    /// True when this upload id holds an explicit PENDING marker (issue #1188): undelivered and not
+    /// True when this upload id holds an explicit, READABLE PENDING marker (issue #1188): undelivered and not
     /// abandoned, its chunks retained. The enforced per-session dictation lock is a projection of this.
+    ///
+    /// A marker that cannot be read is NOT pending here. That is a decision, not the #2745 fold, and it goes
+    /// the other way from delivery on purpose: the lock keeps the human's keyboard out of a session while a
+    /// dictation is in flight, and a marker nobody can read can never finish flying - every delivery path
+    /// refuses it (see <see cref="Read"/>) - so locking on it would wedge the session shut until an operator
+    /// found the file, with no client action able to release it. The Core-side lock reader documents the
+    /// same fail-open choice for the same reason, and the user-input source default compensates for a missed
+    /// lock; nothing compensates for a re-injected dictation, which is why delivery is the side that refuses.
     /// </summary>
-    public bool IsPending(string uploadId) => ReadRecord(uploadId) is { State: DictationDeliveryState.Pending };
+    public bool IsPending(string uploadId)
+        => Read(uploadId) is { Kind: DictationRecordReadKind.Present, Record.State: DictationDeliveryState.Pending };
 
     /// <summary>
     /// Write the explicit durable PENDING marker for this upload id, carrying the owning session id (issue
@@ -944,7 +1037,7 @@ public sealed class VoiceUploadStore
             // NO CANARY HERE EITHER, and for a different reason than the containment guard in
             // PartitionRootFor - this one is REDUNDANT rather than unreachable. Measured: removing this line
             // reddens nothing. It cannot, because the container directory holds other tenants' partitions and
-            // no record.json of its own, so ReadRecordFile returns null and the pattern match already declines
+            // no record.json of its own, so ReadRecordFile answers Absent and the pattern match already declines
             // it; and even if a record were somehow found there, BelongsHere on the same line refuses a record
             // belonging to another tenant. Two independent things downstream already give the right answer.
             //
@@ -952,7 +1045,10 @@ public sealed class VoiceUploadStore
             // stops a pointless file probe per partition on every projection. It is clarity and cost, not a
             // security boundary; the security boundary on this line is BelongsHere, and THAT one has canaries.
             if (IsPartitionContainer(dir)) continue;
-            if (ReadRecordFile(RecordPath(dir)) is { State: DictationDeliveryState.Pending } rec && BelongsHere(rec))
+            // A readable PENDING marker of our own, and nothing else: a marker that cannot be read holds no
+            // lock, for the reason given on IsPending.
+            if (ReadRecordFile(RecordPath(dir)) is { Kind: DictationRecordReadKind.Present, Record: { State: DictationDeliveryState.Pending } rec }
+                && BelongsHere(rec))
                 yield return (Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)), rec);
         }
     }
@@ -1017,7 +1113,18 @@ public sealed class VoiceUploadStore
         // write PENDING back over a tombstone that landed in between, resurrecting a resolved upload id.
         return WithRecordLock(uid, () =>
         {
-            if (ReadRecord(uid) is not { State: DictationDeliveryState.Failed } failed) return false;
+            // Through Read, not ReadRecord: this is a query ("was there a FAILED marker to clear?") and the
+            // honest answer for a marker that cannot be read is "no, and I wrote nothing" - which is what
+            // false says. The endpoint has already refused the complete that would have got here for such a
+            // marker (issue #2745); this line keeps the store from writing over it on its own account.
+            var read = Read(uid);
+            if (read.Kind != DictationRecordReadKind.Present)
+            {
+                if (read.Kind != DictationRecordReadKind.Absent)
+                    FileLog.Write($"[VoiceUploadStore] ClearFailed: uploadId={uid} marker is {read.Kind}; not cleared ({read.Problem})");
+                return false;
+            }
+            if (read.Record is not { State: DictationDeliveryState.Failed } failed) return false;
             try
             {
                 WriteRecordMarker(DirFor(uid), new DictationDeliveryRecord(
@@ -1064,7 +1171,17 @@ public sealed class VoiceUploadStore
         //      over a tombstone that landed in the meantime and resurrect a delivered upload id (issue #1183).
         return WithRecordLock(uid, () =>
         {
-            if (ReadRecord(uid) is not { } record) return false;
+            // Through Read: a marker that cannot be read gets no re-baseline written over it - false is the
+            // true answer ("nothing recorded"), and the marker stays as the evidence it is (issue #2745).
+            var read = Read(uid);
+            if (read.Kind != DictationRecordReadKind.Present)
+            {
+                if (read.Kind != DictationRecordReadKind.Absent)
+                    FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline: uploadId={uid} marker is {read.Kind}; " +
+                        $"not written ({read.Problem})");
+                return false;
+            }
+            var record = read.Record!;
             // Terminal is final: its guard has already run for the last time, and rewriting the tombstone here
             // is precisely how a resolved upload id would come back to life.
             if (record.State is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned) return false;
@@ -1126,11 +1243,17 @@ public sealed class VoiceUploadStore
 
     // The owning session id already recorded for this upload id (empty when there is no record yet), so a
     // state transition preserves the session id first written by MarkPending at register (issue #1188).
+    //
+    // Through the STRICT ReadRecord, on purpose (issue #2745): every writer that composes a new marker asks
+    // one of these two helpers first, inside the gate, and ReadRecord throws for a marker it cannot read. So
+    // no writer - MarkPending, MarkDelivered, MarkAbandoned, MarkFailed - can put a fresh marker on top of a
+    // corrupt, locked, or foreign one; the write fails loudly with the file named, and the evidence stays.
     private string ExistingSessionId(string uploadId) => ReadRecord(uploadId)?.SessionId ?? "";
 
     // The re-baseline already recorded for this upload id (null when there is no record, or no attempt has
     // failed), so a NON-TERMINAL state transition preserves what a failed delivery attempt learned (#1593).
     // The terminal tombstones deliberately do NOT carry it: their guard has already run for the last time.
+    // Strict for the same reason as ExistingSessionId.
     private long? ExistingRebaseline(string uploadId) => ReadRecord(uploadId)?.RebaselineBufferBytes;
 
     // Write the small durable marker first (atomic temp+move), THEN discard the heavy chunk bytes, so a
@@ -1360,3 +1483,82 @@ public sealed record DictationDeliveryRecord(
     string SessionId = "",
     long? RebaselineBufferBytes = null,
     string Tenant = "");
+
+/// <summary>
+/// Every answer a read of an upload id's record.json can give (issue #2745). The reader used to have two -
+/// a record, or null - and null stood for both "no record" and "a record I could not read". The de-dupe
+/// guard at register read the second as the first and re-opened a delivered upload, so the operator's
+/// speech was injected twice. Now each answer has a name, and only <see cref="Absent"/> means "go ahead".
+/// </summary>
+public enum DictationRecordReadKind
+{
+    /// <summary>No record.json for this upload id: never resolved here. The only answer that permits opening.</summary>
+    Absent,
+    /// <summary>A record this build can read and that belongs to this partition's tenant.</summary>
+    Present,
+    /// <summary>
+    /// A record.json is there and its bytes were read, but it is not a delivery record this build understands:
+    /// invalid JSON, a half-written file, a state value the enum does not name. It is evidence that this upload
+    /// id was already resolved by SOMETHING, and it must not be re-opened or written over.
+    /// </summary>
+    Malformed,
+    /// <summary>
+    /// Could not look: the file could not be read at all - locked by another process, permission denied, a
+    /// disk fault. Whether a record is there is unknown, and unknown is not "absent".
+    /// </summary>
+    Unreadable,
+    /// <summary>
+    /// A readable record stamped for a different tenant than this partition (issue #1884). The directory
+    /// partition makes this unreachable unless a partition root was mis-computed, which is exactly when writing
+    /// over it would be worst. Refused, and never treated as absent.
+    /// </summary>
+    ForeignTenant,
+}
+
+/// <summary>
+/// The result of <see cref="VoiceUploadStore.Read"/>: the kind, the record (only when
+/// <see cref="Kind"/> is <see cref="DictationRecordReadKind.Present"/>), and for the refusals the path of
+/// the file and what was wrong with it, so a log line or an error response can name the fix.
+/// </summary>
+public sealed record DictationRecordRead(DictationRecordReadKind Kind, DictationDeliveryRecord? Record, string? Path, string? Problem)
+{
+    public static readonly DictationRecordRead Absent = new(DictationRecordReadKind.Absent, null, null, null);
+
+    public static DictationRecordRead Found(DictationDeliveryRecord record)
+        => new(DictationRecordReadKind.Present, record, null, null);
+
+    public static DictationRecordRead NotUnderstood(string path, string problem)
+        => new(DictationRecordReadKind.Malformed, null, path, problem);
+
+    public static DictationRecordRead CouldNotRead(string path, string problem)
+        => new(DictationRecordReadKind.Unreadable, null, path, problem);
+
+    public static DictationRecordRead Foreign(string path)
+        => new(DictationRecordReadKind.ForeignTenant, null, path, "the record is stamped for another tenant");
+
+    /// <summary>
+    /// True for every answer that forbids opening, delivering, or writing over this upload id: anything but a
+    /// record we can read or a record that is genuinely not there.
+    /// </summary>
+    public bool Refuses => Kind is not (DictationRecordReadKind.Present or DictationRecordReadKind.Absent);
+
+    /// <summary>One line, ASCII, naming the kind, the file and the problem - for logs and error bodies.</summary>
+    public string Describe(string uploadId)
+        => $"the delivery record for upload {uploadId} is {Kind}: {Problem} (file: {Path})";
+}
+
+/// <summary>
+/// Thrown by the strict <see cref="VoiceUploadStore.ReadRecord"/> for any answer other than a readable record
+/// or a genuinely absent one (issue #2745). Carries the full <see cref="Read"/> so the handler that catches it
+/// can say which file, and what was wrong, rather than only that something was.
+/// </summary>
+public sealed class UnreadableDictationRecordException : InvalidOperationException
+{
+    public DictationRecordRead Read { get; }
+
+    public UnreadableDictationRecordException(string uploadId, DictationRecordRead read)
+        : base(read.Describe(uploadId) + "; refusing to treat it as absent")
+    {
+        Read = read;
+    }
+}

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -940,24 +940,48 @@ public sealed class VoiceUploadStore
             using var doc = JsonDocument.Parse(text);
             if (doc.RootElement.ValueKind != JsonValueKind.Object)
                 return Malformed(path, "the file does not hold a JSON object");
-            foreach (var required in RequiredRecordProperties)
-                if (!doc.RootElement.TryGetProperty(required, out _))
-                    return Malformed(path, $"the record has no {required} property");
+            foreach (var (name, allowed) in RequiredRecordProperties)
+            {
+                if (!doc.RootElement.TryGetProperty(name, out var value))
+                    return Malformed(path, $"the record has no {name} property");
+                if (Array.IndexOf(allowed, value.ValueKind) < 0)
+                    return Malformed(path, $"the record's {name} is a JSON {value.ValueKind}, not {string.Join(" or ", allowed)}");
+            }
             record = JsonSerializer.Deserialize<DictationDeliveryRecord>(text, RecordJson)!;
         }
         catch (JsonException ex)
         {
             return Malformed(path, ex.Message);
         }
-        // A number the enum does not name deserializes without complaint, and then matches no state anywhere.
+        // A state NAME the enum does not carry throws above; this is the remaining way a value could arrive
+        // that matches no state anywhere, and it is kept so the claim "Present means a known state" is checked
+        // where it is made rather than assumed from the converter.
         if (!Enum.IsDefined(record.State))
             return Malformed(path, $"state {(int)record.State} is not a delivery state this build knows");
         return DictationRecordRead.Found(record);
     }
 
-    // The properties every delivery record has carried since issue #1183. Case-sensitive, exactly as the
-    // serializer matches them: a file spelling one differently is one the serializer would silently default.
-    private static readonly string[] RequiredRecordProperties = { "State", "Submitted", "MovedOn", "Transcript", "Reason" };
+    // The properties every delivery record has carried since issue #1183, each with the JSON kinds the store
+    // itself writes. Case-sensitive, exactly as the serializer matches them: a file spelling one differently is
+    // one the serializer would silently default.
+    //
+    // State must be a NAME, never a number. The enum converter accepts integers too, and 0 is PENDING and 1 is
+    // DELIVERED: "State":0 would read as a re-openable pending record, and "State":1 as a delivered outcome
+    // the phone would acknowledge - and then drop its only copy of the audio for. Transcript must be a string,
+    // because a delivered outcome carries it verbatim to the client. Reason is the one field the store writes
+    // as null.
+    //
+    // Properties this build does NOT know are accepted on purpose: a record written by a newer Gateway carries
+    // fields an older build has never heard of, and a rollback that refused every one of them would hold every
+    // upload on the machine. The five known properties, present and of the right kind, are the contract.
+    private static readonly (string Name, JsonValueKind[] Allowed)[] RequiredRecordProperties =
+    {
+        ("State", new[] { JsonValueKind.String }),
+        ("Submitted", new[] { JsonValueKind.True, JsonValueKind.False }),
+        ("MovedOn", new[] { JsonValueKind.True, JsonValueKind.False }),
+        ("Transcript", new[] { JsonValueKind.String }),
+        ("Reason", new[] { JsonValueKind.String, JsonValueKind.Null }),
+    };
 
     private static DictationRecordRead Malformed(string path, string problem)
     {
@@ -975,9 +999,12 @@ public sealed class VoiceUploadStore
     /// removed that rejection deliberately (see <c>Session.SendTextAsync</c>) - so a missed lock costs a
     /// missing badge, nothing more. A marker nobody can read can never finish arriving, because every
     /// delivery path refuses it (see <see cref="Read"/>); projecting a lock from it would paint the session as
-    /// receiving a dictation until an operator found the file, with no client action able to clear it. The
-    /// Core-side lock reader documents the same fail-open choice for the same reason. Nothing compensates for
-    /// a re-injected dictation, which is why delivery is the side that refuses and this side is not.
+    /// receiving a dictation until an operator found the file, because nothing on the delivery or abandon
+    /// paths can clear such a marker. Only an explicit acknowledgement can - <see cref="Acknowledge"/> retires
+    /// the directory without reading it, and that is the client stating its own copy is gone, which the
+    /// official client never does after a refusal. The Core-side lock reader documents the same fail-open
+    /// choice for the same reason. Nothing compensates for a re-injected dictation, which is why delivery is
+    /// the side that refuses and this side is not.
     /// </summary>
     public bool IsPending(string uploadId)
         => Read(uploadId) is { Kind: DictationRecordReadKind.Present, Record.State: DictationDeliveryState.Pending };
@@ -987,7 +1014,12 @@ public sealed class VoiceUploadStore
     /// #1188). While a PENDING marker exists the session is LOCKED for human input (a projection read by
     /// <see cref="IsSessionLocked"/>). Called at register so the session id is on disk and the lock survives
     /// a Gateway restart. Keeps any staged chunks and overwrites a prior PENDING or FAILED marker (a retry
-    /// re-entry back to PENDING); the DELIVERED/ABANDONED short-circuit means those never reach here.
+    /// re-entry back to PENDING).
+    ///
+    /// This is the RAW writer. It does not decide: it will write PENDING over a terminal tombstone if told to,
+    /// which is why the register leg no longer calls it - the register transition is <see cref="OpenPending"/>,
+    /// which reads, decides and writes under one hold of the gate (issue #2745). What this still refuses, by
+    /// reading through the strict <see cref="ReadRecord"/>, is a marker it cannot read at all.
     /// </summary>
     public void MarkPending(string uploadId, string sessionId)
     {
@@ -1003,6 +1035,49 @@ public sealed class VoiceUploadStore
             WriteRecordMarker(dir, new DictationDeliveryRecord(
                 DictationDeliveryState.Pending, false, false, "", null, sessionId ?? "", ExistingRebaseline(uid)));
             FileLog.Write($"[VoiceUploadStore] MarkPending: uploadId={uid} sessionId={sessionId}");
+        });
+    }
+
+    /// <summary>
+    /// The REGISTER transition as ONE operation under the per-upload gate (issue #2745, review round two): read
+    /// the record, decide, refresh the staging directory, and write the PENDING marker - or not - without
+    /// releasing the gate in between. The endpoint used to do this as three calls (a read, then Register, then
+    /// MarkPending), and a complete could land the DELIVERED tombstone between the read and the PENDING write;
+    /// the write then buried the tombstone, and the next complete injected the same speech again. That is the
+    /// issue's harm reached through a race rather than a fold, and only a single gated operation closes it.
+    ///
+    /// Returns the normalized upload id (a blank or non-GUID id mints a fresh one, exactly as
+    /// <see cref="Register"/> does), what the record was BEFORE, and whether PENDING was written. It is NOT
+    /// written when the read refuses (Malformed, Unreadable, ForeignTenant - the caller answers with the
+    /// refusal, and the directory is left untouched) or when the record is terminal (DELIVERED or ABANDONED -
+    /// the caller answers with the cached outcome; the staging directory is still refreshed, as a re-register
+    /// always did, so the sweep does not take it out from under a client that is about to acknowledge). A
+    /// PENDING, FAILED, or absent record is (re-)opened, carrying the #1593 re-baseline forward from a FAILED
+    /// marker for the same reason <see cref="MarkPending"/> gives.
+    /// </summary>
+    public DictationOpenOutcome OpenPending(string? uploadId, string sessionId)
+    {
+        var uid = NormalizeId(uploadId) ?? Guid.NewGuid().ToString("N");
+        return WithRecordLock(uid, () =>
+        {
+            var before = Read(uid);
+            if (before.Refuses)
+            {
+                FileLog.Write($"[VoiceUploadStore] OpenPending: uploadId={uid} refused ({before.Kind}); nothing written");
+                return new DictationOpenOutcome(uid, before, false);
+            }
+            EnsureFreshStaging(uid); // the gate is reentrant on this thread, so this stays inside it
+            if (before.Record is { State: DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned })
+            {
+                FileLog.Write($"[VoiceUploadStore] OpenPending: uploadId={uid} is terminal ({before.Record.State}); not re-opened");
+                return new DictationOpenOutcome(uid, before, false);
+            }
+            BetweenRecordReadAndWriteForTests?.Invoke(uid);
+            WriteRecordMarker(DirFor(uid), new DictationDeliveryRecord(
+                DictationDeliveryState.Pending, false, false, "", null, sessionId ?? "", before.Record?.RebaselineBufferBytes));
+            FileLog.Write($"[VoiceUploadStore] OpenPending: uploadId={uid} sessionId={sessionId} opened " +
+                $"(was {(before.Record is { } r ? r.State.ToString() : before.Kind.ToString())})");
+            return new DictationOpenOutcome(uid, before, true);
         });
     }
 
@@ -1580,3 +1655,10 @@ public sealed class UnreadableDictationRecordException : InvalidOperationExcepti
         Read = read;
     }
 }
+
+/// <summary>
+/// What <see cref="VoiceUploadStore.OpenPending"/> did: the normalized upload id, the record as it was BEFORE
+/// (so the caller can answer a refusal or a terminal outcome from the same read the decision was made on),
+/// and whether the PENDING marker was written.
+/// </summary>
+public sealed record DictationOpenOutcome(string UploadId, DictationRecordRead Before, bool Opened);


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle_internal#1941.

## What was wrong

`VoiceUploadStore.ReadRecord` answered `null` for two different facts: "there is no record for this upload id" and "there is a record and I could not read it". The de-dupe guard in front of register and complete tests positively for a DELIVERED or ABANDONED record, which is the right direction, but `null` fails that test. So a tombstone that was corrupt, half-written, or locked by another process fell through to `Register` plus `MarkPending`: the upload was re-opened as a fresh PENDING and the operator's own speech was injected into a live session a second time. The comment four lines above the guard promised that could not happen.

## What changed

The read now names every answer the file can give:

| Kind | Meaning | Action |
|---|---|---|
| Absent | no record.json | open the upload (the only permissive answer) |
| Present | a record this build can read | act on its state, as before |
| Malformed | there, but not a delivery record: bad JSON, empty, not an object, missing any of the five properties a record has always carried or holding one of the wrong kind (a numeric state, a null transcript), or an unknown state name | refuse: it is evidence the id was already resolved |
| Unreadable | could not look (locked, permission, a disk fault) | refuse and say so; a retry may read it |
| ForeignTenant | readable, stamped for another tenant | refuse; never treated as absent |

- `VoiceUploadStore.Read` returns the kind, the record when Present, and for the refusals the file path and the problem. The reader checks the SHAPE before the value: the serializer defaults every omitted property, and the default for State is PENDING, so `{}` would otherwise read as a re-openable pending record.
- The register transition is one operation under the per-upload gate (`VoiceUploadStore.OpenPending`): read, decide, refresh the staging directory, write PENDING. As three calls, a complete could land the DELIVERED tombstone between the read and the PENDING write and the write buried it: the same harm through a race.
- The old `ReadRecord` stays but is strict: `null` only for Absent, a thrown `UnreadableDictationRecordException` for the other three, so no caller can fold them back into "absent".
- Every writer composes its new marker through the strict read inside the record gate, so `MarkPending`, `MarkDelivered`, `MarkAbandoned` and `MarkFailed` refuse to put a marker on top of one they cannot read and leave the file byte for byte. `ClearFailed`, the re-baseline and both sweeps leave such a marker standing, and the resolved-tombstone sweep now applies the tenant check the stale-pending sweep already had.
- The session lock does not project from an unreadable marker. That is a documented decision on `IsPending`, matching the Core lock reader's fail-open choice: nothing a client can do would release a lock held by a marker every delivery path refuses, and the user-input send source is the compensating fail-closed default. Delivery is the side that refuses.
- The register, complete and abandon legs refuse with 409 (Malformed, ForeignTenant: an operator is needed at the file the body names) or 423 Locked (Unreadable: a retry may read it; not 503, which the phone reads as an unreachable Gateway). No terminal fields are returned, so the phone keeps its copy. Nothing is written.
- The phone recognises the refusal: the complete loop no longer reads every 409 as a missing-chunk answer, the held message names the record problem instead of a transcription outage, and the upload result carries a typed refusal kind. The background driver keeps that reason on screen past the one-hour throttle and retries the operator-needed case on the slow five-minute cadence from the first attempt. No acknowledgement is ever sent for a refusal, so the server's evidence stays.
- The de-dupe comment above register is now true rather than softened to match the code.

## Proof

- `VoiceUploadStoreUnreadableRecordTests` (default gate): every kind by name including valid-but-wrong-shape JSON (`{}`, an unrelated object, a State-only object, wrong-case properties), the strict read throwing, each writer leaving the bytes untouched, both sweeps, the lock decision, and controls for Absent and Present. `VoiceUploadStoreTenantPartitionTests` gains the planted-foreign-record canary for the tombstone sweep.
- `dictationUnreadableRecord.test.ts` and three driver tests in `backgroundSend.test.ts` (client-core, 1,020 tests green): register and complete refusals at 409 and 423, the missing-chunk control, the message mapper, the reason surviving the throttle hour, and the slow cadence.
- The interleaving proof: a test holds the record gate inside the register transition, starts a delivery on another thread, and shows it cannot land until the open has finished; the tombstone is what remains.
- `UnreadableDictationTombstoneTests` (parked Gateway suite, real GatewayHost over HTTP): a re-register of a corrupt tombstone is refused, the file is unchanged and no PENDING marker exists, next to a control showing a fresh id still opens; the same for complete (nothing injected) and abandon (not turned into ABANDONED); on Windows a tombstone held open by another process is refused as Unreadable and reads normally once released.
- Revert-proof, twice: with the reader's JSON-failure branch put back to the old fold (answer Absent), six store tests go red on the claim (the Malformed kind, and each of the four writers overwriting the corrupt marker); with the shape check disabled, five go red (`{}`, the unrelated object, the State-only object, the wrong-case object, and MarkPending over `{}`). All pass with the fix restored.
- `.\scripts\test-local.ps1` green: all nine default projects passed (3,745 Gateway unit tests among them).
- Parked Gateway suite: see the comment below with the run result.

## Review

Two independent Codex reviews. Round one found two high findings (valid-but-empty JSON read as PENDING; the tombstone sweep skipping the tenant check), one medium (the phone hiding the refusal) and one low (a stale lock rationale). Round two found two high (a numeric state passing the shape check; register's read and write not being one gated operation), one medium (the background driver hiding the refusal past the throttle hour and retrying it fast) and two low (a test comparing the wrong id form; the lock rationale overstating acknowledgement). All are closed on the branch. A third review of the round-two changes is recorded below.

## Not verified

- `CcDirector.Core.Tests` was not run: no file under Core changed, and the gate script's own reasoning names only the two Gateway suites for these files.
