### PR TITLE
Transcription pipeline v2.0: a sentence with no sound behind it is not delivered

### DIFF
--- a/src/CcDirector.Core/Audio/WavPeakReader.cs
+++ b/src/CcDirector.Core/Audio/WavPeakReader.cs
@@ -1,0 +1,152 @@
+using System.Text;
+
+namespace CcDirector.Core.Audio;
+
+/// <summary>
+/// Reads how LOUD a PCM WAV is between two moments, so a claim about what was said at a given
+/// time can be checked against the sound that was actually there.
+///
+/// Written for the transcript evidence gate (pipeline v2.0): a speech model must produce a
+/// caption for every part of a clip, so on a silent stretch it writes the likeliest caption from
+/// its training data rather than nothing. The only way to catch that is to measure the audio in
+/// the span the model claims those words occupy.
+///
+/// PEAK, not average. A short word inside a longer quiet span barely moves the average but shows
+/// clearly in the peak, so an average would hide exactly the quiet real speech that must survive.
+///
+/// dBFS, relative to full scale, so the numbers are comparable across sample formats. Callers
+/// compare spans WITHIN one clip: absolute levels depend on the microphone, its gain and how
+/// close the speaker sat, and a fixed threshold that fits one machine deletes speech on another.
+///
+/// Linear PCM only (8, 16, 24 and 32-bit integer). Anything else - a compressed WAV, a WebM/Opus
+/// upload, a truncated header - returns null so the caller can fail open rather than guess.
+/// </summary>
+public sealed class WavPeakReader
+{
+    private readonly byte[] _wav;
+    private readonly int _dataOffset;
+    private readonly int _dataLength;
+    private readonly int _bytesPerSample;
+    private readonly int _channels;
+
+    /// <summary>Samples per second.</summary>
+    public int SampleRate { get; }
+
+    /// <summary>The clip's length in seconds, from the sample data actually present.</summary>
+    public double DurationSeconds =>
+        _dataLength / (double)(SampleRate * _channels * _bytesPerSample);
+
+    private WavPeakReader(byte[] wav, int dataOffset, int dataLength, int sampleRate, int channels, int bitsPerSample)
+    {
+        _wav = wav;
+        _dataOffset = dataOffset;
+        _dataLength = dataLength;
+        _channels = channels;
+        _bytesPerSample = bitsPerSample / 8;
+        SampleRate = sampleRate;
+    }
+
+    /// <summary>
+    /// Parse a linear PCM WAV, or return null for anything else. Scans the chunk list, so the
+    /// format and data chunks may appear in any order with other chunks between them.
+    /// </summary>
+    public static WavPeakReader? TryRead(byte[]? wav)
+    {
+        if (wav is null || wav.Length < 12) return null;
+        if (!(wav[0] == 'R' && wav[1] == 'I' && wav[2] == 'F' && wav[3] == 'F')) return null;
+        if (!(wav[8] == 'W' && wav[9] == 'A' && wav[10] == 'V' && wav[11] == 'E')) return null;
+
+        int sampleRate = 0, channels = 0, bits = 0, dataOffset = 0, dataLength = 0;
+        bool haveFmt = false, haveData = false;
+        int p = 12;
+        while (p + 8 <= wav.Length)
+        {
+            string id = Encoding.ASCII.GetString(wav, p, 4);
+            int size = BitConverter.ToInt32(wav, p + 4);
+            int body = p + 8;
+
+            // A declared size past the end of the buffer (a streaming size of 0, or a stale
+            // length) means trusting the bytes actually present rather than reading out of range.
+            if (size < 0 || body + size > wav.Length) size = wav.Length - body;
+            if (size < 0) break;
+
+            if (id == "fmt ")
+            {
+                if (size < 16) return null;
+                short audioFormat = BitConverter.ToInt16(wav, body);
+                if (audioFormat != 1) return null;         // linear PCM only
+                channels = BitConverter.ToInt16(wav, body + 2);
+                sampleRate = BitConverter.ToInt32(wav, body + 4);
+                bits = BitConverter.ToInt16(wav, body + 14);
+                haveFmt = true;
+            }
+            else if (id == "data")
+            {
+                dataOffset = body;
+                dataLength = size;
+                haveData = true;
+            }
+
+            int advance = size + (size & 1);              // chunks are word-aligned
+            p = body + advance;
+        }
+
+        if (!haveFmt || !haveData || dataLength <= 0) return null;
+        if (channels <= 0 || sampleRate <= 0) return null;
+        if (bits != 8 && bits != 16 && bits != 24 && bits != 32) return null;
+        return new WavPeakReader(wav, dataOffset, dataLength, sampleRate, channels, bits);
+    }
+
+    /// <summary>
+    /// The loudest moment between two times, in dBFS. Silence returns -120. A span outside the
+    /// audio, or one that contains no whole sample, also returns -120: there is no sound there,
+    /// which is the truthful answer to "how loud was it".
+    /// </summary>
+    public double PeakDbBetween(double startSeconds, double endSeconds)
+    {
+        int frameBytes = _channels * _bytesPerSample;
+        int totalFrames = _dataLength / frameBytes;
+        if (totalFrames <= 0) return -120.0;
+
+        int first = (int)Math.Floor(Math.Max(0, startSeconds) * SampleRate);
+        int last = (int)Math.Ceiling(Math.Max(0, endSeconds) * SampleRate);
+        first = Math.Clamp(first, 0, totalFrames);
+        last = Math.Clamp(last, 0, totalFrames);
+        if (last <= first) return -120.0;
+
+        double peak = 0.0;
+        for (int f = first; f < last; f++)
+        {
+            int baseIndex = _dataOffset + f * frameBytes;
+            for (int c = 0; c < _channels; c++)
+            {
+                double v = Math.Abs(SampleAt(baseIndex + c * _bytesPerSample));
+                if (v > peak) peak = v;
+            }
+        }
+
+        if (peak <= 0.0) return -120.0;
+        return Math.Max(-120.0, 20.0 * Math.Log10(peak));
+    }
+
+    /// <summary>One sample, normalised to -1..1 whatever the bit depth. 8-bit PCM is unsigned
+    /// with a midpoint of 128; every wider format is signed little-endian.</summary>
+    private double SampleAt(int offset)
+    {
+        switch (_bytesPerSample)
+        {
+            case 1:
+                return (_wav[offset] - 128) / 128.0;
+            case 2:
+                return BitConverter.ToInt16(_wav, offset) / 32768.0;
+            case 3:
+                int v24 = _wav[offset] | (_wav[offset + 1] << 8) | (_wav[offset + 2] << 16);
+                if ((v24 & 0x800000) != 0) v24 |= unchecked((int)0xFF000000);   // sign-extend
+                return v24 / 8388608.0;
+            case 4:
+                return BitConverter.ToInt32(_wav, offset) / 2147483648.0;
+            default:
+                return 0.0;
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj
+++ b/src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj
@@ -63,4 +63,12 @@
     <Delete Files="$(OutDir)hosted-gateway.image" />
   </Target>
 
+
+  <ItemGroup>
+    <!-- Conformance fixture for the transcript evidence gate: the peak levels of the real corpus
+         and the verdict the Python spec gives for each, so the C# is proven to agree with the
+         spec rather than merely resembling it. Carries no audio and no transcript text. -->
+    <None Include="Fixtures/transcript-gate-conformance.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/CcDirector.Gateway.Tests/Fixtures/transcript-gate-conformance.json
+++ b/src/CcDirector.Gateway.Tests/Fixtures/transcript-gate-conformance.json
@@ -1,0 +1,1758 @@
+{
+ "spec": "devthrottle_internal tools/transcription-lab/corpus/gate.py",
+ "version": "v2.0",
+ "generated": "2026-09-09",
+ "note": "Per-segment peak levels from the real 44-clip corpus and the verdict the Python spec gives for each. Filenames and transcript text are deliberately absent: this fixture proves the C# arithmetic and the median-reference choice match the spec, and carries none of the owner's speech.",
+ "cases": [
+  {
+   "clip": "clip00",
+   "segments": [
+    {
+     "start": 0.96,
+     "end": 5.1,
+     "peakDb": -31.7,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip01",
+   "segments": [
+    {
+     "start": 0.81,
+     "end": 3.19,
+     "peakDb": -32.7,
+     "drop": false
+    },
+    {
+     "start": 4.2,
+     "end": 7.54,
+     "peakDb": -30.7,
+     "drop": false
+    },
+    {
+     "start": 8.13,
+     "end": 9.07,
+     "peakDb": -34.2,
+     "drop": false
+    },
+    {
+     "start": 9.9,
+     "end": 14.28,
+     "peakDb": -27.5,
+     "drop": false
+    },
+    {
+     "start": 15.12,
+     "end": 18.74,
+     "peakDb": -17.7,
+     "drop": false
+    },
+    {
+     "start": 19.08,
+     "end": 22.62,
+     "peakDb": -18.8,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip02",
+   "segments": [
+    {
+     "start": 0.69,
+     "end": 3.33,
+     "peakDb": -24.9,
+     "drop": false
+    },
+    {
+     "start": 6.72,
+     "end": 7.32,
+     "peakDb": -33.3,
+     "drop": false
+    },
+    {
+     "start": 7.35,
+     "end": 10.11,
+     "peakDb": -25.0,
+     "drop": false
+    },
+    {
+     "start": 10.92,
+     "end": 13.86,
+     "peakDb": -25.6,
+     "drop": false
+    },
+    {
+     "start": 14.28,
+     "end": 16.54,
+     "peakDb": -26.4,
+     "drop": false
+    },
+    {
+     "start": 17.64,
+     "end": 17.96,
+     "peakDb": -32.0,
+     "drop": false
+    },
+    {
+     "start": 19.11,
+     "end": 23.41,
+     "peakDb": -27.8,
+     "drop": false
+    },
+    {
+     "start": 24.12,
+     "end": 26.04,
+     "peakDb": -29.2,
+     "drop": false
+    },
+    {
+     "start": 26.46,
+     "end": 27.46,
+     "peakDb": -30.6,
+     "drop": false
+    },
+    {
+     "start": 30.48,
+     "end": 33.78,
+     "peakDb": -26.7,
+     "drop": false
+    },
+    {
+     "start": 34.32,
+     "end": 36.16,
+     "peakDb": -27.5,
+     "drop": false
+    },
+    {
+     "start": 36.48,
+     "end": 39.16,
+     "peakDb": -28.4,
+     "drop": false
+    },
+    {
+     "start": 39.72,
+     "end": 40.78,
+     "peakDb": -32.6,
+     "drop": false
+    },
+    {
+     "start": 41.4,
+     "end": 42.28,
+     "peakDb": -29.8,
+     "drop": false
+    },
+    {
+     "start": 44.16,
+     "end": 45.66,
+     "peakDb": -27.0,
+     "drop": false
+    },
+    {
+     "start": 46.68,
+     "end": 49.84,
+     "peakDb": -27.0,
+     "drop": false
+    },
+    {
+     "start": 50.13,
+     "end": 51.57,
+     "peakDb": -25.2,
+     "drop": false
+    },
+    {
+     "start": 52.95,
+     "end": 55.99,
+     "peakDb": -25.0,
+     "drop": false
+    },
+    {
+     "start": 56.58,
+     "end": 60.0,
+     "peakDb": -28.7,
+     "drop": false
+    },
+    {
+     "start": 60.18,
+     "end": 61.86,
+     "peakDb": -28.4,
+     "drop": false
+    },
+    {
+     "start": 62.01,
+     "end": 63.21,
+     "peakDb": -28.5,
+     "drop": false
+    },
+    {
+     "start": 63.24,
+     "end": 67.36,
+     "peakDb": -28.2,
+     "drop": false
+    },
+    {
+     "start": 67.68,
+     "end": 69.98,
+     "peakDb": -26.0,
+     "drop": false
+    },
+    {
+     "start": 70.5,
+     "end": 72.58,
+     "peakDb": -27.8,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip03",
+   "segments": [
+    {
+     "start": 0.06,
+     "end": 0.52,
+     "peakDb": -18.4,
+     "drop": false
+    },
+    {
+     "start": 0.81,
+     "end": 3.67,
+     "peakDb": -18.5,
+     "drop": false
+    },
+    {
+     "start": 4.95,
+     "end": 8.71,
+     "peakDb": -18.6,
+     "drop": false
+    },
+    {
+     "start": 9.66,
+     "end": 12.38,
+     "peakDb": -16.6,
+     "drop": false
+    },
+    {
+     "start": 14.34,
+     "end": 26.64,
+     "peakDb": -16.3,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip04",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 0.45,
+     "peakDb": -23.0,
+     "drop": false
+    },
+    {
+     "start": 0.78,
+     "end": 2.84,
+     "peakDb": -14.8,
+     "drop": false
+    },
+    {
+     "start": 4.23,
+     "end": 5.67,
+     "peakDb": -17.6,
+     "drop": false
+    },
+    {
+     "start": 13.17,
+     "end": 14.03,
+     "peakDb": -17.1,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip05",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 0.55,
+     "peakDb": -23.0,
+     "drop": false
+    },
+    {
+     "start": 1.29,
+     "end": 2.89,
+     "peakDb": -15.1,
+     "drop": false
+    },
+    {
+     "start": 3.24,
+     "end": 7.72,
+     "peakDb": -16.8,
+     "drop": false
+    },
+    {
+     "start": 8.07,
+     "end": 10.83,
+     "peakDb": -15.9,
+     "drop": false
+    },
+    {
+     "start": 11.85,
+     "end": 16.95,
+     "peakDb": -14.9,
+     "drop": false
+    },
+    {
+     "start": 17.52,
+     "end": 22.3,
+     "peakDb": -17.0,
+     "drop": false
+    },
+    {
+     "start": 23.58,
+     "end": 28.14,
+     "peakDb": -17.2,
+     "drop": false
+    },
+    {
+     "start": 28.71,
+     "end": 34.63,
+     "peakDb": -17.0,
+     "drop": false
+    },
+    {
+     "start": 35.22,
+     "end": 35.72,
+     "peakDb": -38.2,
+     "drop": true
+    }
+   ]
+  },
+  {
+   "clip": "clip06",
+   "segments": [
+    {
+     "start": 0.45,
+     "end": 0.93,
+     "peakDb": -61.1,
+     "drop": true
+    },
+    {
+     "start": 0.99,
+     "end": 7.33,
+     "peakDb": -13.2,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip07",
+   "segments": [
+    {
+     "start": 0.06,
+     "end": 0.7,
+     "peakDb": -45.9,
+     "drop": true
+    },
+    {
+     "start": 1.32,
+     "end": 4.74,
+     "peakDb": -11.9,
+     "drop": false
+    },
+    {
+     "start": 5.25,
+     "end": 11.47,
+     "peakDb": -14.7,
+     "drop": false
+    },
+    {
+     "start": 13.41,
+     "end": 16.23,
+     "peakDb": -6.4,
+     "drop": false
+    },
+    {
+     "start": 16.86,
+     "end": 20.52,
+     "peakDb": -14.4,
+     "drop": false
+    },
+    {
+     "start": 21.18,
+     "end": 23.58,
+     "peakDb": -15.4,
+     "drop": false
+    },
+    {
+     "start": 24.09,
+     "end": 25.63,
+     "peakDb": -16.3,
+     "drop": false
+    },
+    {
+     "start": 26.55,
+     "end": 29.97,
+     "peakDb": -12.6,
+     "drop": false
+    },
+    {
+     "start": 31.11,
+     "end": 35.35,
+     "peakDb": -11.7,
+     "drop": false
+    },
+    {
+     "start": 35.7,
+     "end": 37.7,
+     "peakDb": -26.9,
+     "drop": true
+    },
+    {
+     "start": 37.23,
+     "end": 37.71,
+     "peakDb": -26.9,
+     "drop": true
+    },
+    {
+     "start": 39.06,
+     "end": 47.74,
+     "peakDb": -10.2,
+     "drop": false
+    },
+    {
+     "start": 48.45,
+     "end": 58.99,
+     "peakDb": -11.5,
+     "drop": false
+    },
+    {
+     "start": 59.58,
+     "end": 61.18,
+     "peakDb": -10.7,
+     "drop": false
+    },
+    {
+     "start": 61.35,
+     "end": 70.69,
+     "peakDb": -12.2,
+     "drop": false
+    },
+    {
+     "start": 71.19,
+     "end": 76.81,
+     "peakDb": -9.1,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip08",
+   "segments": [
+    {
+     "start": 2.97,
+     "end": 5.53,
+     "peakDb": -5.2,
+     "drop": false
+    },
+    {
+     "start": 9.24,
+     "end": 19.46,
+     "peakDb": -6.4,
+     "drop": false
+    },
+    {
+     "start": 20.64,
+     "end": 22.26,
+     "peakDb": -5.8,
+     "drop": false
+    },
+    {
+     "start": 25.44,
+     "end": 28.2,
+     "peakDb": -7.8,
+     "drop": false
+    },
+    {
+     "start": 30.87,
+     "end": 32.19,
+     "peakDb": -10.1,
+     "drop": false
+    },
+    {
+     "start": 32.4,
+     "end": 35.12,
+     "peakDb": -5.9,
+     "drop": false
+    },
+    {
+     "start": 36.75,
+     "end": 40.35,
+     "peakDb": -7.9,
+     "drop": false
+    },
+    {
+     "start": 41.46,
+     "end": 43.68,
+     "peakDb": -10.8,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip09",
+   "segments": [
+    {
+     "start": 1.95,
+     "end": 8.89,
+     "peakDb": -5.3,
+     "drop": false
+    },
+    {
+     "start": 9.72,
+     "end": 11.96,
+     "peakDb": -10.2,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip10",
+   "segments": [
+    {
+     "start": 1.77,
+     "end": 8.01,
+     "peakDb": -8.7,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip11",
+   "segments": [
+    {
+     "start": 1.44,
+     "end": 6.22,
+     "peakDb": -6.7,
+     "drop": false
+    },
+    {
+     "start": 6.57,
+     "end": 12.09,
+     "peakDb": -11.4,
+     "drop": false
+    },
+    {
+     "start": 14.01,
+     "end": 15.09,
+     "peakDb": -11.0,
+     "drop": false
+    },
+    {
+     "start": 15.6,
+     "end": 19.66,
+     "peakDb": -11.8,
+     "drop": false
+    },
+    {
+     "start": 21.3,
+     "end": 22.96,
+     "peakDb": -11.5,
+     "drop": false
+    },
+    {
+     "start": 23.19,
+     "end": 25.43,
+     "peakDb": -11.6,
+     "drop": false
+    },
+    {
+     "start": 26.07,
+     "end": 31.93,
+     "peakDb": -9.0,
+     "drop": false
+    },
+    {
+     "start": 32.64,
+     "end": 40.4,
+     "peakDb": -5.6,
+     "drop": false
+    },
+    {
+     "start": 40.53,
+     "end": 44.61,
+     "peakDb": -6.5,
+     "drop": false
+    },
+    {
+     "start": 45.0,
+     "end": 49.28,
+     "peakDb": -6.7,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip12",
+   "segments": [
+    {
+     "start": 2.31,
+     "end": 7.67,
+     "peakDb": -9.4,
+     "drop": false
+    },
+    {
+     "start": 8.22,
+     "end": 10.74,
+     "peakDb": -8.1,
+     "drop": false
+    },
+    {
+     "start": 12.0,
+     "end": 16.6,
+     "peakDb": -5.5,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip13",
+   "segments": [
+    {
+     "start": 0.0,
+     "end": 0.6,
+     "peakDb": -7.5,
+     "drop": false
+    },
+    {
+     "start": 0.84,
+     "end": 4.62,
+     "peakDb": -0.2,
+     "drop": false
+    },
+    {
+     "start": 6.45,
+     "end": 12.41,
+     "peakDb": -2.4,
+     "drop": false
+    },
+    {
+     "start": 13.08,
+     "end": 17.96,
+     "peakDb": -3.3,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip14",
+   "segments": [
+    {
+     "start": 1.95,
+     "end": 2.55,
+     "peakDb": -34.0,
+     "drop": true
+    },
+    {
+     "start": 3.66,
+     "end": 5.56,
+     "peakDb": -9.4,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip15",
+   "segments": [
+    {
+     "start": 2.28,
+     "end": 8.84,
+     "peakDb": -7.2,
+     "drop": false
+    },
+    {
+     "start": 10.26,
+     "end": 14.02,
+     "peakDb": -8.7,
+     "drop": false
+    },
+    {
+     "start": 14.28,
+     "end": 16.12,
+     "peakDb": -11.5,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip16",
+   "segments": [
+    {
+     "start": 1.35,
+     "end": 5.41,
+     "peakDb": -8.2,
+     "drop": false
+    },
+    {
+     "start": 7.2,
+     "end": 8.48,
+     "peakDb": -12.1,
+     "drop": false
+    },
+    {
+     "start": 8.58,
+     "end": 11.3,
+     "peakDb": -8.0,
+     "drop": false
+    },
+    {
+     "start": 12.15,
+     "end": 17.43,
+     "peakDb": -7.9,
+     "drop": false
+    },
+    {
+     "start": 18.12,
+     "end": 20.7,
+     "peakDb": -7.4,
+     "drop": false
+    },
+    {
+     "start": 21.87,
+     "end": 35.13,
+     "peakDb": -8.1,
+     "drop": false
+    },
+    {
+     "start": 35.43,
+     "end": 35.77,
+     "peakDb": -52.8,
+     "drop": true
+    }
+   ]
+  },
+  {
+   "clip": "clip17",
+   "segments": [
+    {
+     "start": 1.02,
+     "end": 6.22,
+     "peakDb": -19.2,
+     "drop": false
+    },
+    {
+     "start": 8.19,
+     "end": 19.83,
+     "peakDb": -21.6,
+     "drop": false
+    },
+    {
+     "start": 20.91,
+     "end": 25.39,
+     "peakDb": -20.3,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip18",
+   "segments": [
+    {
+     "start": 0.75,
+     "end": 4.33,
+     "peakDb": -23.3,
+     "drop": false
+    },
+    {
+     "start": 4.95,
+     "end": 9.99,
+     "peakDb": -24.5,
+     "drop": false
+    },
+    {
+     "start": 10.2,
+     "end": 10.62,
+     "peakDb": -63.9,
+     "drop": true
+    },
+    {
+     "start": 11.79,
+     "end": 13.33,
+     "peakDb": -27.0,
+     "drop": false
+    },
+    {
+     "start": 14.01,
+     "end": 16.05,
+     "peakDb": -25.3,
+     "drop": false
+    },
+    {
+     "start": 16.38,
+     "end": 19.02,
+     "peakDb": -24.1,
+     "drop": false
+    },
+    {
+     "start": 20.01,
+     "end": 22.21,
+     "peakDb": -25.1,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip19",
+   "segments": [
+    {
+     "start": 0.0,
+     "end": 0.42,
+     "peakDb": -25.7,
+     "drop": false
+    },
+    {
+     "start": 0.69,
+     "end": 5.75,
+     "peakDb": -16.0,
+     "drop": false
+    },
+    {
+     "start": 6.54,
+     "end": 10.0,
+     "peakDb": -18.1,
+     "drop": false
+    },
+    {
+     "start": 10.35,
+     "end": 12.35,
+     "peakDb": -19.8,
+     "drop": false
+    },
+    {
+     "start": 12.54,
+     "end": 15.9,
+     "peakDb": -19.3,
+     "drop": false
+    },
+    {
+     "start": 16.44,
+     "end": 23.3,
+     "peakDb": -21.0,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip20",
+   "segments": [
+    {
+     "start": 0.9,
+     "end": 4.12,
+     "peakDb": -18.2,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip21",
+   "segments": [
+    {
+     "start": 0.0,
+     "end": 0.46,
+     "peakDb": -26.8,
+     "drop": false
+    },
+    {
+     "start": 1.02,
+     "end": 6.6,
+     "peakDb": -14.1,
+     "drop": false
+    },
+    {
+     "start": 6.72,
+     "end": 8.88,
+     "peakDb": -26.8,
+     "drop": false
+    },
+    {
+     "start": 10.62,
+     "end": 13.54,
+     "peakDb": -21.5,
+     "drop": false
+    },
+    {
+     "start": 14.31,
+     "end": 15.93,
+     "peakDb": -20.9,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip22",
+   "segments": [
+    {
+     "start": 0.06,
+     "end": 8.06,
+     "peakDb": -12.7,
+     "drop": false
+    },
+    {
+     "start": 7.23,
+     "end": 10.27,
+     "peakDb": -22.6,
+     "drop": false
+    },
+    {
+     "start": 13.2,
+     "end": 22.08,
+     "peakDb": -17.8,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip23",
+   "segments": [
+    {
+     "start": 0.06,
+     "end": 0.6,
+     "peakDb": -24.2,
+     "drop": false
+    },
+    {
+     "start": 0.78,
+     "end": 4.78,
+     "peakDb": -15.6,
+     "drop": false
+    },
+    {
+     "start": 4.89,
+     "end": 6.65,
+     "peakDb": -21.5,
+     "drop": false
+    },
+    {
+     "start": 7.32,
+     "end": 14.54,
+     "peakDb": -16.2,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip24",
+   "segments": [
+    {
+     "start": 1.59,
+     "end": 10.63,
+     "peakDb": -18.5,
+     "drop": false
+    },
+    {
+     "start": 10.8,
+     "end": 11.92,
+     "peakDb": -19.2,
+     "drop": false
+    },
+    {
+     "start": 12.27,
+     "end": 13.07,
+     "peakDb": -19.8,
+     "drop": false
+    },
+    {
+     "start": 13.86,
+     "end": 17.44,
+     "peakDb": -16.8,
+     "drop": false
+    },
+    {
+     "start": 17.46,
+     "end": 19.06,
+     "peakDb": -18.6,
+     "drop": false
+    },
+    {
+     "start": 19.44,
+     "end": 24.9,
+     "peakDb": -18.1,
+     "drop": false
+    },
+    {
+     "start": 26.07,
+     "end": 30.17,
+     "peakDb": -18.0,
+     "drop": false
+    },
+    {
+     "start": 31.89,
+     "end": 34.33,
+     "peakDb": -18.9,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip25",
+   "segments": [
+    {
+     "start": 1.65,
+     "end": 5.85,
+     "peakDb": -19.6,
+     "drop": false
+    },
+    {
+     "start": 6.27,
+     "end": 8.27,
+     "peakDb": -24.5,
+     "drop": false
+    },
+    {
+     "start": 9.21,
+     "end": 21.07,
+     "peakDb": -23.0,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip26",
+   "segments": [
+    {
+     "start": 0.06,
+     "end": 0.3,
+     "peakDb": -26.6,
+     "drop": false
+    },
+    {
+     "start": 0.99,
+     "end": 3.67,
+     "peakDb": -14.4,
+     "drop": false
+    },
+    {
+     "start": 5.67,
+     "end": 11.91,
+     "peakDb": -19.5,
+     "drop": false
+    },
+    {
+     "start": 12.66,
+     "end": 22.26,
+     "peakDb": -17.7,
+     "drop": false
+    },
+    {
+     "start": 22.68,
+     "end": 23.18,
+     "peakDb": -49.7,
+     "drop": true
+    }
+   ]
+  },
+  {
+   "clip": "clip27",
+   "segments": [
+    {
+     "start": 0.0,
+     "end": 0.24,
+     "peakDb": -29.2,
+     "drop": false
+    },
+    {
+     "start": 0.54,
+     "end": 1.02,
+     "peakDb": -42.6,
+     "drop": true
+    },
+    {
+     "start": 1.92,
+     "end": 2.76,
+     "peakDb": -17.7,
+     "drop": false
+    },
+    {
+     "start": 2.85,
+     "end": 8.69,
+     "peakDb": -19.2,
+     "drop": false
+    },
+    {
+     "start": 8.88,
+     "end": 13.56,
+     "peakDb": -17.8,
+     "drop": false
+    },
+    {
+     "start": 13.65,
+     "end": 18.21,
+     "peakDb": -20.9,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip28",
+   "segments": [
+    {
+     "start": 0.06,
+     "end": 4.08,
+     "peakDb": -13.2,
+     "drop": false
+    },
+    {
+     "start": 5.31,
+     "end": 11.77,
+     "peakDb": -16.8,
+     "drop": false
+    },
+    {
+     "start": 11.85,
+     "end": 15.79,
+     "peakDb": -18.4,
+     "drop": false
+    },
+    {
+     "start": 15.87,
+     "end": 17.17,
+     "peakDb": -24.8,
+     "drop": false
+    },
+    {
+     "start": 17.25,
+     "end": 20.77,
+     "peakDb": -22.3,
+     "drop": false
+    },
+    {
+     "start": 21.12,
+     "end": 41.76,
+     "peakDb": -14.9,
+     "drop": false
+    },
+    {
+     "start": 43.12,
+     "end": 46.16,
+     "peakDb": -15.1,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip29",
+   "segments": [
+    {
+     "start": 0.84,
+     "end": 3.52,
+     "peakDb": -20.5,
+     "drop": false
+    },
+    {
+     "start": 3.6,
+     "end": 4.9,
+     "peakDb": -23.4,
+     "drop": false
+    },
+    {
+     "start": 5.55,
+     "end": 17.33,
+     "peakDb": -20.4,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip30",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 0.35,
+     "peakDb": -30.1,
+     "drop": false
+    },
+    {
+     "start": 0.63,
+     "end": 4.17,
+     "peakDb": -17.7,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip31",
+   "segments": [
+    {
+     "start": 0.69,
+     "end": 2.25,
+     "peakDb": -22.1,
+     "drop": false
+    },
+    {
+     "start": 3.33,
+     "end": 5.47,
+     "peakDb": -24.5,
+     "drop": false
+    },
+    {
+     "start": 6.0,
+     "end": 6.48,
+     "peakDb": -56.7,
+     "drop": true
+    },
+    {
+     "start": 6.54,
+     "end": 8.8,
+     "peakDb": -23.9,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip32",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 0.51,
+     "peakDb": -19.3,
+     "drop": false
+    },
+    {
+     "start": 0.72,
+     "end": 7.42,
+     "peakDb": -18.5,
+     "drop": false
+    },
+    {
+     "start": 7.92,
+     "end": 13.14,
+     "peakDb": -18.5,
+     "drop": false
+    },
+    {
+     "start": 14.19,
+     "end": 17.99,
+     "peakDb": -18.1,
+     "drop": false
+    },
+    {
+     "start": 18.54,
+     "end": 21.16,
+     "peakDb": -18.5,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip33",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 0.53,
+     "peakDb": -18.2,
+     "drop": false
+    },
+    {
+     "start": 0.78,
+     "end": 5.82,
+     "peakDb": -10.1,
+     "drop": false
+    },
+    {
+     "start": 7.59,
+     "end": 8.89,
+     "peakDb": -19.2,
+     "drop": false
+    },
+    {
+     "start": 9.18,
+     "end": 10.86,
+     "peakDb": -17.7,
+     "drop": false
+    },
+    {
+     "start": 11.01,
+     "end": 15.61,
+     "peakDb": -13.2,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip34",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 0.53,
+     "peakDb": -19.6,
+     "drop": false
+    },
+    {
+     "start": 0.78,
+     "end": 2.04,
+     "peakDb": -14.5,
+     "drop": false
+    },
+    {
+     "start": 2.28,
+     "end": 4.52,
+     "peakDb": -18.0,
+     "drop": false
+    },
+    {
+     "start": 5.37,
+     "end": 9.93,
+     "peakDb": -14.4,
+     "drop": false
+    },
+    {
+     "start": 11.19,
+     "end": 12.87,
+     "peakDb": -14.6,
+     "drop": false
+    },
+    {
+     "start": 15.15,
+     "end": 17.03,
+     "peakDb": -14.6,
+     "drop": false
+    },
+    {
+     "start": 17.46,
+     "end": 26.34,
+     "peakDb": -12.5,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip35",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 0.45,
+     "peakDb": -19.3,
+     "drop": false
+    },
+    {
+     "start": 0.84,
+     "end": 3.18,
+     "peakDb": -16.4,
+     "drop": false
+    },
+    {
+     "start": 3.42,
+     "end": 5.42,
+     "peakDb": -15.0,
+     "drop": false
+    },
+    {
+     "start": 5.4,
+     "end": 6.96,
+     "peakDb": -14.5,
+     "drop": false
+    },
+    {
+     "start": 8.07,
+     "end": 13.27,
+     "peakDb": -13.2,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip36",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 3.21,
+     "peakDb": -14.2,
+     "drop": false
+    },
+    {
+     "start": 3.81,
+     "end": 6.51,
+     "peakDb": -15.9,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip37",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 3.03,
+     "peakDb": -21.3,
+     "drop": false
+    },
+    {
+     "start": 4.44,
+     "end": 9.42,
+     "peakDb": -25.7,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip38",
+   "segments": [
+    {
+     "start": 0.66,
+     "end": 1.8,
+     "peakDb": -14.8,
+     "drop": false
+    },
+    {
+     "start": 3.42,
+     "end": 10.88,
+     "peakDb": -16.6,
+     "drop": false
+    },
+    {
+     "start": 11.46,
+     "end": 12.12,
+     "peakDb": -17.0,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip39",
+   "segments": [
+    {
+     "start": 1.08,
+     "end": 5.92,
+     "peakDb": -20.2,
+     "drop": false
+    },
+    {
+     "start": 6.18,
+     "end": 9.6,
+     "peakDb": -18.0,
+     "drop": false
+    },
+    {
+     "start": 10.23,
+     "end": 13.01,
+     "peakDb": -25.4,
+     "drop": false
+    },
+    {
+     "start": 13.44,
+     "end": 13.92,
+     "peakDb": -34.9,
+     "drop": false
+    },
+    {
+     "start": 13.98,
+     "end": 16.62,
+     "peakDb": -25.4,
+     "drop": false
+    },
+    {
+     "start": 17.04,
+     "end": 22.72,
+     "peakDb": -24.2,
+     "drop": false
+    },
+    {
+     "start": 22.95,
+     "end": 23.35,
+     "peakDb": -51.5,
+     "drop": true
+    },
+    {
+     "start": 23.64,
+     "end": 26.1,
+     "peakDb": -22.5,
+     "drop": false
+    },
+    {
+     "start": 27.36,
+     "end": 30.56,
+     "peakDb": -25.4,
+     "drop": false
+    },
+    {
+     "start": 30.75,
+     "end": 32.35,
+     "peakDb": -28.0,
+     "drop": false
+    },
+    {
+     "start": 33.36,
+     "end": 34.64,
+     "peakDb": -24.6,
+     "drop": false
+    },
+    {
+     "start": 34.98,
+     "end": 38.42,
+     "peakDb": -26.8,
+     "drop": false
+    },
+    {
+     "start": 39.21,
+     "end": 42.03,
+     "peakDb": -28.0,
+     "drop": false
+    },
+    {
+     "start": 42.42,
+     "end": 45.78,
+     "peakDb": -29.2,
+     "drop": false
+    },
+    {
+     "start": 45.84,
+     "end": 48.24,
+     "peakDb": -25.7,
+     "drop": false
+    },
+    {
+     "start": 48.57,
+     "end": 51.63,
+     "peakDb": -29.8,
+     "drop": false
+    },
+    {
+     "start": 51.96,
+     "end": 55.44,
+     "peakDb": -27.2,
+     "drop": false
+    },
+    {
+     "start": 55.65,
+     "end": 59.29,
+     "peakDb": -25.2,
+     "drop": false
+    },
+    {
+     "start": 59.64,
+     "end": 63.4,
+     "peakDb": -28.1,
+     "drop": false
+    },
+    {
+     "start": 63.51,
+     "end": 65.17,
+     "peakDb": -28.3,
+     "drop": false
+    },
+    {
+     "start": 66.06,
+     "end": 70.14,
+     "peakDb": -25.6,
+     "drop": false
+    },
+    {
+     "start": 71.55,
+     "end": 76.31,
+     "peakDb": -26.0,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip40",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 4.75,
+     "peakDb": -24.6,
+     "drop": false
+    },
+    {
+     "start": 4.8,
+     "end": 8.64,
+     "peakDb": -28.2,
+     "drop": false
+    },
+    {
+     "start": 8.7,
+     "end": 10.96,
+     "peakDb": -31.0,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip41",
+   "segments": [
+    {
+     "start": 2.07,
+     "end": 8.83,
+     "peakDb": -19.0,
+     "drop": false
+    },
+    {
+     "start": 9.12,
+     "end": 11.6,
+     "peakDb": -25.0,
+     "drop": false
+    },
+    {
+     "start": 12.66,
+     "end": 20.66,
+     "peakDb": -20.7,
+     "drop": false
+    },
+    {
+     "start": 20.91,
+     "end": 25.49,
+     "peakDb": -16.2,
+     "drop": false
+    },
+    {
+     "start": 25.98,
+     "end": 27.88,
+     "peakDb": -21.5,
+     "drop": false
+    },
+    {
+     "start": 27.99,
+     "end": 29.55,
+     "peakDb": -24.4,
+     "drop": false
+    },
+    {
+     "start": 30.03,
+     "end": 33.35,
+     "peakDb": -18.7,
+     "drop": false
+    },
+    {
+     "start": 33.66,
+     "end": 37.52,
+     "peakDb": -21.3,
+     "drop": false
+    },
+    {
+     "start": 38.91,
+     "end": 40.17,
+     "peakDb": -22.2,
+     "drop": false
+    },
+    {
+     "start": 40.98,
+     "end": 42.3,
+     "peakDb": -18.4,
+     "drop": false
+    },
+    {
+     "start": 42.66,
+     "end": 44.38,
+     "peakDb": -26.8,
+     "drop": false
+    },
+    {
+     "start": 44.49,
+     "end": 47.23,
+     "peakDb": -19.3,
+     "drop": false
+    },
+    {
+     "start": 47.46,
+     "end": 48.66,
+     "peakDb": -22.2,
+     "drop": false
+    },
+    {
+     "start": 48.78,
+     "end": 53.46,
+     "peakDb": -18.9,
+     "drop": false
+    },
+    {
+     "start": 56.25,
+     "end": 60.69,
+     "peakDb": -19.8,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip42",
+   "segments": [
+    {
+     "start": 0.03,
+     "end": 0.27,
+     "peakDb": -28.5,
+     "drop": false
+    },
+    {
+     "start": 0.48,
+     "end": 2.86,
+     "peakDb": -18.0,
+     "drop": false
+    }
+   ]
+  },
+  {
+   "clip": "clip43",
+   "segments": [
+    {
+     "start": 2.37,
+     "end": 4.53,
+     "peakDb": -24.7,
+     "drop": false
+    },
+    {
+     "start": 4.59,
+     "end": 8.35,
+     "peakDb": -26.5,
+     "drop": false
+    },
+    {
+     "start": 9.45,
+     "end": 12.01,
+     "peakDb": -23.9,
+     "drop": false
+    },
+    {
+     "start": 12.99,
+     "end": 14.83,
+     "peakDb": -30.4,
+     "drop": false
+    },
+    {
+     "start": 15.18,
+     "end": 17.78,
+     "peakDb": -24.5,
+     "drop": false
+    },
+    {
+     "start": 18.12,
+     "end": 18.84,
+     "peakDb": -25.6,
+     "drop": false
+    },
+    {
+     "start": 19.47,
+     "end": 22.23,
+     "peakDb": -27.4,
+     "drop": false
+    },
+    {
+     "start": 24.6,
+     "end": 30.12,
+     "peakDb": -24.5,
+     "drop": false
+    },
+    {
+     "start": 30.75,
+     "end": 31.71,
+     "peakDb": -31.9,
+     "drop": false
+    },
+    {
+     "start": 32.1,
+     "end": 34.3,
+     "peakDb": -28.2,
+     "drop": false
+    }
+   ]
+  }
+ ]
+}

--- a/src/CcDirector.Gateway.Tests/TranscriptEvidenceGateTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptEvidenceGateTests.cs
@@ -1,0 +1,205 @@
+using System.Text.Json;
+using CcDirector.Core.Audio;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The evidence gate (pipeline v2.0): a transcript sentence with no sound behind it is not
+/// delivered.
+///
+/// Two kinds of test here, and the second is the one that matters:
+///   - behaviour, on audio built in the test so the expected answer is known by construction;
+///   - CONFORMANCE against the Python spec, replayed over the real corpus's measurements. The
+///     spec is where the rule is developed and scored; without this test the C# could drift
+///     from it and still look correct.
+/// </summary>
+public sealed class TranscriptEvidenceGateTests
+{
+    // ---- audio built to order, so the right answer is known before the gate runs ----
+
+    private static byte[] Wav(params (double seconds, double amplitude)[] parts)
+    {
+        const int sampleRate = 16000;
+        var samples = new List<short>();
+        foreach (var (seconds, amplitude) in parts)
+        {
+            int n = (int)(seconds * sampleRate);
+            for (int i = 0; i < n; i++)
+            {
+                // A 200 Hz tone at the requested amplitude: something with a real, measurable peak.
+                double v = Math.Sin(2 * Math.PI * 200 * i / sampleRate) * amplitude;
+                samples.Add((short)Math.Round(v * short.MaxValue));
+            }
+        }
+        var pcm = new byte[samples.Count * 2];
+        Buffer.BlockCopy(samples.ToArray(), 0, pcm, 0, pcm.Length);
+        return PcmWav.Wrap(pcm, sampleRate, 1, 16);
+    }
+
+    private static TranscriptEvidenceGate.Segment Seg(double start, double end, string text)
+        => new(start, end, text);
+
+    [Fact]
+    public void ASentenceOverSilenceIsDropped_AndTheRestIsDeliveredUntouched()
+    {
+        // three seconds of speech, one second of near-silence, three more seconds of speech
+        var audio = Wav((3.0, 0.50), (1.0, 0.0004), (3.0, 0.50));
+        var segments = new[]
+        {
+            Seg(0.0, 3.0, "the first real sentence"),
+            Seg(3.0, 4.0, "Thank you."),
+            Seg(4.0, 7.0, "the second real sentence"),
+        };
+
+        var r = TranscriptEvidenceGate.Apply(audio, segments, "ignored");
+
+        Assert.True(r.Applied);
+        Assert.Equal("the first real sentence the second real sentence", r.Text);
+        Assert.Single(r.DroppedSegments);
+        Assert.Equal("Thank you.", r.DroppedSegments[0].Text);
+        Assert.True(r.DroppedSegments[0].DbBelowClip > TranscriptEvidenceGate.MinDbBelowClip);
+    }
+
+    [Fact]
+    public void QuietSpeechSurvives_ItIsWithinTheBandOfTheClipsOwnVoice()
+    {
+        // A sentence 10 dB below the others is a person trailing off, not an invention.
+        var audio = Wav((2.0, 0.50), (2.0, 0.158), (2.0, 0.50));   // 0.158 is about -10 dB
+        var segments = new[]
+        {
+            Seg(0.0, 2.0, "loud one"),
+            Seg(2.0, 4.0, "the quiet one"),
+            Seg(4.0, 6.0, "loud two"),
+        };
+
+        var r = TranscriptEvidenceGate.Apply(audio, segments, "loud one the quiet one loud two");
+
+        Assert.False(r.Applied);
+        Assert.Empty(r.DroppedSegments);
+        Assert.Contains("the quiet one", r.Text);
+    }
+
+    [Fact]
+    public void TheReferenceIsTheMiddleSentence_NotTheLoudest()
+    {
+        // One emphatic sentence 14 dB above the rest. With the LOUDEST as the reference the
+        // ordinary sentences fall below the threshold and are deleted; with the MIDDLE they do
+        // not. This is the choice that was measured, so it gets a test of its own.
+        var audio = Wav((1.0, 1.0), (1.0, 0.2), (1.0, 0.2), (1.0, 0.2));
+        var segments = new[]
+        {
+            Seg(0.0, 1.0, "SHOUTED"),
+            Seg(1.0, 2.0, "ordinary one"),
+            Seg(2.0, 3.0, "ordinary two"),
+            Seg(3.0, 4.0, "ordinary three"),
+        };
+
+        var r = TranscriptEvidenceGate.Apply(audio, segments, "all of it");
+
+        // With the middle as the reference, nothing is deleted.
+        Assert.Empty(r.DroppedSegments);
+        Assert.False(r.Applied);
+
+        // And the choice is load-bearing: measure the same audio against the LOUDEST sentence
+        // and the three ordinary ones fall past the threshold. If this half ever stops failing,
+        // the tone levels drifted and the test above stopped proving anything.
+        var meter = WavPeakReader.TryRead(audio)!;
+        var peaks = segments.Select(s => meter.PeakDbBetween(s.Start, s.End)).ToArray();
+        var wouldDropAgainstLoudest = peaks.Count(p => peaks.Max() - p > TranscriptEvidenceGate.MinDbBelowClip);
+        Assert.Equal(3, wouldDropAgainstLoudest);
+    }
+
+    [Fact]
+    public void NoTimes_DeliversTheTranscriptUnchanged()
+    {
+        var r = TranscriptEvidenceGate.Apply(Wav((1.0, 0.5)), Array.Empty<TranscriptEvidenceGate.Segment>(), "the words");
+        Assert.False(r.Applied);
+        Assert.Equal("the words", r.Text);
+    }
+
+    [Fact]
+    public void UndecodableAudio_DeliversTheTranscriptUnchanged()
+    {
+        // A WebM/Opus upload, a truncated header - anything we cannot measure. Fail open.
+        var r = TranscriptEvidenceGate.Apply(new byte[] { 1, 2, 3, 4 },
+            new[] { Seg(0, 1, "the words") }, "the words");
+        Assert.False(r.Applied);
+        Assert.Equal("the words", r.Text);
+    }
+
+    [Fact]
+    public void EverySentenceUnsupported_RefusesToDeliverNothing()
+    {
+        // A measurement gone wrong must not silently empty a user's dictation.
+        var audio = Wav((2.0, 0.0004));
+        var segments = new[] { Seg(0.0, 1.0, "Thank you."), Seg(1.0, 2.0, "Thank you.") };
+
+        var r = TranscriptEvidenceGate.Apply(audio, segments, "Thank you. Thank you.");
+
+        Assert.False(r.Applied);
+        Assert.Equal("Thank you. Thank you.", r.Text);
+    }
+
+    // ---- conformance: the C# must agree with the Python spec on the real corpus ----
+
+    private sealed record FixtureSegment(double Start, double End, double PeakDb, bool Drop);
+    private sealed record FixtureCase(string Clip, List<FixtureSegment> Segments);
+    private sealed record Fixture(string Spec, string Version, string Generated, string Note, List<FixtureCase> Cases);
+
+    [Fact]
+    public void MatchesThePythonSpecOnEveryClipOfTheCorpus()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "transcript-gate-conformance.json");
+        Assert.True(File.Exists(path), $"conformance fixture missing at {path}");
+        var fixture = JsonSerializer.Deserialize<Fixture>(File.ReadAllText(path),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+        Assert.Equal(TranscriptEvidenceGate.Version, fixture.Version);
+        Assert.NotEmpty(fixture.Cases);
+
+        int segments = 0, drops = 0;
+        foreach (var c in fixture.Cases)
+        {
+            // Replay the spec's own measurements through the C# decision, so this compares the
+            // RULE - the median reference and the threshold - not the level meter.
+            var peaks = c.Segments.Select(s => s.PeakDb).ToArray();
+            var reference = Median(peaks);
+            for (int i = 0; i < c.Segments.Count; i++)
+            {
+                var below = reference - peaks[i];
+                var drop = below > TranscriptEvidenceGate.MinDbBelowClip;
+                Assert.True(drop == c.Segments[i].Drop,
+                    $"{c.Clip} segment {i}: C# says drop={drop}, the spec says {c.Segments[i].Drop} "
+                    + $"(peak {peaks[i]:0.0} dB, reference {reference:0.0} dB)");
+                segments++;
+                if (drop) drops++;
+            }
+        }
+
+        Assert.Equal(255, segments);   // the corpus as it stood on 2026-09-09
+        Assert.Equal(12, drops);
+    }
+
+    private static double Median(double[] values)
+    {
+        var v = (double[])values.Clone();
+        Array.Sort(v);
+        int n = v.Length;
+        return n % 2 == 1 ? v[n / 2] : (v[n / 2 - 1] + v[n / 2]) / 2.0;
+    }
+
+    // ---- the level meter itself ----
+
+    [Fact]
+    public void PeakReader_MeasuresTheSpanItIsAskedAbout_NotTheWholeClip()
+    {
+        var audio = Wav((1.0, 1.0), (1.0, 0.01));
+        var r = WavPeakReader.TryRead(audio)!;
+        Assert.NotNull(r);
+        Assert.True(r.PeakDbBetween(0.0, 1.0) > -1.0);      // full scale
+        Assert.True(r.PeakDbBetween(1.0, 2.0) < -30.0);     // the quiet half
+        Assert.Equal(-120.0, r.PeakDbBetween(5.0, 6.0));    // past the end: no sound there
+    }
+}

--- a/src/CcDirector.Gateway/Transcription/BatchTranscriptionPipeline.cs
+++ b/src/CcDirector.Gateway/Transcription/BatchTranscriptionPipeline.cs
@@ -381,7 +381,12 @@ public sealed class BatchTranscriptionPipeline : IDisposable
         audioContent.Headers.ContentType = new MediaTypeHeaderValue(GuessAudioContentType(fileName));
         form.Add(audioContent, "file", string.IsNullOrEmpty(fileName) ? "audio.webm" : fileName);
         form.Add(new StringContent(routing.Model), "model");
-        form.Add(new StringContent("json"), "response_format");
+        // verbose_json, not json: it returns each sentence with the span it claims to occupy, which
+        // is what the evidence gate needs to check the words against the sound. This changes only
+        // what OUR proxy hands back - the proxy's own request to the speech model carries no format -
+        // so the transcript itself cannot change. A provider that ignores it simply returns no
+        // segments, and the gate then fails open (pipeline v2.0).
+        form.Add(new StringContent("verbose_json"), "response_format");
         // Spoken-language hint, when the caller knows it. Only sent when set, so the provider keeps
         // auto-detecting for every existing caller. Detection is what fails hardest on the cases this
         // matters for - a short clip, an accent, or a language that shares vocabulary with English -
@@ -410,7 +415,36 @@ public sealed class BatchTranscriptionPipeline : IDisposable
         using var doc = JsonDocument.Parse(body);
         if (!doc.RootElement.TryGetProperty("text", out var textProp))
             throw new InvalidOperationException("Transcription response missing 'text' field");
-        return (textProp.GetString() ?? "").Trim();
+        var text = (textProp.GetString() ?? "").Trim();
+
+        // THE EVIDENCE GATE (pipeline v2.0). Run it HERE, per part, because a long recording is
+        // split and each part's segment times start at zero - gating after the parts are joined
+        // would point every time at the wrong audio. Fails open on anything it cannot measure.
+        var gated = TranscriptEvidenceGate.Apply(audio, ReadSegments(doc.RootElement), text);
+        if (gated.Applied)
+            FileLog.Write($"[BatchTranscriptionPipeline] evidence gate {TranscriptEvidenceGate.Version}: {gated.Reason}");
+        return gated.Text;
+    }
+
+    /// <summary>
+    /// The per-sentence spans from a verbose_json body, or an empty list when the provider did not
+    /// return any. An empty list makes the gate fail open, which is the intended behaviour for a
+    /// provider or format that carries no times.
+    /// </summary>
+    private static IReadOnlyList<TranscriptEvidenceGate.Segment> ReadSegments(JsonElement root)
+    {
+        if (!root.TryGetProperty("segments", out var segs) || segs.ValueKind != JsonValueKind.Array)
+            return Array.Empty<TranscriptEvidenceGate.Segment>();
+
+        var list = new List<TranscriptEvidenceGate.Segment>();
+        foreach (var s in segs.EnumerateArray())
+        {
+            if (!s.TryGetProperty("start", out var a) || !s.TryGetProperty("end", out var b)) continue;
+            if (!s.TryGetProperty("text", out var t)) continue;
+            if (a.ValueKind != JsonValueKind.Number || b.ValueKind != JsonValueKind.Number) continue;
+            list.Add(new TranscriptEvidenceGate.Segment(a.GetDouble(), b.GetDouble(), t.GetString() ?? ""));
+        }
+        return list;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Transcription/TranscriptEvidenceGate.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscriptEvidenceGate.cs
@@ -1,0 +1,130 @@
+using CcDirector.Core.Audio;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// The evidence gate, pipeline v2.0: a transcript sentence that no sound supports is not
+/// delivered.
+///
+/// WHY. whisper-large-v3 is handed a clip and must produce a caption for all of it. It has no
+/// way to answer "nothing was said here", so on a stretch with no intelligible speech it emits
+/// the highest-prior caption from its training corpus - "Thank you.", "you", "Bye.", "um" - and
+/// then repeats it. Since the 2026-08-29 cutover about one dictation in eight has carried a
+/// word the speaker never said. The spoken words are the agent's instructions; a word the model
+/// invents is an instruction nobody gave.
+///
+/// THE RULE. Drop a sentence whose loudest moment is more than
+/// <see cref="MinDbBelowClip"/> dB below the MIDDLE of the clip's own sentence peaks.
+///
+/// THE REFERENCE IS THE MIDDLE, NOT THE LOUDEST. Measured, not assumed: with the loudest
+/// sentence as the reference, one emphatic sentence drags the reference up and quiet real
+/// sentences fall below it - 3 real words deleted, and no threshold clears the inventions
+/// without losses. With the middle, there is a 6.7 dB gap between the quietest real sentence
+/// and the loudest invented one.
+///
+/// MEASURED on a 44-clip corpus (255 sentences), labelled by gpt-transcribe - OpenAI's newest
+/// transcriber, and NOT a whisper model, so it does not share whisper's hallucination priors:
+/// 12 of 12 invented sentences removed, 0 of 221 real sentences deleted, 0 of 22 doubtful ones
+/// touched. A held-out third scores the same as the training two-thirds.
+/// Research: devthrottle_internal docs/research/transcription/2026-09-09-unspoken-words.md
+/// Spec, versioned with its score: tools/transcription-lab/corpus/gate.py
+///
+/// RAW TEXT IS NEVER TOUCHED. The caller stores the model's FULL output as the raw transcript;
+/// this decides only what is delivered, and every drop carries its reason so a removal is
+/// auditable by query exactly as a dictionary edit already is.
+///
+/// FAILS OPEN, DELIBERATELY. Without per-sentence times, or without decodable PCM to measure,
+/// the gate returns the transcript UNCHANGED rather than guessing. Losing a word the user said
+/// is far worse than keeping one they did not, so every uncertainty resolves towards delivering
+/// what the model produced.
+/// </summary>
+public static class TranscriptEvidenceGate
+{
+    /// <summary>Pipeline version this rule implements. Travels into the log with every drop.</summary>
+    public const string Version = "v2.0";
+
+    /// <summary>
+    /// How far below the clip's middle sentence a span must be before its words are treated as
+    /// unsupported. 12 dB is a quarter of the amplitude - not a close call. On the corpus the
+    /// safe window runs from about 12 to 21 dB; below it real quiet speech starts to be at risk,
+    /// above it inventions survive.
+    /// </summary>
+    public const double MinDbBelowClip = 12.0;
+
+    /// <summary>One sentence the speech model produced, with the span it claims to occupy.</summary>
+    /// <param name="Start">Seconds from the start of THIS part's audio.</param>
+    /// <param name="End">Seconds from the start of THIS part's audio.</param>
+    public sealed record Segment(double Start, double End, string Text);
+
+    /// <summary>A sentence that was not delivered, and why.</summary>
+    public sealed record Dropped(double Start, double End, string Text, double DbBelowClip, string Reason);
+
+    /// <summary>The gate's verdict: what to deliver, and what was removed.</summary>
+    public sealed record Result(string Text, IReadOnlyList<Dropped> DroppedSegments, bool Applied, string Reason)
+    {
+        /// <summary>The transcript unchanged, with the reason the gate did not run.</summary>
+        public static Result NotApplied(string text, string reason) => new(text, Array.Empty<Dropped>(), false, reason);
+    }
+
+    /// <summary>
+    /// Apply the gate. <paramref name="audio"/> must be the SAME bytes whose transcription
+    /// produced <paramref name="segments"/>, and the segment times must be relative to those
+    /// bytes - a long recording is split into parts and each part's times start at zero, so the
+    /// gate runs per part, before the parts are joined.
+    /// </summary>
+    public static Result Apply(byte[] audio, IReadOnlyList<Segment> segments, string fullText)
+    {
+        if (segments is null || segments.Count == 0)
+            return Result.NotApplied(fullText, "the provider returned no per-sentence times");
+
+        var pcm = WavPeakReader.TryRead(audio);
+        if (pcm is null)
+            return Result.NotApplied(fullText, "the audio is not decodable PCM WAV, so nothing can be measured");
+
+        var peaks = new double[segments.Count];
+        for (int i = 0; i < segments.Count; i++)
+            peaks[i] = pcm.PeakDbBetween(segments[i].Start, segments[i].End);
+
+        var reference = Median(peaks);
+        var kept = new List<string>(segments.Count);
+        var dropped = new List<Dropped>();
+
+        for (int i = 0; i < segments.Count; i++)
+        {
+            var below = reference - peaks[i];
+            if (below > MinDbBelowClip)
+            {
+                dropped.Add(new Dropped(segments[i].Start, segments[i].End, segments[i].Text, Math.Round(below, 1),
+                    $"{below:0.0} dB below this clip's speech - no sound supports these words"));
+            }
+            else
+            {
+                kept.Add(segments[i].Text);
+            }
+        }
+
+        if (dropped.Count == 0)
+            return Result.NotApplied(fullText, "every sentence is supported by sound");
+
+        // EVERY sentence failed the test. That is a clip which is entirely non-speech, or a
+        // measurement gone wrong; either way, delivering nothing is worse than delivering what
+        // the model produced. Fail open and say so.
+        if (kept.Count == 0)
+            return Result.NotApplied(fullText, "every sentence measured as unsupported - refusing to deliver an empty transcript");
+
+        var text = string.Join(" ", kept.Select(t => t.Trim()).Where(t => t.Length > 0));
+        foreach (var d in dropped)
+            FileLog.Write($"[TranscriptEvidenceGate] {Version} dropped \"{d.Text.Trim()}\" at {d.Start:0.00}-{d.End:0.00}s: {d.Reason}");
+
+        return new Result(text, dropped, true, $"{dropped.Count} sentence(s) had no sound behind them");
+    }
+
+    private static double Median(double[] values)
+    {
+        var v = (double[])values.Clone();
+        Array.Sort(v);
+        int n = v.Length;
+        return n % 2 == 1 ? v[n / 2] : (v[n / 2 - 1] + v[n / 2]) / 2.0;
+    }
+}


### PR DESCRIPTION
## Why

whisper-large-v3 has to caption every part of a clip and cannot answer "nothing was said here". On a silent stretch it writes the likeliest caption from its training corpus - "Thank you.", "you", "Bye." - and then repeats it. Counted across 6,064 stored dictations, this began exactly at the 2026-08-29 cutover:

```
2026-08-20 .. 08-29   ~1,900 clips    0 (0.0%)
2026-08-30               125 clips   16 (12.8%)
2026-09-09               267 clips   51 (19.1%)
```

The spoken words are the agent's instructions. A word the model invents is an instruction nobody gave.

## The rule

```
Drop a sentence whose loudest moment is more than 12 dB below
the MIDDLE of the clip's own sentence peaks.
```

**The reference is the middle, not the loudest** - measured, not assumed. Against the loudest sentence, one emphatic sentence drags the reference up and quiet real sentences are deleted (3 real words lost, and no threshold clears the inventions without losses). There is a test for this choice specifically.

## Measured

44-clip corpus, 255 sentences, labelled by `gpt-transcribe` - OpenAI's newest transcriber and **not** a whisper model, so it does not share whisper's hallucination priors.

| | invented removed | real deleted | doubtful touched |
|---|---|---|---|
| today | 0 / 12 | 0 / 221 | 0 / 22 |
| **v2.0** | **12 / 12** | **0 / 221** | **0 / 22** |

A held-out third scores the same as the training two-thirds.

## Fails open, deliberately

No per-sentence times, undecodable audio (a WebM/Opus upload), or *every* sentence failing - each delivers the model's text unchanged. Losing a word someone said is far worse than keeping one they did not, so every uncertainty resolves towards delivering what the model produced.

Raw text is untouched: this decides only what is delivered, and every drop is logged with its reason.

## Proof

```
TranscriptEvidenceGateTests        8 passed
CcDirector.Gateway.Tests         116 passed  (all transcription tests)
CcDirector.Gateway.UnitTests   4,241 passed, 0 failed
CcDirector.Core.Tests (audio)     48 passed
```

The conformance test replays the real corpus's measurements and asserts the C# reaches the same verdict as the Python spec on all 255 sentences. Mutation check: changing `MinDbBelowClip` from 12 to 18 fails it. The fixture carries peak levels and verdicts only - no audio, no transcript text.

## Note for review

`response_format` moves from `json` to `verbose_json`. This changes only what our own proxy returns to the Gateway; the proxy's request to the speech model carries no format field, so the transcript itself cannot change. A provider that ignores it returns no segments, and the gate then fails open.

Research and version register: `devthrottle_internal/docs/research/transcription/2026-09-09-unspoken-words.md` and `docs/architecture/transcription-pipeline-versions.md`.
