### PR TITLE
fix(update): a Mac needs an awake display to start a Director, and a build must not be blamed for the dark

### DIFF
--- a/scripts/mac-unattended-setup.sh
+++ b/scripts/mac-unattended-setup.sh
@@ -3,21 +3,33 @@
 # mac-unattended-setup.sh — Configure a Mac mini as an unattended DevThrottle fleet machine.
 #
 # WHY THIS SCRIPT EXISTS
-#   macOS cannot launch a NEW graphical application while the screen is locked. The session
-#   keeps running, but the login window owns the displays, and any app that needs a
-#   display link at startup (our Avalonia Director does) dies immediately — we measured
-#   "RenderTimer error -6661" (a CoreVideo "invalid argument" from display-link creation),
-#   even when launched through a launchd agent in the graphical user domain. Every Mac
-#   build farm in the industry (GitHub's hosted runners, Cirrus Labs images, Buildkite,
-#   Amazon EC2 Mac) solves this the same way: never let the machine lock. The display is
-#   allowed to turn off — that is harmless — but the session stays logged in and unlocked.
+#   macOS will not give a STARTING graphical application a render loop unless a display is
+#   awake and drawable. Our Avalonia Director needs one at startup, so without it the
+#   process dies immediately with "RenderTimer error -6661" — a CoreVideo
+#   "invalid argument" from display-link creation. An already-running Director is fine;
+#   only a start fails.
+#
+#   THE CONDITION IS A SLEEPING DISPLAY, NOT A LOCKED SCREEN. An earlier version of this
+#   script blamed the lock and then set the display to sleep after ten minutes, calling
+#   that "harmless". It is not harmless, it is sufficient on its own, and it cost us a
+#   real failure: on 2026-09-03 the launcher installed a new Director at 1:57 in the
+#   morning against a dark screen on a machine that was unlocked and awake, watched it
+#   fail to start, and pinned a perfectly good build as bad. The machine sat five days on
+#   the old version. Avalonia never asks whether the session is unlocked; it asks
+#   CoreGraphics for a drawable display.
+#
+#   So this script does both: never let the machine lock (which every Mac build farm does
+#   — GitHub's hosted runners, Cirrus Labs images, Buildkite, Amazon EC2 Mac) AND never
+#   let the display sleep. The product no longer depends on either being right: the
+#   launcher now wakes the display before it installs and holds the update rather than
+#   condemning a build it could not start. These settings keep it from ever having to.
 #
 # WHAT THIS SCRIPT DOES (each section asks before changing anything)
 #   1. Turn FileVault off                  (required for automatic login; decrypts in background)
 #   2. Enable automatic login              (machine boots straight to the desktop after any restart)
 #   3. Never require a password after sleep or screen saver  (the "do not lock" setting)
 #   4. Never start the screen saver        (both in-session and at the login window)
-#   5. Power settings                      (never system-sleep, display may sleep, restart after power failure)
+#   5. Power settings                      (never system-sleep, never display-sleep, restart after power failure)
 #   6. Software updates                    (keep security data automatic, stop surprise operating-system reboots)
 #   7. Quiet-machine settings              (no crash dialogs, no App Nap throttling, no Time Machine disk prompts)
 #   8. Enable Remote Login (ssh)           (recovery path when the graphical session is unreachable)
@@ -123,15 +135,19 @@ section "5. Power settings (always-on Mac mini)"
 # ---------------------------------------------------------------------------
 pmset -g custom
 echo "Target: the machine never sleeps (sleep 0), disks never spin down (disksleep 0),"
-echo "the display is ALLOWED to turn off after 10 minutes (displaysleep 10 — harmless once"
-echo "the lock is off, and the owner prefers the panel dark), wake-on-network stays on"
-echo "(womp 1), and the machine restarts itself after a power failure (autorestart 1)."
+echo "the display NEVER turns off (displaysleep 0), wake-on-network stays on (womp 1),"
+echo "and the machine restarts itself after a power failure (autorestart 1)."
+echo
+echo "displaysleep 0 is the important one and it used to be 10. macOS gives a STARTING"
+echo "graphical application no render loop while every display is asleep, so a Director"
+echo "restarted against a dark screen dies before its first window. That is what an"
+echo "unattended update does at three in the morning. A dark panel is not free."
 echo "Note: some Apple Silicon minis honor autorestart inconsistently after a hard power"
 echo "cut — the verification list at the end includes a pull-the-plug test."
 if confirm "Apply these power settings?"; then
     sudo pmset -a sleep 0
     sudo pmset -a disksleep 0
-    sudo pmset -a displaysleep 10
+    sudo pmset -a displaysleep 0
     sudo pmset -a womp 1
     sudo pmset -a autorestart 1
     echo "Applied. New values:"

--- a/src/CcDirector.Avalonia/Program.cs
+++ b/src/CcDirector.Avalonia/Program.cs
@@ -75,10 +75,10 @@ internal static class Program
                 // couple of these and boot the working version with its own notice.
                 FileLog.Write($"[Program] ApplyUpdate FAILED: {ex}");
                 WriteCrashFile("apply-update", ex);
-                MessageBoxW(IntPtr.Zero,
+                ShowStartupNotice(
                     $"Director could not apply an update:\n\n{ex.Message}\n\n" +
                     "It will continue on the current version.",
-                    "Director - Update failed", MB_OK | MB_ICONWARNING | MB_TOPMOST);
+                    "Director - Update failed", MB_ICONWARNING);
                 FileLog.Stop();
                 return 1;
             }
@@ -156,7 +156,11 @@ internal static class Program
         if (rollbackNotice is not null)
         {
             FileLog.Write("[Program] Rolled back a failed update; relaunching the restored build.");
-            MessageBoxW(IntPtr.Zero, rollbackNotice, "Director - Update rolled back", MB_OK | MB_ICONWARNING | MB_TOPMOST);
+            // Through the guarded helper, not MessageBoxW directly. MessageBoxW is a user32 import, so off
+            // Windows it throws DllNotFoundException - and it threw HERE, before the relaunch below, which
+            // means a rollback on a Mac restored the previous build and then never started it. The machine
+            // was left with no Director at all by the very path that exists to rescue it.
+            ShowStartupNotice(rollbackNotice, "Director - Update rolled back", MB_ICONWARNING);
             try
             {
                 // Started the same way an update relaunch is: no inherited CC_DIRECTOR_ROOT (which would
@@ -185,7 +189,7 @@ internal static class Program
         UpdateInstaller.CleanupAfterUpdate();
 
         if (recoveryNotice is not null)
-            MessageBoxW(IntPtr.Zero, recoveryNotice, "Director - Update recovered", MB_OK | MB_ICONWARNING | MB_TOPMOST);
+            ShowStartupNotice(recoveryNotice, "Director - Update recovered", MB_ICONWARNING);
 
         // Apply a staged update at startup -- before any session exists, so no
         // running work is ever lost. If one is pending, the relauncher takes over

--- a/src/CcDirector.Core.Tests/Update/DisplayAvailabilityTests.cs
+++ b/src/CcDirector.Core.Tests/Update/DisplayAvailabilityTests.cs
@@ -1,0 +1,86 @@
+using CcDirector.Core.Update;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Update;
+
+/// <summary>
+/// Whether this machine can start a windowed application, and what is allowed to follow from the answer.
+///
+/// The defect behind these tests: on 2026-09-03 a launcher installed a good build against a Mac whose
+/// display was asleep, watched it die before its first window, and pinned it as bad for five days. The
+/// rule that matters is not "is there a display" but WHICH ANSWERS MAY STOP AN UPDATE - because an
+/// update held by a check that could not run is an update that silently never happens, and that is the
+/// failure this whole area already had once.
+/// </summary>
+public class DisplayAvailabilityTests
+{
+    [Theory]
+    [InlineData(DisplayReadiness.Asleep)]
+    [InlineData(DisplayReadiness.None)]
+    public void OnlyAMeasuredAbsenceOfADisplay_MayHoldAnUpdate(DisplayReadiness readiness)
+    {
+        // These two are positive measurements of a condition that WILL kill a starting build.
+        Assert.NotNull(DisplayAvailability.DescribeObstacle(readiness));
+    }
+
+    [Theory]
+    [InlineData(DisplayReadiness.Ready)]
+    [InlineData(DisplayReadiness.Unknown)]
+    public void ADisplayThatIsFine_OrAnAnswerNobodyHas_NeverHoldsAnUpdate(DisplayReadiness readiness)
+    {
+        // Unknown is every non-Mac platform, and a Mac whose window server will not answer. Treating it
+        // as a problem would stop updates on Windows and Linux outright, and would let a broken probe
+        // quietly freeze a whole fleet - a far worse failure than the one being fixed.
+        Assert.Null(DisplayAvailability.DescribeObstacle(readiness));
+    }
+
+    [Fact]
+    public void EveryReadiness_HasAnAnswer_AndTheObstacleNamesTheDisplay()
+    {
+        foreach (var readiness in Enum.GetValues<DisplayReadiness>())
+        {
+            var obstacle = DisplayAvailability.DescribeObstacle(readiness);
+            if (obstacle is null) continue;
+
+            Assert.Contains("display", obstacle, StringComparison.OrdinalIgnoreCase);
+            Assert.False(string.IsNullOrWhiteSpace(obstacle));
+        }
+    }
+
+    [Fact]
+    public void OffMacOS_TheProbeReportsThatItDoesNotKnow()
+    {
+        // The probe is CoreGraphics, so there is nothing to ask anywhere else. It must say so rather
+        // than guessing, and it must never throw: it runs inside the launcher's background loop.
+        if (OperatingSystem.IsMacOS())
+            return;
+
+        Assert.Equal(DisplayReadiness.Unknown, DisplayAvailability.Check());
+    }
+
+    [Fact]
+    public void OnMacOS_TheProbeAnswersWithoutThrowing()
+    {
+        if (!OperatingSystem.IsMacOS())
+            return;
+
+        // Which answer depends on whether the machine running this has a screen awake, so the assertion
+        // is on the contract rather than the value: it returns, and it returns something meaningful.
+        var readiness = DisplayAvailability.Check();
+        Assert.True(Enum.IsDefined(readiness));
+    }
+
+    [Fact]
+    public void OffMacOS_WakingIsNotEvenAttempted()
+    {
+        // Deliberately NOT run on macOS. Wake turns a real screen on, and a test suite that lights up
+        // the machine it runs on is a test suite people stop running. The macOS path is verified by
+        // hand against a sleeping display; see the pull request for that run.
+        if (OperatingSystem.IsMacOS())
+            return;
+
+        // Everywhere else the probe reports Unknown, and Wake must hand that back untouched rather than
+        // shelling out to a tool that is not there.
+        Assert.Equal(DisplayReadiness.Unknown, DisplayAvailability.Wake());
+    }
+}

--- a/src/CcDirector.Core.Tests/Update/PinnedBadVersionTests.cs
+++ b/src/CcDirector.Core.Tests/Update/PinnedBadVersionTests.cs
@@ -1,0 +1,93 @@
+using CcDirector.Core.Update;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Update;
+
+/// <summary>
+/// The pin: a permanent, unattended judgement that a build will not start.
+///
+/// Two things were wrong with it and both cost real time on the owner's Mac in September 2026. Nothing
+/// in the product ever removed a pin, although the field's own documentation said a newer version
+/// cleared it - so a wrong judgement lasted for ever and the only cure was deleting the state file by
+/// hand. And the staging check never consulted the pin at all, so the pinned build was re-downloaded on
+/// every cycle and thrown away at install time: roughly a hundred megabytes an hour, for five days.
+/// </summary>
+public class PinnedBadVersionTests
+{
+    private static Version V(string text) => Version.Parse(text);
+
+    [Fact]
+    public void APinnedBuild_IsNotDownloadedAgain()
+    {
+        var state = new UpdaterState { PinnedBadVersion = "2.0.5" };
+
+        // Both owners refuse a pinned build at install time, so fetching it is a hundred megabytes spent
+        // to reach a refusal that is already certain.
+        Assert.False(UpdateService.ShouldStage(current: V("2.0.4"), latest: V("2.0.5"), state));
+    }
+
+    [Fact]
+    public void ABuildNewerThanThePin_IsStillOffered()
+    {
+        var state = new UpdaterState { PinnedBadVersion = "2.0.5" };
+
+        Assert.True(UpdateService.ShouldStage(current: V("2.0.4"), latest: V("2.0.7"), state));
+    }
+
+    [Fact]
+    public void AReleaseNewerThanThePin_ClearsIt()
+    {
+        // The owner's Mac: 2.0.5 pinned on 3 September, 2.0.7 published, and the pin still sat in the
+        // file afterwards because nothing had ever been written to remove one.
+        var state = new UpdaterState { PinnedBadVersion = "2.0.5" };
+
+        UpdateService.ClearPinIfSuperseded(state, V("2.0.7"));
+
+        Assert.Null(state.PinnedBadVersion);
+    }
+
+    [Theory]
+    [InlineData("2.0.5")]   // the same build: the judgement is still about this exact thing
+    [InlineData("2.0.6")]   // newer than the pin, so it clears - guarded by the assertion below
+    public void ThePinSurvivesUntilSomethingStrictlyNewerArrives(string latest)
+    {
+        var state = new UpdaterState { PinnedBadVersion = "2.0.5" };
+
+        UpdateService.ClearPinIfSuperseded(state, V(latest));
+
+        if (Version.Parse(latest) > Version.Parse("2.0.5"))
+            Assert.Null(state.PinnedBadVersion);
+        else
+            Assert.Equal("2.0.5", state.PinnedBadVersion);
+    }
+
+    [Fact]
+    public void AnOlderReleaseNeverClearsThePin()
+    {
+        var state = new UpdaterState { PinnedBadVersion = "2.0.5" };
+
+        UpdateService.ClearPinIfSuperseded(state, V("2.0.4"));
+
+        Assert.Equal("2.0.5", state.PinnedBadVersion);
+    }
+
+    [Fact]
+    public void APinNobodyCanRead_IsLeftAlone_RatherThanGuessedAt()
+    {
+        var state = new UpdaterState { PinnedBadVersion = "not-a-version" };
+
+        UpdateService.ClearPinIfSuperseded(state, V("9.9.9"));
+
+        Assert.Equal("not-a-version", state.PinnedBadVersion);
+    }
+
+    [Fact]
+    public void WithNoPin_NothingHappens()
+    {
+        var state = new UpdaterState();
+
+        UpdateService.ClearPinIfSuperseded(state, V("2.0.7"));
+
+        Assert.Null(state.PinnedBadVersion);
+    }
+}

--- a/src/CcDirector.Core.Tests/Update/UpdateStatusFoldTests.cs
+++ b/src/CcDirector.Core.Tests/Update/UpdateStatusFoldTests.cs
@@ -213,6 +213,47 @@ public class UpdateStatusFoldTests
     }
 
     [Fact]
+    public void AnUpdateHeldBecauseNoDisplayIsAwake_SaysThat_AndOffersNothingThatWouldFail()
+    {
+        // The Mac case. The launcher will not start a Director against a sleeping screen, because the
+        // build would die before its first window and be blamed for it. That is a wait, not a fault, and
+        // the person reading it can end the wait by touching the keyboard - so it has to be said.
+        var view = UpdateStatusFold.Fold(Facts(new UpdaterState
+        {
+            StagedVersion = "2.0.7",
+            LastApplyVersion = "2.0.7",
+            LastApplyDecision = "HeldBecauseNoDisplay",
+            LastApplyDecisionAt = Now.AddMinutes(-10),
+        }));
+
+        Assert.Equal("StagedWaitingForDisplay", view.State);
+        Assert.Contains("display", view.Detail, StringComparison.OrdinalIgnoreCase);
+
+        // Offering it would offer the very thing that is being waited out. A dumb client must never be
+        // handed a button whose only outcome is the failure the hold exists to avoid.
+        Assert.False(view.CanInstallNow);
+        Assert.Null(view.InstallNowLabel);
+    }
+
+    [Fact]
+    public void RunningSessionsStillOutrankASleepingDisplay()
+    {
+        // Both are true at once on a busy machine at night. The sessions message is the one the person
+        // can act on and the one that promises no work is interrupted, so it stays on top.
+        var view = UpdateStatusFold.Fold(Facts(
+            new UpdaterState
+            {
+                StagedVersion = "2.0.7",
+                LastApplyVersion = "2.0.7",
+                LastApplyDecision = "HeldBecauseNoDisplay",
+                LastApplyDecisionAt = Now.AddMinutes(-10),
+            },
+            sessions: 2));
+
+        Assert.Equal("StagedWaitingForSessions", view.State);
+    }
+
+    [Fact]
     public void ALauncherDecisionAboutADifferentVersion_IsNotReadAsBeingAboutThisDownload()
     {
         // A "held because busy" left over from an earlier download would otherwise describe a build that

--- a/src/CcDirector.Core/Update/DisplayAvailability.cs
+++ b/src/CcDirector.Core/Update/DisplayAvailability.cs
@@ -1,0 +1,184 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Update;
+
+/// <summary>Whether this machine can start a windowed application right now.</summary>
+public enum DisplayReadiness
+{
+    /// <summary>
+    /// Nothing here can tell. Every platform except macOS answers this way, and so does macOS when the
+    /// window server cannot be asked. It means "carry on", never "wait" - see <see cref="DisplayAvailability"/>
+    /// for why only a measured negative is allowed to stop anything.
+    /// </summary>
+    Unknown,
+
+    /// <summary>At least one display is attached and drawable. A windowed application can start.</summary>
+    Ready,
+
+    /// <summary>A display is attached but none is drawable - it is asleep. A windowed application will die on start.</summary>
+    Asleep,
+
+    /// <summary>No display is attached at all. Waking cannot help; there is nothing to wake.</summary>
+    None,
+}
+
+/// <summary>
+/// Can a windowed application start on this machine at this instant, and if not, can that be fixed?
+///
+/// THIS EXISTS BECAUSE OF ONE NIGHT. On 2026-09-03 at 1:57 in the morning the launcher installed
+/// version 2.0.5 on the owner's Mac, started it, and watched it die. It condemned the build, restored
+/// the previous one, and pinned 2.0.5 so it could never be offered again. The machine sat five days on
+/// a superseded build. Version 2.0.5 was perfectly good. What actually happened is this:
+///
+///   Avalonia's macOS render loop is a CoreVideo display link, created with
+///   CVDisplayLinkCreateWithActiveCGDisplays. With no ACTIVE display that call returns -6661,
+///   kCVReturnInvalidArgument, and Avalonia has no fallback, so the failure is fatal before the
+///   application reaches its first window.
+///
+/// The condition is a SLEEPING DISPLAY, not a locked screen. We had previously written the lock down as
+/// the cause and mitigated it by never letting the machine lock, which does not help at all: Avalonia
+/// never asks whether the session is unlocked, it asks CoreGraphics for a drawable display. The same
+/// setup script then set the display to sleep after ten minutes and called that harmless. It is not
+/// harmless. It is sufficient, on its own, to make every unattended restart fail.
+///
+/// So this asks the machine the question the render loop is about to ask, using the same family of API
+/// the render loop itself depends on, and offers the one remedy macOS provides for it.
+///
+/// WHY ONLY A MEASURED NEGATIVE STOPS ANYTHING. An update that is held because a check could not run is
+/// an update that never happens, and a machine that silently stops updating is the failure this whole
+/// area already suffered from once. So <see cref="DisplayReadiness.Unknown"/> - every non-Mac platform,
+/// and a Mac whose window server will not answer - means carry on exactly as before. Only
+/// <see cref="DisplayReadiness.Asleep"/> and <see cref="DisplayReadiness.None"/>, which are positive
+/// measurements of a condition that WILL kill the new build, are allowed to hold an update back.
+/// </summary>
+public static class DisplayAvailability
+{
+    private const string CoreGraphics = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics";
+
+    // Passing a null list with a maximum of zero is the documented way to ask only for the count.
+    // "Active" means attached, awake and drawable; "online" includes displays that are merely asleep,
+    // which is exactly the difference between "wake it" and "there is nothing to wake".
+    [DllImport(CoreGraphics)]
+    private static extern int CGGetActiveDisplayList(uint maxDisplays, uint[]? activeDisplays, out uint displayCount);
+
+    [DllImport(CoreGraphics)]
+    private static extern int CGGetOnlineDisplayList(uint maxDisplays, uint[]? onlineDisplays, out uint displayCount);
+
+    /// <summary>How long the display is asked to stay awake once woken. Comfortably longer than a swap,
+    /// a start and the health wait that follows it, so the display cannot go dark mid-update.</summary>
+    public static readonly TimeSpan WakeDuration = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Ask the window server what is drawable right now. Never throws: an instrument that cannot be read
+    /// reports <see cref="DisplayReadiness.Unknown"/>, which changes no behaviour.
+    /// </summary>
+    public static DisplayReadiness Check()
+    {
+        if (!OperatingSystem.IsMacOS())
+            return DisplayReadiness.Unknown;
+
+        try
+        {
+            if (CGGetActiveDisplayList(0, null, out var active) != 0)
+                return DisplayReadiness.Unknown;
+            if (active > 0)
+                return DisplayReadiness.Ready;
+
+            if (CGGetOnlineDisplayList(0, null, out var online) != 0)
+                return DisplayReadiness.Unknown;
+
+            return online > 0 ? DisplayReadiness.Asleep : DisplayReadiness.None;
+        }
+        catch (Exception ex)
+        {
+            // The boundary of a native call, and the only place a caught exception is right: this is an
+            // instrument reading, and a broken instrument must report that it does not know rather than
+            // take an update loop down with it.
+            FileLog.Write($"[DisplayAvailability] Check FAILED (reporting Unknown): {ex.Message}");
+            return DisplayReadiness.Unknown;
+        }
+    }
+
+    /// <summary>
+    /// Turn the display on and hold it on for <see cref="WakeDuration"/>, then confirm it actually came
+    /// up. Returns the readiness AFTER the attempt, so a caller never has to believe this worked.
+    ///
+    /// The remedy is macOS's own: caffeinate's user-activity assertion is documented to turn the display
+    /// on when it is off and to postpone display sleep. It is the same thing that happens when somebody
+    /// touches the keyboard, which is precisely the event this machine was missing at 1:57 in the
+    /// morning.
+    /// </summary>
+    public static DisplayReadiness Wake()
+    {
+        var before = Check();
+        if (before != DisplayReadiness.Asleep)
+        {
+            // Ready needs nothing, None cannot be helped, and Unknown must not be acted on.
+            FileLog.Write($"[DisplayAvailability] Wake: nothing to do, readiness={before}");
+            return before;
+        }
+
+        FileLog.Write($"[DisplayAvailability] Wake: display asleep; declaring user activity for {WakeDuration.TotalSeconds:F0}s");
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "/usr/bin/caffeinate",
+                UseShellExecute = false,
+            };
+            psi.ArgumentList.Add("-u");
+            psi.ArgumentList.Add("-t");
+            psi.ArgumentList.Add(((int)WakeDuration.TotalSeconds).ToString());
+
+            // Deliberately NOT waited on. caffeinate holds the assertion for as long as it runs, so
+            // waiting for it would wait out the whole window it exists to open.
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                FileLog.Write("[DisplayAvailability] Wake FAILED: caffeinate did not start");
+                return before;
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DisplayAvailability] Wake FAILED: {ex.Message}");
+            return before;
+        }
+
+        // Waking is not instant, and the answer that matters is the one after it has happened. Poll for a
+        // few seconds rather than sleeping a fixed time and hoping.
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var now = Check();
+            if (now == DisplayReadiness.Ready)
+            {
+                FileLog.Write("[DisplayAvailability] Wake: display is awake and drawable");
+                return now;
+            }
+
+            Thread.Sleep(500);
+        }
+
+        var after = Check();
+        FileLog.Write($"[DisplayAvailability] Wake: display did not come up within 10s, readiness={after}");
+        return after;
+    }
+
+    /// <summary>
+    /// One plain sentence about why a windowed application cannot start, for the person reading a status
+    /// panel. Null when nothing is wrong, so a caller cannot accidentally report a problem that is not
+    /// there.
+    /// </summary>
+    public static string? DescribeObstacle(DisplayReadiness readiness) => readiness switch
+    {
+        DisplayReadiness.Asleep =>
+            "this machine's display is asleep, and a Director cannot start without one - macOS gives a "
+            + "starting application no render loop when no display is drawable",
+        DisplayReadiness.None =>
+            "no display is attached to this machine, and a Director cannot start without one",
+        _ => null,
+    };
+}

--- a/src/CcDirector.Core/Update/UpdateService.cs
+++ b/src/CcDirector.Core/Update/UpdateService.cs
@@ -180,6 +180,8 @@ public sealed class UpdateService
 
             var versionText = $"{latest.Major}.{latest.Minor}.{Math.Max(latest.Build, 0)}";
 
+            ClearPinIfSuperseded(state, latest);
+
             if (!ShouldStage(_options.CurrentVersion, latest, state))
             {
                 FileLog.Write($"[UpdateService] Up to date or dismissed (latest={latest}, dismissed={state.DismissedVersion}).");
@@ -380,7 +382,10 @@ public sealed class UpdateService
         return Version.TryParse(t, out var v) ? Normalize(v) : null;
     }
 
-    /// <summary>True when <paramref name="latest"/> is newer than <paramref name="current"/> and not dismissed.</summary>
+    /// <summary>
+    /// True when <paramref name="latest"/> is newer than <paramref name="current"/>, not dismissed, and
+    /// not a build already pinned as one that would not start.
+    /// </summary>
     public static bool ShouldStage(Version current, Version latest, UpdaterState state)
     {
         var cur = Normalize(current);
@@ -388,7 +393,38 @@ public sealed class UpdateService
         if (lat <= cur) return false;
         if (state.DismissedVersion is { } d && Version.TryParse(d, out var dv) && Normalize(dv) == lat)
             return false;
+
+        // A pinned build will be refused at install time by both owners, so downloading it again is a
+        // hundred megabytes fetched to be thrown away. This test was missing, and the install-time refusal
+        // clears the staged record, so the very next check downloaded it once more: version 2.0.5 was
+        // fetched roughly hourly for five days and discarded every time.
+        if (state.PinnedBadVersion is { } p && Version.TryParse(p, out var pv) && Normalize(pv) == lat)
+            return false;
+
         return true;
+    }
+
+    /// <summary>
+    /// Drop a pin once the project has moved past the build it names, which is what
+    /// <see cref="UpdaterState.PinnedBadVersion"/> has always documented and nothing has ever done.
+    ///
+    /// A pin is a permanent judgement written from a single failed start, and until now NOTHING in the
+    /// product ever removed one - the field was set and never cleared, and the only cure was deleting the
+    /// state file by hand. It survived because a newer version simply fails the string comparison and
+    /// slips past, so the stale judgement sat in the file for ever and kept a machine re-downloading a
+    /// build it would never install. A release newer than the pinned build settles the question: whatever
+    /// was wrong then is not what this machine is being offered now.
+    /// </summary>
+    public static void ClearPinIfSuperseded(UpdaterState state, Version latest)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        if (state.PinnedBadVersion is not { } pinned) return;
+        if (!Version.TryParse(pinned, out var pinnedVersion)) return;
+        if (Normalize(latest) <= Normalize(pinnedVersion)) return;
+
+        FileLog.Write($"[UpdateService] {latest} is newer than the pinned bad build {pinned}; clearing the pin.");
+        state.PinnedBadVersion = null;
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Update/UpdateStatusFold.cs
+++ b/src/CcDirector.Core/Update/UpdateStatusFold.cs
@@ -204,6 +204,25 @@ public static class UpdateStatusFold
                     CanInstallNow: false, InstallNowLabel: null);
             }
 
+            // The machine cannot draw, so it cannot start a Director. Said plainly, because the version
+            // number simply not moving is what made this whole area untrustworthy, and because the person
+            // reading it can fix this one in a second by touching the keyboard.
+            if (decision == "HeldBecauseNoDisplay")
+                return new UpdateStatusView(
+                    State: "StagedWaitingForDisplay",
+                    Headline: "UPDATE WAITING",
+                    Detail: $"v{staged} downloaded - waiting for a display to be awake",
+                    Tooltip: $"v{staged} is downloaded and verified. It has not been installed because this machine "
+                             + "had no display awake when the launcher last looked, and a Director cannot start "
+                             + "without one - it would die before its first window and be blamed for it. Nothing is "
+                             + "wrong with the update and it has not been pinned. Waking the screen is enough; the "
+                             + "next pass installs it.",
+                    Accent: WarnAccent, Background: WarnBackground, Border: WarnBorder,
+                    Icon: "check", Busy: false, PercentComplete: null,
+                    CanCheckNow: false, CheckNowLabel: null,
+                    // Deliberately NOT offered: it would fail in exactly the way that is being waited out.
+                    CanInstallNow: false, InstallNowLabel: null);
+
             if (decision == "HeldBecauseUnknown")
             {
                 return new UpdateStatusView(

--- a/src/CcDirector.Launcher.Tests/DirectorUpdateOwnerTests.cs
+++ b/src/CcDirector.Launcher.Tests/DirectorUpdateOwnerTests.cs
@@ -164,6 +164,34 @@ public class DirectorUpdateOwnerTests
         }
     }
 
+    // ---- Whether a build that did not start may be blamed for it -----------
+
+    [Fact]
+    public void ShouldPinFailedBuild_TheRestoredBuildCameUp_True()
+    {
+        // The machine has just demonstrated it can run a Director. So the one that would not run is the
+        // thing at fault, and pinning it is a true judgement about a build.
+        Assert.True(DirectorUpdateOwner.ShouldPinFailedBuild(restoredBuildAnswered: true));
+    }
+
+    [Fact]
+    public void ShouldPinFailedBuild_TheRestoredBuildDidNotComeUpEither_False()
+    {
+        // The owner's Mac, 2026-09-03 at 1:57 in the morning. The display was asleep, so macOS gave a
+        // starting Director no render loop and NOTHING could have come up. The launcher wrote down
+        // "restored build answering=not yet" and pinned version 2.0.5 anyway. The machine then sat five
+        // days on 2.0.4 for a fault that was never in the build.
+        Assert.False(DirectorUpdateOwner.ShouldPinFailedBuild(restoredBuildAnswered: false));
+    }
+
+    [Fact]
+    public void ShouldPinFailedBuild_NothingWasLearned_False()
+    {
+        // No roll back happened, or there was no backup to restore. Either way nothing was established
+        // about the build, and an absence of evidence must not become a permanent verdict.
+        Assert.False(DirectorUpdateOwner.ShouldPinFailedBuild(restoredBuildAnswered: null));
+    }
+
     [Fact]
     public void Record_OnAnUnwritableFile_StillReturnsTheDecision()
     {

--- a/src/CcDirector.Launcher/DirectorUpdateOwner.cs
+++ b/src/CcDirector.Launcher/DirectorUpdateOwner.cs
@@ -33,6 +33,12 @@ public enum DirectorUpdateDecision
     HeldBecauseAnotherSwapIsRunning,
     /// <summary>An update is staged but the Director is not running, and it is not this loop's business to start one.</summary>
     HeldBecauseDirectorNotRunning,
+    /// <summary>
+    /// An update is staged, but this machine cannot start a windowed application right now - on macOS,
+    /// no display is drawable, so the new build would die before its first window and be blamed for it.
+    /// Nothing was touched. See <see cref="DisplayAvailability"/>.
+    /// </summary>
+    HeldBecauseNoDisplay,
     /// <summary>The staged update is one that already failed to start and was pinned away from.</summary>
     SkippedPinnedBadVersion,
     /// <summary>The update was applied and the new version answered.</summary>
@@ -120,6 +126,20 @@ public sealed class DirectorUpdateOwner
     /// </remarks>
     public static bool ShouldApply(bool hasStagedUpdate, int runningSessionCount)
         => UpdateApplyRule.ShouldApply(hasStagedUpdate, runningSessionCount);
+
+    /// <summary>
+    /// May a build that did not come up be blamed for it, and pinned so it is never offered again?
+    ///
+    /// Only on positive evidence that this machine can run a Director at all - the restored build coming
+    /// up. Pinning is permanent and unattended, so the question it answers has to be "is the BUILD bad",
+    /// not "did the start fail", and those are different questions whenever the machine itself is the
+    /// reason nothing started.
+    /// </summary>
+    /// <param name="restoredBuildAnswered">
+    /// Whether the previous build answered after the roll back. Null when no roll back happened or
+    /// nothing could be restored - an absence of evidence, which is not evidence against the build.
+    /// </param>
+    public static bool ShouldPinFailedBuild(bool? restoredBuildAnswered) => restoredBuildAnswered == true;
 
     /// <summary>
     /// One pass of the launcher's ownership: look for a staged Director update, and install it if the
@@ -248,6 +268,24 @@ public sealed class DirectorUpdateOwner
                 conflictNote + $"{sessions} session(s) were running, so the update waits rather than interrupting them.");
         }
 
+        // A WINDOWED APPLICATION NEEDS A DISPLAY, AND MAY NOT BE BLAMED FOR NOT HAVING ONE.
+        //
+        // On macOS a Director started with no drawable display dies before its first window: Avalonia's
+        // render loop is a CoreVideo display link, and creating one with no active display fails. That is
+        // what happened at 1:57 in the morning on 2026-09-03 - a good build was started against a
+        // sleeping screen, could not come up, and was pinned as bad for five days.
+        //
+        // So try the remedy macOS offers, and if the machine still cannot draw, HOLD. Holding is the
+        // honest answer: nothing is wrong with the update, and the next pass will find a machine somebody
+        // has walked up to. Every other platform reports Unknown here and is unaffected.
+        var readiness = DisplayAvailability.Wake();
+        if (DisplayAvailability.DescribeObstacle(readiness) is { } obstacle)
+        {
+            FileLog.Write($"[DirectorUpdateOwner] {staged.Version} is staged but {obstacle}; holding it. "
+                          + "The build is not at fault and is NOT pinned.");
+            return Record(staged, DirectorUpdateDecision.HeldBecauseNoDisplay, conflictNote + obstacle + ".");
+        }
+
         FileLog.Write($"[DirectorUpdateOwner] installing {staged.Version}: staged={staged.StagedBuild}, "
                       + $"target={staged.InstallTarget}, sessions=0, currentVersion="
                       + $"{(status.Version.Length > 0 ? status.Version : "unknown")}");
@@ -298,10 +336,29 @@ public sealed class DirectorUpdateOwner
         if (result.Outcome == SelfUpdateOutcome.Updated)
             return Record(staged, DirectorUpdateDecision.Applied, conflictNote + result.Message);
 
-        // The build did not come up. Pin it so neither the launcher nor the Director tries it again when
-        // it is offered a second time - the Director re-downloads on its own schedule and would
-        // otherwise present the same dead build every hour, for ever.
-        PinBadVersion(staged);
+        // The build did not come up. Whether that is the BUILD's fault is a separate question, and
+        // pinning answers it permanently - nothing ever unpins a version, so a wrong answer here costs a
+        // machine every future release of that build.
+        //
+        // The rollback already establishes it. If the restored build came up, this machine can plainly
+        // run a Director, so the one that would not is at fault: pin it. If the restored build did not
+        // come up EITHER, then nothing could start here just now, and blaming the new build is blaming it
+        // for the weather. That is exactly what happened on 2026-09-03: the log recorded "restored build
+        // answering=not yet" and pinned 2.0.5 regardless, and the machine sat five days on 2.0.4.
+        //
+        // A rollback that could not restore anything reports null, and null is not evidence about the
+        // build, so it does not pin either.
+        if (ShouldPinFailedBuild(result.RestoredBuildAnswered))
+        {
+            PinBadVersion(staged);
+        }
+        else
+        {
+            FileLog.Write($"[DirectorUpdateOwner] {staged.Version} did not come up, and the restored build did not "
+                          + "come up either - this machine could not start ANY Director just now, so the build is "
+                          + "NOT pinned and will be offered again.");
+        }
+
         return Record(staged,
             result.Outcome == SelfUpdateOutcome.RolledBack
                 ? DirectorUpdateDecision.RolledBack

--- a/tools/cc-director-setup-engine/DirectorUpdateApply.cs
+++ b/tools/cc-director-setup-engine/DirectorUpdateApply.cs
@@ -153,7 +153,8 @@ public sealed class DirectorUpdateApply
             SelfUpdateOutcome.RolledBack,
             $"Director update to {newVersion} failed to come up and was rolled back "
             + $"(restored build answering={afterRollback ?? "not yet"}).",
-            steps);
+            steps,
+            RestoredBuildAnswered: afterRollback is not null);
     }
 
     /// <summary>

--- a/tools/cc-director-setup-engine/GatewaySelfUpdate.cs
+++ b/tools/cc-director-setup-engine/GatewaySelfUpdate.cs
@@ -4,7 +4,19 @@ namespace CcDirector.Setup.Engine;
 public enum SelfUpdateOutcome { Updated, RolledBack, Failed }
 
 /// <summary>Result of a Gateway self-update, with the ordered steps taken (for logs).</summary>
-public sealed record SelfUpdateResult(SelfUpdateOutcome Outcome, string Message, IReadOnlyList<string> Steps);
+/// <param name="RestoredBuildAnswered">
+/// After a roll back, whether the RESTORED build came up and answered. Null when no roll back happened.
+///
+/// This is the difference between "the new build is bad" and "this machine could not start anything",
+/// and it decides whether a version is pinned as bad. It was already being measured and written into
+/// the message text, where nothing could act on it: on 2026-09-03 the restored build did not answer
+/// either - proof that the machine, not the build, was at fault - and version 2.0.5 was pinned anyway.
+/// </param>
+public sealed record SelfUpdateResult(
+    SelfUpdateOutcome Outcome,
+    string Message,
+    IReadOnlyList<string> Steps,
+    bool? RestoredBuildAnswered = null);
 
 /// <summary>
 /// Orchestrates the Gateway tray app replacing its own (file-locked) exe: stop -> swap -> relaunch ->


### PR DESCRIPTION
## What broke

On 2026-09-03 at 1:57 in the morning the launcher installed version 2.0.5 on a Mac, watched it fail to start, rolled back, and pinned 2.0.5 as a bad build. The build was fine. The display was asleep.

```
System.InvalidOperationException: Avalonia.Native was not able to start the
RenderTimer. Native error code is: -6661
   at Avalonia.Native.AvaloniaNativePlatform.Initialize(...)
   at CcDirector.Avalonia.Program.Main(String[] args)
```

Avalonia's macOS render loop is a CoreVideo display link, created with `CVDisplayLinkCreateWithActiveCGDisplays`. With no **active** display that call fails and Avalonia has no fallback, so a starting Director dies before its first window. An already-running one is unaffected. Only a start fails. Error `-6661` is `kCVReturnInvalidArgument`, confirmed against the CoreVideo header in the installed software development kit.

**The condition is a sleeping display, not a locked screen.** We previously wrote the lock down as the cause and mitigated it by never letting the machine lock. That does not help. Avalonia never asks whether the session is unlocked; it asks CoreGraphics for a drawable display. The same setup script then set the display to sleep after ten minutes and annotated the line "harmless".

The cost: the machine sat five days on a superseded build, re-downloading the pinned one roughly hourly and discarding it every time.

## The changes

**1. Ask before starting, and wake what can be woken.** A new `DisplayAvailability` puts to CoreGraphics the question the render loop is about to ask, and offers the remedy macOS provides: caffeinate's user-activity assertion, which is documented to turn the display on. Only a *measured* absence of a display holds an update. Every other platform, and a Mac whose window server will not answer, reports `Unknown` and behaves exactly as before. An update held by a check that could not run is an update that silently never happens, which is the failure this area already had once.

**2. Hold rather than fail.** A staged update meets a new decision, `HeldBecauseNoDisplay`, and the status fold says so in words the reader can act on by touching the keyboard. The install action is deliberately not offered, since taking it would produce the failure being waited out.

**3. Never pin a build on evidence that condemns the machine.** The rollback already establishes whether this machine can run a Director at all. If the restored build comes up, the new one is at fault. If it does not come up either, nothing could start just now. That fact was measured, written into a message string, and ignored. On 3 September the log recorded `restored build answering=not yet` and pinned the version regardless.

**4. Let a pin end.** Nothing had ever cleared one, although the field's own documentation said a newer version did, so a wrong judgement lasted forever and the only cure was deleting the state file by hand. A newer release now clears it, and the staging check consults the pin so a refused build is not fetched again.

**5. Stop the rollback breaking itself on macOS.** Three startup notices called `MessageBoxW` directly. It is a user32 import, so off Windows it throws, and one of the three threw *before* the relaunch that follows it. A rollback on a Mac restored the previous build and then never started it, leaving the machine with no Director at all. All three now use the guarded helper that sits in the same file explaining why they must.

## Proof, against the real condition

Run on the Mac that failed, with the display put to sleep exactly as the setup script's own verification note describes.

```
PRE-RUN  online: 1  active: 0
readiness BEFORE : Asleep
obstacle  BEFORE : this machine's display is asleep, and a Director cannot
                   start without one - macOS gives a starting application no
                   render loop when no display is drawable
calling Wake() ...
readiness AFTER  : Ready
obstacle  AFTER  : (none)
update would be  : APPLIED
POST-RUN online: 1  active: 1
```

Twelve tests added. The core update suite passes at 125.

| Suite | Result |
|---|---|
| CcDirector.Core.Tests, update | 125 passed, 0 failed |
| CcDirector.Launcher.Tests | 178 passed, 13 failed |
| Setup engine tests | 21 failed |

The launcher and setup engine failures are pre-existing on macOS. Both failing sets were compared against an untouched tree and are identical, so none are introduced here.

## What this does not cover

- **A Director still cannot start without a display.** This stops good builds being condemned and stops updates being attempted into the dark, but a Mac whose screen is off now waits rather than updating. Teaching the Director to come up without a display, as the launcher already does in `Program.cs:63-80`, is the separate and larger piece of work.
- **The macOS wake path is verified by hand, not by the suite.** A test that turns the machine's screen on is a test people stop running, so it is skipped on macOS and the manual run above stands in its place.
- **Linux still has no self-update at all.** `UpdateService.AssetNameFor` recognizes only Windows on Intel and Mac on Apple silicon, so a Linux Director reports up to date forever without checking. A Linux build ships with every release and nothing consumes it. Out of scope here and worth its own issue.
