### PR TITLE
Cron dispatch resolves to a live Director, not a stopped registration

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/RegistryDirectorTargetResolverTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/RegistryDirectorTargetResolverTests.cs
@@ -324,4 +324,85 @@ public sealed class RegistryDirectorTargetResolverTests
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => resolver.ResolveAsync("M", director: null, CancellationToken.None));
     }
+
+    /// <summary>A Director that said goodbye: MarkStopped stamps StoppedAtUtc and keeps the entry for the
+    /// 24h eviction horizon, so a stopped registration is a normal thing to find in the list.</summary>
+    private static DirectorDto Stopped(string id, string machine, DateTime lastSeen) => new()
+    {
+        DirectorId = id, MachineName = machine, ControlEndpoint = "", Version = "0.9.10",
+        LastSeen = lastSeen, StoppedAtUtc = lastSeen,
+    };
+
+    private static DirectorDto Running(string id, string machine, DateTime lastSeen) => new()
+    {
+        DirectorId = id, MachineName = machine, ControlEndpoint = "", Version = "0.9.10",
+        LastSeen = lastSeen, StoppedAtUtc = null,
+    };
+
+    [Fact]
+    public async Task Resolve_SkipsTheStoppedRegistration_AndPicksTheLiveDirectorOnTheSameMachine()
+    {
+        // Issue #2785. A restart leaves the previous registration in the list, stopped, for up to 24h.
+        // The stopped one is deliberately placed FIRST: the old rule was an unordered FirstOrDefault, so
+        // this ordering is what made it dispatch into a closed tunnel and record infraStatus=not-started.
+        var directors = new List<DirectorDto>
+        {
+            Stopped("d-corpse", "SOREN_NORTH", new DateTime(2026, 9, 8, 19, 41, 35, DateTimeKind.Utc)),
+            Running("d-live", "SOREN_NORTH", new DateTime(2026, 9, 9, 15, 4, 18, DateTimeKind.Utc)),
+        };
+        var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch when one is running"));
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => directors, () => TenantId.Local, launcher, FastTimeout, FastPoll);
+
+        var result = await resolver.ResolveAsync("SOREN_NORTH", director: null, CancellationToken.None);
+
+        Assert.Null(result.Error);
+        Assert.Equal("d-live", result.DirectorId);
+        Assert.Equal(0, launcher.StartCount);
+    }
+
+    [Fact]
+    public async Task Resolve_PrefersTheFreshestHeartbeat_WhenSeveralAreRunning()
+    {
+        // Two live Directors on one machine is ambiguous by construction (issue #2786); the freshest
+        // heartbeat is at least a stated rule rather than dictionary order.
+        var directors = new List<DirectorDto>
+        {
+            Running("d-stale", "SOREN_NORTH", new DateTime(2026, 9, 9, 10, 0, 0, DateTimeKind.Utc)),
+            Running("d-fresh", "SOREN_NORTH", new DateTime(2026, 9, 9, 15, 0, 0, DateTimeKind.Utc)),
+        };
+        var launcher = new FakeLauncher(_ => throw new InvalidOperationException("must not launch"));
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => directors, () => TenantId.Local, launcher, FastTimeout, FastPoll);
+
+        var result = await resolver.ResolveAsync("SOREN_NORTH", director: null, CancellationToken.None);
+
+        Assert.Equal("d-fresh", result.DirectorId);
+    }
+
+    [Fact]
+    public async Task Resolve_EveryRegistrationStopped_AsksTheLauncher_RatherThanResolvingToACorpse()
+    {
+        // The whole point of excluding the stopped ones: "none running" must reach the launcher branch.
+        // Resolving to a corpse instead is what made a missed schedule look like a started one.
+        var directors = new List<DirectorDto>
+        {
+            Stopped("d-corpse-1", "SOREN_NORTH", new DateTime(2026, 9, 8, 19, 41, 35, DateTimeKind.Utc)),
+            Stopped("d-corpse-2", "SOREN_NORTH", new DateTime(2026, 9, 8, 20, 0, 0, DateTimeKind.Utc)),
+        };
+        var launcher = new FakeLauncher(machine =>
+        {
+            directors.Add(Running("d-launched", machine, new DateTime(2026, 9, 9, 16, 0, 0, DateTimeKind.Utc)));
+            return true;
+        });
+        var resolver = new RegistryDirectorTargetResolver(
+            _ => directors, () => TenantId.Local, launcher, FastTimeout, FastPoll);
+
+        var result = await resolver.ResolveAsync("SOREN_NORTH", director: null, CancellationToken.None);
+
+        Assert.Null(result.Error);
+        Assert.Equal("d-launched", result.DirectorId);
+        Assert.Equal(1, launcher.StartCount);
+        Assert.Equal("SOREN_NORTH", launcher.LastMachine);
+    }
 }

--- a/src/CcDirector.Gateway/Running/IDirectorTargetResolver.cs
+++ b/src/CcDirector.Gateway/Running/IDirectorTargetResolver.cs
@@ -144,12 +144,6 @@ public sealed class RegistryDirectorTargetResolver : IDirectorTargetResolver
                 "tenant boundary.");
 
     /// <summary>
-    /// First registered Director on the machine. Gateway Cleanup mission (tunnel-only): a registered Director
-    /// IS reachable - it is reached over its tunnel by id, not by dialing a control endpoint - so this no
-    /// longer requires a non-empty ControlEndpoint or an advertised-endpoint reachability state (both are
-    /// artifacts of the deleted HTTP-dial path).
-    /// </summary>
-    /// <summary>
     /// Resolve ONE named Director - by id or by display name, case-insensitively - within the caller's
     /// tenant, optionally narrowed to a machine. A named Director identifies its own machine, so
     /// <paramref name="machine"/> is only a further filter and may be blank.
@@ -199,11 +193,33 @@ public sealed class RegistryDirectorTargetResolver : IDirectorTargetResolver
         return new DirectorTargetResult(chosen.DirectorId, null);
     }
 
+    /// <summary>
+    /// The RUNNING Director on the machine, freshest heartbeat first, or null when none is running.
+    /// Tunnel-only: a running Director is reached over its tunnel by id, so this requires neither a
+    /// non-empty ControlEndpoint nor an advertised-endpoint reachability state (both artifacts of the
+    /// deleted HTTP-dial path). What it does require is that the Director has not said goodbye - see
+    /// the note in the body, and issue #2785.
+    /// </summary>
     private DirectorDto? PickReachable(TenantId tenant, string machine)
     {
         // Confine the machine-name match to the caller's OWN tenant partition (audit H1, gap audit-e): a
         // fleet-global scan could return another tenant's Director that happens to run on the same machine.
-        return _listDirectors(tenant).FirstOrDefault(x =>
-            string.Equals(x.MachineName, machine, StringComparison.OrdinalIgnoreCase));
+        //
+        // REGISTERED IS NOT RUNNING (issue #2785). A Director that said goodbye keeps its registration
+        // until the 24h eviction horizon - MarkStopped stamps StoppedAtUtc and deliberately never removes
+        // the entry - so for a full day after any restart a machine carries both a corpse and the live
+        // Director. An unordered FirstOrDefault over the registry dictionary picked between them by
+        // hash-bucket order, which is stable for the life of the Gateway process: lose that draw and EVERY
+        // schedule on that machine dispatches into a closed tunnel and records infraStatus=not-started
+        // against the dead Director's id, silently, until the corpse is evicted.
+        //
+        // So skip the stopped ones and prefer the freshest heartbeat. When every registration on the
+        // machine is stopped this returns null, which is the right answer and not a failure: the caller
+        // then asks the launcher to start one, which is what should have happened all along.
+        return _listDirectors(tenant)
+            .Where(x => string.Equals(x.MachineName, machine, StringComparison.OrdinalIgnoreCase))
+            .Where(x => x.StoppedAtUtc is null)
+            .OrderByDescending(x => x.LastSeen ?? DateTime.MinValue)
+            .FirstOrDefault();
     }
 }


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle_internal#1966.

## The defect

`RegistryDirectorTargetResolver.PickReachable` was the whole machine-to-Director rule:

```csharp
return _listDirectors(tenant).FirstOrDefault(x =>
    string.Equals(x.MachineName, machine, StringComparison.OrdinalIgnoreCase));
```

Machine-name equality, `FirstOrDefault`, no liveness filter, no ordering.

`MarkStopped` stamps `StoppedAtUtc` and deliberately keeps the entry until the 24h eviction horizon, so for a full day after any restart a machine carries both a corpse and the live Director. `_directors` is a `ConcurrentDictionary`, so "first" is hash-bucket order: arbitrary, but stable for the life of the Gateway process. Lose that draw and every schedule on that machine dispatches into a closed tunnel and records `infraStatus: not-started` against the dead Director's id, silently, until the corpse is evicted.

The roster read already honours the verdict (`GatewayEndpoints.cs:1239-1260`). The cron resolver did not.

## The change

```csharp
return _listDirectors(tenant)
    .Where(x => string.Equals(x.MachineName, machine, StringComparison.OrdinalIgnoreCase))
    .Where(x => x.StoppedAtUtc is null)
    .OrderByDescending(x => x.LastSeen ?? DateTime.MinValue)
    .FirstOrDefault();
```

When every registration on the machine is stopped this returns null, which reaches the existing launcher branch at `ResolveAsync` and starts one - what should have happened all along.

Also moves the orphaned `<summary>` (it sat above `PickNamed` while describing `PickReachable`) onto the method it documents, and drops its "a registered Director IS reachable" claim. That claim is exactly what the code was relying on, and it is false for a Director that has said goodbye.

## Tests

Three added to `RegistryDirectorTargetResolverTests`:

- `Resolve_SkipsTheStoppedRegistration_AndPicksTheLiveDirectorOnTheSameMachine` - the stopped entry is placed FIRST in the list on purpose, since that ordering is what the old rule tripped on.
- `Resolve_PrefersTheFreshestHeartbeat_WhenSeveralAreRunning`
- `Resolve_EveryRegistrationStopped_AsksTheLauncher_RatherThanResolvingToACorpse`

**Verified the tests actually bind the behaviour.** With the production change reverted, all three fail and the 13 pre-existing tests still pass:

```
Failed  Resolve_PrefersTheFreshestHeartbeat_WhenSeveralAreRunning
Failed  Resolve_EveryRegistrationStopped_AsksTheLauncher_RatherThanResolvingToACorpse
Failed  Resolve_SkipsTheStoppedRegistration_AndPicksTheLiveDirectorOnTheSameMachine
Failed! - Failed: 3, Passed: 13, Total: 16
```

With the fix restored:

```
Passed! - Failed: 0, Passed: 16, Total: 16      RegistryDirectorTargetResolverTests
Passed! - Failed: 0, Passed: 4185, Skipped: 2   CcDirector.Gateway.UnitTests (whole project)
Passed! - Failed: 0, Passed: 42                 Gateway.Tests, cron + launcher + cross-tenant filters
```

## What this does not fix

Nothing here changes the outcome when two Directors on one machine are BOTH live - that resolves by freshest heartbeat, which is a stated rule rather than dictionary order, but still arbitrary. A schedule cannot pin a Director because `CronJobTarget` carries only a machine name. Filed separately as thefrederiksen/devthrottle_internal#1967.

This also does not retro-fix a running Gateway: the hosted Gateway needs deploying before the behaviour changes anywhere.

## Evidence from the incident

On 2026-09-09, SOREN_NORTH lost eleven scheduled runs to this - repo cleanup, error triage, i18n coverage, code review, hygiene audit, health check-in, email assistant, job search, Upwork scan, PE outreach, dictionary digest. Every run recorded `not-started` against `6a7e127e`, stopped since 2026-09-08T19:41:35Z, while `6d4523e2` was live and hosting twelve sessions. A schedule created seconds before a manual fire reproduced it identically, which ruled out stale state on the job.
