### PR TITLE
Show the running agent tool on mobile roster cards

### DIFF
--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -596,10 +596,14 @@ function unreachableNote(mark: RosterSessionMark): string {
   return mark.lastSeenLabel.length > 0 ? `${base} - ${mark.lastSeenLabel}` : base;
 }
 
-function SessionRow({ session, mark, fromTab = "all" }: { session: SessionDto; mark?: RosterSessionMark; fromTab?: RosterTab }) {
+export function SessionRow({ session, mark, fromTab = "all" }: { session: SessionDto; mark?: RosterSessionMark; fromTab?: RosterTab }) {
   const name = session.name && session.name.trim().length > 0 ? session.name : "(unnamed session)";
   const repo = repoLeaf(session);
   const machine = machineName(session);
+  // The Gateway folds the raw SessionDto.agent identity into finished display words. An absent stamp is
+  // kept loud for an older Gateway instead of producing an empty chip that looks like a complete card.
+  // Neither path reads currentModel/modelDisplay: a model is what the tool runs, never which tool runs it.
+  const agentTool = (session.agentToolDisplay ?? "").trim() || "Agent tool not reported";
   // TWO different questions, which this row used to answer with one flag - inspection 1, finding 2.
   //
   //  - DIMMED is display: "is this row's content last-known rather than current?" The retention mark is
@@ -678,16 +682,18 @@ function SessionRow({ session, mark, fromTab = "all" }: { session: SessionDto; m
               winding down
             </span>
           )}
-          {/* The facts you navigate and filter by - the machine the session runs on and its repo - are
-              a bottom row of small chips, so a fleet spread across several machines is legible at a
-              glance without crowding the status line. The machine chip is accent-tinted; the repo chip
-              is neutral. Either is omitted when the Gateway did not stamp it. */}
-          {(machine || repo) && (
-            <span className="row-chips">
-              {machine && <span className="row-chip row-chip-machine">{machine}</span>}
-              {repo && <span className="row-chip row-chip-repo">{repo}</span>}
+          {/* The running agent tool and the places you navigate and filter by are a bottom row of small
+              chips. The tool is the Gateway's finished SessionDto.agentToolDisplay string, rendered
+              verbatim; it never comes from the independently reported model. Machine and repo are omitted
+              when the Gateway did not stamp them, while an unstamped tool stays visibly unknown rather
+              than silently disappearing. */}
+          <span className="row-chips">
+            <span className="row-chip row-chip-agent" title="Agent tool">
+              {agentTool}
             </span>
-          )}
+            {machine && <span className="row-chip row-chip-machine">{machine}</span>}
+            {repo && <span className="row-chip row-chip-repo">{repo}</span>}
+          </span>
           {/* Mobile-resilience Phase 2: when the owning machine is unreachable, a short plain note says so
               and names the machine - the card is kept and grayed, never dropped, so the reader knows this
               is stale-but-preserved, not gone. */}

--- a/apps/mobile/src/pages/HomeRosterCard.test.tsx
+++ b/apps/mobile/src/pages/HomeRosterCard.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { SessionDto } from "@devthrottle/client-core/api/client";
+import {
+  getSessionsEnvelope,
+  REACHABILITY_OFFLINE,
+  REACHABILITY_ONLINE,
+  type SessionsEnvelope,
+} from "@devthrottle/client-core/fleet/fleetClient";
+import { emptyRetentionCache, mergeRosterRetention } from "@devthrottle/client-core/fleet/rosterRetention";
+import { SessionRow } from "./Home";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function session(overrides: Partial<SessionDto> = {}): SessionDto {
+  return {
+    sessionId: "session-one",
+    directorId: "director-one",
+    machineName: "SOREN_NORTH",
+    name: "testing pi",
+    agent: "Pi",
+    agentToolDisplay: "Pi",
+    currentModel: "gpt-5.6-sol",
+    modelDisplay: {
+      kind: "reported",
+      text: "gpt-5.6-sol",
+      modelId: "gpt-5.6-sol",
+      tooltip: "gpt-5.6-sol",
+      isAbsent: false,
+    },
+    activityState: "Working",
+    status: "Running",
+    effectiveColor: "blue",
+    effectiveColorHex: "#3b82f6",
+    triageBucket: "active",
+    stateLabel: "Working",
+    ...overrides,
+  } as SessionDto;
+}
+
+function mockFetch(body: unknown) {
+  return vi.fn(async (): Promise<Response> => ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  }) as Response);
+}
+
+function renderRow(value: SessionDto) {
+  return render(
+    <MemoryRouter>
+      <SessionRow session={value} />
+    </MemoryRouter>,
+  );
+}
+
+describe("mobile roster card agent tool", () => {
+  it("carries the Gateway tool label through the roster read, retained state, and card", async () => {
+    vi.stubGlobal("fetch", mockFetch({
+      sessions: [session()],
+      machineErrors: [],
+      directors: [{ directorId: "director-one", state: REACHABILITY_ONLINE }],
+      unreachableBanner: null,
+    }));
+
+    const envelope = await getSessionsEnvelope();
+    const live = mergeRosterRetention(emptyRetentionCache(), envelope);
+    const unavailable: SessionsEnvelope = {
+      sessions: [],
+      machineErrors: [],
+      directors: [{ directorId: "director-one", state: REACHABILITY_OFFLINE }],
+      unreachableBanner: null,
+    };
+    const retained = mergeRosterRetention(live.cache, unavailable);
+    expect(retained.roster.sessions).toHaveLength(1);
+    expect(retained.roster.sessions[0].agentToolDisplay).toBe("Pi");
+    const { container } = renderRow(retained.roster.sessions[0]);
+
+    const tool = screen.getByTitle("Agent tool");
+    expect(tool.textContent).toBe("Pi");
+    expect(container.textContent).not.toContain("gpt-5.6-sol");
+  });
+
+  it("renders the Gateway display spelling instead of the raw token or the model", () => {
+    const { container } = renderRow(session({
+      agent: "ClaudeCode",
+      agentToolDisplay: "Claude Code",
+      currentModel: "claude-fable-5",
+    }));
+
+    expect(screen.getByTitle("Agent tool").textContent).toBe("Claude Code");
+    expect(container.textContent).not.toContain("ClaudeCode");
+    expect(container.textContent).not.toContain("claude-fable-5");
+  });
+
+  it("keeps an absent Gateway display stamp visible without deriving from the raw token", () => {
+    renderRow(session({ agent: "Pi", agentToolDisplay: undefined }));
+
+    expect(screen.getByTitle("Agent tool").textContent).toBe("Agent tool not reported");
+  });
+
+  it("keeps the existing session name visible beside the added tool metadata", () => {
+    renderRow(session());
+
+    expect(screen.getByText("testing pi")).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/pages/HomeRosterCard.test.tsx
+++ b/apps/mobile/src/pages/HomeRosterCard.test.tsx
@@ -10,7 +10,11 @@ import {
   type SessionsEnvelope,
 } from "@devthrottle/client-core/fleet/fleetClient";
 import { emptyRetentionCache, mergeRosterRetention } from "@devthrottle/client-core/fleet/rosterRetention";
-import { SessionRow } from "./Home";
+import { Home, SessionRow } from "./Home";
+
+vi.mock("@devthrottle/client-core/restart/RestartRequestsPanel", () => ({
+  RestartRequestsPanel: () => null,
+}));
 
 afterEach(() => {
   cleanup();
@@ -60,6 +64,36 @@ function renderRow(value: SessionDto) {
 }
 
 describe("mobile roster card agent tool", () => {
+  it("polls, groups, and renders the tool label through the assembled Home roster", async () => {
+    localStorage.clear();
+    const fetch = mockFetch({
+      sessions: [session({
+        agent: "ClaudeCode",
+        agentToolDisplay: "Claude Code",
+        currentModel: "gpt-5.6-sol",
+      })],
+      machineErrors: [],
+      directors: [{ directorId: "director-one", state: REACHABILITY_ONLINE }],
+      unreachableBanner: null,
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Other sessions" })).toBeTruthy();
+    expect(screen.getByText("testing pi")).toBeTruthy();
+    expect(screen.getByTitle("Agent tool").textContent).toBe("Claude Code");
+    expect(screen.queryByText("gpt-5.6-sol")).toBeNull();
+    expect(fetch).toHaveBeenCalledWith(
+      "/sessions?envelope=true",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
   it("carries the Gateway tool label through the roster read, retained state, and card", async () => {
     vi.stubGlobal("fetch", mockFetch({
       sessions: [session()],

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -540,8 +540,8 @@ a.banner-btn {
   white-space: nowrap;
 }
 
-/* The bottom "facts" row on a card: small chips for the machine and repo. It wraps if a phone is too
-   narrow to hold both. Kept a touch tighter to the status line above it than the name gap. */
+/* The bottom "facts" row on a card: small chips for the agent tool, machine and repo. It wraps if a
+   phone is too narrow to hold them. Kept a touch tighter to the status line above it than the name gap. */
 .row-chips {
   display: flex;
   flex-wrap: wrap;
@@ -570,6 +570,19 @@ a.banner-btn {
   flex: 0 0 auto;
   width: 7px;
   height: 7px;
+}
+
+.row-chip-agent {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+/* A compact round tool mark distinguishes the running agent tool from the two location facts. */
+.row-chip-agent::before {
+  background: currentColor;
+  border-radius: 50%;
+  opacity: 0.72;
 }
 
 .row-chip-machine {

--- a/packages/client-core/src/api/schema.ts
+++ b/packages/client-core/src/api/schema.ts
@@ -10879,6 +10879,7 @@ export interface components {
             sessionId?: string;
             directorId?: string;
             agent?: string;
+            agentToolDisplay?: string;
             groupId?: null | string;
             groupRole?: null | string;
             repoPath?: string;

--- a/packages/client-core/src/fleet/rosterRetention.test.ts
+++ b/packages/client-core/src/fleet/rosterRetention.test.ts
@@ -316,6 +316,31 @@ describe("roster keep-and-mark retention merge", () => {
     expect(online.roster.marks.size).toBe(0);
   });
 
+  it("replaces an older retained agent-tool label with the newer live label", () => {
+    const older = session("s1", "d1");
+    older.agentToolDisplay = "Pi";
+    const first = mergeRosterRetention(
+      emptyRetentionCache(),
+      envelope([older], [director("d1", REACHABILITY_ONLINE)]),
+    );
+    const offline = mergeRosterRetention(
+      first.cache,
+      envelope([], [director("d1", REACHABILITY_OFFLINE)]),
+    );
+    expect(offline.roster.sessions[0].agentToolDisplay).toBe("Pi");
+
+    const newer = session("s1", "d1");
+    newer.agentToolDisplay = "Codex";
+    const online = mergeRosterRetention(
+      offline.cache,
+      envelope([newer], [director("d1", REACHABILITY_ONLINE)]),
+    );
+
+    expect(online.roster.sessions[0]).toBe(newer);
+    expect(online.roster.sessions[0].agentToolDisplay).toBe("Codex");
+    expect(online.cache.byDirector.get("d1")?.[0]).toBe(newer);
+  });
+
   it("never retains a session with no owning Director id (live-only)", () => {
     const first = mergeRosterRetention(emptyRetentionCache(), envelope([session("s1", "")], []));
     expect(first.roster.sessions.map((s) => s.sessionId)).toEqual(["s1"]);

--- a/src/CcDirector.Gateway.Contracts/AgentToolDisplayFold.cs
+++ b/src/CcDirector.Gateway.Contracts/AgentToolDisplayFold.cs
@@ -1,0 +1,30 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The one fold that turns <see cref="SessionDto.Agent"/>, the Director's raw agent-kind token, into the
+/// finished agent-tool label every Gateway roster client renders. The tool and the model are separate
+/// facts: this fold never reads <see cref="SessionDto.CurrentModel"/> or <see cref="SessionDto.ModelDisplay"/>.
+/// </summary>
+public static class AgentToolDisplayFold
+{
+    /// <summary>
+    /// Return the human-facing tool name for one raw agent-kind token. Unknown future tokens are preserved
+    /// verbatim so a new tool remains visible even before this fold learns a prettier spelling. A missing
+    /// token is named explicitly instead of producing a blank chip that looks like a complete card.
+    /// </summary>
+    public static string For(string? agent)
+    {
+        var token = (agent ?? "").Trim();
+        if (token.Length == 0)
+            return "Agent tool not reported";
+
+        if (string.Equals(token, "ClaudeCode", StringComparison.OrdinalIgnoreCase))
+            return "Claude Code";
+        if (string.Equals(token, "Copilot", StringComparison.OrdinalIgnoreCase))
+            return "GitHub Copilot";
+        if (string.Equals(token, "RawCli", StringComparison.OrdinalIgnoreCase))
+            return "Custom CLI";
+
+        return token;
+    }
+}

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -12,8 +12,16 @@ public sealed class SessionDto
     /// <summary>Which Director owns this session. Empty in Director-local responses.</summary>
     public string DirectorId { get; set; } = "";
 
-    /// <summary>Agent CLI kind: ClaudeCode, Pi, Codex, Gemini, OpenCode, RawCli.</summary>
+    /// <summary>Agent tool kind: ClaudeCode, Pi, Codex, Gemini, OpenCode, Cursor, Grok, Copilot, RawCli.</summary>
     public string Agent { get; set; } = "";
+
+    /// <summary>
+    /// Gateway-folded display name for the running agent tool, such as <c>Claude Code</c>, <c>Pi</c>, or
+    /// <c>Codex</c>. Browser clients render this verbatim and never infer the tool from
+    /// <see cref="CurrentModel"/>. Empty in Director-local responses; the Gateway stamps every served
+    /// roster row through <see cref="AgentToolDisplayFold"/>.
+    /// </summary>
+    public string AgentToolDisplay { get; set; } = "";
 
     /// <summary>Group identity (issue #225) when this session belongs to a group; null for
     /// solo sessions. Lets a by-repo / fleet view keep group members adjacent.</summary>

--- a/src/CcDirector.Gateway.Tests/AgentToolDisplayRouteTests.cs
+++ b/src/CcDirector.Gateway.Tests/AgentToolDisplayRouteTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Host-bound proof for the agent-tool display field on the real <c>GET /sessions</c> route. The setup
+/// uses hosted mode, enrolled device keys, tenant-bound tunnel Hellos, pushed Director snapshots, the
+/// authentication middleware, the request tenant resolver, the route's roster fold, and its JSON response.
+/// </summary>
+public sealed class AgentToolDisplayRouteTests : IAsyncLifetime
+{
+    private const string Token = "test-token";
+    private const string TenantASession = "tenant-a-session";
+    private const string TenantBSession = "tenant-b-session";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-agent-tool-route-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _directorA = null!;
+    private FakeTunnelDirector _directorB = null!;
+    private string _keyA = "";
+    private string _keyB = "";
+    private string? _priorHosted;
+    private bool _cleanedUp;
+
+    public async Task InitializeAsync()
+    {
+        _priorHosted = Environment.GetEnvironmentVariable("CC_GATEWAY_HOSTED");
+        Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", "1");
+
+        try
+        {
+            _gateway = new GatewayHost(
+                port: GatewayHost.OperatingSystemAssignedPort,
+                token: Token,
+                authEnabled: true,
+                instancesDirectory: _instancesDir,
+                workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+                snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"),
+                streamMode: true);
+            await _gateway.StartAsync();
+            _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+
+            var deviceA = HostedTestEnrollment.Enroll(
+                _gateway, "agent-tool-tenant-a", "agent-tool-a@example.com", "agent-tool-device-a", "MA");
+            var deviceB = HostedTestEnrollment.Enroll(
+                _gateway, "agent-tool-tenant-b", "agent-tool-b@example.com", "agent-tool-device-b", "MB");
+            _keyA = deviceA.DeviceKey;
+            _keyB = deviceB.DeviceKey;
+
+            _directorA = await FakeTunnelDirector.StartAsync(_gateway, _keyA, "agent-tool-dir-a", "MA");
+            _directorB = await FakeTunnelDirector.StartAsync(_gateway, _keyB, "agent-tool-dir-b", "MB");
+            await _directorA.PushSnapshotAsync(Session(TenantASession, "Pi", "gpt-5.6-sol"));
+            await _directorB.PushSnapshotAsync(Session(TenantBSession, "Codex", "gpt-5.6-sol"));
+        }
+        catch
+        {
+            await CleanupAsync();
+            throw;
+        }
+    }
+
+    public Task DisposeAsync() => CleanupAsync();
+
+    [Fact]
+    public async Task Authenticated_tenant_sessions_route_serializes_tool_from_agent_when_model_disagrees()
+    {
+        await _directorA.PushSnapshotAsync(Session("agent-model-disagree", "ClaudeCode", "gpt-5.6-sol"));
+
+        using var document = await GetSessionsDocument(_keyA);
+        var row = SessionRow(document, "agent-model-disagree");
+
+        Assert.Equal("ClaudeCode", row.GetProperty("agent").GetString());
+        Assert.Equal("gpt-5.6-sol", row.GetProperty("currentModel").GetString());
+        Assert.Equal("Claude Code", row.GetProperty("agentToolDisplay").GetString());
+    }
+
+    [Fact]
+    public async Task Authenticated_tenant_sessions_route_serializes_loud_tool_label_when_agent_is_absent()
+    {
+        await _directorA.PushSnapshotAsync(Session("agent-absent", "", "gpt-5.6-sol"));
+
+        using var document = await GetSessionsDocument(_keyA);
+        var row = SessionRow(document, "agent-absent");
+
+        Assert.Equal("", row.GetProperty("agent").GetString());
+        Assert.Equal("gpt-5.6-sol", row.GetProperty("currentModel").GetString());
+        Assert.Equal("Agent tool not reported", row.GetProperty("agentToolDisplay").GetString());
+    }
+
+    [Fact]
+    public async Task Sessions_route_authentication_and_tenant_selection_control()
+    {
+        using var unauthenticated = await _http.GetAsync("sessions?envelope=true");
+        Assert.Equal(HttpStatusCode.Unauthorized, unauthenticated.StatusCode);
+
+        using var document = await GetSessionsDocument(_keyA);
+        var sessionIds = document.RootElement.GetProperty("sessions").EnumerateArray()
+            .Select(row => row.GetProperty("sessionId").GetString())
+            .ToArray();
+
+        Assert.Contains(TenantASession, sessionIds);
+        Assert.DoesNotContain(TenantBSession, sessionIds);
+    }
+
+    private async Task<JsonDocument> GetSessionsDocument(string deviceKey)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "sessions?envelope=true");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        using var response = await _http.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    }
+
+    private static JsonElement SessionRow(JsonDocument document, string sessionId) =>
+        Assert.Single(
+            document.RootElement.GetProperty("sessions").EnumerateArray(),
+            row => row.GetProperty("sessionId").GetString() == sessionId);
+
+    private static SessionDto Session(string sessionId, string agent, string currentModel) => new()
+    {
+        SessionId = sessionId,
+        Agent = agent,
+        CurrentModel = currentModel,
+        RepoPath = "/repo",
+        ActivityState = "Working",
+        Status = "Running",
+        StatusColor = "blue",
+        CreatedAt = DateTime.UtcNow,
+        LastActivityAt = DateTime.UtcNow,
+    };
+
+    private async Task CleanupAsync()
+    {
+        if (_cleanedUp)
+            return;
+        _cleanedUp = true;
+
+        try
+        {
+            _http?.Dispose();
+            if (_directorA is not null)
+                await _directorA.DisposeAsync();
+            if (_directorB is not null)
+                await _directorB.DisposeAsync();
+            if (_gateway is not null)
+                await _gateway.StopAsync();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_GATEWAY_HOSTED", _priorHosted);
+            try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/AgentToolDisplayFoldTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/AgentToolDisplayFoldTests.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The agent tool and model are independent session facts. These tests drive both the pure display fold
+/// and the shared roster enrichment used by every served session path, so a correct label that never
+/// reaches the wire cannot satisfy the proof.
+/// </summary>
+public sealed class AgentToolDisplayFoldTests
+{
+    [Theory]
+    [InlineData("ClaudeCode", "Claude Code")]
+    [InlineData("claudecode", "Claude Code")]
+    [InlineData("Pi", "Pi")]
+    [InlineData("Codex", "Codex")]
+    [InlineData("Gemini", "Gemini")]
+    [InlineData("OpenCode", "OpenCode")]
+    [InlineData("Cursor", "Cursor")]
+    [InlineData("Grok", "Grok")]
+    [InlineData("Copilot", "GitHub Copilot")]
+    [InlineData("RawCli", "Custom CLI")]
+    public void For_ReportedAgentToken_ReturnsFinishedToolName(string agent, string expected)
+    {
+        Assert.Equal(expected, AgentToolDisplayFold.For(agent));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void For_MissingAgentToken_ReturnsLoudFallback(string? agent)
+    {
+        Assert.Equal("Agent tool not reported", AgentToolDisplayFold.For(agent));
+    }
+
+    [Fact]
+    public void For_UnknownFutureAgentToken_PreservesTrimmedToken()
+    {
+        Assert.Equal("FutureTool", AgentToolDisplayFold.For("  FutureTool  "));
+    }
+
+    [Fact]
+    public void StampFleetRolesAndFold_AgentAndModelDisagree_StampsToolFromAgent()
+    {
+        var session = Fold(new SessionDto
+        {
+            SessionId = "session-one",
+            ActivityState = "Working",
+            Agent = "ClaudeCode",
+            CurrentModel = "gpt-5.6-sol",
+        });
+
+        Assert.Equal("Claude Code", session.AgentToolDisplay);
+        Assert.NotEqual(session.CurrentModel, session.AgentToolDisplay);
+    }
+
+    [Fact]
+    public void StampFleetRolesAndFold_MissingAgent_StampsLoudFallbackOnServedJson()
+    {
+        var session = Fold(new SessionDto
+        {
+            SessionId = "session-one",
+            ActivityState = "Working",
+            Agent = "",
+        });
+
+        var json = JsonSerializer.Serialize(
+            session,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.Equal("Agent tool not reported", session.AgentToolDisplay);
+        Assert.Contains("\"agentToolDisplay\":\"Agent tool not reported\"", json);
+    }
+
+    private static SessionDto Fold(SessionDto session)
+    {
+        var sessions = new List<SessionDto> { session };
+        GatewayEndpoints.StampFleetRolesAndFold(sessions, sessions);
+        return session;
+    }
+}

--- a/src/CcDirector.Gateway.UnitTests/AgentToolDisplayFoldTests.cs
+++ b/src/CcDirector.Gateway.UnitTests/AgentToolDisplayFoldTests.cs
@@ -6,9 +6,9 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// The agent tool and model are independent session facts. These tests drive both the pure display fold
-/// and the shared roster enrichment used by every served session path, so a correct label that never
-/// reaches the wire cannot satisfy the proof.
+/// The agent tool and model are independent session facts. These unit tests drive the pure display fold
+/// and the shared in-memory roster enrichment helper. They do not invoke a mapped route; the host-bound
+/// route and response proof lives in <c>AgentToolDisplayRouteTests</c>.
 /// </summary>
 public sealed class AgentToolDisplayFoldTests
 {
@@ -59,7 +59,7 @@ public sealed class AgentToolDisplayFoldTests
     }
 
     [Fact]
-    public void StampFleetRolesAndFold_MissingAgent_StampsLoudFallbackOnServedJson()
+    public void StampFleetRolesAndFold_MissingAgent_StampsLoudFallbackOnWebJsonSerialization()
     {
         var session = Fold(new SessionDto
         {

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -5126,6 +5126,11 @@ internal static class GatewayEndpoints
         {
             var effectiveColor = SessionOrdering.EffectiveColor(s);
             s.EffectiveColor = effectiveColor;
+            // Which coding tool is running this session. Agent is the Director's raw identity token;
+            // AgentToolDisplay is the finished label browser clients render. Stamp it independently from
+            // CurrentModel so a Pi session running gpt-5.6-sol can never be presented as the model instead
+            // of the tool.
+            s.AgentToolDisplay = AgentToolDisplayFold.For(s.Agent);
             // The "Dumb Clients" palette slice: resolve the colour NAME to its pixel HEX through the ONE
             // canonical map, right here beside the name, so the /sessions consumers (the web phone and the
             // Cockpit) paint that hex verbatim and carry no name->hex table that can drift. The DESKTOP does


### PR DESCRIPTION
## What changed

- Adds a Gateway-owned display label for the running agent tool and carries it through the browser contract to every main mobile roster card.
- Keeps the tool independent from the selected model and shows `Agent tool not reported` when the Director supplies no agent token.
- Adds hosted, authenticated, tenant-bound HTTP proof for the real `GET /sessions?envelope=true` response.
- Adds a real `Home` roster render through its polling, retention, grouping, and card path.
- Adds direct proof that a newer live agent-tool value replaces an older retained value.

## Repair after inspection

Repair commit: `7499d8d76ec6624a477c6804dcdc7abbbe4fd68d`

The new host suite starts the real Gateway in hosted mode, enrolls two device keys, binds two tunnel Directors to distinct tenants, pushes their session snapshots, and requests the mapped roster route with the caller's Bearer credential. It proves the serialized `agentToolDisplay` is `Claude Code` when `Agent=ClaudeCode` and `CurrentModel=gpt-5.6-sol`, and is `Agent tool not reported` when `Agent` is absent. A separate control proves the route returns 401 without authentication and that tenant A's credential sees tenant A's session but not tenant B's.

The earlier unit comment and test name now state their actual boundary: an in-memory shared fold and web JSON serialization, not a served route.

## Mutation proof

The production route stamp was temporarily bypassed by replacing `AgentToolDisplayFold.For(s.Agent)` with an empty value, then restored.

Exact command:

```powershell
dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter FullyQualifiedName~AgentToolDisplayRouteTests --nologo
```

With the stamp bypassed, the run exited 1: 2 failed, 1 passed, 0 skipped. The two route-response facts received an empty `agentToolDisplay` instead of `Claude Code` and `Agent tool not reported`; the authentication-and-tenant-selection control stayed green. After restoration, the same command exited 0: 3 passed, 0 failed, 0 skipped.

## Final verification

- Gateway host route facts: 3 passed, 0 failed, 0 skipped.
- Gateway unit fold facts: 16 passed, 0 failed, 0 skipped.
- Client-core retention facts: 24 passed across 1 test file.
- Mobile roster-card facts: 5 passed across 1 test file.
- Client-core typecheck: passed.
- Mobile typecheck: passed.
- Mobile production build: passed; 172 modules transformed and 3 application-shell entries precached.
- `git diff --check`: passed before commit.

The existing production-build large-chunk warning remains: the main JavaScript asset is 856.27 kilobytes before compression and 244.17 kilobytes after compression. Narrow-device pixel or screenshot proof was not run.

## Not included

- No Wingman changes.
- No deployment or merge.

## Inspection and hosted CI

Fresh independent reinspection passed with no high, medium, or low findings after the served-route, assembled-Home, and retained-value proof repairs.

Commit-bound hosted run `34672537780` is green on head `7499d8d76`. Web and tool-contract jobs passed. The successful .NET retry passed the previously flaky Launcher identity fact in both target frameworks, all three `AgentToolDisplayRouteTests`, 2,415 passed plus 47 skipped out of 2,462 Gateway tests, and installer suites 25 of 25 and 541 of 541.

Attempt 1 had one unrelated Launcher process-identity failure after every Gateway test passed; the same fact passed locally in both target frameworks and passed twice in the successful hosted retry.