### PR TITLE
Release notes for v2.0.7

### DIFF
--- a/docs/public/release-notes/v2.0.7.md
+++ b/docs/public/release-notes/v2.0.7.md
@@ -1,0 +1,59 @@
+# DevThrottle v2.0.7
+
+The first release that runs on Linux. It also changes how the launcher gets updated, and fixes a
+settings bug that could quietly throw away the rest of your configuration.
+
+## DevThrottle runs on Linux
+
+There is now a Linux download. The Director, the setup wizard, the setup command line tool and the
+launcher are all published for `linux-x64`, and the Python tools bundle is built for Linux too.
+
+- **Nothing has to be installed first.** The Linux builds are self-contained: the runtime travels
+  inside the download, so a clean desktop needs no separate framework install. The file is larger
+  because of it.
+- **One command installs it**, in the same shape as the macOS install: it fetches the setup wizard
+  from the release, checks it against the release manifest before running anything, and hands over
+  to the wizard.
+- **Proven on Ubuntu 24.04 desktop**, on a GNOME session, as an ordinary non-root user. The Director
+  starts with normal window decorations and its menu bar, the setup wizard runs, and a session drives
+  a coding agent that does real work in a real repository.
+
+What is honestly not there yet:
+
+- **Only Ubuntu 24.04 has been tested.** Other distributions are likely to work and none of them has
+  been tried, so we are not claiming them.
+- **`linux-arm64` is built but has never been run by anyone.** It is not published as a supported
+  download for that reason.
+- **The preview panes for HTML, Markdown and PDF have no renderer on Linux**, and local audio capture
+  and local dictation do not work there.
+- **The setup wizard offers to install one coding agent, not all of them.** Any other agent is
+  installed the way you would normally install it, and DevThrottle picks it up from your PATH.
+
+## The Director now installs the launcher's update
+
+The launcher is the part of DevThrottle that replaces the Director when an update arrives. Until now
+nothing owned the launcher's *own* update, so a launcher that fell behind stayed behind - and because
+the launcher is what would receive a remote fix, a machine in that state could not be repaired
+remotely at all. One real machine sat on a launcher from two versions back with an update staged for
+a week that nothing ever installed.
+
+A Director update now carries the launcher's update with it and installs it. **This changes how
+future updates arrive on every machine, not only Linux ones**, which is worth knowing before you
+update rather than after.
+
+## A settings file that could not be read is no longer overwritten
+
+Saving from the settings dialog is a merge: it edits a few fields inside a file it does not own and
+preserves everything else. The read behind that merge could not tell "there is no settings file"
+apart from "there is a settings file and I could not read it", and treated both as empty.
+
+So if the file happened to be locked by another process for an instant, or had been hand-edited into
+invalid JSON, saving replaced it with only the handful of fields the dialog knows about. Everything
+else in it was lost, including hooks. The dialog now refuses to save rather than write over a file it
+could not read.
+
+## Also in this release
+
+Most of the other work since v2.0.6 is in the hosted service rather than in this download - turn
+logging, narration retries, per-account controls and several security fixes - and it reaches you when
+the service updates, not when you install this. A plugin marketplace was also published.


### PR DESCRIPTION
The release workflow stopped on its notes guard. This is the missing docs/public/release-notes/v2.0.7.md - 2,812 non-whitespace characters against the guard's floor of 200. Covers Linux support, the launcher self-update change (#2728) and the settings-merge fix (#2736), and states the limits plainly.