### PR TITLE
The stored raw transcript must be the model's full output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,3 +392,66 @@ every `git commit`, `gh pr create`, `gh issue create`, and `gh pr comment`, grep
 the text for "Claude", "Anthropic", "Co-Authored-By", "Generated with" and strip
 any hit. If attribution reaches a commit that is not yet pushed, amend it before
 it goes anywhere near GitHub.
+
+## THE SPOKEN WORDS REACH THE AGENT VERBATIM - HARD RULE FOR EVERY TRANSCRIPTION PATH
+
+**What the user said is what the agent gets. Only TWO changes are allowed between
+the speech model's output and the agent's prompt: a deterministic, in-process,
+dictionary find/replace of individual terms the user listed by hand, and the removal
+of a sentence the audio does not support.**
+
+**The removal, in full (the owner's amendment, 2026-09-10):** *a sentence may be
+removed only when the audio in its own time span contains no speech-level sound;
+nothing may ever be added or reworded.* It exists because whisper-large-v3 must
+caption every part of a clip and cannot answer "nothing was said here", so on a silent
+stretch it writes the likeliest caption from its training data - "Thank you.", "you",
+"Bye." - and about one dictation in eight carried a word the speaker never said. A word
+the model invents is an instruction nobody gave, so removing it SERVES this rule rather
+than bending it. What may never happen is a removal the audio does not justify: see
+`docs/architecture/transcription-pipeline-versions.md` for the rule and its measured
+score, and the research behind it in
+`docs/research/transcription/2026-09-09-unspoken-words.md`.
+
+This binds the Gateway (`CcDirector.Gateway/Transcription`, `CcDirector.Core/Dictation`),
+the Director's local dictation, the phone app, Notes, Wingman, and the proxy in
+`devthrottle_internal/website/api/v1/audio.js` - every path that turns audio into text.
+
+FORBIDDEN, in any of those paths:
+- Any generative model that can reword, translate, summarise, answer, or "clean up"
+  the transcript. A model that WRITES text is not a transcriber. This includes
+  post-processing passes (the o4-mini cleanup removed in July 2026) AND generative
+  speech-to-text models used as the transcriber itself: on 2026-08-29 the primary
+  provider was `gpt-4o-transcribe`, and it emitted invented German ("Koennt ihr dem
+  Aufgabschornel noch geholfen?") and rewrote whole sentences ("Why do you use it
+  that strong now to send email?") for an English speaker. The Gateway's stored
+  RawText matched what hit the screen and CleanupApplied was false - the damage was
+  done INSIDE the speech model, where no downstream rule can catch it. The primary
+  transcriber must be a non-generative acoustic model (whisper-large-v3).
+- Replacing a word the user did NOT list. The fuzzy matcher did this from
+  2026-08-08 to 2026-08-17 ("sure" -> "Soren" 261 times, "many" -> "Banya" 138,
+  "code" -> "Codex", "single" -> "SignalR", "focus" -> "Opus") before it was made
+  opt-in and off (#2597). It stays off. A judge model may only ever answer with
+  candidate ids - it never supplies text - and it does not make an unlisted swap
+  allowed; the user's own list does.
+- Sending the model a vocabulary `prompt`, a language override, or any bias the
+  user did not configure. A hint changes what the model hears.
+
+REQUIRED:
+- `dictation_transcripts.RawText` is the speech model's FULL output byte-for-byte,
+  including any sentence the evidence gate removed. `CleanedText` differs from it only
+  by accepted `ChangedWords`, each a hand-listed correction, and by whole sentences the
+  gate dropped - never by a reword and never by an addition. A test must prove
+  `Raw + ChangedWords - DroppedSentences == Cleaned`.
+- A removal is only permitted when it is RECORDED. The dropped sentences travel with
+  the result, so a removal is answerable by query exactly as a dictionary edit is. A
+  gate that quietly shrinks a transcript, leaving the evidence only in a log file, is
+  the defect fixed in devthrottle#2805 - not the design.
+- The proof of compliance is the stored rows, not the code comments: diff
+  RawText vs CleanedText over the last 30 days
+  (see the 2026-08-29 query in devthrottle_internal `docs/incidents/`). Any edit
+  whose Find is not in the tenant's Corrections list is a defect, not a feature.
+- Changing the transcription provider or model is a product decision made by the
+  owner in writing. Never switch to a generative model for "reliability".
+
+**Why:** the agent acts on the words. A wrong word from the speaker is the
+speaker's problem; a wrong word from us is an instruction the user never gave.

--- a/src/CcDirector.Gateway.Tests/TranscriptEvidenceGateTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptEvidenceGateTests.cs
@@ -202,4 +202,31 @@ public sealed class TranscriptEvidenceGateTests
         Assert.True(r.PeakDbBetween(1.0, 2.0) < -30.0);     // the quiet half
         Assert.Equal(-120.0, r.PeakDbBetween(5.0, 6.0));    // past the end: no sound there
     }
+
+    // ---- the record must show what was removed ----
+
+    [Fact]
+    public void TheRawTranscriptKeepsTheModelsFullOutput_SoARemovalIsVisibleInTheRecord()
+    {
+        // The defect this pins down: gating the text where the RAW transcript is read made the
+        // stored raw equal the delivered text, so a removal left no trace anywhere except the
+        // Gateway's log file. Diffing the record against what was delivered is how the repo
+        // proves nothing was silently altered, and that only works if the raw is untouched.
+        var audio = Wav((3.0, 0.50), (1.0, 0.0004), (3.0, 0.50));
+        var segments = new[]
+        {
+            Seg(0.0, 3.0, "the first real sentence"),
+            Seg(3.0, 4.0, "Thank you."),
+            Seg(4.0, 7.0, "the second real sentence"),
+        };
+        const string modelWrote = "the first real sentence Thank you. the second real sentence";
+
+        var r = TranscriptEvidenceGate.Apply(audio, segments, modelWrote);
+
+        Assert.True(r.Applied);
+        Assert.DoesNotContain("Thank you.", r.Text);            // not delivered
+        Assert.Single(r.DroppedSegments);                        // and named in the record
+        Assert.Equal("Thank you.", r.DroppedSegments[0].Text);
+        Assert.Contains("Thank you.", modelWrote);               // the model's own words are intact
+    }
 }

--- a/src/CcDirector.Gateway/Transcription/BatchTranscriptionPipeline.cs
+++ b/src/CcDirector.Gateway/Transcription/BatchTranscriptionPipeline.cs
@@ -145,17 +145,21 @@ public sealed class BatchTranscriptionPipeline : IDisposable
 
         FileLog.Write($"[BatchTranscriptionPipeline] TranscribeAsync: bytes={audio.Length}, mode={routing.Mode.ToConfigString()}, model={routing.Model}");
 
-        var raw = await TranscribeBatchAsync(audio, fileName, routing, ct, progress);
-        FileLog.Write($"[BatchTranscriptionPipeline] raw transcript len={raw.Length}");
+        var part = await TranscribeBatchAsync(audio, fileName, routing, ct, progress);
+        FileLog.Write($"[BatchTranscriptionPipeline] raw transcript len={part.Raw.Length}, delivered len={part.Delivered.Length}, dropped={part.Dropped.Count}");
 
-        var corrected = await ApplyDictionaryAsync(raw, routing, dictionary, profileName, ct);
+        // The dictionary runs on what will be DELIVERED, not on the raw text: correcting words
+        // inside a sentence that is not going out would be work nobody sees, and would make the
+        // change list describe edits the user never receives.
+        var corrected = await ApplyDictionaryAsync(part.Delivered, routing, dictionary, profileName, ct);
 
         return new BatchTranscriptionResult(
-            RawTranscript: raw,
+            RawTranscript: part.Raw,
             CorrectedTranscript: corrected.Text,
             DictionaryApplied: corrected.Applied,
             ChangedWords: corrected.ChangedWords,
-            Reason: corrected.Reason);
+            Reason: corrected.Reason,
+            DroppedSegments: part.Dropped);
     }
 
     /// <summary>
@@ -182,7 +186,7 @@ public sealed class BatchTranscriptionPipeline : IDisposable
             throw new ArgumentException("audio blob is empty; the Audio Completeness Gate must run before transcription", nameof(audio));
 
         FileLog.Write($"[BatchTranscriptionPipeline] TranscribeRawAsync: bytes={audio.Length}, mode={routing.Mode.ToConfigString()}, model={routing.Model}");
-        return await TranscribeBatchAsync(audio, fileName, routing, ct, progress);
+        return (await TranscribeBatchAsync(audio, fileName, routing, ct, progress)).Delivered;
     }
 
     /// <summary>
@@ -198,7 +202,7 @@ public sealed class BatchTranscriptionPipeline : IDisposable
     /// than posting an oversized body, because a silent 413 is exactly the failure this removes (the
     /// no-fallback rule). Every capture surface sends PCM WAV, so the long-recording paths are covered.
     /// </summary>
-    private async Task<string> TranscribeBatchAsync(
+    private async Task<PartTranscript> TranscribeBatchAsync(
         byte[] audio, string fileName, ResolvedTranscription routing, CancellationToken ct,
         IProgress<TranscriptionProgress>? progress = null)
     {
@@ -270,11 +274,11 @@ public sealed class BatchTranscriptionPipeline : IDisposable
     /// whole job throws the original typed exception - no silent partial transcripts. The split is
     /// non-overlapping, so a single space joins the parts with no de-duplication.
     /// </summary>
-    private async Task<string> TranscribeChunksInParallelAsync(
+    private async Task<PartTranscript> TranscribeChunksInParallelAsync(
         IReadOnlyList<byte[]> parts, string fileName, ResolvedTranscription routing, CancellationToken ct,
         IProgress<TranscriptionProgress>? progress)
     {
-        var texts = new string[parts.Count];
+        var texts = new PartTranscript[parts.Count];
         int completed = 0;
         progress?.Report(new TranscriptionProgress(0, parts.Count));
 
@@ -288,7 +292,7 @@ public sealed class BatchTranscriptionPipeline : IDisposable
                 var text = await PostOneWithRetryAsync(parts[idx], PartFileName(fileName, idx), routing, idx, ct);
                 texts[idx] = text;
                 int done = Interlocked.Increment(ref completed);
-                FileLog.Write($"[BatchTranscriptionPipeline] chunk {idx + 1}/{parts.Count} done: bytes={parts[idx].Length}, chars={text.Length}");
+                FileLog.Write($"[BatchTranscriptionPipeline] chunk {idx + 1}/{parts.Count} done: bytes={parts[idx].Length}, chars={text.Delivered.Length}");
                 progress?.Report(new TranscriptionProgress(done, parts.Count));
             }
             finally
@@ -301,7 +305,7 @@ public sealed class BatchTranscriptionPipeline : IDisposable
         for (int i = 0; i < parts.Count; i++) tasks[i] = ProcessAsync(i);
         await Task.WhenAll(tasks);   // throws the first chunk failure -> job fails clean
 
-        return string.Join(" ", texts.Where(t => !string.IsNullOrEmpty(t)));
+        return PartTranscript.Join(texts);
     }
 
     /// <summary>
@@ -311,7 +315,7 @@ public sealed class BatchTranscriptionPipeline : IDisposable
     /// (out of credits) is NOT retried and propagates its original typed exception so the caller's
     /// credit/retry handling still works. The chunk index is logged on failure.
     /// </summary>
-    private async Task<string> PostOneWithRetryAsync(
+    private async Task<PartTranscript> PostOneWithRetryAsync(
         byte[] audio, string fileName, ResolvedTranscription routing, int chunkIndex, CancellationToken ct)
     {
         for (int attempt = 0; ; attempt++)
@@ -365,7 +369,7 @@ public sealed class BatchTranscriptionPipeline : IDisposable
     /// transport for the shared pipeline - there is no streaming/partial path here. Callers over the
     /// per-request size limit are split into several of these by <see cref="TranscribeBatchAsync"/>.
     /// </summary>
-    private async Task<string> PostOneAsync(
+    private async Task<PartTranscript> PostOneAsync(
         byte[] audio, string fileName, ResolvedTranscription routing, CancellationToken ct)
     {
         var endpoint = routing.BaseUrl.TrimEnd('/') + "/audio/transcriptions";
@@ -420,10 +424,15 @@ public sealed class BatchTranscriptionPipeline : IDisposable
         // THE EVIDENCE GATE (pipeline v2.0). Run it HERE, per part, because a long recording is
         // split and each part's segment times start at zero - gating after the parts are joined
         // would point every time at the wrong audio. Fails open on anything it cannot measure.
+        //
+        // BOTH texts come back. The model's FULL output stays the raw transcript, so a removal is
+        // visible by diffing what was stored against what was delivered - the same way a dictionary
+        // edit is. Returning only the gated text would make the removal invisible in the record and
+        // leave the Gateway's log file as the only evidence, which is not an audit trail.
         var gated = TranscriptEvidenceGate.Apply(audio, ReadSegments(doc.RootElement), text);
         if (gated.Applied)
             FileLog.Write($"[BatchTranscriptionPipeline] evidence gate {TranscriptEvidenceGate.Version}: {gated.Reason}");
-        return gated.Text;
+        return new PartTranscript(text, gated.Text, gated.DroppedSegments);
     }
 
     /// <summary>
@@ -511,7 +520,33 @@ public sealed record BatchTranscriptionResult(
     string CorrectedTranscript,
     bool DictionaryApplied,
     IReadOnlyList<TranscriptEdit> ChangedWords,
-    string? Reason);
+    string? Reason,
+    IReadOnlyList<TranscriptEvidenceGate.Dropped>? DroppedSegments = null);
+
+/// <summary>
+/// One transcribed part: what the model actually wrote, what survived the evidence gate, and the
+/// sentences the gate removed.
+///
+/// Both texts are carried on purpose. RAW is the model's full output and is what gets stored, so a
+/// removal stays visible by comparing the record against what was delivered - the same way a
+/// dictionary edit is visible. Returning only the gated text made the removal invisible everywhere
+/// except the Gateway's own log file, which is not an audit trail.
+/// </summary>
+public sealed record PartTranscript(
+    string Raw,
+    string Delivered,
+    IReadOnlyList<TranscriptEvidenceGate.Dropped> Dropped)
+{
+    /// <summary>Join parts in ORIGINAL order, raw with raw and delivered with delivered, so the two
+    /// stay aligned across a split recording.</summary>
+    public static PartTranscript Join(IReadOnlyList<PartTranscript> parts)
+    {
+        var raw = string.Join(" ", parts.Where(p => p is not null && p.Raw.Length > 0).Select(p => p.Raw));
+        var delivered = string.Join(" ", parts.Where(p => p is not null && p.Delivered.Length > 0).Select(p => p.Delivered));
+        var dropped = parts.Where(p => p is not null).SelectMany(p => p.Dropped).ToList();
+        return new PartTranscript(raw, delivered, dropped);
+    }
+}
 
 /// <summary>
 /// Progress of a batch transcription while it runs: how many bounded parts have finished out of the


### PR DESCRIPTION
Regression from #2804, live since 2026-09-10 01:46 UTC.

## What is wrong

The gate ran inside `PostOneAsync`, which is where the **raw** transcript is read. So `RawText` in `dictation_transcripts` became the *post-gate* text, and a removal left no trace anywhere except the Gateway's own log file.

Five places say the opposite - the code comment, the commit, the PR, the research doc and the version register all state "raw text is never touched, every drop is auditable by query". That was false as shipped.

Diffing the stored record against what was delivered is how this repo proves nothing was silently altered. It is the method the verbatim rule names, and the same method that catches an unlisted dictionary edit. It only works if the raw side is untouched.

## The fix

A transcribed part now carries both texts plus the sentences the gate removed:

- `RawTranscript` is the model's full output, including anything dropped
- the dictionary corrector runs on what will actually be **delivered** - correcting words inside a sentence nobody receives would put edits in the change list that never reach the user
- the dropped sentences ride on `BatchTranscriptionResult`, so a removal is in the record rather than only in a log

**Behaviour towards the user is unchanged** - the same sentences are delivered. This restores the evidence, it does not change the decision.

## Proof

```
TranscriptEvidenceGateTests        9 passed  (one new, pinning the raw side)
Gateway.Tests (transcription)    117 passed
Gateway.UnitTests              4,241 passed, 0 failed
```

The new test states the defect directly: the gate drops the sentence, does not deliver it, names it in the record, and the model's own words stay intact.

## Deploy note

main's `Build & Test (.NET)` is red for a pre-existing, unrelated reason - `SessionCommandExecutorLivenessTests.Kill_WithNoInjectedCheck_WillNotCallAnUnreadableLiveProcessAlreadyStopped` needs the host to deny process access and the GitHub runner grants it anyway. It fails on every recent main commit and passes locally. The deploy workflow refuses a commit whose checks have FAILED, so that test blocks the next Gateway deploy until it is fixed.
