### PR TITLE
fix(update): a rolled-back install stops being red once the machine moves past it

### DIFF
--- a/src/CcDirector.Core.Tests/Update/UpdateStatusFoldTests.cs
+++ b/src/CcDirector.Core.Tests/Update/UpdateStatusFoldTests.cs
@@ -213,6 +213,90 @@ public class UpdateStatusFoldTests
     }
 
     [Fact]
+    public void RolledBack_KeepsBeingSaid_ForAsLongAsTheMachineIsStuckOnTheRestoredBuild()
+    {
+        // A clock must not silence this. A machine still sitting on the build that was restored has
+        // nothing new to report, and that is exactly why it must keep reporting: going quiet after a
+        // day would hide the one case the message exists for.
+        var view = UpdateStatusFold.Fold(Facts(new UpdaterState
+        {
+            LastApplyDecision = "RolledBack",
+            LastApplyVersion = "1.9.1",
+            LastApplyDecisionAt = Now.AddDays(-40),
+            LastCheckOutcome = "UpToDate",
+            LastCheckedAt = Now.AddMinutes(-2),
+        }));
+
+        Assert.Equal("RolledBack", view.State);
+    }
+
+    [Fact]
+    public void RolledBack_StopsBeingSaid_OnceTheMachineHasMovedPastTheBuildThatFailed()
+    {
+        // The owner's Mac, 2026-09-08. Version 2.0.5 was rolled back five days earlier because the
+        // screen was locked at 1:57 in the morning and no build could start; 2.0.7 then installed and
+        // proved healthy. The panel still showed UPDATE ROLLED BACK on a machine that was fine, and
+        // told him "v2.0.7 was put back" - which never happened. 2.0.4 was what was put back.
+        var view = UpdateStatusFold.Fold(Facts(
+            new UpdaterState
+            {
+                LastApplyDecision = "RolledBack",
+                LastApplyVersion = "2.0.5",
+                LastApplyDecisionAt = Now.AddDays(-5),
+                LastCheckOutcome = "UpToDate",
+                LastCheckLatestVersion = "2.0.7",
+                LastCheckedAt = Now.AddMinutes(-1),
+            },
+            current: "2.0.7"));
+
+        Assert.Equal("UpToDate", view.State);
+        Assert.DoesNotContain("was put back", view.Detail);
+
+        // History, not silence: the version that failed is pinned and will not be offered again, so it
+        // stays reachable in the tooltip.
+        Assert.Contains("2.0.5", view.Tooltip);
+        Assert.Contains("rolled back", view.Tooltip);
+    }
+
+    [Fact]
+    public void AnInstallThatFailed_StopsBeingSaid_OnceTheMachineHasMovedPastThatVersion()
+    {
+        var view = UpdateStatusFold.Fold(Facts(
+            new UpdaterState
+            {
+                LastApplyDecision = "Failed",
+                LastApplyVersion = "2.0.5",
+                LastApplyDecisionAt = Now.AddDays(-5),
+                LastCheckOutcome = "UpToDate",
+                LastCheckedAt = Now.AddMinutes(-1),
+            },
+            current: "2.0.7"));
+
+        Assert.Equal("UpToDate", view.State);
+        Assert.Contains("2.0.5", view.Tooltip);
+        Assert.Contains("could not be installed", view.Tooltip);
+    }
+
+    [Fact]
+    public void ARolledBackVersionThatCannotBeRead_KeepsBeingSaid()
+    {
+        // An unreadable version means "it is not known whether this machine has moved on", and that is
+        // a reason to keep saying the failure happened - never a reason to go quiet about it.
+        var view = UpdateStatusFold.Fold(Facts(
+            new UpdaterState
+            {
+                LastApplyDecision = "RolledBack",
+                LastApplyVersion = "2.0.5-preview",
+                LastApplyDecisionAt = Now.AddDays(-5),
+                LastCheckOutcome = "UpToDate",
+                LastCheckedAt = Now.AddMinutes(-1),
+            },
+            current: "2.0.7"));
+
+        Assert.Equal("RolledBack", view.State);
+    }
+
+    [Fact]
     public void ALauncherDecisionAboutADifferentVersion_IsNotReadAsBeingAboutThisDownload()
     {
         // A "held because busy" left over from an earlier download would otherwise describe a build that

--- a/src/CcDirector.Core/Update/UpdateStatusFold.cs
+++ b/src/CcDirector.Core/Update/UpdateStatusFold.cs
@@ -242,7 +242,28 @@ public static class UpdateStatusFold
         var lastDecision = state.LastApplyDecision;
         var decidedPhrase = Describe(state.LastApplyDecisionAt, facts.Now);
 
-        if (lastDecision == "RolledBack")
+        // ...but only while this machine is still WORSE OFF for it. A failed install is worth a red
+        // panel because it leaves the machine stuck on an older build. Once the machine is running the
+        // version that failed, or anything past it, the failure is history and the red panel is a false
+        // alarm about a machine that is fine.
+        //
+        // That is what went wrong on the owner's Mac. Version 2.0.5 was rolled back at 1:57 in the
+        // morning on 2026-09-03 - the screen was locked, so no build could have started, and the
+        // restored build did not come up either. Version 2.0.7 then installed cleanly five days later
+        // and proved healthy, and the panel still said UPDATE ROLLED BACK, because this record was
+        // ranked above the check outcome, never expired, and was never overwritten by the install that
+        // succeeded.
+        //
+        // The test is PROGRESS, not a clock. Ageing the record out after a few hours would go quiet on
+        // the one machine that most needs to speak: the one still sitting on the restored build. It has
+        // nothing new to report, and that is precisely why it must keep reporting.
+        //
+        // It also makes the sentence below true. "v{CurrentVersion} was put back" is now only ever
+        // rendered when the running build really is older than the one that failed, so it can no longer
+        // name a version this machine has since moved on to as the one that was restored.
+        var superseded = HasMovedPastFailedVersion(facts.CurrentVersion, state.LastApplyVersion);
+
+        if (lastDecision == "RolledBack" && !superseded)
             return new UpdateStatusView(
                 State: "RolledBack",
                 Headline: "UPDATE ROLLED BACK",
@@ -255,7 +276,7 @@ public static class UpdateStatusFold
                 CanCheckNow: true, CheckNowLabel: CheckNow,
                 CanInstallNow: false, InstallNowLabel: null);
 
-        if (lastDecision == "Failed")
+        if (lastDecision == "Failed" && !superseded)
             return new UpdateStatusView(
                 State: "InstallFailed",
                 Headline: "UPDATE INSTALL FAILED",
@@ -267,6 +288,34 @@ public static class UpdateStatusFold
                 CanCheckNow: true, CheckNowLabel: CheckNow,
                 CanInstallNow: false, InstallNowLabel: null);
 
+        // The failure is history now, but it is not nothing: the version that did not stick is pinned
+        // and will not be offered again. Carry it into the tooltip of whatever the check concluded
+        // rather than dropping it, so the record stays reachable without shouting.
+        var supersededNote = superseded && lastDecision is "RolledBack" or "Failed"
+            ? $" v{state.LastApplyVersion} "
+              + (lastDecision == "RolledBack" ? "was rolled back" : "could not be installed")
+              + $" {decidedPhrase} and is not offered again; this machine has since moved to "
+              + $"v{facts.CurrentVersion}."
+            : "";
+
+        var concluded = ConcludeFromLastCheck(facts, state, checkedPhrase, lastDecision, decidedPhrase);
+        return supersededNote.Length == 0
+            ? concluded
+            : concluded with { Tooltip = concluded.Tooltip + supersededNote };
+    }
+
+    /// <summary>
+    /// What the last completed check concluded, and what to say when nothing has concluded at all.
+    /// Split out of <see cref="Fold"/> for one reason only - so a superseded install failure can be
+    /// appended to whichever of these answers is reached. It decides nothing on its own.
+    /// </summary>
+    private static UpdateStatusView ConcludeFromLastCheck(
+        UpdateStatusFacts facts,
+        UpdaterState state,
+        string checkedPhrase,
+        string? lastDecision,
+        string decidedPhrase)
+    {
         // 5. What the last completed check concluded.
         switch (state.LastCheckOutcome)
         {
@@ -365,6 +414,19 @@ public static class UpdateStatusFold
     /// </summary>
     private static string? DecisionAbout(UpdaterState state, string stagedVersion)
         => VersionMatches(state.LastApplyVersion, stagedVersion) ? state.LastApplyDecision : null;
+
+    /// <summary>
+    /// True when the build running now is at, or past, the version an install pass failed to leave
+    /// behind - the machine has moved on and the failure no longer costs it anything.
+    ///
+    /// Deliberately FALSE whenever either version cannot be read as a version. Not knowing whether the
+    /// machine has moved on is a reason to keep saying the failure happened, never a reason to go
+    /// quiet: an unreadable version must not be able to silence a real problem.
+    /// </summary>
+    private static bool HasMovedPastFailedVersion(string? currentVersion, string? failedVersion)
+        => Version.TryParse(currentVersion?.TrimStart('v', 'V'), out var current)
+           && Version.TryParse(failedVersion?.TrimStart('v', 'V'), out var failed)
+           && current >= failed;
 
     private static bool VersionMatches(string? a, string? b)
         => !string.IsNullOrEmpty(a) && !string.IsNullOrEmpty(b)


### PR DESCRIPTION
## The defect

The update panel showed a red **UPDATE ROLLED BACK** on a machine that was completely healthy, and the sentence it showed was false: *"v2.0.7 did not start - v2.0.7 was put back 5 days ago"* names a version that was never rolled back.

## What actually happened on the Mac

The launcher installed version 2.0.5 at 1:57 in the morning on 2026-09-03, unattended. It crashed on startup:

```
System.InvalidOperationException: Avalonia.Native was not able to start the RenderTimer.
Native error code is: -6661
   at Avalonia.Native.AvaloniaNativePlatform.Initialize(...)
   at CcDirector.Avalonia.Program.Main(String[] args)
```

That is the locked-screen posture, not a bad build. There was no window server to give a graphical application a render loop at that hour. The proof is that the rollback did not help either - the launcher recorded `restored build answering=not yet`, and a second startup at 02:00:32 failed with the identical error. No build could have started on that machine at that time. Version 2.0.5 was pinned bad on evidence that would have condemned anything, and the machine sat on 2.0.4 for five days.

Version 2.0.7 installed on 2026-09-08 and proved healthy. The panel stayed red, because the rollback record is ranked above the check outcome, never expires, and is never overwritten by an install that succeeds.

## The change

A failed install is reported only while this machine is still worse off for it - while the build running is older than the version that failed.

The test is **progress, not a clock**. Ageing the record out after a few hours would go quiet on the one machine that most needs to speak: the one still sitting on the restored build. It has nothing new to report, and that is precisely why it must keep reporting.

Once the machine has moved past the failed version, the failure becomes a sentence appended to the tooltip of whatever the check concluded, rather than a red panel. The record stays reachable without shouting.

This also makes the wording honest. `v{current} was put back` is now only rendered when the running build really is older than the one that failed, so it can no longer name a version the machine has since moved on to as the one that was restored.

An unreadable version deliberately keeps the failure visible. Not knowing whether the machine has moved on is a reason to keep saying the failure happened, never a reason to go quiet.

## Proof

Four tests added to `UpdateStatusFoldTests`:

| Test | Against current code | Against this change |
|---|---|---|
| `RolledBack_StopsBeingSaid_OnceTheMachineHasMovedPastTheBuildThatFailed` | fails | passes |
| `AnInstallThatFailed_StopsBeingSaid_OnceTheMachineHasMovedPastThatVersion` | fails | passes |
| `RolledBack_KeepsBeingSaid_ForAsLongAsTheMachineIsStuckOnTheRestoredBuild` | passes | passes |
| `ARolledBackVersionThatCannotBeRead_KeepsBeingSaid` | passes | passes |

The first two are the behaviour change. The last two exist to catch an over-correction into silence, so they are expected to pass both ways.

`CcDirector.Core.Tests` update suite: 111 passed, 0 failed. The desktop project builds with no warnings. The fold's public signature is unchanged, so its two callers are untouched.

## Not covered by this change

- **The stale record itself.** Only the launcher writes the apply decision. The Director's own in-process installer is what applied 2.0.7, and it records nothing, so a successful in-process install still leaves the previous decision in place. This change makes that harmless rather than fixing it.
- **`pinnedBadVersion` is never cleared.** Its own documentation says it is cleared once a strictly newer version is offered. It is not. Harmless today, because the pin only blocks an exact version match.
- **The unattended-startup failure.** Nothing here stops a graphical build being launched at 1:57 in the morning against a locked screen and being condemned for it.
