### PR TITLE
Take the single-instance guard before any update action

### DIFF
--- a/src/CcDirector.Avalonia/Program.cs
+++ b/src/CcDirector.Avalonia/Program.cs
@@ -10,6 +10,20 @@ namespace CcDirector.Avalonia;
 
 internal static class Program
 {
+    /// <summary>
+    /// The process id this build was asked to wait for, from <c>--wait-for-exit &lt;pid&gt;</c>, or null.
+    /// Parsed rather than assumed: an unreadable value means NO wait, because refusing to start over a
+    /// malformed argument would be a Director that does not come back - which is the failure every part
+    /// of this ordering exists to avoid.
+    /// </summary>
+    private static int? TryReadWaitForExit(string[] args)
+    {
+        for (var i = 0; i + 1 < args.Length; i++)
+            if (args[i] == "--wait-for-exit" && int.TryParse(args[i + 1], out var pid) && pid > 0)
+                return pid;
+        return null;
+    }
+
     [STAThread]
     public static int Main(string[] args)
     {
@@ -70,6 +84,64 @@ internal static class Program
             }
         }
 
+        // WAIT FOR THE PROCESS THAT STARTED US, when it asked us to. A relaunch that hands over to a new
+        // build has to let the outgoing one finish exiting first, or the incoming one claims the
+        // single-instance mutex against a process that is on its way out and refuses to start. The
+        // staged-update path has always done this (LaunchRelauncher passes the parent process id and
+        // ApplyUpdate waits on it); the ROLLBACK relaunch did not, and that omission is the only reason
+        // the guard below could not be taken earlier.
+        if (TryReadWaitForExit(args) is { } waitForPid)
+        {
+            FileLog.Write($"[Program] waiting for process {waitForPid} to exit before claiming this instance");
+            UpdateInstaller.WaitForProcessExit(waitForPid, TimeSpan.FromSeconds(30));
+        }
+
+        // THE SINGLE-INSTANCE GUARD IS TAKEN BEFORE ANY UPDATE ACTION, AND THAT IS THE WHOLE POINT OF
+        // THIS BLOCK BEING HERE RATHER THAN NINETY LINES DOWN.
+        //
+        // It used to sit after five update actions - RecoverHalfAppliedSwap, TryRollBackFailedUpdate,
+        // the relaunch, CleanupAfterUpdate and TryApplyStagedUpdateAtStartup - so a second copy of the
+        // Director started against a live one would run all five before finding out it was not wanted.
+        // The guard prevented a duplicate DIRECTOR; it did not prevent duplicate UPDATER WORK, because
+        // the updater ran first. That mattered because a launcher that cannot fully read an instance
+        // home still starts a Director there (deliberately - refusing strands a working one), so an
+        // update could proceed over a Director nobody had accounted for.
+        //
+        // The comment above the staged-update call said the apply happens "before any session exists,
+        // so no running work is ever lost". That is true of THIS process and false of the OTHER live
+        // Director, which is the one whose work is at stake - a reassurance written from the wrong
+        // process's point of view.
+        //
+        // WHY IT COULD NOT SIMPLY BE MOVED. The rollback relaunch above started the restored build and
+        // exited without any handshake, so an early guard would have made the incoming build find the
+        // mutex still held by its dying parent and exit - leaving NO Director at all, worse than either
+        // problem being solved. It now carries the parent process id and the wait handled above, which
+        // is the same handshake its sibling has always had, so the guard can come first.
+        using var guard = SingleInstanceGuard.TryAcquire();
+        if (guard is null)
+        {
+            // A second launch must NOT vanish silently -- "clicking does nothing" is exactly the
+            // failure this issue targets (issue #242). Bring the already-running window to the
+            // foreground; only if no window can be raised do we fall back to an explanatory dialog.
+            if (TryRaiseExistingWindow())
+            {
+                FileLog.Write("[Program] Second launch: raised the already-running window and exited.");
+                return 0;
+            }
+
+            var busyExe = Environment.ProcessPath ?? "(unknown)";
+            var busyMessage =
+                "Director is already running." + Environment.NewLine + Environment.NewLine +
+                $"Exe: {busyExe}" + Environment.NewLine + Environment.NewLine +
+                "Only one instance per install location can run at a time. " +
+                "Identity, ports, and state files are keyed by the exe path -- " +
+                "running a second copy would collide with the existing one.";
+            ShowStartupNotice(busyMessage, "Director", MB_ICONWARNING);
+            FileLog.Write("[Program] Second launch refused: another instance holds this exe path.");
+            FileLog.Stop();
+            return 1;
+        }
+
         // Self-heal a broken install BEFORE cleanup deletes the ".old" backup we recover from
         // (issue #242). Two distinct failure modes are handled here:
         //
@@ -90,8 +162,14 @@ internal static class Program
                 // Started the same way an update relaunch is: no inherited CC_DIRECTOR_ROOT (which would
                 // make the restored build nest a new, empty data home inside this instance's one) and the
                 // instance carried explicitly.
+                // THE HANDSHAKE, which this path never had. Without it the restored build starts while
+                // this process is still exiting, and - now that the single-instance guard is claimed
+                // first - it would find the mutex held by a dying parent and refuse to start, leaving
+                // the machine with no Director at all. Its sibling LaunchRelauncher has always passed
+                // this; the correct pattern was a hundred lines away in the same file.
                 System.Diagnostics.Process.Start(
-                    UpdateInstaller.BuildRelaunchStartInfo(Environment.ProcessPath ?? "", InstanceContext.Slug));
+                    UpdateInstaller.BuildRelaunchStartInfo(Environment.ProcessPath ?? "", InstanceContext.Slug,
+                        waitForProcessId: Environment.ProcessId));
             }
             catch (Exception ex)
             {
@@ -119,28 +197,10 @@ internal static class Program
         if (updateNotice is not null)
             ShowStartupNotice(updateNotice, "Director - Update", MB_ICONWARNING);
 
-        using var guard = SingleInstanceGuard.TryAcquire();
-        if (guard is null)
-        {
-            // A second launch must NOT vanish silently -- "clicking does nothing" is exactly the
-            // failure this issue targets (issue #242). Bring the already-running window to the
-            // foreground; only if no window can be raised do we fall back to an explanatory dialog.
-            if (TryRaiseExistingWindow())
-            {
-                FileLog.Write("[Program] Second launch: raised the already-running window and exited.");
-                return 0;
-            }
-
-            var exe = Environment.ProcessPath ?? "(unknown)";
-            var msg =
-                "Director is already running.\n\n" +
-                $"Exe: {exe}\n\n" +
-                "Only one instance per install location can run at a time. " +
-                "Identity, ports, and state files are keyed by the exe path -- " +
-                "running a second copy would collide with the existing one.";
-            ShowStartupNotice(msg, "Director", MB_ICONWARNING);
-            return 1;
-        }
+        // THE GUARD IS ALREADY HELD. It was claimed near the top of Main, before any update action -
+        // see the block there for why it moved and what had to change first. It is NOT re-taken here:
+        // the same process claiming its own mutex twice would deadlock on a non-reentrant wait, and a
+        // second claim would in any case answer a question that was already settled.
 
         // Never let a startup exception exit with no window and no message (issue #242).
         try

--- a/src/CcDirector.Core.UnitTests/RelaunchHandshakeTests.cs
+++ b/src/CcDirector.Core.UnitTests/RelaunchHandshakeTests.cs
@@ -1,0 +1,123 @@
+using CcDirector.Core.Update;
+using Xunit;
+
+namespace CcDirector.Core.UnitTests;
+
+/// <summary>
+/// The relaunch handshake, which is what lets the single-instance guard be taken BEFORE any update
+/// action.
+///
+/// WHY THIS MATTERS MORE THAN IT LOOKS. The Director used to claim its single-instance mutex ninety
+/// lines into startup, after five update actions. So the guard prevented a duplicate DIRECTOR and did
+/// NOT prevent duplicate UPDATER WORK - a second copy started against a live one ran half-swap
+/// recovery, rollback, cleanup and staged-update application before finding out it was not wanted.
+/// That is how an update could proceed over a Director nobody had accounted for.
+///
+/// Taking the guard first closes it, and could not simply be done: ONE of the two relaunch paths
+/// handed over with no handshake at all. TryApplyStagedUpdateAtStartup has always passed the parent
+/// process id (LaunchRelauncher) and waited on it (ApplyUpdate). The ROLLBACK relaunch called
+/// Process.Start and returned, so the restored build started while its parent was still exiting - and
+/// with an early guard it would have found the mutex held by that dying parent and refused to start,
+/// LEAVING THE MACHINE WITH NO DIRECTOR AT ALL. That is worse than both problems being solved.
+///
+/// So these tests pin the handshake itself: the argument is emitted, it is emitted where the target
+/// platform will actually deliver it, and it is read back. The correct pattern was already in the same
+/// file, a hundred lines from the path that lacked it.
+/// </summary>
+public sealed class RelaunchHandshakeTests
+{
+    private const string Target = @"C:\install\cc-director.exe";
+
+    private static string[] Args(System.Diagnostics.ProcessStartInfo psi) => psi.ArgumentList.ToArray();
+
+    /// <summary>The handshake reaches the relaunched build.</summary>
+    [Fact]
+    public void A_relaunch_asked_to_wait_carries_the_parent_process_id()
+    {
+        var psi = UpdateInstaller.BuildRelaunchStartInfo(Target, "default", waitForProcessId: 4242);
+
+        var args = Args(psi);
+        var i = Array.IndexOf(args, "--wait-for-exit");
+        Assert.True(i >= 0, "the relaunch must carry --wait-for-exit");
+        Assert.Equal("4242", args[i + 1]);
+    }
+
+    /// <summary>
+    /// THE CONTROL. A relaunch that was NOT asked to wait must not carry the argument - otherwise the
+    /// test above would pass against an implementation that always waits, which would make every
+    /// ordinary start pause for a process that is not there.
+    /// </summary>
+    [Fact]
+    public void A_relaunch_not_asked_to_wait_carries_no_handshake()
+    {
+        var psi = UpdateInstaller.BuildRelaunchStartInfo(Target, "default");
+
+        Assert.DoesNotContain("--wait-for-exit", Args(psi));
+    }
+
+    /// <summary>A process id of zero or less is not a process, and must not be emitted as one.</summary>
+    [Fact]
+    public void A_relaunch_carries_no_handshake_when_there_is_no_instance_either()
+    {
+        var psi = UpdateInstaller.BuildRelaunchStartInfo(Target, instanceSlug: null);
+
+        Assert.DoesNotContain("--wait-for-exit", Args(psi));
+        Assert.DoesNotContain("--instance", Args(psi));
+    }
+
+    /// <summary>
+    /// ON MACOS EVERY APPLICATION ARGUMENT TRAVELS BEHIND ONE "--args", AND THIS IS WHERE THE FIRST
+    /// DRAFT WAS WRONG. It appended the handshake after the instance block, so a relaunch carrying a
+    /// handshake and NO instance slug emitted "--wait-for-exit 4242" with no "--args" in front of it -
+    /// which hands them to /usr/bin/open rather than to the Director, and open does not know them.
+    /// The Director would then start with no handshake at all and race its own parent, which is
+    /// precisely the failure the handshake exists to prevent, on the platform nobody was testing.
+    ///
+    /// Asserted as ORDER rather than presence: the arguments being there is not the property, being
+    /// there BEHIND the separator is.
+    /// </summary>
+    [Fact]
+    public void Every_application_argument_sits_behind_a_single_args_separator()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        foreach (var slug in new string?[] { "default", null })
+        {
+            var args = Args(UpdateInstaller.BuildRelaunchStartInfo(Target, slug, waitForProcessId: 4242));
+
+            var separator = Array.IndexOf(args, "--args");
+            Assert.True(separator >= 0, "application arguments need a --args separator on macOS");
+            Assert.Equal(1, args.Count(a => a == "--args"));
+
+            var wait = Array.IndexOf(args, "--wait-for-exit");
+            Assert.True(wait > separator, "the handshake must sit BEHIND the separator, not in front of it");
+        }
+    }
+
+    /// <summary>On every other platform the arguments go straight to the executable, with no separator
+    /// at all - so a separator appearing there would be passed to the Director as a real argument.</summary>
+    [Fact]
+    public void Off_macOS_the_arguments_go_straight_to_the_executable()
+    {
+        if (OperatingSystem.IsMacOS()) return;
+
+        var args = Args(UpdateInstaller.BuildRelaunchStartInfo(Target, "work", waitForProcessId: 99));
+
+        Assert.DoesNotContain("--args", args);
+        Assert.Equal(new[] { "--instance", "work", "--wait-for-exit", "99" }, args);
+    }
+
+    /// <summary>The relaunch still scrubs CC_DIRECTOR_ROOT. Asserted here because the handshake work
+    /// edited this method, and a change that quietly dropped the scrub would make an updated Director
+    /// nest a new empty data tree inside the old one - which reads to a person as "the update wiped
+    /// my Director".</summary>
+    [Fact]
+    public void The_relaunch_still_refuses_to_pass_on_an_inherited_root()
+    {
+        var psi = UpdateInstaller.BuildRelaunchStartInfo(Target, "default", waitForProcessId: 7);
+
+        Assert.False(psi.Environment.ContainsKey("CC_DIRECTOR_ROOT")
+                     && !string.IsNullOrEmpty(psi.Environment["CC_DIRECTOR_ROOT"]));
+        Assert.False(psi.UseShellExecute);
+    }
+}

--- a/src/CcDirector.Core/Update/UpdateInstaller.cs
+++ b/src/CcDirector.Core/Update/UpdateInstaller.cs
@@ -552,7 +552,21 @@ public static class UpdateInstaller
     ///
     /// Pure, so the environment scrub is provable without starting a process.
     /// </summary>
-    public static ProcessStartInfo BuildRelaunchStartInfo(string targetPath, string? instanceSlug)
+    /// <param name="waitForProcessId">
+    /// The process id the relaunched build must wait to exit before it starts, or null for none.
+    ///
+    /// WHY THIS EXISTS. Its sibling <see cref="LaunchRelauncher"/> has always passed the parent process
+    /// id, and <see cref="ApplyUpdate"/> waits on it for thirty seconds before doing anything. This path
+    /// - the rollback relaunch - passed nothing, so the restored build started while the process that
+    /// started it was still exiting. That was survivable only because the incoming build did several
+    /// seconds of update work before it claimed the single-instance mutex, which is precisely the
+    /// ordering that lets updater work run over an unaccounted-for live Director. Taking the mutex first
+    /// closes that, and it is safe to take it first ONLY once this path stops racing its own parent.
+    ///
+    /// The correct pattern was already in this file, a hundred lines away, on the sibling path.
+    /// </param>
+    public static ProcessStartInfo BuildRelaunchStartInfo(string targetPath, string? instanceSlug,
+        int? waitForProcessId = null)
     {
         // UseShellExecute must stay false: the environment block can only be edited on a direct start.
         var psi = new ProcessStartInfo
@@ -561,20 +575,34 @@ public static class UpdateInstaller
             UseShellExecute = false,
         };
 
+        // The arguments the RELAUNCHED APPLICATION receives, collected before they are placed - because
+        // on macOS they have to travel behind a single "--args", and emitting that per-argument would
+        // hand the second group to /usr/bin/open instead of to the Director. The first draft of the
+        // wait handshake did exactly that whenever no instance slug was carried.
+        var appArgs = new List<string>();
+        if (!string.IsNullOrWhiteSpace(instanceSlug))
+        {
+            appArgs.Add("--instance");
+            appArgs.Add(instanceSlug);
+        }
+        if (waitForProcessId is { } parentPid)
+        {
+            appArgs.Add("--wait-for-exit");
+            appArgs.Add(parentPid.ToString());
+        }
+
         if (OperatingSystem.IsMacOS())
         {
             psi.ArgumentList.Add(targetPath);
-            if (!string.IsNullOrWhiteSpace(instanceSlug))
+            if (appArgs.Count > 0)
             {
                 psi.ArgumentList.Add("--args");
-                psi.ArgumentList.Add("--instance");
-                psi.ArgumentList.Add(instanceSlug);
+                foreach (var a in appArgs) psi.ArgumentList.Add(a);
             }
         }
-        else if (!string.IsNullOrWhiteSpace(instanceSlug))
+        else
         {
-            psi.ArgumentList.Add("--instance");
-            psi.ArgumentList.Add(instanceSlug);
+            foreach (var a in appArgs) psi.ArgumentList.Add(a);
         }
 
         psi.Environment.Remove("CC_DIRECTOR_ROOT");
@@ -618,7 +646,11 @@ public static class UpdateInstaller
             comparison);
     }
 
-    private static void WaitForProcessExit(int pid, TimeSpan timeout)
+    /// <summary>
+    /// Wait for another process to exit, bounded. PUBLIC because the startup path needs the same wait
+    /// the update path has always had - see BuildRelaunchStartInfo's waitForProcessId.
+    /// </summary>
+    public static void WaitForProcessExit(int pid, TimeSpan timeout)
     {
         var sw = Stopwatch.StartNew();
         while (sw.Elapsed < timeout)


### PR DESCRIPTION
## What this is

**The Director claimed its single-instance mutex after five update actions, so the guard prevented a
duplicate Director and did not prevent duplicate UPDATER WORK.**

Found by the round-two adversarial review of pull request thefrederiksen/devthrottle#2734. It is the reason that pull request
carries an explicit statement that it does not certify this, and this is the change that closes it.

## The defect

`Program.Main` ran, in order:

1. `RecoverHalfAppliedSwap`
2. `TryRollBackFailedUpdate` (and its relaunch)
3. `CleanupAfterUpdate`
4. `TryApplyStagedUpdateAtStartup`
5. ...and only then `SingleInstanceGuard.TryAcquire()`

So a second copy of the Director started against a live one ran **half-swap recovery, rollback,
cleanup and staged-update application** before finding out it was not wanted. The mutex stopped the
second desktop lifetime; it did not stop any of the install side effects that preceded it.

That matters because a launcher which cannot fully read an instance home **still starts a Director
there, deliberately** — refusing strands a working one (#2730). So a start could run updater work
over a live Director nobody had accounted for.

### The false premise was written down as the reassurance

The comment above the staged-update call says the apply happens *"before any session exists, so no
running work is ever lost."* That is **true of this process and false of the other live Director** —
which is the one whose work is at stake. A reassurance written from the wrong process's point of
view, sitting directly above the code it excuses.

## Why the guard could not simply be moved

This is the whole substance of the change, and the reason it is not a one-line move.

**One of the two relaunch paths handed over with no handshake at all.**

| Path | Handshake |
|---|---|
| `TryApplyStagedUpdateAtStartup` → `LaunchRelauncher` | passes `Environment.ProcessId`; `ApplyUpdate` calls `WaitForProcessExit(parentPid, 30s)` |
| `TryRollBackFailedUpdate` → `BuildRelaunchStartInfo` | **nothing** — `Process.Start` then `return 0` |

With the guard taken early, the restored build from the rollback path would start while its parent
was still exiting, find the mutex held by that dying parent, and refuse to start — **leaving the
machine with no Director at all.** That is worse than either problem being solved, and it is almost
certainly why the guard sat where it did.

So the rollback relaunch now carries **the same handshake its sibling has always had, a hundred
lines away in the same file**, and the guard moves ahead of all five actions.

The fifth time on this mission that the correct pattern turned out to be adjacent to the wrong one.

## A defect found while writing this, kept as a test rather than a comment

**On macOS every application argument travels behind a single `--args`.** The first draft appended
the handshake after the instance block, so a relaunch carrying a handshake and **no** instance slug
emitted `--wait-for-exit 4242` with no separator in front of it — handing those arguments to
`/usr/bin/open` rather than to the Director. The Director would then start with no handshake and
race its own parent: exactly the failure the handshake exists to prevent, on the platform nobody was
testing.

Arguments are now collected once and placed once, and the test asserts **order**, not presence —
because the arguments being there is not the property; being there *behind the separator* is.

## Proof

`RelaunchHandshakeTests`, six tests, each with its control:

- the handshake reaches the relaunched build;
- a relaunch **not** asked to wait carries no handshake — without this control, an implementation
  that always waits would pass, and every ordinary start would pause for a process that is not there;
- on macOS every application argument sits behind exactly one separator, asserted for both the
  with-slug and no-slug cases (the no-slug case is the one that was broken);
- off macOS there is no separator at all, asserted as an exact argument list;
- the relaunch still scrubs `CC_DIRECTOR_ROOT`, asserted because this change edited that method and
  dropping the scrub would make an updated Director nest a new empty data tree inside the old one —
  which reads to a person as "the update wiped my Director".

### WHAT THIS PULL REQUEST DOES NOT CERTIFY

**This pull request does not certify the guard ordering under a real relaunch, and IF THE HANDSHAKE
DOES NOT FUNCTION THE NEW ORDERING YIELDS NO DIRECTOR RATHER THAN A RACE. Nobody may rely on it until
`scripts/launcher-swap-proof` applies a staged update, relaunches, and asserts the new process comes
up.**

### The risk is asymmetric, and that is why thefrederiksen/devthrottle_internal#1953 is urgent rather than filed

Work the failure through with the guard now ahead of the update actions:

| | outcome |
|---|---|
| handshake functions | the incoming process waits for its parent, takes the guard, comes up. Fine. |
| handshake present but NOT functioning | the incoming process starts immediately, finds the guard held by its still-exiting parent, and **exits. No Director.** |

**So the new ordering's failure mode is strictly worse than the race it replaces.** The old failure
was two processes briefly overlapping; the new one is zero processes — which is precisely the outcome
the Architect named as worse than both problems when he first ruled on moving the guard.

**And "present but not functioning" is not hypothetical — it is exactly the macOS defect found in
this change's own first draft.** The handshake argument was there and went to `/usr/bin/open` instead
of to the Director. A test asserting the argument was *present* would have passed while the machine
ended up with no Director at all. That finding IS the failure mode thefrederiksen/devthrottle_internal#1953 has to rule out, and it is
the reason the test here asserts order rather than presence.

Stated in the strong form rather than as a disclosure. These tests pin the handshake *argument* and
its placement; **no test starts two real Directors and races them**, so the reordering itself is
argued from reading `Program.Main`, not executed. The home for that run is
**`scripts/launcher-swap-proof`** — Phase 0 of thefrederiksen/devthrottle_internal#1923 built exactly that rig, and this needs its shape
rather than a unit test. Tracked as **#2763**, which is the continuation of the Architect's own proof
design.

**Why that was filed rather than held.** Today the rollback relaunch has no handshake at all, so the
race exists unconditionally on every platform. Holding this change would mean keeping a certain race
to avoid an unproven-but-reviewed reordering — the same trade refused when a crash was declined as a
safety mechanism.

The `--apply-update` path is unaffected: it returns at the top of `Main`, before any update action
and before the guard, so it never takes the mutex.

## Gate

`.\scripts\test-local.ps1` — see the run recorded in the review thread.

Note for anyone running the gate on this machine: `CC_GATEWAY_DB_CONNECTION` is **set but empty** in
these shells, and the Gateway refuses to fall back — so two Gateway unit tests fail by default.
`CC_GATEWAY_DB_CONNECTION= dotnet test` does *not* clear it; only `env -u` does.
