### PR TITLE
Keep a dictation clip with its transcript, so an invented word leaves evidence

### DIFF
--- a/src/CcDirector.Avalonia.Tests/BackgroundDictationSendTests.cs
+++ b/src/CcDirector.Avalonia.Tests/BackgroundDictationSendTests.cs
@@ -209,4 +209,47 @@ public sealed class BackgroundDictationSendTests : IDisposable
             Assert.Equal(expectedSpoken, spoken);
         }
     }
+
+    [Fact]
+    public async Task CorpusOn_DeliveredDictationKeepsTheClipAndItsTranscript()
+    {
+        // The seam: the safety-net file is still deleted on delivery, and the corpus pair is written
+        // somewhere else. Keeping the clip must not resurrect the safety net's "something went wrong"
+        // meaning, so the two directories are checked separately.
+        var corpusDir = Path.Combine(_dir, "corpus");
+        var recorder = await NewRecordingRecorderAsync(new byte[] { 1, 2, 3, 4 });
+
+        await BackgroundDictationSend.RunAsync(
+            recorder, prefix: "", NewSession(),
+            new FakeTranscriber { Text = "the words" },
+            submit: (_, _, _) => Task.CompletedTask,
+            onFailed: (_, _) => throw new InvalidOperationException("delivery must not report failure"),
+            recordingsDirectory: _dir,
+            corpusConfig: new DictationCorpusConfig(Enabled: true, MaxClips: 100, MaxAgeDays: 90),
+            corpusDirectory: corpusDir);
+
+        Assert.Empty(SavedRecordings());   // the safety net still cleans up after itself
+        Assert.Single(Directory.GetFiles(corpusDir, "*.wav"));
+        Assert.Single(Directory.GetFiles(corpusDir, "*.json"));
+        Assert.Contains("the words", File.ReadAllText(Directory.GetFiles(corpusDir, "*.json")[0]));
+    }
+
+    [Fact]
+    public async Task CorpusOff_DeliveredDictationKeepsNothing()
+    {
+        var corpusDir = Path.Combine(_dir, "corpus");
+        var recorder = await NewRecordingRecorderAsync(new byte[] { 1, 2, 3, 4 });
+
+        await BackgroundDictationSend.RunAsync(
+            recorder, prefix: "", NewSession(),
+            new FakeTranscriber { Text = "the words" },
+            submit: (_, _, _) => Task.CompletedTask,
+            onFailed: (_, _) => throw new InvalidOperationException("delivery must not report failure"),
+            recordingsDirectory: _dir,
+            corpusConfig: new DictationCorpusConfig(Enabled: false, MaxClips: 100, MaxAgeDays: 90),
+            corpusDirectory: corpusDir);
+
+        Assert.Empty(SavedRecordings());
+        Assert.False(Directory.Exists(corpusDir), "the corpus must write nothing while it is off");
+    }
 }

--- a/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
+++ b/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Dictation;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Transcription;
@@ -46,6 +47,11 @@ public static class BackgroundDictationSend
     /// <param name="recordingsDirectory">Where the disk safety net saves the WAV. Null (production)
     /// means <see cref="DictationRecordingStore.DefaultDirectory"/>; tests point it at a scratch
     /// directory.</param>
+    /// <param name="corpusConfig">Dictation-corpus settings. Null (production) reads config.json, where
+    /// the corpus is OFF unless the user turned it on.</param>
+    /// <param name="corpusDirectory">Where kept clip/transcript pairs are written. Null (production)
+    /// means <see cref="DictationCorpusStore.DefaultDirectory"/>; tests point it at a scratch
+    /// directory.</param>
     public static async Task RunAsync(
         BatchDictationRecorder recorder,
         string prefix,
@@ -55,7 +61,9 @@ public static class BackgroundDictationSend
         string before = "",
         string after = "",
         Action<string, string?>? onFailed = null,
-        string? recordingsDirectory = null)
+        string? recordingsDirectory = null,
+        DictationCorpusConfig? corpusConfig = null,
+        string? corpusDirectory = null)
     {
         FileLog.Write($"[BackgroundDictationSend] start: session={target.Id}, state={target.ActivityState}");
         target.IsTranscribing = true;
@@ -84,10 +92,12 @@ public static class BackgroundDictationSend
             // 2. Transcribe once. On failure there is no transcript to restore - report loudly, do not
             //    queue or retry. The saved WAV is now the only copy of the spoken words, so it is KEPT
             //    and the report names it.
+            DictationTranscript transcribed;
             string transcript;
             try
             {
-                transcript = (await transcriber.TranscribeAsync(captured.Wav)).CleanedTranscript;
+                transcribed = await transcriber.TranscribeAsync(captured.Wav);
+                transcript = transcribed.CleanedTranscript;
             }
             catch (Exception ex)
             {
@@ -96,6 +106,13 @@ public static class BackgroundDictationSend
                 savedPath = null; // kept for the user; do not delete below
                 return;
             }
+
+            // 2b. Dictation corpus (OFF unless the user turned it on): keep this clip together with the
+            //     transcript it produced. A transcript carrying a word nobody said looks like a success,
+            //     so the safety net below deletes the only evidence of it seconds later. This writes the
+            //     pair somewhere else, leaves the safety net's meaning alone, and is fail-open - it can
+            //     never cost the user their dictation. See DictationCorpusStore.
+            DictationCorpusStore.TryKeep(captured.Wav, transcribed, corpusConfig, corpusDirectory);
 
             // 3. Compose the turn (dictation dropped at the caret inside any typed text) and submit it
             //    straight through the echo-verified terminal submit. From here on the composed text is

--- a/src/CcDirector.Core.Tests/DictationCorpusStoreTests.cs
+++ b/src/CcDirector.Core.Tests/DictationCorpusStoreTests.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Transcription;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// The dictation corpus: a clip kept together with the transcript it produced, so a transcript carrying
+/// a word nobody said can be checked against the audio afterwards.
+///
+/// The properties that matter: it writes NOTHING until the user turns it on; a kept pair carries the RAW
+/// transcript as well as the corrected one (the verbatim rule needs both halves); both bounds prune
+/// whole pairs; and nothing here may ever throw into the dictation path.
+/// </summary>
+public sealed class DictationCorpusStoreTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-director-tests", Guid.NewGuid().ToString("N"));
+
+    private static DictationCorpusConfig On(int maxClips = 100, int maxAgeDays = 90)
+        => new(Enabled: true, MaxClips: maxClips, MaxAgeDays: maxAgeDays);
+
+    private static DictationTranscript Words(string raw, string? cleaned = null, int corrected = 0)
+        => new(raw, cleaned ?? raw, corrected);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* scratch dir; best effort */ }
+    }
+
+    [Fact]
+    public void Disabled_WritesNothingAndDoesNotCreateTheDirectory()
+    {
+        var config = new DictationCorpusConfig(Enabled: false, MaxClips: 100, MaxAgeDays: 90);
+
+        var path = DictationCorpusStore.TryKeep(new byte[] { 1, 2, 3 }, Words("hello"), config, _dir);
+
+        Assert.Null(path);
+        Assert.False(Directory.Exists(_dir), "the corpus directory must not be created until the user turns the corpus on");
+    }
+
+    [Fact]
+    public void Enabled_KeepsTheClipAndItsTranscriptAsAPair()
+    {
+        var wav = new byte[] { 9, 8, 7, 6 };
+
+        var path = DictationCorpusStore.TryKeep(wav, Words("raw words", "clean words", 2), On(), _dir);
+
+        Assert.NotNull(path);
+        Assert.EndsWith(".wav", path);
+        Assert.Equal(wav, File.ReadAllBytes(path!));
+
+        var jsonPath = Path.ChangeExtension(path!, ".json");
+        Assert.True(File.Exists(jsonPath), "a kept clip must have its transcript beside it");
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
+        var root = doc.RootElement;
+        Assert.Equal(Path.GetFileName(path!), root.GetProperty("clip").GetString());
+        Assert.Equal("raw words", root.GetProperty("rawTranscript").GetString());
+        Assert.Equal("clean words", root.GetProperty("cleanedTranscript").GetString());
+        Assert.Equal(2, root.GetProperty("dictionaryWordsCorrected").GetInt32());
+        Assert.Equal(wav.Length, root.GetProperty("audioBytes").GetInt32());
+    }
+
+    [Fact]
+    public void RawTranscriptIsKeptSeparately_SoADictionaryEditCanBeSeen()
+    {
+        // The verbatim rule is provable only when BOTH halves survive: what the speech model wrote,
+        // and what the dictionary then changed. Keeping only the corrected text would erase the edit.
+        var path = DictationCorpusStore.TryKeep(new byte[] { 1 }, Words("mind zee studio", "mindzieStudio", 1), On(), _dir);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(Path.ChangeExtension(path!, ".json")));
+        Assert.NotEqual(
+            doc.RootElement.GetProperty("rawTranscript").GetString(),
+            doc.RootElement.GetProperty("cleanedTranscript").GetString());
+    }
+
+    [Fact]
+    public void EachKeepGetsItsOwnPair()
+    {
+        var first = DictationCorpusStore.TryKeep(new byte[] { 1 }, Words("one"), On(), _dir);
+        var second = DictationCorpusStore.TryKeep(new byte[] { 2 }, Words("two"), On(), _dir);
+
+        Assert.NotEqual(first, second);
+        Assert.Equal(2, Directory.GetFiles(_dir, "*.wav").Length);
+        Assert.Equal(2, Directory.GetFiles(_dir, "*.json").Length);
+    }
+
+    [Fact]
+    public void CountBound_PrunesTheOldestWholePairs()
+    {
+        var config = On(maxClips: 2);
+
+        var oldest = DictationCorpusStore.TryKeep(new byte[] { 1 }, Words("one"), config, _dir);
+        Backdate(oldest!, DateTime.UtcNow.AddMinutes(-30));
+        var middle = DictationCorpusStore.TryKeep(new byte[] { 2 }, Words("two"), config, _dir);
+        Backdate(middle!, DateTime.UtcNow.AddMinutes(-20));
+        DictationCorpusStore.TryKeep(new byte[] { 3 }, Words("three"), config, _dir);
+
+        Assert.False(File.Exists(oldest!), "the oldest clip must be pruned past the count bound");
+        Assert.False(File.Exists(Path.ChangeExtension(oldest!, ".json")), "its transcript must go with it");
+        Assert.Equal(2, Directory.GetFiles(_dir, "*.wav").Length);
+        Assert.Equal(2, Directory.GetFiles(_dir, "*.json").Length);
+    }
+
+    [Fact]
+    public void AgeBound_PrunesPairsPastTheMaxAge()
+    {
+        var config = On(maxAgeDays: 7);
+
+        var stale = DictationCorpusStore.TryKeep(new byte[] { 1 }, Words("old"), config, _dir);
+        Backdate(stale!, DateTime.UtcNow.AddDays(-8));
+
+        DictationCorpusStore.TryKeep(new byte[] { 2 }, Words("new"), config, _dir);
+
+        Assert.False(File.Exists(stale!), "a clip past the age bound must be pruned");
+        Assert.False(File.Exists(Path.ChangeExtension(stale!, ".json")));
+        Assert.Single(Directory.GetFiles(_dir, "*.wav"));
+    }
+
+    [Fact]
+    public void NoAudio_KeepsNothingAndDoesNotThrow()
+    {
+        Assert.Null(DictationCorpusStore.TryKeep(Array.Empty<byte>(), Words("hello"), On(), _dir));
+        Assert.Null(DictationCorpusStore.TryKeep(null!, Words("hello"), On(), _dir));
+    }
+
+    [Fact]
+    public void NoTranscript_KeepsNothingAndDoesNotThrow()
+    {
+        Assert.Null(DictationCorpusStore.TryKeep(new byte[] { 1 }, null!, On(), _dir));
+    }
+
+    [Fact]
+    public void AnUnwritableDirectoryIsSwallowed_KeepingIsNeverAGate()
+    {
+        // A file where the directory should be: creating the directory must fail. The dictation must
+        // still be unaffected, so TryKeep reports null rather than throwing into the send path.
+        var blocked = Path.Combine(_dir, "blocked");
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(blocked, "not a directory");
+
+        var path = DictationCorpusStore.TryKeep(new byte[] { 1 }, Words("hello"), On(), blocked);
+
+        Assert.Null(path);
+    }
+
+    private static void Backdate(string clipPath, DateTime whenUtc)
+    {
+        File.SetLastWriteTimeUtc(clipPath, whenUtc);
+        var json = Path.ChangeExtension(clipPath, ".json");
+        if (File.Exists(json)) File.SetLastWriteTimeUtc(json, whenUtc);
+    }
+}

--- a/src/CcDirector.Core/Configuration/DictationCorpusConfig.cs
+++ b/src/CcDirector.Core/Configuration/DictationCorpusConfig.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// Settings for the dictation corpus: keeping each dictation clip together with the transcript it
+/// produced, so the transcriber can be measured against real speech instead of studio-clean test clips.
+///
+/// WHY THIS EXISTS. Nothing keeps the pair today. The disk safety net
+/// (<c>DictationRecordingStore</c>) deletes the clip the moment the words are delivered, and the hosted
+/// Gateway does not archive audio at all, so a transcript that comes back with a word the user never
+/// said leaves no evidence behind. On 2026-09-09 roughly one dictation in eight carried an invented
+/// filler ("Thank you.", "you", "Bye.") that the speech model wrote over a pause, and not one of those
+/// clips still existed. A fix cannot be proven against audio nobody kept.
+///
+/// Persisted in config.json under the top-level object "dictation_corpus":
+///   - "enabled"       (bool) - master switch. DEFAULT FALSE (opt-in). Keeping recorded speech on disk
+///                              is the user's decision, never a default. Nothing is written, and no
+///                              directory is created, until this is explicitly turned on.
+///   - "max_clips"     (int)  - keep at most this many clips, newest first. DEFAULT 2000.
+///   - "max_age_days"  (int)  - drop a clip older than this. DEFAULT 90.
+/// Both bounds apply, so neither a quiet month nor a busy afternoon can run the disk up.
+///
+/// LOCAL ONLY. The corpus is written on the machine that recorded it and is never transmitted,
+/// exactly like the safety net it sits beside.
+///
+/// No-fallback rule: a present-but-wrong-typed key THROWS with the fix named, rather than silently
+/// picking a default (matching <see cref="AutoResumeConfig"/>).
+/// </summary>
+public sealed record DictationCorpusConfig(
+    bool Enabled,
+    int MaxClips,
+    int MaxAgeDays)
+{
+    /// <summary>The default posture: off. A user who has not asked for this keeps nothing.</summary>
+    public static readonly DictationCorpusConfig Default = new(
+        Enabled: false,
+        MaxClips: 2000,
+        MaxAgeDays: 90);
+
+    /// <summary>Convenience: the age bound as a span.</summary>
+    public TimeSpan MaxAge => TimeSpan.FromDays(MaxAgeDays);
+
+    /// <summary>Read the effective config from config.json's "dictation_corpus" object; missing keys
+    /// fall back to <see cref="Default"/> per key.</summary>
+    public static DictationCorpusConfig Get()
+    {
+        var node = CcDirectorConfigService.ReadRaw()["dictation_corpus"];
+        if (node is null)
+            return Default;
+
+        if (node is not JsonObject obj)
+            throw new InvalidOperationException(
+                "config.json key 'dictation_corpus' must be an object. " +
+                "Fix the value or remove the key to use the defaults (disabled).");
+
+        return new DictationCorpusConfig(
+            Enabled: ReadBool(obj, "enabled", Default.Enabled),
+            MaxClips: ReadPositiveInt(obj, "max_clips", Default.MaxClips),
+            MaxAgeDays: ReadPositiveInt(obj, "max_age_days", Default.MaxAgeDays));
+    }
+
+    private static bool ReadBool(JsonObject obj, string key, bool fallback)
+    {
+        var node = obj[key];
+        if (node is null)
+            return fallback;
+        if (node is JsonValue v && v.GetValueKind() == JsonValueKind.True) return true;
+        if (node is JsonValue v2 && v2.GetValueKind() == JsonValueKind.False) return false;
+
+        throw new InvalidOperationException(
+            $"config.json key 'dictation_corpus.{key}' must be true or false. " +
+            "Fix the value or remove the key to use the default.");
+    }
+
+    private static int ReadPositiveInt(JsonObject obj, string key, int fallback)
+    {
+        var node = obj[key];
+        if (node is null)
+            return fallback;
+        if (node is JsonValue v && v.GetValueKind() == JsonValueKind.Number)
+        {
+            var n = v.GetValue<int>();
+            if (n <= 0)
+                throw new InvalidOperationException(
+                    $"config.json key 'dictation_corpus.{key}' must be a positive whole number. " +
+                    "Fix the value or remove the key to use the default.");
+            return n;
+        }
+
+        throw new InvalidOperationException(
+            $"config.json key 'dictation_corpus.{key}' must be a positive whole number. " +
+            "Fix the value or remove the key to use the default.");
+    }
+}

--- a/src/CcDirector.Core/Dictation/DictationCorpusStore.cs
+++ b/src/CcDirector.Core/Dictation/DictationCorpusStore.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Transcription;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Dictation;
+
+/// <summary>
+/// Keeps a dictation clip together with the transcript it produced, so the transcriber can be measured
+/// against real speech.
+///
+/// WHY THIS IS NOT THE SAFETY NET. <see cref="DictationRecordingStore"/> saves a clip so that a FAILED
+/// transcription cannot lose the user's words, and deletes it the instant those words are safe. A file
+/// sitting there means something went wrong, and the failure report names its path - that meaning is
+/// worth keeping, so this store writes somewhere else entirely and never touches it. The safety net
+/// catches a transcription that FAILS; this catches one that LIES, which looks like a success and
+/// therefore leaves no evidence at all.
+///
+/// WHAT A PAIR IS. Two files sharing one stem in <see cref="CcStorage.DictationCorpus"/>:
+///   dictation-20260909-182530-a1b2c3d4.wav    the exact bytes that were transcribed
+///   dictation-20260909-182530-a1b2c3d4.json   what came back, and when
+/// The json holds the RAW transcript and the dictionary-corrected one separately, so the pair proves
+/// both halves of the verbatim rule: what the speech model wrote, and what the dictionary then changed.
+///
+/// OFF UNLESS ASKED. Keeping recorded speech is the user's decision. Nothing is written and no
+/// directory is created until <c>dictation_corpus.enabled</c> is true in config.json. LOCAL ONLY -
+/// never transmitted, exactly like the safety net beside it.
+///
+/// BOUNDED BY CONSTRUCTION. Every keep prunes pairs past the configured age and, whatever their age,
+/// all but the newest configured count. Both bounds apply.
+///
+/// FAIL-OPEN. Keeping a clip is a diagnostic, never a gate: a full disk, a locked file or a bad config
+/// value is logged and swallowed, so nothing here can cost a user their dictation.
+/// </summary>
+public static class DictationCorpusStore
+{
+    /// <summary>Where pairs are kept. Resolved per access so CC_DIRECTOR_ROOT redirects it.</summary>
+    public static string DefaultDirectory => CcStorage.DictationCorpus();
+
+    /// <summary>
+    /// Keep one clip and its transcript, and return the full path of the saved WAV - or null when
+    /// nothing was kept (the corpus is off, there is no audio, or writing failed).
+    /// </summary>
+    /// <param name="wav">The exact WAV bytes that were sent for transcription.</param>
+    /// <param name="transcript">What came back: raw, corrected, and how many dictionary terms changed.</param>
+    /// <param name="config">The corpus settings; null (production) reads config.json.</param>
+    /// <param name="directory">Where to write; null (production) means <see cref="DefaultDirectory"/>.
+    /// Tests point it at a scratch directory.</param>
+    public static string? TryKeep(
+        byte[] wav,
+        DictationTranscript transcript,
+        DictationCorpusConfig? config = null,
+        string? directory = null)
+    {
+        try
+        {
+            var cfg = config ?? DictationCorpusConfig.Get();
+            if (!cfg.Enabled) return null;
+
+            if (wav is null || wav.Length == 0)
+            {
+                FileLog.Write("[DictationCorpusStore] TryKeep skipped: no audio bytes");
+                return null;
+            }
+            if (transcript is null)
+            {
+                FileLog.Write("[DictationCorpusStore] TryKeep skipped: no transcript");
+                return null;
+            }
+
+            var dir = directory ?? DefaultDirectory;
+            Directory.CreateDirectory(dir);
+
+            var stem = $"dictation-{DateTime.Now:yyyyMMdd-HHmmss}-{Guid.NewGuid().ToString("N")[..8]}";
+            var wavPath = Path.Combine(dir, stem + ".wav");
+            var jsonPath = Path.Combine(dir, stem + ".json");
+
+            File.WriteAllBytes(wavPath, wav);
+
+            var record = new JsonObject
+            {
+                ["clip"] = stem + ".wav",
+                ["recordedAtUtc"] = DateTime.UtcNow.ToString("o"),
+                ["audioBytes"] = wav.Length,
+                ["rawTranscript"] = transcript.RawTranscript,
+                ["cleanedTranscript"] = transcript.CleanedTranscript,
+                ["dictionaryWordsCorrected"] = transcript.DictionaryWordsCorrected,
+            };
+            File.WriteAllText(jsonPath, record.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+            FileLog.Write($"[DictationCorpusStore] kept {wav.Length} bytes + transcript as {stem}");
+            Prune(dir, cfg);
+            return wavPath;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DictationCorpusStore] TryKeep FAILED: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Enforce both bounds: drop any pair older than the configured age, then drop the oldest until at
+    /// most the configured count remain. A pair is deleted as a unit - a clip without its transcript is
+    /// not evidence of anything, and a transcript without its clip cannot be checked against the audio.
+    /// Never throws: a file that cannot be deleted is disk noise, not a functional problem.
+    /// </summary>
+    private static void Prune(string dir, DictationCorpusConfig cfg)
+    {
+        try
+        {
+            var clips = new DirectoryInfo(dir)
+                .GetFiles("dictation-*.wav")
+                .OrderByDescending(f => f.LastWriteTimeUtc)
+                .ToList();
+
+            var cutoff = DateTime.UtcNow - cfg.MaxAge;
+            var doomed = clips
+                .Where((f, index) => index >= cfg.MaxClips || f.LastWriteTimeUtc < cutoff)
+                .ToList();
+
+            foreach (var clip in doomed)
+            {
+                TryDeletePair(clip);
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DictationCorpusStore] prune FAILED: {ex.Message}");
+        }
+    }
+
+    private static void TryDeletePair(FileInfo clip)
+    {
+        var json = Path.ChangeExtension(clip.FullName, ".json");
+        try
+        {
+            clip.Delete();
+            if (File.Exists(json)) File.Delete(json);
+            FileLog.Write($"[DictationCorpusStore] pruned {Path.GetFileNameWithoutExtension(clip.Name)}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DictationCorpusStore] prune FAILED for {clip.Name}: {ex.Message}");
+        }
+    }
+}

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -325,6 +325,10 @@ public static class CcStorage
     /// <summary>Per-session dictation logs: base/dictation/sessions/.</summary>
     public static string DictationSessions() => Path.Combine(Dictation(), "sessions");
 
+    /// <summary>Kept dictation clips and their transcripts: base/dictation/corpus/. Written only when
+    /// the user turns the corpus on (<c>dictation_corpus.enabled</c>); see <c>DictationCorpusStore</c>.</summary>
+    public static string DictationCorpus() => Path.Combine(Dictation(), "corpus");
+
     /// <summary>The preamble file handed to the Pi agent: base/pi-preamble/.</summary>
     public static string PiPreamble() => Path.Combine(Base(), "pi-preamble");
 


### PR DESCRIPTION
## Why

A transcript carrying a word nobody said looks like a success, so nothing keeps the proof. The disk safety net (`DictationRecordingStore`) deletes the clip the moment the words are delivered, and the hosted Gateway does not archive audio at all (`TranscriptionAudioArchive.TrySave` returns early on hosted, deliberately). Today roughly one dictation in eight comes back with a filler the speech model wrote over a pause -- "Thank you.", "you", "Bye." -- and not one of those clips still exists to prove it or to test a fix against.

## What this adds

A dictation corpus: each clip kept beside the transcript it produced.

```
dictation-20260909-193200-a1b2c3d4.wav     the exact bytes that were transcribed
dictation-20260909-193200-a1b2c3d4.json    { rawTranscript, cleanedTranscript,
                                             dictionaryWordsCorrected, recordedAtUtc, ... }
```

Raw and corrected are stored separately on purpose: the pair then proves both halves of the verbatim rule -- what the speech model wrote, and what the dictionary changed.

- **Off unless asked.** `dictation_corpus.enabled`, default false. Nothing is written and no directory is created until it is turned on. Keeping recorded speech is the user's decision, never a default.
- **Local only**, never transmitted, exactly like the safety net beside it.
- **Bounded** by count (2,000) and age (90 days), both applied, pruned as whole pairs -- a clip without its transcript proves nothing, and a transcript without its clip cannot be checked against the audio.
- **Fail-open.** Keeping a clip is a diagnostic, never a gate; a full disk or a bad config value is logged and swallowed so it cannot cost anyone their dictation.

It deliberately does **not** reuse the safety-net directory. A file there means a transcription failed and the failure report names its path; that meaning is worth keeping intact.

## Proof

```
DictationCorpusStoreTests          9 passed
BackgroundDictationSendTests       7 passed  (5 existing + 2 new, covering the seam)
CcDirector.Core.Tests (full)   4,405 passed, 0 failed, 8 skipped
```

Both new areas were checked against a mutation, so the tests are known to bite:

- deleting `if (!cfg.Enabled) return null;` from the store -> 1 failure (`Disabled_WritesNothingAndDoesNotCreateTheDirectory`)
- deleting the `DictationCorpusStore.TryKeep(...)` call from `BackgroundDictationSend` -> 1 failure (`CorpusOn_DeliveredDictationKeepsTheClipAndItsTranscript`)

Both restored afterwards.
