### PR TITLE
The liveness test could not build its own precondition on an elevated host

### DIFF
--- a/src/CcDirector.Gateway.UnitTests/DebugPrivilege.cs
+++ b/src/CcDirector.Gateway.UnitTests/DebugPrivilege.cs
@@ -1,0 +1,169 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Turns SeDebugPrivilege off in THIS process for a while, and puts it back.
+///
+/// WHY A TEST NEEDS THIS. SeDebugPrivilege exists to let a debugger open any process on the machine,
+/// and it does that by bypassing the target's access control list entirely. A test that builds a
+/// process it must not be able to open - by giving that process a list which denies everyone - is
+/// therefore defeated by the privilege: the deny is written, and the open succeeds anyway.
+///
+/// That is not hypothetical. <see cref="SessionCommandExecutorLivenessTests"/> failed on every CI run
+/// from at least 2026-09-08 with "this host still granted the test PROCESS_QUERY_LIMITED_INFORMATION
+/// on a process whose access control list denies everyone". The GitHub Windows runner executes the
+/// job elevated, so it holds SeDebugPrivilege; a developer machine running as a standard user does
+/// not, which is why the same test passed locally and failed in CI for days. An explicit deny ACE for
+/// that access right has no other way of being overridden - the object's owner is implicitly granted
+/// READ_CONTROL and WRITE_DAC, and nothing else.
+///
+/// THE POINT IS TO KEEP THE TEST, NOT TO SKIP IT. Suppressing the privilege lets the real assertion
+/// run on an elevated host instead of being reported as an unreachable precondition. Where the state
+/// still cannot be produced, the caller fails loudly as it always did.
+///
+/// SCOPE. A privilege belongs to the process token, so this affects the whole test host while it is
+/// held. Keep the window to the test that needs it and dispose promptly. Disposal restores exactly the
+/// prior state, including the case where the privilege was already disabled.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class DebugPrivilege : IDisposable
+{
+    private const string SeDebugName = "SeDebugPrivilege";
+    private const uint TokenAdjustPrivileges = 0x0020;
+    private const uint TokenQuery = 0x0008;
+    private const uint SePrivilegeEnabled = 0x0002;
+    private const int ErrorNotAllAssigned = 1300;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Luid { public uint LowPart; public int HighPart; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LuidAndAttributes { public Luid Luid; public uint Attributes; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct TokenPrivileges { public uint PrivilegeCount; public LuidAndAttributes Privilege; }
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr GetCurrentProcess();
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool OpenProcessToken(IntPtr processHandle, uint desiredAccess, out IntPtr tokenHandle);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool LookupPrivilegeValue(string? systemName, string name, out Luid luid);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool AdjustTokenPrivileges(IntPtr tokenHandle, bool disableAll,
+        ref TokenPrivileges newState, uint bufferLength, out TokenPrivileges previousState, out uint returnLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr handle);
+
+    private readonly IntPtr _token;
+    private TokenPrivileges _previous;
+    private readonly bool _restore;
+    private bool _disposed;
+
+    private DebugPrivilege(IntPtr token, TokenPrivileges previous, bool restore)
+    {
+        _token = token;
+        _previous = previous;
+        _restore = restore;
+    }
+
+    /// <summary>
+    /// True when this process's token carries SeDebugPrivilege and it is currently ENABLED - the state
+    /// in which an access control list is bypassed. Reported in failure messages so a host that cannot
+    /// produce the unreadable state says whether this was the reason.
+    /// </summary>
+    public static bool IsEnabledForThisProcess()
+    {
+        if (!OpenProcessToken(GetCurrentProcess(), TokenQuery | TokenAdjustPrivileges, out var token))
+            return false;
+        try
+        {
+            if (!LookupPrivilegeValue(null, SeDebugName, out var luid)) return false;
+
+            // Ask for a no-op adjustment: it reports the PREVIOUS state without changing anything that
+            // matters, and its "not all assigned" error says the privilege is absent from the token.
+            var request = new TokenPrivileges
+            {
+                PrivilegeCount = 1,
+                Privilege = new LuidAndAttributes { Luid = luid, Attributes = SePrivilegeEnabled },
+            };
+            if (!AdjustTokenPrivileges(token, false, ref request,
+                    (uint)Marshal.SizeOf<TokenPrivileges>(), out var previous, out _))
+                return false;
+            if (Marshal.GetLastWin32Error() == ErrorNotAllAssigned) return false;
+
+            var wasEnabled = previous.PrivilegeCount == 1
+                && (previous.Privilege.Attributes & SePrivilegeEnabled) == SePrivilegeEnabled;
+
+            // Put back whatever was there before this question was asked.
+            if (previous.PrivilegeCount == 1)
+                AdjustTokenPrivileges(token, false, ref previous,
+                    (uint)Marshal.SizeOf<TokenPrivileges>(), out _, out _);
+            return wasEnabled;
+        }
+        finally
+        {
+            CloseHandle(token);
+        }
+    }
+
+    /// <summary>
+    /// Disable SeDebugPrivilege until the returned object is disposed. Returns null when there is
+    /// nothing to do or nothing can be done - the privilege is absent, already disabled, or the token
+    /// refuses the adjustment - because in every one of those cases the caller's next attempt is
+    /// unaffected by this and should proceed and be judged on its own result.
+    /// </summary>
+    public static DebugPrivilege? Suppress()
+    {
+        if (!OpenProcessToken(GetCurrentProcess(), TokenQuery | TokenAdjustPrivileges, out var token))
+            return null;
+
+        if (!LookupPrivilegeValue(null, SeDebugName, out var luid))
+        {
+            CloseHandle(token);
+            return null;
+        }
+
+        var request = new TokenPrivileges
+        {
+            PrivilegeCount = 1,
+            Privilege = new LuidAndAttributes { Luid = luid, Attributes = 0 },   // 0 = disabled
+        };
+        if (!AdjustTokenPrivileges(token, false, ref request,
+                (uint)Marshal.SizeOf<TokenPrivileges>(), out var previous, out _)
+            || Marshal.GetLastWin32Error() == ErrorNotAllAssigned)
+        {
+            CloseHandle(token);
+            return null;
+        }
+
+        var wasEnabled = previous.PrivilegeCount == 1
+            && (previous.Privilege.Attributes & SePrivilegeEnabled) == SePrivilegeEnabled;
+        if (!wasEnabled)
+        {
+            // It was already off, so nothing was changed and there is nothing to restore.
+            CloseHandle(token);
+            return null;
+        }
+
+        return new DebugPrivilege(token, previous, restore: true);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        if (_restore)
+        {
+            AdjustTokenPrivileges(_token, false, ref _previous,
+                (uint)Marshal.SizeOf<TokenPrivileges>(), out _, out _);
+        }
+        CloseHandle(_token);
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/DebugPrivilege.cs
+++ b/src/CcDirector.Gateway.UnitTests/DebugPrivilege.cs
@@ -35,6 +35,7 @@ public sealed class DebugPrivilege : IDisposable
     private const uint TokenQuery = 0x0008;
     private const uint SePrivilegeEnabled = 0x0002;
     private const int ErrorNotAllAssigned = 1300;
+    private const int TokenPrivilegesClass = 3;   // TOKEN_INFORMATION_CLASS.TokenPrivileges
 
     [StructLayout(LayoutKind.Sequential)]
     private struct Luid { public uint LowPart; public int HighPart; }
@@ -58,6 +59,10 @@ public sealed class DebugPrivilege : IDisposable
     private static extern bool AdjustTokenPrivileges(IntPtr tokenHandle, bool disableAll,
         ref TokenPrivileges newState, uint bufferLength, out TokenPrivileges previousState, out uint returnLength);
 
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool GetTokenInformation(IntPtr tokenHandle, int tokenInformationClass,
+        IntPtr tokenInformation, uint tokenInformationLength, out uint returnLength);
+
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern bool CloseHandle(IntPtr handle);
 
@@ -75,37 +80,47 @@ public sealed class DebugPrivilege : IDisposable
 
     /// <summary>
     /// True when this process's token carries SeDebugPrivilege and it is currently ENABLED - the state
-    /// in which an access control list is bypassed. Reported in failure messages so a host that cannot
-    /// produce the unreadable state says whether this was the reason.
+    /// in which an access control list is bypassed.
+    ///
+    /// READ-ONLY, and that is the whole point. The first version answered this by asking
+    /// AdjustTokenPrivileges to enable the privilege and reading the previous state out of the reply.
+    /// That mutates the thing it is measuring: on the CI runner it left the privilege ENABLED, so this
+    /// method reported "not held" while <see cref="Suppress"/> immediately afterwards found it on and
+    /// suppressed it - two functions disagreeing about one token, and a test failing on the
+    /// contradiction rather than on anything real. GetTokenInformation only reads, so it cannot
+    /// disagree with itself or leave the host in a state the next test inherits.
     /// </summary>
     public static bool IsEnabledForThisProcess()
     {
-        if (!OpenProcessToken(GetCurrentProcess(), TokenQuery | TokenAdjustPrivileges, out var token))
+        if (!OpenProcessToken(GetCurrentProcess(), TokenQuery, out var token))
             return false;
         try
         {
-            if (!LookupPrivilegeValue(null, SeDebugName, out var luid)) return false;
+            if (!LookupPrivilegeValue(null, SeDebugName, out var wanted)) return false;
 
-            // Ask for a no-op adjustment: it reports the PREVIOUS state without changing anything that
-            // matters, and its "not all assigned" error says the privilege is absent from the token.
-            var request = new TokenPrivileges
+            GetTokenInformation(token, TokenPrivilegesClass, IntPtr.Zero, 0, out var needed);
+            if (needed == 0) return false;
+
+            var buffer = Marshal.AllocHGlobal((int)needed);
+            try
             {
-                PrivilegeCount = 1,
-                Privilege = new LuidAndAttributes { Luid = luid, Attributes = SePrivilegeEnabled },
-            };
-            if (!AdjustTokenPrivileges(token, false, ref request,
-                    (uint)Marshal.SizeOf<TokenPrivileges>(), out var previous, out _))
-                return false;
-            if (Marshal.GetLastWin32Error() == ErrorNotAllAssigned) return false;
+                if (!GetTokenInformation(token, TokenPrivilegesClass, buffer, needed, out _))
+                    return false;
 
-            var wasEnabled = previous.PrivilegeCount == 1
-                && (previous.Privilege.Attributes & SePrivilegeEnabled) == SePrivilegeEnabled;
-
-            // Put back whatever was there before this question was asked.
-            if (previous.PrivilegeCount == 1)
-                AdjustTokenPrivileges(token, false, ref previous,
-                    (uint)Marshal.SizeOf<TokenPrivileges>(), out _, out _);
-            return wasEnabled;
+                var count = Marshal.ReadInt32(buffer);
+                var entrySize = Marshal.SizeOf<LuidAndAttributes>();
+                for (int i = 0; i < count; i++)
+                {
+                    var entry = Marshal.PtrToStructure<LuidAndAttributes>(buffer + sizeof(int) + (i * entrySize));
+                    if (entry.Luid.LowPart != wanted.LowPart || entry.Luid.HighPart != wanted.HighPart) continue;
+                    return (entry.Attributes & SePrivilegeEnabled) == SePrivilegeEnabled;
+                }
+                return false;   // not in this token at all
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
         }
         finally
         {

--- a/src/CcDirector.Gateway.UnitTests/SessionCommandExecutorLivenessTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/SessionCommandExecutorLivenessTests.cs
@@ -199,8 +199,15 @@ public sealed class SessionCommandExecutorLivenessTests
     /// If the state cannot be produced this FAILS the test with the reason. It never skips.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    private static Process StartAChildThisMachineCannotRead()
+    private static (Process Child, DebugPrivilege? Suppressed) StartAChildThisMachineCannotRead()
     {
+        // SeDebugPrivilege bypasses an access control list outright, so on a host that holds it - an
+        // elevated CI runner, for one - a deny-everyone list is written and the open succeeds anyway,
+        // and the state this fixture exists to build cannot be built. Turn it off for the duration and
+        // the deny is honoured, so the REAL assertion runs instead of the precondition failing. This is
+        // why the test failed on every CI run from at least 2026-09-08 while passing on a developer
+        // machine, where the account is a standard user and never had the privilege.
+        var suppressed = DebugPrivilege.Suppress();
         var child = StartAChildProcess();
 
         var securityDescriptor = new RawSecurityDescriptor("D:P(D;;GA;;;WD)");
@@ -211,6 +218,7 @@ public sealed class SessionCommandExecutorLivenessTests
         {
             var error = Marshal.GetLastWin32Error();
             EndTheChild(child);
+            suppressed?.Dispose();
             Assert.Fail($"This host would not let the test close a process off from itself "
                 + $"(SetKernelObjectSecurity failed with Windows error {error}), so the state where a LIVE "
                 + "process cannot be read could not be produced. This test protects the production liveness "
@@ -228,14 +236,21 @@ public sealed class SessionCommandExecutorLivenessTests
         {
             CloseHandle(reopened);
             EndTheChild(child);
+            var debugStillOn = DebugPrivilege.IsEnabledForThisProcess();
+            suppressed?.Dispose();
             Assert.Fail("This host still granted the test PROCESS_QUERY_LIMITED_INFORMATION on a process "
                 + "whose access control list denies everyone, so a live-but-unreadable process could not be "
                 + "produced here. This test protects the production liveness check against exactly that "
-                + "state and must not be skipped.");
+                + "state and must not be skipped. "
+                + $"SeDebugPrivilege enabled after suppression: {debugStillOn}; suppression "
+                + $"{(suppressed is null ? "was not needed or not possible" : "was applied")}. "
+                + "If the privilege is still on, that is the cause and the suppression failed; if it is "
+                + "off, this host bypasses the list some other way and the reason is not yet known.");
         }
         if (openError != ErrorAccessDenied)
         {
             EndTheChild(child);
+            suppressed?.Dispose();
             Assert.Fail($"Opening the child process failed with Windows error {openError} rather than "
                 + $"{ErrorAccessDenied} (access denied), which means it was not closed off - most likely it "
                 + "had already exited. The live-but-unreadable state was not produced, and this test must "
@@ -247,6 +262,7 @@ public sealed class SessionCommandExecutorLivenessTests
             using var reader = Process.GetProcessById(child.Id);
             var exited = reader.HasExited;
             EndTheChild(child);
+            suppressed?.Dispose();
             Assert.Fail($"Reading HasExited on the closed-off child answered {exited} instead of throwing, "
                 + "so this host does not produce the live-but-unreadable state at all. The production "
                 + "liveness check's Unreadable answer is UNPROVEN here and this test must not pass.");
@@ -258,12 +274,13 @@ public sealed class SessionCommandExecutorLivenessTests
         catch (ArgumentException)
         {
             child.Dispose();
+            suppressed?.Dispose();
             Assert.Fail("The child process had exited before the unreadable state could be built, so this "
                 + "test would have been asserting against a process that really was gone. This is a fault "
                 + "in the test fixture, not a verdict on the production liveness check.");
         }
 
-        return child;
+        return (child, suppressed);
     }
 
     // ------------------------------------------------------------------------ the three answers ----
@@ -358,7 +375,7 @@ public sealed class SessionCommandExecutorLivenessTests
             return;
         }
 
-        var child = StartAChildThisMachineCannotRead();
+        var (child, suppressed) = StartAChildThisMachineCannotRead();
         var askedToShutDown = false;
         var (sm, session, worktree) = NewSessionOn(
             new RealProcessBackend(child.Id, onShutdown: () => askedToShutDown = true));
@@ -399,7 +416,45 @@ public sealed class SessionCommandExecutorLivenessTests
         {
             EndTheChild(child);
             sm.Dispose();
+            // Put SeDebugPrivilege back. It belongs to the process token, so leaving it off would change
+            // what every later test on this host can open.
+            suppressed?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// THE FIXTURE ITSELF, on a host that holds SeDebugPrivilege. The test above depends on being able to
+    /// build a live process it cannot open, and that is impossible while the privilege is enabled - the
+    /// privilege exists to bypass exactly the access control list the fixture writes. This states the
+    /// dependency out loud so the next person meets it as a named condition rather than as a CI failure
+    /// nobody can reproduce on their own machine.
+    ///
+    /// It asserts the SHAPE of the suppression, not the host's configuration: an elevated host must be
+    /// able to give the privilege up, and a standard-user host must report that there was nothing to give
+    /// up. Both are correct; the two together are what let one test run everywhere.
+    /// </summary>
+    [Fact]
+    public void TheUnreadableFixtureSuppressesTheDebugPrivilegeThatWouldDefeatIt()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var heldBefore = DebugPrivilege.IsEnabledForThisProcess();
+        using (var suppression = DebugPrivilege.Suppress())
+        {
+            if (heldBefore)
+            {
+                Assert.NotNull(suppression);
+                Assert.False(DebugPrivilege.IsEnabledForThisProcess(),
+                    "SeDebugPrivilege was held and Suppress() returned a suppression, but the privilege is "
+                    + "still enabled - the fixture's deny-everyone list would still be bypassed.");
+            }
+            else
+            {
+                Assert.Null(suppression);   // nothing to suppress, and nothing to restore
+            }
+        }
+
+        Assert.Equal(heldBefore, DebugPrivilege.IsEnabledForThisProcess());
     }
 
     // ---------------------------------------------------- a session with no process identifier ----


### PR DESCRIPTION
`Build & Test (.NET)` has failed on **every main commit since at least 2026-09-08**, including the v2.1.0 release, on one test:

```
SessionCommandExecutorLivenessTests.Kill_WithNoInjectedCheck_WillNotCallAnUnreadableLiveProcessAlreadyStopped

"This host still granted the test PROCESS_QUERY_LIMITED_INFORMATION on a process
 whose access control list denies everyone, so a live-but-unreadable process could
 not be produced here."
```

## The cause

`SeDebugPrivilege` exists to let a debugger open any process, and it does that by **bypassing the target's access control list outright**.

The fixture builds a live process it must not be able to open, by giving that process a list denying everyone. On a host holding the privilege, the deny is written and the open succeeds anyway — the state cannot be built at all. The GitHub Windows runner executes the job elevated and holds it; a developer machine running as a standard user never had it.

That is the whole of why this passed locally and failed in CI for days, and why it could not be reproduced. Nothing else can override an explicit deny for that access right: the object's owner is implicitly granted `READ_CONTROL` and `WRITE_DAC` and nothing more.

The test was right to fail loudly. It was wrong about what it could do about it.

## The fix

The fixture turns the privilege off for the duration and restores it afterwards, so the **real assertion runs** on an elevated host instead of the precondition failing.

- Where the state still cannot be produced it fails as loudly as before, and now reports whether the privilege was still on — so the next such failure carries its own diagnosis instead of being a puzzle.
- A second test states the dependency out loud: an elevated host must be able to give the privilege up, a standard-user host must report there was nothing to give up, and either way the prior state is restored.
- The privilege belongs to the process token, so it is restored in a `finally` — leaving it off would change what every later test on the host can open.

**The test's intent is unchanged.** It still injects no liveness seam, still drives the production `DefaultProcessLiveness`, still uses a real child process, and still refuses to skip.

## Proof, and its limit

4,242 gateway unit tests pass locally, 0 failures (one more than before — the new shape test).

**Local green does not prove this fix.** This machine is a standard user with no `SeDebugPrivilege`, so the failing condition cannot be reproduced here; the fix targets a host I cannot run. CI on this pull request is the test that matters, because the runner is the elevated host in question.

## Why it matters now

The deploy workflow refuses a commit whose checks have FAILED. Until this is green, no Gateway deploy can run — including devthrottle#2805, which restores the audit trail for the transcript evidence gate.
