### PR TITLE
Refuse to start a session that would not know the rules it runs under (#2719)

### DIFF
--- a/src/CcDirector.Core.Tests/Sessions/SessionRefusedWithoutItsRulesTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/SessionRefusedWithoutItsRulesTests.cs
@@ -1,0 +1,105 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// A session that starts without the fleet preamble is a session that does not know the rules it
+/// runs under - including the rule that keeps an assistant's name out of the owner's repositories
+/// and his clients' deliverables. It used to start anyway and write one line to a file log.
+///
+/// THESE TESTS EXIST ON A BOUNDARY THAT WAS PREVIOUSLY UNCOVERED, and the boundary is the point.
+/// Both installers already had tests for their own failure branches - CodexHookInstaller even has
+/// one asserting it returns false and does not clobber - because making a file malformed and calling
+/// a function is cheap. What the CALLER did with that false was untested, because reaching it means
+/// creating a session. So the producer's failure was covered, the consumer's response was not, and a
+/// green suite testing the producer read as though the pair were covered.
+/// </summary>
+public sealed class SessionRefusedWithoutItsRulesTests
+{
+    private static SessionManager ManagerWith(Func<string?> claudeHooks, Func<bool> codexHooks) =>
+        new(new AgentOptions
+        {
+            ClaudePath = TestShell.Path,
+            CodexPath = TestShell.Path,
+            DefaultBufferSizeBytes = 65536,
+            GracefulShutdownTimeoutSeconds = 2,
+        })
+        {
+            InstallClaudeHooks = claudeHooks,
+            InstallCodexHooks = codexHooks,
+        };
+
+    /// <summary>
+    /// THE REGRESSION TEST for Claude. Before this change the session started and the only trace was
+    /// a file-log line, so a session that did not know the rules was indistinguishable from one that
+    /// did.
+    /// </summary>
+    [Fact]
+    public void ClaudeHookInstallFails_TheSessionIsRefused_NotLaunchedQuietly()
+    {
+        var manager = ManagerWith(claudeHooks: () => null, codexHooks: () => true);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => manager.CreateSession(Path.GetTempPath(), AgentKind.ClaudeCode, null, SessionBackendType.ConPty, null));
+
+        // The message has to carry the CONSEQUENCE, not just the mechanism - the person reading it at
+        // the moment it happens is the only one who can act on it.
+        Assert.Contains("without the fleet preamble", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("rules", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("session-start hook could not be installed", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        // And nothing was left running.
+        Assert.Empty(manager.ListSessions());
+    }
+
+    /// <summary>The same for Codex, whose hook is the preamble channel outright.</summary>
+    [Fact]
+    public void CodexHookInstallFails_TheSessionIsRefused_NotLaunchedQuietly()
+    {
+        var manager = ManagerWith(claudeHooks: () => "settings.json", codexHooks: () => false);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => manager.CreateSession(Path.GetTempPath(), AgentKind.Codex, null, SessionBackendType.ConPty, null));
+
+        Assert.Contains("without the fleet preamble", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("hooks.json", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(manager.ListSessions());
+    }
+
+    /// <summary>
+    /// The refusal must not over-correct. When the hooks install, the session starts exactly as
+    /// before - a refusal that fired always would be just as wrong in the other direction, and this
+    /// is what stops the fix being "never launch anything".
+    /// </summary>
+    [Fact]
+    public void HooksInstall_TheSessionStartsAsBefore()
+    {
+        var manager = ManagerWith(claudeHooks: () => "settings.json", codexHooks: () => true);
+
+        var session = manager.CreateSession(Path.GetTempPath(), AgentKind.ClaudeCode, null, SessionBackendType.ConPty, null);
+
+        Assert.NotNull(session);
+        Assert.Single(manager.ListSessions());
+    }
+
+    /// <summary>
+    /// AN AGENT THAT WAS NEVER GOING TO GET A HOOK IS NOT A FAILURE. Pi carries the preamble on its
+    /// launch system prompt, so refusing it over a missing hook would be refusing over a state that
+    /// is not a fault - which is the same class of error as the fold this change removes, pointing
+    /// the other way.
+    /// </summary>
+    [Fact]
+    public void AnAgentWithNoHookChannel_IsNotRefused()
+    {
+        var manager = ManagerWith(claudeHooks: () => null, codexHooks: () => false);
+
+        var session = manager.CreateSession(Path.GetTempPath(), AgentKind.Pi, null, SessionBackendType.ConPty, null);
+
+        Assert.NotNull(session);
+        Assert.Single(manager.ListSessions());
+    }
+}

--- a/src/CcDirector.Core.Tests/Sessions/SessionRefusedWithoutItsRulesTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/SessionRefusedWithoutItsRulesTests.cs
@@ -50,7 +50,11 @@ public sealed class SessionRefusedWithoutItsRulesTests
         // the moment it happens is the only one who can act on it.
         Assert.Contains("without the fleet preamble", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("rules", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("session-start hook could not be installed", ex.Message, StringComparison.OrdinalIgnoreCase);
+        // AND IT MUST NAME THE EXACT PATH. A refusal without a fix is a wall, and this one has to be
+        // actionable by somebody who has never heard of a hook - a path they can look at beats a
+        // description of a mechanism they do not know exists.
+        Assert.Contains(CcDirector.Core.Claude.ClaudeHookInstaller.HookDirectory(), ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("writable", ex.Message, StringComparison.OrdinalIgnoreCase);
 
         // And nothing was left running.
         Assert.Empty(manager.ListSessions());
@@ -66,7 +70,8 @@ public sealed class SessionRefusedWithoutItsRulesTests
             () => manager.CreateSession(Path.GetTempPath(), AgentKind.Codex, null, SessionBackendType.ConPty, null));
 
         Assert.Contains("without the fleet preamble", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("hooks.json", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(CcDirector.Core.Codex.CodexHookInstaller.HooksJsonPath(), ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("valid JSON", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Empty(manager.ListSessions());
     }
 

--- a/src/CcDirector.Core/Claude/ClaudeHookInstaller.cs
+++ b/src/CcDirector.Core/Claude/ClaudeHookInstaller.cs
@@ -154,6 +154,12 @@ public static class ClaudeHookInstaller
         }
     }
 
+    /// <summary>
+    /// Where the Claude hook files are written - inside the Director's OWN per-user data directory,
+    /// not the user's Claude configuration. PUBLIC so a refusal can name the exact directory.
+    /// </summary>
+    public static string HookDirectory() => CcStorage.ClaudeHooks();
+
     private static string DefaultDirectory() => CcStorage.ClaudeHooks();
 
     private static string BuildSettingsJson(string scriptPath, bool forWindows)

--- a/src/CcDirector.Core/Claude/ClaudeHookInstaller.cs
+++ b/src/CcDirector.Core/Claude/ClaudeHookInstaller.cs
@@ -112,8 +112,14 @@ public static class ClaudeHookInstaller
     /// <summary>
     /// Ensure the hook script and settings file exist under the per-user Director data dir,
     /// and return the absolute settings-file path to pass to Claude via <c>--settings</c>.
-    /// Returns null if the files could not be written, in which case the caller launches the
-    /// session without hook-based pointer tracking (the session still starts).
+    /// Returns null if the files could not be written. THE CALLER NO LONGER LAUNCHES ANYWAY: this
+    /// hook is both the session-pointer tracking and the channel that surfaces the fleet preamble,
+    /// so a null here means the session would not be told the rules it runs under, and
+    /// <c>SessionManager.CreateSession</c> refuses to start it and says why.
+    ///
+    /// This comment used to end "the session still starts", stated as a reassurance. It was the
+    /// defect: the third state was seen, its consequence understood well enough to write down, and
+    /// shipped as a note rather than fixed.
     /// </summary>
     public static string? EnsureInstalled() => EnsureInstalled(DefaultDirectory(), OperatingSystem.IsWindows());
 

--- a/src/CcDirector.Core/Codex/CodexHookInstaller.cs
+++ b/src/CcDirector.Core/Codex/CodexHookInstaller.cs
@@ -102,8 +102,12 @@ public static class CodexHookInstaller
     /// <summary>
     /// Ensure the hook script exists and our SessionStart entry is present in the user's Codex
     /// hooks.json. Returns true on success (the Director should then append
-    /// <see cref="BypassTrustFlag"/> to the Codex command); false if anything failed, in which case
-    /// the session still launches, just without the preamble hook.
+    /// <see cref="BypassTrustFlag"/> to the Codex command); false if anything failed. A false NO
+    /// LONGER launches the session without the preamble hook: without it the fleet preamble never
+    /// reaches the session, so <c>SessionManager.CreateSession</c> refuses to start it and says why.
+    ///
+    /// This comment used to end "the session still launches, just without the preamble hook", which
+    /// named the consequence exactly and then shipped it.
     /// </summary>
     public static bool EnsureInstalled() =>
         EnsureInstalled(DefaultScriptDirectory(), DefaultCodexHooksPath(), OperatingSystem.IsWindows());

--- a/src/CcDirector.Core/Codex/CodexHookInstaller.cs
+++ b/src/CcDirector.Core/Codex/CodexHookInstaller.cs
@@ -224,6 +224,13 @@ public static class CodexHookInstaller
 
     private static string DefaultScriptDirectory() => CcStorage.CodexHooks();
 
+    /// <summary>
+    /// Where the Codex hook is merged: <c>~/.codex/hooks.json</c>, or CODEX_HOME when that is set.
+    /// PUBLIC so a refusal can name the exact file rather than describing it - a person who has never
+    /// heard of a hook cannot act on "the Codex hook could not be merged", and can act on a path.
+    /// </summary>
+    public static string HooksJsonPath() => DefaultCodexHooksPath();
+
     private static string DefaultCodexHooksPath()
     {
         var codexHome = Environment.GetEnvironmentVariable("CODEX_HOME");

--- a/src/CcDirector.Core/Sessions/PreambleDelivery.cs
+++ b/src/CcDirector.Core/Sessions/PreambleDelivery.cs
@@ -1,0 +1,49 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// Whether the fleet preamble - the text that tells a session the rules it runs under - actually
+/// reached a session being launched.
+///
+/// WHY THIS IS A REFUSAL AND NOT A LOG LINE. The preamble is not a convenience. It carries the
+/// standing rules, including the one forbidding an assistant's name in the owner's repositories and
+/// his clients' deliverables. A session that starts without it is not slightly degraded: it does not
+/// know the rules, and nothing about it looks any different from one that does.
+///
+/// The code this replaces got the ANALYSIS right and the ANSWER wrong, which is why it is worth
+/// spelling out. Both installers documented the fold and its consequence in their own doc comments -
+/// "in which case the caller launches the session without hook-based pointer tracking (the session
+/// still starts)" and "false if anything failed, in which case the session still launches, just
+/// without the preamble hook". The third state was seen, understood precisely enough to be written
+/// down, written down, and shipped anyway. So this is not a case of an unconsidered branch: it is a
+/// warning in a document, and a warning in a document is a design defect wearing a note.
+///
+/// The test that settles it: VISIBLE TO THE PERSON THE CONSEQUENCE HAPPENS TO, AT THE MOMENT IT
+/// HAPPENS. A file-log line fails that test twice over - the log is not read at launch and it is not
+/// read by the person. A badge on the session fails it too, more subtly: a session launched into a
+/// fleet of twenty may never be looked at, so a mark that must be LOOKED AT is not a mark that
+/// reaches anyone at the moment it matters. A refusal at launch is unmissable, arrives exactly when
+/// the person can act, and says what to fix - the same shape the unresolvable-executable refusal in
+/// <c>SessionManager.CreateSession</c> already uses, which is the proven-visible path in this code.
+/// </summary>
+public enum PreambleDelivery
+{
+    /// <summary>
+    /// The preamble file was written and the hook that reads it is installed. The session will be
+    /// told the rules within moments of starting.
+    /// </summary>
+    Delivered,
+
+    /// <summary>
+    /// This agent family has no <c>SessionStart</c> hook and is not expected to have one - its rules
+    /// arrive by another route, or not at all. NOT a failure, and deliberately its own value rather
+    /// than folded into <see cref="Delivered"/>: "we did not need to" and "we did it" are different
+    /// facts, and a future reader counting delivered sessions must not be handed the wrong one.
+    /// </summary>
+    NotApplicable,
+
+    /// <summary>
+    /// The preamble could NOT be delivered. The session must not start: it would run without the
+    /// standing rules, and nobody would be told.
+    /// </summary>
+    Failed,
+}

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -803,8 +803,8 @@ public sealed class SessionManager : IDisposable
                     // fleet preamble into the session's context. Without it the session is untracked
                     // across /clear AND never told the rules, and the only previous sign of either was
                     // a line in a file log.
-                    preambleFailures.Add("the Claude session-start hook could not be installed under the "
-                                         + "Director's data directory");
+                    preambleFailures.Add("the Claude session-start hook could not be written to "
+                                         + Claude.ClaudeHookInstaller.HookDirectory());
                 }
             }
 
@@ -826,7 +826,8 @@ public sealed class SessionManager : IDisposable
                 {
                     delivery = PreambleDelivery.Failed;
                     preambleFailures.Add("the Codex fleet-preamble hook could not be merged into "
-                                         + "~/.codex/hooks.json");
+                                         + Codex.CodexHookInstaller.HooksJsonPath()
+                                         + " (it must be a writable file containing valid JSON)");
                 }
             }
 
@@ -848,10 +849,13 @@ public sealed class SessionManager : IDisposable
                     + "the rule that keeps an assistant's name out of your repositories and your "
                     + $"clients' deliverables.{Environment.NewLine}{Environment.NewLine}"
                     + $"What failed: {whatFailed}.{Environment.NewLine}{Environment.NewLine}"
+                    + $"What to do: check that the path above exists, is writable by you, and - if it is "
+                    + "a .json file - contains valid JSON. The commonest cause is a hand-edited "
+                    + "hooks.json with a syntax error, which this Director will not overwrite because it "
+                    + "is yours. Correct or move that file and start the session again."
+                    + $"{Environment.NewLine}{Environment.NewLine}"
                     + "This used to start the session anyway and write one line to the Director log, so "
-                    + "a session that did not know the rules looked exactly like one that did. Fix the "
-                    + "above - most often a permissions or disk problem on your home directory - and "
-                    + "start the session again.");
+                    + "a session that did not know the rules looked exactly like one that did.");
             }
 
             // For Pi, write the fleet preamble to a per-session file and pass it via

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -181,6 +181,26 @@ public sealed class SessionManager : IDisposable
     /// </summary>
     public bool PlacesSkillsOnLaunch { get; init; }
 
+    /// <summary>
+    /// Installs the Claude session-start hook and returns the settings path to pass via
+    /// <c>--settings</c>, or null when it could not be installed. Defaults to the real installer.
+    ///
+    /// A seam, because the alternative is untestable in both directions. The refusal below cannot be
+    /// exercised without making a hook install fail, and the real installer writes into the running
+    /// user's own home directory - so proving the refusal would mean breaking the developer's Claude
+    /// configuration, and every other test that creates a session would silently depend on that
+    /// directory being writable. This is the boundary the previous coverage stopped at: the
+    /// installers' own failure branches were tested because they are cheap, and what the CALLER does
+    /// with a failure was not, because it is expensive.
+    /// </summary>
+    public Func<string?> InstallClaudeHooks { get; set; } = Claude.ClaudeHookInstaller.EnsureInstalled;
+
+    /// <summary>
+    /// Installs the Codex fleet-preamble hook, returning false when it could not be. Defaults to the
+    /// real installer. A seam for the same reason as <see cref="InstallClaudeHooks"/>.
+    /// </summary>
+    public Func<bool> InstallCodexHooks { get; set; } = Codex.CodexHookInstaller.EnsureInstalled;
+
     /// <summary>Invoke OnSessionCreated. Public so external endpoint mappers (web Control API)
     /// can announce sessions they created without going through CreateSession overloads.</summary>
     public void RaiseSessionCreated(Session session)
@@ -704,6 +724,18 @@ public sealed class SessionManager : IDisposable
             // Only the two agent families that have a SessionStart hook get these. Pi has its own
             // launch-time system-prompt file, and an agent with no hook would be handed a path nothing
             // reads.
+            // WHETHER THE RULES REACHED THIS SESSION, as a three-valued answer rather than a flag.
+            //
+            // Started at NotApplicable because most agent families have no SessionStart hook and were
+            // never going to receive one - that is not a failure and must not be counted as a delivery
+            // either. The two families that DO get the preamble move it to Delivered or Failed below.
+            // Holding the distinction in the VALUE is what lets the refusal ask one question; a
+            // nullable "reason" would have folded Delivered and NotApplicable together and forced the
+            // refusal to re-derive the difference from the agent kind, which is a second place to get
+            // it wrong.
+            var delivery = PreambleDelivery.NotApplicable;
+            var preambleFailures = new List<string>();
+
             if (agent.Kind is AgentKind.ClaudeCode or AgentKind.Codex)
             {
                 try
@@ -714,11 +746,13 @@ public sealed class SessionManager : IDisposable
                 }
                 catch (Exception ex)
                 {
-                    // A preamble that cannot be written must never stop a session starting. The
-                    // variable is then not stamped at all, so the hook prints nothing rather than
-                    // reading a path that does not resolve.
-                    _log?.Invoke($"The fleet preamble file could not be written for this session: {ex.Message}");
-                    FileLog.Write($"[SessionManager] preamble file write FAILED (session still launching): {ex}");
+                    // A preamble that cannot be WRITTEN is a session that will not be told the rules,
+                    // exactly like a hook that cannot be INSTALLED. It used to be logged and launched
+                    // anyway; the log is a file nobody reads at launch, so the session ran ruleless and
+                    // silent. Recorded here and refused below, with the other two.
+                    delivery = PreambleDelivery.Failed;
+                    preambleFailures.Add($"the preamble file could not be written ({ex.Message})");
+                    FileLog.Write($"[SessionManager] preamble file write FAILED: {ex}");
                 }
             }
 
@@ -753,11 +787,24 @@ public sealed class SessionManager : IDisposable
             // file paths stamped above from the environment.
             if (agent.Kind == AgentKind.ClaudeCode)
             {
-                var hookSettings = CcDirector.Core.Claude.ClaudeHookInstaller.EnsureInstalled();
+                var hookSettings = InstallClaudeHooks();
                 if (!string.IsNullOrEmpty(hookSettings))
                 {
                     args = $"{args} --settings \"{hookSettings}\"".Trim();
                     _log?.Invoke("Installed Claude session-pointer hooks (--settings).");
+                    // Promote ONLY from NotApplicable. An earlier failure - the preamble file itself -
+                    // must not be erased by a later success, because the hook has nothing to read.
+                    if (delivery == PreambleDelivery.NotApplicable) delivery = PreambleDelivery.Delivered;
+                }
+                else
+                {
+                    delivery = PreambleDelivery.Failed;
+                    // This hook is BOTH the session-pointer tracking and the channel that surfaces the
+                    // fleet preamble into the session's context. Without it the session is untracked
+                    // across /clear AND never told the rules, and the only previous sign of either was
+                    // a line in a file log.
+                    preambleFailures.Add("the Claude session-start hook could not be installed under the "
+                                         + "Director's data directory");
                 }
             }
 
@@ -767,11 +814,44 @@ public sealed class SessionManager : IDisposable
             // the hook reads the preamble file path stamped above from the environment.
             if (agent.Kind == AgentKind.Codex)
             {
-                if (CcDirector.Core.Codex.CodexHookInstaller.EnsureInstalled())
+                if (InstallCodexHooks())
                 {
                     args = $"{args} {CcDirector.Core.Codex.CodexHookInstaller.BypassTrustFlag}".Trim();
                     _log?.Invoke("Installed Codex fleet-preamble SessionStart hook (--dangerously-bypass-hook-trust).");
+                    // Promote ONLY from NotApplicable. An earlier failure - the preamble file itself -
+                    // must not be erased by a later success, because the hook has nothing to read.
+                    if (delivery == PreambleDelivery.NotApplicable) delivery = PreambleDelivery.Delivered;
                 }
+                else
+                {
+                    delivery = PreambleDelivery.Failed;
+                    preambleFailures.Add("the Codex fleet-preamble hook could not be merged into "
+                                         + "~/.codex/hooks.json");
+                }
+            }
+
+            // THE REFUSAL. Everything above that can stop the rules reaching this session lands here.
+            //
+            // This is a decision, not a report about the world, so folding the unknown into "decline"
+            // is the safe direction and is taken deliberately. It asks ONE question, because only the
+            // two families that are SUPPOSED to receive the preamble can reach Failed - Pi carries its
+            // rules on its launch system prompt and other agents have no such channel, so they stay at
+            // NotApplicable and refusing them would be refusing over a state that is not a failure.
+            if (delivery == PreambleDelivery.Failed)
+            {
+                var display = ToolDetectionService.DisplayName(agent.Kind);
+                var whatFailed = string.Join("; ", preambleFailures);
+                FileLog.Write($"[SessionManager] CreateSession REFUSED for {agent.Kind}: {whatFailed}");
+                throw new InvalidOperationException(
+                    $"{display} was not started, because this session would have run WITHOUT the fleet "
+                    + "preamble - the text that tells a session the rules it operates under, including "
+                    + "the rule that keeps an assistant's name out of your repositories and your "
+                    + $"clients' deliverables.{Environment.NewLine}{Environment.NewLine}"
+                    + $"What failed: {whatFailed}.{Environment.NewLine}{Environment.NewLine}"
+                    + "This used to start the session anyway and write one line to the Director log, so "
+                    + "a session that did not know the rules looked exactly like one that did. Fix the "
+                    + "above - most often a permissions or disk problem on your home directory - and "
+                    + "start the session again.");
             }
 
             // For Pi, write the fleet preamble to a per-session file and pass it via


### PR DESCRIPTION
Part of the "Restart a Director without losing the fleet" mission (#2719). Found by the class sweep in thefrederiksen/devthrottle#2733.

## The defect

The fleet preamble is the text that tells a session the rules it operates under - including the one that keeps an assistant's name out of the owner's repositories and his clients' deliverables.

**Three** things had to work for it to arrive, and all three folded a failure into "carry on":

| Where | On failure |
|---|---|
| `SessionManager` line 711 - the preamble **file** write | logged, session launched |
| `ClaudeHookInstaller.EnsureInstalled` | returned `null`, session launched |
| `CodexHookInstaller.EnsureInstalled` | returned `false`, session launched |

Each wrote one line to a file log. `_log` is `msg => FileLog.Write(...)`, so nothing reached a screen. A session that did not know the rules was indistinguishable from one that did.

## What makes this different from the rest of the sweep

**Nobody missed this case.** Both installers documented the fold *and its consequence* in their own doc comments:

> "…in which case the caller launches the session without hook-based pointer tracking (**the session still starts**)."

> "…false if anything failed, in which case **the session still launches**, just without the preamble hook."

The third state was seen, understood well enough to write down, written down, and shipped. That is not an enumeration gap - it is a warning in a document, which is a design defect wearing a note. Both comments now say what the code does instead.

## Refuse, not mark - and why

The test applied was: **visible to the person the consequence happens to, at the moment it happens.**

- A file-log line fails it twice: not read at launch, not read by that person.
- **A badge fails it too**, less obviously. A session launched into a fleet of twenty may never be *looked at*, so a mark that must be looked at reaches nobody at the moment it matters.
- A refusal at launch is unmissable, arrives while the person can still act, and names what to fix - reusing the proven-visible path already in this method (the unresolvable-executable refusal, which reaches a message box through `_lastSessionCreateError`).

Delivery is a **three-valued** answer rather than a flag. `NotApplicable` is its own value because most agent families have no such hook and were never going to get one: folding that into `Delivered` would count a session as told-the-rules that never was, and folding it into `Failed` would refuse over a state that is not a fault. Only the two families that are supposed to receive the preamble can reach `Failed`, so the refusal asks one question instead of re-deriving the difference from the agent kind.

## Two instances of the class found in this change, by re-reading it for the defect it fixes

- The three-state type was created and then the refusal was wired with a **nullable string**, which collapses `Delivered` and `NotApplicable` back into one value.
- A comment promised the person is "told everything that is wrong in one go" while the code kept only the **first** failure. The comment was right about what it should do, so the code now collects and reports every failure.

## Evidence

Four tests, on a boundary that had no coverage. Both installers already tested their **own** failure branches - `CodexHookInstaller` even asserts it returns false and does not clobber - because malforming a file and calling a function is cheap. What the **caller** did with that false was untested, because reaching it means creating a session. The producer's failure was covered, the consumer's response was not, and a green suite testing the producer read as if the pair were covered.

Mutation run and watched: removing the refusal **compiles cleanly** and kills two of the four; the two that guard against over-correcting - hooks install and the session starts; an agent with no hook channel is not refused - correctly survive.

The installers are reached through seams defaulting to the real ones, because the refusal is otherwise untestable in both directions: proving it would mean breaking the developer's own Claude configuration, and every other test that creates a session would silently depend on that directory being writable.

## Gate: one suite green, one UNDETERMINED

**`CcDirector.Core.Tests` - the suite that covers this change - is GREEN**: `outcome=Completed`, `total=4413`, including the four new tests.

That run was necessary, not belt-and-braces: **the default gate exits zero having never executed these tests**, because `Core.Tests` is parked. It prints `COVERAGE GAP` naming it, which is the gate correctly refusing to be read as proof - filed as thefrederiksen/devthrottle_internal#1949.

**`CcDirector.Gateway.Tests` is UNDETERMINED - it never ran.** Its TRX reports `outcome=Failed` with `total=0`, and the reason is:

> The active test run was aborted. Reason: Test host process crashed : `[gateway-test-lock] WAITING. Another run … holds the per-user test lock … THIS IS NOT A HANG. Holder: process 64404 … devthrottle-restart-p3 … holding since 411s ago.`

It queued correctly behind another seat, waited legitimately, and was killed by a watchdog that counts waiting as hanging - filed as thefrederiksen/devthrottle_internal#1952. `total=0` is a run that never ran being reported as a run that broke.

**This is deliberately not exonerated by reachability.** On thefrederiksen/devthrottle#2736 that argument was available because the failing suite had no project reference to the changed assembly. Here it is not: `Gateway` references `Core`, so this `SessionManager` change is reachable from that suite in principle. So the honest state is undetermined - neither green nor red - and it is stated rather than resolved privately.

**This will not be merged on an undetermined.** That suite will be re-run alone once the machine-wide lock frees; the lock is currently held by another worktree.

## Who this refusal reaches, verified rather than assumed

`CreateSession` has exactly three production callers, and the refusal was checked against each:

| Caller | What a refusal does there |
|---|---|
| `MainWindow.axaml.cs` - the desktop | caught, sets `_lastSessionCreateError`, shown in a message box |
| `SessionCommandExecutor.cs` - the fleet spawn path | caught, returned as `DirectorCommandResult.Fail(Error, ex.Message)` |
| `SessionWriteExecutor.cs` | same family |

So the message reaches a human at the desktop and reaches the *requesting agent* on a fleet spawn. Neither path swallows it.

## The cost of choosing refuse, stated plainly

**If hooks cannot be installed on a machine, every session creation on that machine now fails** - desktop and fleet spawn alike. That is a total outage of session creation rather than a degraded mode, and it is the strongest argument for MARK over REFUSE.

It is taken deliberately, on the grounds that the failure is loud, names its cause, and is usually a permissions or disk problem on the user's own home directory that they can fix - whereas the behaviour it replaces was a silent, unbounded number of sessions running without the owner's rules. But the trade is real, it is not hidden here, and it is the part to revisit first if this turns out to bite.
