### PR TITLE
release: v2.1.0 - the Mac update stops blaming good builds, and a Director can be drained before a restart

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>2.0.7</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
   <!--
     THE MUTATION-PROOF PIN GUARD, linked into every test assembly in the repository.

--- a/docs/public/release-notes/v2.1.0.md
+++ b/docs/public/release-notes/v2.1.0.md
@@ -1,0 +1,96 @@
+# DevThrottle v2.1.0
+
+A release about closing a Director safely and about updates that stop blaming good builds. It also
+moves your saved workspaces onto the Gateway, which changes what a Director without a Gateway can do.
+
+## An update no longer condemns a build because the screen was dark
+
+On a Mac, a Director that is starting needs a display that is awake. Its window layer asks macOS for
+a display to draw on, and when every display is asleep there is nothing to give it, so the new build
+dies before its first window appears. A Director that is already running is unaffected. Only a start
+fails.
+
+Until now the launcher could not tell that apart from a broken build. It would install an update in
+the middle of the night, watch it fail to start, put the previous version back, and mark the new
+version as bad so it was never offered again. One machine lost five days that way to a release that
+was perfectly good, and re-downloaded the release it had blacklisted roughly every hour for the whole
+five days.
+
+Three things change:
+
+- **The display is woken before an update is installed**, the same way it wakes when you touch the
+  keyboard. If it cannot be woken, the update waits for a moment when the machine can actually start
+  a Director, and says so on the update panel, instead of failing.
+- **A build is only blamed when the machine proves it can run one.** After putting the previous
+  version back, the launcher checks whether that one came up. If it did not come up either, then
+  nothing could have started just then, and the new version is left alone rather than blacklisted.
+- **A blacklisted version is forgotten once a newer one arrives**, and it is no longer downloaded
+  over and over in the meantime. Nothing in the product had ever cleared one of these marks before,
+  so a single bad night lasted forever.
+
+If you run a Mac unattended, the setup script now keeps the display awake rather than letting it
+sleep after ten minutes. The old setting was recorded as harmless. It was not.
+
+## A rolled back update stops being reported once the machine has moved on
+
+The update panel would show a red "update rolled back" long after the machine had recovered, because
+the record was never cleared by the update that later succeeded. It also named the wrong version as
+the one that had been put back. A failure is now reported only while the machine is still on an older
+build because of it, and once the machine has moved past that version it becomes a line of history
+rather than a red panel.
+
+## Close a Director safely before restarting it
+
+There is a new item in the Director's File menu: **Drain this Director for restart**. It asks every
+session on that computer to write a handover and close in a safe order, sweeps any secrets out of what
+was written, and reports back per seat, with anything still waiting on you called out. At the end it
+says plainly whether the machine is safe to restart.
+
+This needs a Gateway connection, because the handovers are stored there. The restart itself is not
+done from this screen, and neither is bringing the sessions back afterwards. The screen prints the
+request you would make. Treat this as the first half of the job, landed and usable on its own.
+
+## Your saved workspaces now live on the Gateway
+
+**Save Workspace** and **Load Workspace** work as before, but a workspace is now stored on your
+Gateway rather than on the machine that saved it. Workspaces survive the machine and can be opened
+from another computer. Existing local workspaces are imported the first time the new version runs.
+
+**Read this if you run a Director with no Gateway.** Saving and loading workspaces now requires a
+Gateway connection, and a Director without one will refuse both and tell you why. That is a change
+from the previous version, where workspaces were kept on local disk.
+
+## Dictation no longer delivers the same recording twice
+
+A dictated clip whose delivery record could not be read could be re-opened and injected into a session
+a second time. The server now refuses that, and the phone and cockpit say which of the two problems
+happened rather than showing one generic message: a record that could not be read just now and will be
+retried, or a damaged one that needs a person.
+
+## Also in this release
+
+- A second copy of DevThrottle started by accident can no longer run update or rollback work over the
+  copy already running your sessions.
+- An automatic update now declines to run on a machine whose Director registration cannot be read,
+  instead of installing over a session that was still live.
+- On a Mac, a rollback no longer fails part way through. The notice it tried to show was a Windows-only
+  call, and it stopped the rollback before the restored version was started, which could leave the
+  machine with no Director running at all.
+- You can ask, from the command line, whether a given computer is able to stop and start its Director
+  before you close anything: `cc-devthrottle machine restart-capability <machine>`.
+- A new script brings a Mac's launcher up to a release and confirms it took effect. Worth knowing about
+  because on a Mac the launcher does not update itself, so it can fall a long way behind the Director
+  while everything looks healthy.
+
+## Known limitations
+
+- **On a Mac and on Linux the launcher still does not update itself.** The Director installing the
+  launcher's update, described in the previous release, is Windows-only. On the other platforms that
+  check looks for a Windows file that is never there, so the launcher stays on whatever version the
+  installer left. Use the script above, or run the installer, until this is fixed.
+- **Asking for a Director restart from a session is not usable yet.** The parts are in place and the
+  command exists, but the machine reports that this build carries no drain, so the request is refused
+  and no approval ever appears. The drain screen described above is the part that works today.
+- **A Director cannot start on a Mac with no display awake.** This release stops good builds being
+  blamed for that and stops updates being attempted into the dark, but a Mac whose screen is off now
+  waits rather than updating.


### PR DESCRIPTION
Raises the product version to 2.1.0 and adds the public release notes.

## Why a minor bump rather than a patch

There is a new item in the Director's File menu that drains a Director to safe handovers, and there is a behaviour change people will hit: saved workspaces now live on the Gateway, so a Director with no Gateway can no longer save or load one.

## The notes were written against the code, not the commit titles

Four commits merged since v2.0.7 describe a feature that lets a session ask for a Director to be restarted. On this tree the control host still answers with the placeholder that reports no drain:

```csharp
private static IRestartCycleDrain RestartDrainStep() => new NoDrainOnThisBuild();
```

The Gateway refuses to create a request whenever that reports unavailable, so no request is ever written and no approval is ever raised. That is recorded under known limitations rather than announced as shipped. I did not change that line: the restore half of the same mission is not on this tree, so switching it on would let someone close every session on a machine and be handed restore commands containing literal placeholder text.

Two further limitations are stated plainly for the same reason.

- The launcher still does not update itself on macOS or Linux. The Director installing the launcher's update, announced in v2.0.7, is Windows-only, and the code says so in its own comment. This is why a Mac can sit five releases behind while everything looks healthy.
- A Director still cannot start on a Mac with no display awake. This release stops good builds being blamed for that, but such a machine now waits rather than updating.

## What is in the release

Headline items, each verified as real running code that is on by default:

- The Mac update no longer condemns a build because the screen was dark, no longer blacklists a version the machine could not have started, and forgets a blacklisting once a newer version arrives.
- A rolled back update stops being reported once the machine has moved past the version that failed.
- A new File menu item drains a Director to safe, secret-swept handovers before a restart.
- Workspaces are stored on the Gateway.
- Dictation no longer delivers the same recording into a session twice.

## Note on continuous integration

The web check fails on this branch, on main, and on every recent run. It is a cockpit roster test that none of these changes touch, and v2.0.7 shipped with it already red. The .NET check is the one that covers this work.
